### PR TITLE
chore: don't reset inherited color for storybook

### DIFF
--- a/packages/core/.storybook/index.scss
+++ b/packages/core/.storybook/index.scss
@@ -58,7 +58,6 @@
 // set default color and background for stories
 .sb-show-main {
   background-color: $ui-background;
-  color: initial; // reset for the story to ensure the component sets color
 }
 
 /**


### PR DESCRIPTION
We were resetting the inherited color in storybook, to make it obvious when components were not setting their color correctly. However this doesn't work for some components. This PR removes that reset. We will add in another mechanism for doing that testing, perhaps through the style tab.

#### What did you change?

storybook index.scss

#### How did you test and verify your work?

ran storybook (no visible change)
