### PR TITLE
fix(non-linear): update story refs in docs tab

### DIFF
--- a/packages/cloud-cognitive/src/components/NonLinearReading/NonLinearReading.mdx
+++ b/packages/cloud-cognitive/src/components/NonLinearReading/NonLinearReading.mdx
@@ -39,7 +39,7 @@ explain, educate, and cultivate novice users into high-functioning power users._
 All you need for the basics.
 
 <Canvas>
-  <Story id={getStoryId(NonLinearReading.displayName, 'non-linear-reading')} />
+  <Story id={getStoryId(NonLinearReading.displayName, 'single-level')} />
 </Canvas>
 
 ### In series
@@ -47,7 +47,7 @@ All you need for the basics.
 Multiple non-linear reading components can be used in the same text block.
 
 <Canvas>
-  <Story id={getStoryId(NonLinearReading.displayName, 'in-series')} />
+  <Story id={getStoryId(NonLinearReading.displayName, 'multiple-level')} />
 </Canvas>
 
 ```jsx


### PR DESCRIPTION
Contributes to #3001

Storybook examples under the Docs tab are now loading.

#### What did you change?

Updated Storybook story names in `mdx` file to match.

#### How did you test and verify your work?

1. Loaded [Storybook for Non-Linear Reading](https://deploy-preview-3002--v1-carbon-for-ibm-products.netlify.app/?path=/docs/ibm-products-novice-to-pro-nonlinearreading-canary--single-level) component.
2. Switched to Docs tab.
3. Saw that the examples had loaded correctly.
