### PR TITLE
chore(Datagrid): add test for  useInlineEdit hook (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
@@ -2190,86 +2190,6 @@ describe(componentName, () => {
     expect(alertMock).toHaveBeenCalledTimes(3);
   });
 
-  it('Sticky Actions Column', () => {
-    render(
-      <StickyActionsColumn data-testid={dataTestId}></StickyActionsColumn>
-    );
-
-    expect(
-      screen.findByText(
-        'More details documentation check the Notes section below'
-      )
-    ).toBeDefined();
-    for (
-      var i = 0;
-      i <
-      screen
-        .getByRole('table')
-        .getElementsByTagName('tbody')[0]
-        .getElementsByTagName('tr').length;
-      i++
-    ) {
-      expect(
-        screen
-          .getByRole('table')
-          .getElementsByTagName('tbody')[0]
-          .getElementsByTagName('tr')
-          .item(i)
-          .getElementsByTagName('td')[16].classList[0]
-      ).toEqual('c4p--datagrid__right-sticky-column-cell');
-    }
-
-    fireEvent.click(
-      screen
-        .getByRole('table')
-        .getElementsByTagName('tbody')[0]
-        .getElementsByTagName('tr')[0]
-        .getElementsByTagName('td')[16]
-        .getElementsByClassName('c4p--datagrid__actions-column-contents')[0]
-        .getElementsByTagName('button')[0]
-    );
-
-    expect(
-      document
-        .getElementsByTagName('ul')[0]
-        .getElementsByTagName('li')[0]
-        .getElementsByTagName('button')[0].textContent
-    ).toEqual('Edit');
-    fireEvent.click(
-      document
-        .getElementsByTagName('ul')[0]
-        .getElementsByTagName('li')[0]
-        .getElementsByTagName('button')[0]
-    );
-    expect(document.getElementsByTagName('h3')[0].textContent).toMatch(
-      'Clicked [edit] on row:'
-    );
-    fireEvent.click(
-      screen
-        .getByRole('table')
-        .getElementsByTagName('tbody')[0]
-        .getElementsByTagName('tr')[0]
-        .getElementsByTagName('td')[16]
-        .getElementsByClassName('c4p--datagrid__actions-column-contents')[0]
-        .getElementsByTagName('button')[0]
-    );
-    expect(
-      document
-        .getElementsByTagName('ul')[0]
-        .getElementsByTagName('li')[2]
-        .getElementsByTagName('button')[0].textContent
-    ).toEqual('Retire');
-    fireEvent.click(
-      document
-        .getElementsByTagName('ul')[0]
-        .getElementsByTagName('li')[2]
-        .getElementsByTagName('button')[0]
-    );
-    expect(document.getElementsByTagName('h3')[0].textContent).toMatch(
-      'Clicked [retire] on row:'
-    );
-  });
-
   const DatagridInlineEditExample = () => {
     const [data, setData] = useState(makeData(10));
     const columns = React.useMemo(() => getInlineEditColumns(), []);
@@ -2350,5 +2270,85 @@ describe(componentName, () => {
 
     // Check that new cell value can be found within the datagrid component
     screen.getByText(newEditInputValue);
+  });
+
+  it('Sticky Actions Column', () => {
+    render(
+      <StickyActionsColumn data-testid={dataTestId}></StickyActionsColumn>
+    );
+
+    expect(
+      screen.findByText(
+        'More details documentation check the Notes section below'
+      )
+    ).toBeDefined();
+    for (
+      var i = 0;
+      i <
+      screen
+        .getByRole('table')
+        .getElementsByTagName('tbody')[0]
+        .getElementsByTagName('tr').length;
+      i++
+    ) {
+      expect(
+        screen
+          .getByRole('table')
+          .getElementsByTagName('tbody')[0]
+          .getElementsByTagName('tr')
+          .item(i)
+          .getElementsByTagName('td')[16].classList[0]
+      ).toEqual('c4p--datagrid__right-sticky-column-cell');
+    }
+
+    fireEvent.click(
+      screen
+        .getByRole('table')
+        .getElementsByTagName('tbody')[0]
+        .getElementsByTagName('tr')[0]
+        .getElementsByTagName('td')[16]
+        .getElementsByClassName('c4p--datagrid__actions-column-contents')[0]
+        .getElementsByTagName('button')[0]
+    );
+
+    expect(
+      document
+        .getElementsByTagName('ul')[0]
+        .getElementsByTagName('li')[0]
+        .getElementsByTagName('button')[0].textContent
+    ).toEqual('Edit');
+    fireEvent.click(
+      document
+        .getElementsByTagName('ul')[0]
+        .getElementsByTagName('li')[0]
+        .getElementsByTagName('button')[0]
+    );
+    expect(document.getElementsByTagName('h3')[0].textContent).toMatch(
+      'Clicked [edit] on row:'
+    );
+    fireEvent.click(
+      screen
+        .getByRole('table')
+        .getElementsByTagName('tbody')[0]
+        .getElementsByTagName('tr')[0]
+        .getElementsByTagName('td')[16]
+        .getElementsByClassName('c4p--datagrid__actions-column-contents')[0]
+        .getElementsByTagName('button')[0]
+    );
+    expect(
+      document
+        .getElementsByTagName('ul')[0]
+        .getElementsByTagName('li')[2]
+        .getElementsByTagName('button')[0].textContent
+    ).toEqual('Retire');
+    fireEvent.click(
+      document
+        .getElementsByTagName('ul')[0]
+        .getElementsByTagName('li')[2]
+        .getElementsByTagName('button')[0]
+    );
+    expect(document.getElementsByTagName('h3')[0].textContent).toMatch(
+      'Clicked [retire] on row:'
+    );
   });
 });

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
@@ -2297,7 +2297,6 @@ describe(componentName, () => {
 
     const getEditInput = (colHeader) => {
       return screen.getByLabelText(colHeader);
-      // return container.querySelector();
     };
 
     const selectTextInsideOfTextInput = (inputElement) => {

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -119,7 +119,12 @@ export const DatagridContent = ({ datagridState }) => {
             </div>
           )}
           {withInlineEdit ? (
-            <div ref={multiKeyTrackingRef}>{renderTable()}</div>
+            <div
+              ref={multiKeyTrackingRef}
+              className={`${blockClass}__table-key-tracking-wrapper`}
+            >
+              {renderTable()}
+            </div>
           ) : (
             renderTable()
           )}

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
@@ -535,3 +535,7 @@
   height: $spacing-09;
   justify-content: center;
 }
+
+.#{$block-class} .#{$block-class}__table-key-tracking-wrapper {
+  width: 100%;
+}


### PR DESCRIPTION
Contributes to #1781 

Adds the first test for Datagrid `useInlineEdit` hook functionality. In the test, we check that a cell value can be edited via click and keyboard interactions.

#### What did you change?
Added new test for `useInlineEdit` hook
#### How did you test and verify your work?
Ran datagrid tests