### PR TITLE
chore: prettier plugin linter config

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -9,4 +9,11 @@
 
 const prettierConfig = require('prettier-config-carbon');
 
+// This setting is deprecated, undo Carbon usage as this appears to cause a conflict between
+// `yarn format` and the current version of the VS Code plugin.
+//
+// https://prettier.io/docs/en/options.html#deprecated-jsx-brackets
+//
+prettierConfig.jsxBracketSameLine = false;
+
 module.exports = prettierConfig;


### PR DESCRIPTION
Changes project prettier config to prevent conflict between VSCode plugin and yarn format.

#### What did you change?

prettier config

#### How did you test and verify your work?

Opened made non-code change edit and checked formatting was unchanged in a JSX file.