### PR TITLE
build: remove `warn` from global `console` test

### DIFF
--- a/config/jest-config-ibm-cloud-cognitive/setup/setupFilesAfterEnv.js
+++ b/config/jest-config-ibm-cloud-cognitive/setup/setupFilesAfterEnv.js
@@ -31,7 +31,8 @@ expect.extend({ toBeAccessible, toHaveNoAxeViolations });
 // https://github.com/facebook/react/blob/6250462bed19c9f18a8cf3c2b5fcaf9aba1df72b/scripts/jest/setupTests.js#L69
 
 const oldConsole = {};
-['error', 'warn', process.env.CI && 'log'].filter(Boolean).forEach((method) => {
+
+['error', process.env.CI && 'log'].filter(Boolean).forEach((method) => {
   const unexpectedConsoleCallStacks = [];
 
   oldConsole[method] = console[method];


### PR DESCRIPTION
#### Affected issues

- Contributes to https://github.com/carbon-design-system/ibm-security/issues/973
- Resolves https://github.com/carbon-design-system/ibm-cloud-cognitive/runs/3813836468?check_suite_focus=true#step:5:556

#### Proposed change

[Carbon prop deprecation warnings](https://github.com/carbon-design-system/carbon/blob/main/packages/react/src/components/Checkbox/Checkbox.js#L134-L138) with no immediate resolution, in combination with [783](https://github.com/carbon-design-system/ibm-cloud-cognitive/pull/783), are causing [unit tests for the Security migration to fail](https://github.com/carbon-design-system/ibm-cloud-cognitive/runs/3813836468?check_suite_focus=true#step:5:556). 

This relaxes the threshold for failing tests containing `console.warn`, as there may be legitimate cases where a warning is omitted without a path to resolution.