### PR TITLE
fix(SidePanel): fix ref handling in clickOutside useEffect

### DIFF
--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -372,11 +372,12 @@ export let SidePanel = React.forwardRef(
 
     // click outside functionality if `includeOverlay` prop is set
     useEffect(() => {
-      const handleOutsideClick = (e) => {
+      const handleOutsideClick = (event) => {
+        const panelRef = ref || sidePanelRef;
         if (
-          sidePanelRef.current &&
+          panelRef.current &&
           sidePanelOverlayRef.current &&
-          sidePanelOverlayRef.current.contains(e.target) &&
+          sidePanelOverlayRef.current.contains(event.target) &&
           onRequestClose
         ) {
           onRequestClose();
@@ -394,7 +395,7 @@ export let SidePanel = React.forwardRef(
       return () => {
         document.removeEventListener('click', handleOutsideClick);
       };
-    }, [includeOverlay, onRequestClose, open, preventCloseOnClickOutside]);
+    }, [includeOverlay, onRequestClose, open, preventCloseOnClickOutside, ref]);
 
     // initialize the side panel to open
     useEffect(() => {
@@ -904,6 +905,7 @@ SidePanel.defaultProps = {
   currentStep: 0,
   navigationBackIconDescription: 'Back',
   closeIconDescription: 'Close',
+  preventCloseOnClickOutside: false,
 };
 
 SidePanel.displayName = componentName;

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import {
   Button,
@@ -316,6 +316,7 @@ const renderUIShellHeader = () => (
 // eslint-disable-next-line react/prop-types
 const SlideOverTemplate = ({ minimalContent, actions, ...args }) => {
   const [open, setOpen] = useState(false);
+  const testRef = useRef();
   return (
     <>
       {renderUIShellHeader()}
@@ -327,6 +328,7 @@ const SlideOverTemplate = ({ minimalContent, actions, ...args }) => {
         open={open}
         onRequestClose={() => setOpen(false)}
         actions={actionSets[actions]}
+        ref={testRef}
       >
         {!minimalContent && <ChildrenContent />}
       </SidePanel>


### PR DESCRIPTION
Contributes to #1321 

Addresses ref handling in clickOutside useEffect in SidePanel. If a ref was passed in via forwardRef, we were not using the ref that was passed in so the clickOutside functionality wasn't working.

#### What did you change?
`SidePanel.js`
`SidePanel.stories.js`
#### How did you test and verify your work?
Storybook