### PR TITLE
fix: repository links following rename v1

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -183,7 +183,7 @@
     }
   ],
   "contributorsPerLine": 5,
-  "projectName": "ibm-cloud-cognitive",
+  "projectName": "ibm-products",
   "projectOwner": "carbon-design-system",
   "repoType": "github",
   "repoHost": "https://github.com",

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,16 +14,16 @@ line of code.
 
 - Have a question? Visit our
   [Slack channel](https://ibm-casdesign.slack.com/archives/C013ZTX0N6B) and/or
-  [ask a question on GitHub](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/new?assignees=&labels=type%3A+question+%E2%9D%93&template=question.md&title=)
+  [ask a question on GitHub](https://github.com/carbon-design-system/ibm-products/issues/new?assignees=&labels=type%3A+question+%E2%9D%93&template=question.md&title=)
 - Have an issue you’d like resolved, then
-  [raise an issue](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/new?assignees=&labels=type%3A+bug&template=bug-report.md&title=)
+  [raise an issue](https://github.com/carbon-design-system/ibm-products/issues/new?assignees=&labels=type%3A+bug&template=bug-report.md&title=)
 - Have a new component, pattern, or enhancement request, then
-  [tell us about it](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/new?assignees=&labels=&template=component-or-pattern.md)
+  [tell us about it](https://github.com/carbon-design-system/ibm-products/issues/new?assignees=&labels=&template=component-or-pattern.md)
 
 ## Code
 
 There’s only so many hours in a day, so we welcome contributions of code.
-[Find an issue or raise one](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues),
+[Find an issue or raise one](https://github.com/carbon-design-system/ibm-products/issues),
 and follow the guide below.
 
 ### 1. Fork the repo
@@ -76,7 +76,7 @@ See example component enabled via feature flags on
 [CodeSandbox](https://codesandbox.io/s/example-component-canary-olif5).
 
 For more information on how this affects components see
-[CANARY_STRUCTURE.md](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/docs/guides/CANARY_STRUCTURE.md).
+[CANARY_STRUCTURE.md](https://github.com/carbon-design-system/ibm-products/blob/master/docs/guides/CANARY_STRUCTURE.md).
 
 ### 4. Test your JavaScript code
 
@@ -92,7 +92,7 @@ compatibility, and follow the
 ### 5. Make a pull request
 
 **Note:** Before you make a pull request,
-[search the issues](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues)
+[search the issues](https://github.com/carbon-design-system/ibm-products/issues)
 to see if a similar issue has already been submitted. If a similar issue has
 been submitted, assign yourself or ask to be assigned to the issue by posting a
 comment. If the issue does not exist, please make a new issue.
@@ -151,7 +151,7 @@ additional work to do.
 ### 8. New component or pattern
 
 If you create a new component or pattern, it should first be contributed as
-[`canary`](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/docs/guides/CANARY_STRUCTURE.md).
+[`canary`](https://github.com/carbon-design-system/ibm-products/blob/master/docs/guides/CANARY_STRUCTURE.md).
 
 Due to the nature of the monorepo, when you add a new component or pattern, be
 sure to add it in `packages/core/story-structure`. This step will surface the
@@ -161,11 +161,11 @@ To move a component from `canary` to the released state, there are two
 additional tasks that must be completed.
 
 - [ ] See our
-      [design review guidelines](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/main/docs/reviews/DESIGN_REVIEW_GUIDELINES.md)
+      [design review guidelines](https://github.com/carbon-design-system/ibm-products/blob/main/docs/reviews/DESIGN_REVIEW_GUIDELINES.md)
       and then create a new issue based on the
-      [`design-review` template](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/new?assignees=&labels=&design-review.md)
+      [`design-review` template](https://github.com/carbon-design-system/ibm-products/issues/new?assignees=&labels=&design-review.md)
       and complete the steps suggested.
 - [ ] See our
-      [release guidelines](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/main/docs/reviews/RELEASE_REVIEW_GUIDELINES.md)
+      [release guidelines](https://github.com/carbon-design-system/ibm-products/blob/main/docs/reviews/RELEASE_REVIEW_GUIDELINES.md)
       and then create a new issue based on the
-      [`release-review` template](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/new?assignees=&labels=&release-review.md).
+      [`release-review` template](https://github.com/carbon-design-system/ibm-products/issues/new?assignees=&labels=&release-review.md).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,7 +29,7 @@ and follow the guide below.
 ### 1. Fork the repo
 
 Go to the
-[Carbon for IBM Products repository on GitHub](https://github.com/carbon-design-system/ibm-cloud-cognitive)
+[Carbon for IBM Products repository on GitHub](https://github.com/carbon-design-system/ibm-products)
 and [fork the repo](https://help.github.com/articles/fork-a-repo/),
 [syncing with the original repo](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo#keep-your-fork-synced).
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -29,8 +29,8 @@ assignees: ''
 
 > What browser are you working in?
 
-> What version of the @carbon/ibm-products (or @carbon/ibm-products) package are
-> you using?
+> What version of the @carbon/ibm-products (or @carbon/ibm-cloud-cognitive)
+> package are you using?
 
 > What offering/product do you work on? Any pressing ship or release dates we
 > should be aware of?

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -44,7 +44,7 @@ assignees: ''
 
 > Please create a reduced test case in CodeSandbox
 >
-> https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/cloud-cognitive/codesandbox
+> https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/cloud-cognitive/codesandbox
 
 ## Additional information
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -29,8 +29,8 @@ assignees: ''
 
 > What browser are you working in?
 
-> What version of the @carbon/ibm-products (or @carbon/ibm-cloud-cognitive)
-> package are you using?
+> What version of the @carbon/ibm-products (or @carbon/ibm-products) package are
+> you using?
 
 > What offering/product do you work on? Any pressing ship or release dates we
 > should be aware of?

--- a/.github/ISSUE_TEMPLATE/component-or-pattern.md
+++ b/.github/ISSUE_TEMPLATE/component-or-pattern.md
@@ -31,7 +31,7 @@ Before starting work on this epic, please review and complete the following.
 ### Working in Carbon for IBM Products package
 
 - [ ] Have you reviewed our
-      [contribution guidelines](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/.github/CONTRIBUTING.md)?
+      [contribution guidelines](https://github.com/carbon-design-system/ibm-products/blob/master/.github/CONTRIBUTING.md)?
 - [ ] Have you noted our
-      [code guidelines](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/docs/CODE_GUIDELINES.md)?
+      [code guidelines](https://github.com/carbon-design-system/ibm-products/blob/master/docs/CODE_GUIDELINES.md)?
 - [ ] Did you use the CLI to scaffold your new component?

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -2,7 +2,7 @@
 name: Question ❓
 about:
   Usage question or discussion about @carbon/ibm-products (or
-  @carbon/ibm-products) components
+  @carbon/ibm-cloud-cognitive) components
 title: ''
 labels: 'type: question ❓'
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -2,7 +2,7 @@
 name: Question ❓
 about:
   Usage question or discussion about @carbon/ibm-products (or
-  @carbon/ibm-cloud-cognitive) components
+  @carbon/ibm-products) components
 title: ''
 labels: 'type: question ❓'
 assignees: ''

--- a/.vscode/carbon-snippets.code-snippets
+++ b/.vscode/carbon-snippets.code-snippets
@@ -1,5 +1,5 @@
 {
-	// Place your ibm-cloud-cognitive workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and
+	// Place your ibm-products workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and
 	// description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope
 	// is left empty or omitted, the snippet gets applied to all languages. The prefix is what is
 	// used to trigger the snippet and the body will be expanded and inserted. Possible variables are:

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 > Carbon for IBM Cloud and Cognitive, and this name can still be encountered in
 > various places and historical logs.
 
-[![All Contributors](https://img.shields.io/github/all-contributors/carbon-design-system/ibm-cloud-cognitive?color=ee8449)](#contributors-)
+[![All Contributors](https://img.shields.io/github/all-contributors/carbon-design-system/ibm-products?color=ee8449)](#contributors-)
 [![Licensed under the Apache License, Version 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://github.com/carbon-design-system/ibm-products/blob/master/LICENSE)
 [![Build status](https://github.com/carbon-design-system/ibm-products/actions/workflows/ci.yml/badge.svg)](https://github.com/carbon-design-system/ibm-products/actions/workflows/ci.yml)
 [![Netlify status](https://img.shields.io/netlify/f850c678-e8be-43c0-aa95-b2b9cca8ac21)](https://app.netlify.com/sites/carbon-for-ibm-products/deploys)
-[![GitHub Lerna version](https://img.shields.io/github/lerna-json/v/carbon-design-system/ibm-cloud-cognitive)](https://lerna.js.org)
+[![GitHub Lerna version](https://img.shields.io/github/lerna-json/v/carbon-design-system/ibm-products)](https://lerna.js.org)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](https://github.com/carbon-design-system/ibm-products/blob/master/.github/CONTRIBUTING.md)
 
 ## 🚀 Getting started
@@ -21,8 +21,8 @@ If you’re just getting started and looking to browse our React components, tak
 a look at [our Storybook](https://carbon-for-ibm-products.netlify.app).
 
 All of our source code and documentation, including this readme, can be found on
-[our GitHub repo](https://github.com/carbon-design-system/ibm-cloud-cognitive),
-which is also the place to
+[our GitHub repo](https://github.com/carbon-design-system/ibm-products), which
+is also the place to
 [open issues](https://github.com/carbon-design-system/ibm-products/issues/new/choose)
 if you have a problem or find a defect or would like to request a new feature or
 change something.

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 > various places and historical logs.
 
 [![All Contributors](https://img.shields.io/github/all-contributors/carbon-design-system/ibm-cloud-cognitive?color=ee8449)](#contributors-)
-[![Licensed under the Apache License, Version 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/LICENSE)
-[![Build status](https://github.com/carbon-design-system/ibm-cloud-cognitive/actions/workflows/ci.yml/badge.svg)](https://github.com/carbon-design-system/ibm-cloud-cognitive/actions/workflows/ci.yml)
+[![Licensed under the Apache License, Version 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://github.com/carbon-design-system/ibm-products/blob/master/LICENSE)
+[![Build status](https://github.com/carbon-design-system/ibm-products/actions/workflows/ci.yml/badge.svg)](https://github.com/carbon-design-system/ibm-products/actions/workflows/ci.yml)
 [![Netlify status](https://img.shields.io/netlify/f850c678-e8be-43c0-aa95-b2b9cca8ac21)](https://app.netlify.com/sites/carbon-for-ibm-products/deploys)
 [![GitHub Lerna version](https://img.shields.io/github/lerna-json/v/carbon-design-system/ibm-cloud-cognitive)](https://lerna.js.org)
-[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/.github/CONTRIBUTING.md)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](https://github.com/carbon-design-system/ibm-products/blob/master/.github/CONTRIBUTING.md)
 
 ## 🚀 Getting started
 
@@ -23,7 +23,7 @@ a look at [our Storybook](https://carbon-for-ibm-products.netlify.app).
 All of our source code and documentation, including this readme, can be found on
 [our GitHub repo](https://github.com/carbon-design-system/ibm-cloud-cognitive),
 which is also the place to
-[open issues](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/new/choose)
+[open issues](https://github.com/carbon-design-system/ibm-products/issues/new/choose)
 if you have a problem or find a defect or would like to request a new feature or
 change something.
 
@@ -62,12 +62,12 @@ who help us fix bugs, build new features, improve our documentation, etc.
 This repository is a monorepo and contains multiple packages so be sure to check
 the relevant package for any package-specific guidance.
 
-- [@carbon/ibm-products](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/.github/CONTRIBUTING.md)
+- [@carbon/ibm-products](https://github.com/carbon-design-system/ibm-products/blob/master/.github/CONTRIBUTING.md)
 - [@carbon/ibm-cloud-cognitive-cdai](./packages/cdai)
 - [@carbon/ibm-security](./packages/security)
 
 Read also our
-[Contributing Guide](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/.github/CONTRIBUTING.md)
+[Contributing Guide](https://github.com/carbon-design-system/ibm-products/blob/master/.github/CONTRIBUTING.md)
 and
 [Carbon’s Developer Handbook](https://github.com/carbon-design-system/carbon/blob/master/docs/developer-handbook.md)!
 👀
@@ -83,31 +83,31 @@ Thanks goes to these wonderful people
 <table>
   <tbody>
     <tr>
-      <td align="center" valign="top" width="20%"><a href="http://simonfinney.dev"><img src="https://avatars2.githubusercontent.com/u/3846874?v=4?s=100" width="100px;" alt="Simon Finney"/><br /><sub><b>Simon Finney</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=SimonFinney" title="Code">💻</a></td>
-      <td align="center" valign="top" width="20%"><a href="https://github.com/lee-chase"><img src="https://avatars0.githubusercontent.com/u/15086604?v=4?s=100" width="100px;" alt="Lee Chase"/><br /><sub><b>Lee Chase</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=lee-chase" title="Code">💻</a></td>
-      <td align="center" valign="top" width="20%"><a href="https://github.com/moores2"><img src="https://avatars2.githubusercontent.com/u/6977424?v=4?s=100" width="100px;" alt="Simon Moore"/><br /><sub><b>Simon Moore</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=moores2" title="Code">💻</a></td>
-      <td align="center" valign="top" width="20%"><a href="https://github.com/joshblack"><img src="https://avatars1.githubusercontent.com/u/3901764?v=4?s=100" width="100px;" alt="Josh Black"/><br /><sub><b>Josh Black</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=joshblack" title="Code">💻</a></td>
-      <td align="center" valign="top" width="20%"><a href="http://davidmenendez.net"><img src="https://avatars1.githubusercontent.com/u/6370760?v=4?s=100" width="100px;" alt="David Menendez"/><br /><sub><b>David Menendez</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=davidmenendez" title="Code">💻</a> <a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/pulls?q=is%3Apr+reviewed-by%3Adavidmenendez" title="Reviewed Pull Requests">👀</a></td>
+      <td align="center" valign="top" width="20%"><a href="http://simonfinney.dev"><img src="https://avatars2.githubusercontent.com/u/3846874?v=4?s=100" width="100px;" alt="Simon Finney"/><br /><sub><b>Simon Finney</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=SimonFinney" title="Code">💻</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/lee-chase"><img src="https://avatars0.githubusercontent.com/u/15086604?v=4?s=100" width="100px;" alt="Lee Chase"/><br /><sub><b>Lee Chase</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=lee-chase" title="Code">💻</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/moores2"><img src="https://avatars2.githubusercontent.com/u/6977424?v=4?s=100" width="100px;" alt="Simon Moore"/><br /><sub><b>Simon Moore</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=moores2" title="Code">💻</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/joshblack"><img src="https://avatars1.githubusercontent.com/u/3901764?v=4?s=100" width="100px;" alt="Josh Black"/><br /><sub><b>Josh Black</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=joshblack" title="Code">💻</a></td>
+      <td align="center" valign="top" width="20%"><a href="http://davidmenendez.net"><img src="https://avatars1.githubusercontent.com/u/6370760?v=4?s=100" width="100px;" alt="David Menendez"/><br /><sub><b>David Menendez</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=davidmenendez" title="Code">💻</a> <a href="https://github.com/carbon-design-system/ibm-products/pulls?q=is%3Apr+reviewed-by%3Adavidmenendez" title="Reviewed Pull Requests">👀</a></td>
     </tr>
     <tr>
-      <td align="center" valign="top" width="20%"><a href="https://github.com/vladbalanescu"><img src="https://avatars2.githubusercontent.com/u/16047402?v=4?s=100" width="100px;" alt="vladbalanescu"/><br /><sub><b>vladbalanescu</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=vladbalanescu" title="Code">💻</a></td>
-      <td align="center" valign="top" width="20%"><a href="http://www.matthewdgallo.com"><img src="https://avatars0.githubusercontent.com/u/10215203?v=4?s=100" width="100px;" alt="Matthew Gallo"/><br /><sub><b>Matthew Gallo</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=matthewgallo" title="Code">💻</a> <a href="#infra-matthewgallo" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/pulls?q=is%3Apr+reviewed-by%3Amatthewgallo" title="Reviewed Pull Requests">👀</a></td>
-      <td align="center" valign="top" width="20%"><a href="https://github.com/asfordmatt"><img src="https://avatars2.githubusercontent.com/u/14233261?v=4?s=100" width="100px;" alt="Matt Chapman"/><br /><sub><b>Matt Chapman</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=asfordmatt" title="Code">💻</a></td>
-      <td align="center" valign="top" width="20%"><a href="https://github.com/dbrugger"><img src="https://avatars1.githubusercontent.com/u/10086178?v=4?s=100" width="100px;" alt="Dominik Brugger"/><br /><sub><b>Dominik Brugger</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=dbrugger" title="Code">💻</a></td>
-      <td align="center" valign="top" width="20%"><a href="https://github.com/polinaouk"><img src="https://avatars2.githubusercontent.com/u/24444328?v=4?s=100" width="100px;" alt="Polina Olemskaia"/><br /><sub><b>Polina Olemskaia</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=polinaouk" title="Code">💻</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/vladbalanescu"><img src="https://avatars2.githubusercontent.com/u/16047402?v=4?s=100" width="100px;" alt="vladbalanescu"/><br /><sub><b>vladbalanescu</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=vladbalanescu" title="Code">💻</a></td>
+      <td align="center" valign="top" width="20%"><a href="http://www.matthewdgallo.com"><img src="https://avatars0.githubusercontent.com/u/10215203?v=4?s=100" width="100px;" alt="Matthew Gallo"/><br /><sub><b>Matthew Gallo</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=matthewgallo" title="Code">💻</a> <a href="#infra-matthewgallo" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="https://github.com/carbon-design-system/ibm-products/pulls?q=is%3Apr+reviewed-by%3Amatthewgallo" title="Reviewed Pull Requests">👀</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/asfordmatt"><img src="https://avatars2.githubusercontent.com/u/14233261?v=4?s=100" width="100px;" alt="Matt Chapman"/><br /><sub><b>Matt Chapman</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=asfordmatt" title="Code">💻</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/dbrugger"><img src="https://avatars1.githubusercontent.com/u/10086178?v=4?s=100" width="100px;" alt="Dominik Brugger"/><br /><sub><b>Dominik Brugger</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=dbrugger" title="Code">💻</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/polinaouk"><img src="https://avatars2.githubusercontent.com/u/24444328?v=4?s=100" width="100px;" alt="Polina Olemskaia"/><br /><sub><b>Polina Olemskaia</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=polinaouk" title="Code">💻</a></td>
     </tr>
     <tr>
-      <td align="center" valign="top" width="20%"><a href="http://alexandermelo.com"><img src="https://avatars.githubusercontent.com/u/12755042?v=4?s=100" width="100px;" alt="Alexander Melo"/><br /><sub><b>Alexander Melo</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=AlexanderMelox" title="Code">💻</a></td>
-      <td align="center" valign="top" width="20%"><a href="https://github.com/Ratheeshrajan"><img src="https://avatars.githubusercontent.com/u/305492?v=4?s=100" width="100px;" alt="Ratheesh Rajan"/><br /><sub><b>Ratheesh Rajan</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=Ratheeshrajan" title="Code">💻</a> <a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/pulls?q=is%3Apr+reviewed-by%3ARatheeshrajan" title="Reviewed Pull Requests">👀</a></td>
-      <td align="center" valign="top" width="20%"><a href="https://janhassel.de"><img src="https://avatars.githubusercontent.com/u/28265588?v=4?s=100" width="100px;" alt="Jan Hassel"/><br /><sub><b>Jan Hassel</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=janhassel" title="Code">💻</a> <a href="#a11y-janhassel" title="Accessibility">️️️️♿️</a></td>
+      <td align="center" valign="top" width="20%"><a href="http://alexandermelo.com"><img src="https://avatars.githubusercontent.com/u/12755042?v=4?s=100" width="100px;" alt="Alexander Melo"/><br /><sub><b>Alexander Melo</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=AlexanderMelox" title="Code">💻</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/Ratheeshrajan"><img src="https://avatars.githubusercontent.com/u/305492?v=4?s=100" width="100px;" alt="Ratheesh Rajan"/><br /><sub><b>Ratheesh Rajan</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=Ratheeshrajan" title="Code">💻</a> <a href="https://github.com/carbon-design-system/ibm-products/pulls?q=is%3Apr+reviewed-by%3ARatheeshrajan" title="Reviewed Pull Requests">👀</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://janhassel.de"><img src="https://avatars.githubusercontent.com/u/28265588?v=4?s=100" width="100px;" alt="Jan Hassel"/><br /><sub><b>Jan Hassel</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=janhassel" title="Code">💻</a> <a href="#a11y-janhassel" title="Accessibility">️️️️♿️</a></td>
       <td align="center" valign="top" width="20%"><a href="https://github.com/marion-bruells"><img src="https://avatars.githubusercontent.com/u/51152537?v=4?s=100" width="100px;" alt="marion-bruells"/><br /><sub><b>marion-bruells</b></sub></a><br /><a href="#design-marion-bruells" title="Design">🎨</a></td>
-      <td align="center" valign="top" width="20%"><a href="https://www.hellojagath.com"><img src="https://avatars.githubusercontent.com/u/29351394?v=4?s=100" width="100px;" alt="Jagath Jayakumar"/><br /><sub><b>Jagath Jayakumar</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=jagathgj" title="Code">💻</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://www.hellojagath.com"><img src="https://avatars.githubusercontent.com/u/29351394?v=4?s=100" width="100px;" alt="Jagath Jayakumar"/><br /><sub><b>Jagath Jayakumar</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=jagathgj" title="Code">💻</a></td>
     </tr>
     <tr>
       <td align="center" valign="top" width="20%"><a href="https://github.com/Laura-Marshall"><img src="https://avatars.githubusercontent.com/u/53219208?v=4?s=100" width="100px;" alt="Laura Marshall"/><br /><sub><b>Laura Marshall</b></sub></a><br /><a href="#design-Laura-Marshall" title="Design">🎨</a></td>
-      <td align="center" valign="top" width="20%"><a href="https://github.com/glapadre"><img src="https://avatars.githubusercontent.com/u/25260547?v=4?s=100" width="100px;" alt="Drew Glapa"/><br /><sub><b>Drew Glapa</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=glapadre" title="Code">💻</a></td>
-      <td align="center" valign="top" width="20%"><a href="https://linkedin.com/in/mslilypeng/"><img src="https://avatars.githubusercontent.com/u/3118961?v=4?s=100" width="100px;" alt="Lily"/><br /><sub><b>Lily</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=lily-peng" title="Code">💻</a></td>
-      <td align="center" valign="top" width="20%"><a href="https://github.com/mgallo25"><img src="https://avatars.githubusercontent.com/u/23409382?v=4?s=100" width="100px;" alt="Marienella Gallo"/><br /><sub><b>Marienella Gallo</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=mgallo25" title="Code">💻</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/glapadre"><img src="https://avatars.githubusercontent.com/u/25260547?v=4?s=100" width="100px;" alt="Drew Glapa"/><br /><sub><b>Drew Glapa</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=glapadre" title="Code">💻</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://linkedin.com/in/mslilypeng/"><img src="https://avatars.githubusercontent.com/u/3118961?v=4?s=100" width="100px;" alt="Lily"/><br /><sub><b>Lily</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=lily-peng" title="Code">💻</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/mgallo25"><img src="https://avatars.githubusercontent.com/u/23409382?v=4?s=100" width="100px;" alt="Marienella Gallo"/><br /><sub><b>Marienella Gallo</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=mgallo25" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>
@@ -124,6 +124,6 @@ specification. Contributions of any kind welcome!
 ## 📝 License
 
 Licensed under the
-[Apache-2.0 License](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/LICENSE).
+[Apache-2.0 License](https://github.com/carbon-design-system/ibm-products/blob/master/LICENSE).
 
 [![This site is powered by Netlify](https://www.netlify.com/img/global/badges/netlify-color-accent.svg)](https://www.netlify.com)

--- a/config/babel-preset-ibm-cloud-cognitive/CHANGELOG.md
+++ b/config/babel-preset-ibm-cloud-cognitive/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.14.27](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.26...babel-preset-ibm-cloud-cognitive@0.14.27) (2023-03-07)
+## [0.14.27](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.26...babel-preset-ibm-cloud-cognitive@0.14.27) (2023-03-07)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.26](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.25...babel-preset-ibm-cloud-cognitive@0.14.26) (2023-02-07)
+## [0.14.26](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.25...babel-preset-ibm-cloud-cognitive@0.14.26) (2023-02-07)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
@@ -24,7 +24,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.14.25](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.24...babel-preset-ibm-cloud-cognitive@0.14.25) (2023-01-10)
+## [0.14.25](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.24...babel-preset-ibm-cloud-cognitive@0.14.25) (2023-01-10)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.14.24](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.23...babel-preset-ibm-cloud-cognitive@0.14.24) (2022-11-22)
+## [0.14.24](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.23...babel-preset-ibm-cloud-cognitive@0.14.24) (2022-11-22)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
@@ -42,7 +42,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.14.23](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.22...babel-preset-ibm-cloud-cognitive@0.14.23) (2022-11-08)
+## [0.14.23](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.22...babel-preset-ibm-cloud-cognitive@0.14.23) (2022-11-08)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
@@ -51,7 +51,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.14.22](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.21...babel-preset-ibm-cloud-cognitive@0.14.22) (2022-10-25)
+## [0.14.22](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.21...babel-preset-ibm-cloud-cognitive@0.14.22) (2022-10-25)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
@@ -60,263 +60,263 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.14.21](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.20...babel-preset-ibm-cloud-cognitive@0.14.21) (2022-10-11)
+## [0.14.21](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.20...babel-preset-ibm-cloud-cognitive@0.14.21) (2022-10-11)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.14.20](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.19...babel-preset-ibm-cloud-cognitive@0.14.20) (2022-09-27)
+## [0.14.20](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.19...babel-preset-ibm-cloud-cognitive@0.14.20) (2022-09-27)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.14.19](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.18...babel-preset-ibm-cloud-cognitive@0.14.19) (2022-09-06)
+## [0.14.19](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.18...babel-preset-ibm-cloud-cognitive@0.14.19) (2022-09-06)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.14.18](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.17...babel-preset-ibm-cloud-cognitive@0.14.18) (2022-08-02)
+## [0.14.18](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.17...babel-preset-ibm-cloud-cognitive@0.14.18) (2022-08-02)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.14.17](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.16...babel-preset-ibm-cloud-cognitive@0.14.17) (2022-07-19)
+## [0.14.17](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.16...babel-preset-ibm-cloud-cognitive@0.14.17) (2022-07-19)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.14.16](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.15...babel-preset-ibm-cloud-cognitive@0.14.16) (2022-07-12)
+## [0.14.16](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.15...babel-preset-ibm-cloud-cognitive@0.14.16) (2022-07-12)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.14.15](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.14...babel-preset-ibm-cloud-cognitive@0.14.15) (2022-05-10)
+## [0.14.15](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.14...babel-preset-ibm-cloud-cognitive@0.14.15) (2022-05-10)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.14.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.13...babel-preset-ibm-cloud-cognitive@0.14.14) (2022-05-03)
+## [0.14.14](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.13...babel-preset-ibm-cloud-cognitive@0.14.14) (2022-05-03)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.14.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.12...babel-preset-ibm-cloud-cognitive@0.14.13) (2022-04-19)
+## [0.14.13](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.12...babel-preset-ibm-cloud-cognitive@0.14.13) (2022-04-19)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.14.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.11...babel-preset-ibm-cloud-cognitive@0.14.12) (2022-03-29)
+## [0.14.12](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.11...babel-preset-ibm-cloud-cognitive@0.14.12) (2022-03-29)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.14.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.10...babel-preset-ibm-cloud-cognitive@0.14.11) (2022-03-22)
+## [0.14.11](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.10...babel-preset-ibm-cloud-cognitive@0.14.11) (2022-03-22)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.14.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.9...babel-preset-ibm-cloud-cognitive@0.14.10) (2022-03-08)
+## [0.14.10](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.9...babel-preset-ibm-cloud-cognitive@0.14.10) (2022-03-08)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.14.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.8...babel-preset-ibm-cloud-cognitive@0.14.9) (2022-03-01)
+## [0.14.9](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.8...babel-preset-ibm-cloud-cognitive@0.14.9) (2022-03-01)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.14.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.7...babel-preset-ibm-cloud-cognitive@0.14.8) (2022-02-22)
+## [0.14.8](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.7...babel-preset-ibm-cloud-cognitive@0.14.8) (2022-02-22)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.14.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.6...babel-preset-ibm-cloud-cognitive@0.14.7) (2022-02-15)
+## [0.14.7](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.6...babel-preset-ibm-cloud-cognitive@0.14.7) (2022-02-15)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.14.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.5...babel-preset-ibm-cloud-cognitive@0.14.6) (2022-02-09)
+## [0.14.6](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.5...babel-preset-ibm-cloud-cognitive@0.14.6) (2022-02-09)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.14.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.4...babel-preset-ibm-cloud-cognitive@0.14.5) (2022-02-01)
+## [0.14.5](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.4...babel-preset-ibm-cloud-cognitive@0.14.5) (2022-02-01)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.14.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.3...babel-preset-ibm-cloud-cognitive@0.14.4) (2022-01-25)
+## [0.14.4](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.3...babel-preset-ibm-cloud-cognitive@0.14.4) (2022-01-25)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.14.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.2...babel-preset-ibm-cloud-cognitive@0.14.3) (2022-01-11)
+## [0.14.3](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.2...babel-preset-ibm-cloud-cognitive@0.14.3) (2022-01-11)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1513](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1513))
-  ([505ba0e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/505ba0e13ec58bef19422835fd8ffee87c24e82a))
+  ([#1513](https://github.com/carbon-design-system/ibm-products/issues/1513))
+  ([505ba0e](https://github.com/carbon-design-system/ibm-products/commit/505ba0e13ec58bef19422835fd8ffee87c24e82a))
 - update Carbon versions and package dependencies to latest
-  ([#1518](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1518))
-  ([3ddcdf6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3ddcdf6617e0d7c9f182da91e3eb0935b34cbc05))
+  ([#1518](https://github.com/carbon-design-system/ibm-products/issues/1518))
+  ([3ddcdf6](https://github.com/carbon-design-system/ibm-products/commit/3ddcdf6617e0d7c9f182da91e3eb0935b34cbc05))
 
-## [0.14.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.1...babel-preset-ibm-cloud-cognitive@0.14.2) (2021-12-21)
+## [0.14.2](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.1...babel-preset-ibm-cloud-cognitive@0.14.2) (2021-12-21)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1499](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1499))
-  ([8aed3d5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8aed3d53d06cc896984e6847c0450cc647e34041))
+  ([#1499](https://github.com/carbon-design-system/ibm-products/issues/1499))
+  ([8aed3d5](https://github.com/carbon-design-system/ibm-products/commit/8aed3d53d06cc896984e6847c0450cc647e34041))
 
-## [0.14.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.14.0...babel-preset-ibm-cloud-cognitive@0.14.1) (2021-12-14)
+## [0.14.1](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.14.0...babel-preset-ibm-cloud-cognitive@0.14.1) (2021-12-14)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1493](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1493))
-  ([91b8238](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/91b82383e0aa74383ebb81f625a9e7b870f06c00))
+  ([#1493](https://github.com/carbon-design-system/ibm-products/issues/1493))
+  ([91b8238](https://github.com/carbon-design-system/ibm-products/commit/91b82383e0aa74383ebb81f625a9e7b870f06c00))
 
-# [0.14.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.13.0...babel-preset-ibm-cloud-cognitive@0.14.0) (2021-11-23)
+# [0.14.0](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.13.0...babel-preset-ibm-cloud-cognitive@0.14.0) (2021-11-23)
 
 ### Features
 
 - update Carbon versions and dependencies to latest
-  ([#1465](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1465))
-  ([0c6b37f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0c6b37f5b713c54ec320d9da945fbd3f6b3f91d9))
+  ([#1465](https://github.com/carbon-design-system/ibm-products/issues/1465))
+  ([0c6b37f](https://github.com/carbon-design-system/ibm-products/commit/0c6b37f5b713c54ec320d9da945fbd3f6b3f91d9))
 
-# [0.13.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.12.0...babel-preset-ibm-cloud-cognitive@0.13.0) (2021-11-16)
+# [0.13.0](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.12.0...babel-preset-ibm-cloud-cognitive@0.13.0) (2021-11-16)
 
 ### Bug Fixes
 
 - replace "cloud & cognitive" with "Carbon for IBM Products" in docs
-  ([#1437](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1437))
-  ([0a58354](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0a58354ccbdd723173b2e6758907713938a7f163))
+  ([#1437](https://github.com/carbon-design-system/ibm-products/issues/1437))
+  ([0a58354](https://github.com/carbon-design-system/ibm-products/commit/0a58354ccbdd723173b2e6758907713938a7f163))
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1425](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1425))
-  ([4fd5883](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4fd5883961e0f3fc6be1c87bbe084b2cf6dc5db0)),
+  ([#1425](https://github.com/carbon-design-system/ibm-products/issues/1425))
+  ([4fd5883](https://github.com/carbon-design-system/ibm-products/commit/4fd5883961e0f3fc6be1c87bbe084b2cf6dc5db0)),
   closes
-  [#10000](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/10000)
+  [#10000](https://github.com/carbon-design-system/ibm-products/issues/10000)
 
-# [0.12.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.11.0...babel-preset-ibm-cloud-cognitive@0.12.0) (2021-11-09)
-
-### Features
-
-- update Carbon versions and package dependencies to latest
-  ([#1365](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1365))
-  ([ea11cf7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ea11cf7ae44b61b48142c511c16460cf7978b88c))
-
-# [0.11.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.10.0...babel-preset-ibm-cloud-cognitive@0.11.0) (2021-10-14)
+# [0.12.0](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.11.0...babel-preset-ibm-cloud-cognitive@0.12.0) (2021-11-09)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1329](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1329))
-  ([fd3525e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fd3525ec3620b70ff19f85c300e7e0bb05577cd1))
+  ([#1365](https://github.com/carbon-design-system/ibm-products/issues/1365))
+  ([ea11cf7](https://github.com/carbon-design-system/ibm-products/commit/ea11cf7ae44b61b48142c511c16460cf7978b88c))
 
-# [0.10.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.9.0...babel-preset-ibm-cloud-cognitive@0.10.0) (2021-09-21)
-
-### Features
-
-- update Carbon versions and package dependencies to latest
-  ([#1262](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1262))
-  ([ed4dcbe](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ed4dcbe5b6d92baa6ec39240bda6996ec55f7bc4))
-
-# [0.9.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.8.0...babel-preset-ibm-cloud-cognitive@0.9.0) (2021-08-11)
+# [0.11.0](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.10.0...babel-preset-ibm-cloud-cognitive@0.11.0) (2021-10-14)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1133](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1133))
-  ([4dfae1a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4dfae1a9b27f5676d0bde570e2c9ee9ce8550b52))
+  ([#1329](https://github.com/carbon-design-system/ibm-products/issues/1329))
+  ([fd3525e](https://github.com/carbon-design-system/ibm-products/commit/fd3525ec3620b70ff19f85c300e7e0bb05577cd1))
 
-# [0.8.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.7.0...babel-preset-ibm-cloud-cognitive@0.8.0) (2021-08-10)
+# [0.10.0](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.9.0...babel-preset-ibm-cloud-cognitive@0.10.0) (2021-09-21)
+
+### Features
+
+- update Carbon versions and package dependencies to latest
+  ([#1262](https://github.com/carbon-design-system/ibm-products/issues/1262))
+  ([ed4dcbe](https://github.com/carbon-design-system/ibm-products/commit/ed4dcbe5b6d92baa6ec39240bda6996ec55f7bc4))
+
+# [0.9.0](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.8.0...babel-preset-ibm-cloud-cognitive@0.9.0) (2021-08-11)
+
+### Features
+
+- update Carbon versions and package dependencies to latest
+  ([#1133](https://github.com/carbon-design-system/ibm-products/issues/1133))
+  ([4dfae1a](https://github.com/carbon-design-system/ibm-products/commit/4dfae1a9b27f5676d0bde570e2c9ee9ce8550b52))
+
+# [0.8.0](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.7.0...babel-preset-ibm-cloud-cognitive@0.8.0) (2021-08-10)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#1110](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1110))
-  ([b41f433](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b41f4331e31cbd9e41d2364b24e6ef50c7fd2d8d))
+  ([#1110](https://github.com/carbon-design-system/ibm-products/issues/1110))
+  ([b41f433](https://github.com/carbon-design-system/ibm-products/commit/b41f4331e31cbd9e41d2364b24e6ef50c7fd2d8d))
 
-# [0.7.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.6.0...babel-preset-ibm-cloud-cognitive@0.7.0) (2021-07-21)
+# [0.7.0](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.6.0...babel-preset-ibm-cloud-cognitive@0.7.0) (2021-07-21)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#1037](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1037))
-  ([8c5937a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8c5937a865d3a0cfbaf33b9eca13c4d3b4c1365d))
+  ([#1037](https://github.com/carbon-design-system/ibm-products/issues/1037))
+  ([8c5937a](https://github.com/carbon-design-system/ibm-products/commit/8c5937a865d3a0cfbaf33b9eca13c4d3b4c1365d))
 
-# [0.6.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.5.0...babel-preset-ibm-cloud-cognitive@0.6.0) (2021-07-14)
+# [0.6.0](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.5.0...babel-preset-ibm-cloud-cognitive@0.6.0) (2021-07-14)
 
 ### Features
 
 - update Carbon versions and package dependencies
-  ([#994](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/994))
-  ([2ab4845](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2ab4845511573b999d41fcf77e6d412e0d446b9d))
+  ([#994](https://github.com/carbon-design-system/ibm-products/issues/994))
+  ([2ab4845](https://github.com/carbon-design-system/ibm-products/commit/2ab4845511573b999d41fcf77e6d412e0d446b9d))
 
-# [0.5.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.4.1...babel-preset-ibm-cloud-cognitive@0.5.0) (2021-07-07)
-
-### Features
-
-- update Carbon versions and dependencies
-  ([#974](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/974))
-  ([555509b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/555509b5ccb147ed0d794b5816f685aa8f7ae451))
-
-## [0.4.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.4.0...babel-preset-ibm-cloud-cognitive@0.4.1) (2021-07-01)
-
-**Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
-
-# [0.4.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.3.5...babel-preset-ibm-cloud-cognitive@0.4.0) (2021-06-23)
+# [0.5.0](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.4.1...babel-preset-ibm-cloud-cognitive@0.5.0) (2021-07-07)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#927](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/927))
-  ([5a8f7d6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5a8f7d6b81b6da26fd0cb933c1c3de4bd27b481b))
+  ([#974](https://github.com/carbon-design-system/ibm-products/issues/974))
+  ([555509b](https://github.com/carbon-design-system/ibm-products/commit/555509b5ccb147ed0d794b5816f685aa8f7ae451))
 
-## [0.3.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.3.4...babel-preset-ibm-cloud-cognitive@0.3.5) (2021-06-17)
-
-**Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
-
-## [0.3.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.3.3...babel-preset-ibm-cloud-cognitive@0.3.4) (2021-06-07)
+## [0.4.1](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.4.0...babel-preset-ibm-cloud-cognitive@0.4.1) (2021-07-01)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.3.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.3.2...babel-preset-ibm-cloud-cognitive@0.3.3) (2021-06-04)
+# [0.4.0](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.3.5...babel-preset-ibm-cloud-cognitive@0.4.0) (2021-06-23)
+
+### Features
+
+- update Carbon versions and dependencies
+  ([#927](https://github.com/carbon-design-system/ibm-products/issues/927))
+  ([5a8f7d6](https://github.com/carbon-design-system/ibm-products/commit/5a8f7d6b81b6da26fd0cb933c1c3de4bd27b481b))
+
+## [0.3.5](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.3.4...babel-preset-ibm-cloud-cognitive@0.3.5) (2021-06-17)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.3.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.3.1...babel-preset-ibm-cloud-cognitive@0.3.2) (2021-05-28)
+## [0.3.4](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.3.3...babel-preset-ibm-cloud-cognitive@0.3.4) (2021-06-07)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-## [0.3.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.3.0...babel-preset-ibm-cloud-cognitive@0.3.1) (2021-04-15)
+## [0.3.3](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.3.2...babel-preset-ibm-cloud-cognitive@0.3.3) (2021-06-04)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-# [0.3.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.2.0...babel-preset-ibm-cloud-cognitive@0.3.0) (2021-01-20)
+## [0.3.2](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.3.1...babel-preset-ibm-cloud-cognitive@0.3.2) (2021-05-28)
+
+**Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
+
+## [0.3.1](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.3.0...babel-preset-ibm-cloud-cognitive@0.3.1) (2021-04-15)
+
+**Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
+
+# [0.3.0](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.2.0...babel-preset-ibm-cloud-cognitive@0.3.0) (2021-01-20)
 
 ### Features
 
 - **combo-button:** add `ComboButton` logic, story, and styles
-  ([#233](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/233))
-  ([85e2b62](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/85e2b62de80166cda84fa8cc9af311e664d241af))
+  ([#233](https://github.com/carbon-design-system/ibm-products/issues/233))
+  ([85e2b62](https://github.com/carbon-design-system/ibm-products/commit/85e2b62de80166cda84fa8cc9af311e664d241af))
 
-# [0.2.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.1.2...babel-preset-ibm-cloud-cognitive@0.2.0) (2020-12-16)
+# [0.2.0](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.1.2...babel-preset-ibm-cloud-cognitive@0.2.0) (2020-12-16)
 
 ### Features
 
 - Page header tag overflow update
-  ([#264](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/264))
-  ([ee22520](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ee225206e291fa3bca990cb2ccabfece8930fc88))
+  ([#264](https://github.com/carbon-design-system/ibm-products/issues/264))
+  ([ee22520](https://github.com/carbon-design-system/ibm-products/commit/ee225206e291fa3bca990cb2ccabfece8930fc88))
 
-## [0.1.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.1.1...babel-preset-ibm-cloud-cognitive@0.1.2) (2020-12-08)
-
-**Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
-
-## [0.1.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.1.0...babel-preset-ibm-cloud-cognitive@0.1.1) (2020-11-30)
+## [0.1.2](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.1.1...babel-preset-ibm-cloud-cognitive@0.1.2) (2020-12-08)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 
-# [0.1.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/babel-preset-ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.0.3...babel-preset-ibm-cloud-cognitive@0.1.0) (2020-11-26)
+## [0.1.1](https://github.com/carbon-design-system/ibm-products/compare/babel-preset-ibm-cloud-cognitive@0.1.0...babel-preset-ibm-cloud-cognitive@0.1.1) (2020-11-30)
+
+**Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
+
+# [0.1.0](https://github.com/carbon-design-system/ibm-products/tree/master/packages/babel-preset-ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.0.3...babel-preset-ibm-cloud-cognitive@0.1.0) (2020-11-26)
 
 ### Features
 
 - add cdai apikey component
-  ([#223](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/babel-preset-ibm-cloud-cognitive/issues/223))
-  ([4c09f15](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/babel-preset-ibm-cloud-cognitive/commit/4c09f15c3c62c3965d98c91b9695fa7a1cba8f0b))
+  ([#223](https://github.com/carbon-design-system/ibm-products/tree/master/packages/babel-preset-ibm-cloud-cognitive/issues/223))
+  ([4c09f15](https://github.com/carbon-design-system/ibm-products/tree/master/packages/babel-preset-ibm-cloud-cognitive/commit/4c09f15c3c62c3965d98c91b9695fa7a1cba8f0b))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.0.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/babel-preset-ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.0.2...babel-preset-ibm-cloud-cognitive@0.0.3) (2020-11-17)
+## [0.0.3](https://github.com/carbon-design-system/ibm-products/tree/master/packages/babel-preset-ibm-cloud-cognitive/compare/babel-preset-ibm-cloud-cognitive@0.0.2...babel-preset-ibm-cloud-cognitive@0.0.3) (2020-11-17)
 
 **Note:** Version bump only for package babel-preset-ibm-cloud-cognitive
 

--- a/config/babel-preset-ibm-cloud-cognitive/package.json
+++ b/config/babel-preset-ibm-cloud-cognitive/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "url": "https://github.com/carbon-design-system/ibm-products.git",
     "directory": "packages/babel-preset-ibm-cloud-cognitive"
   },
   "bugs": "https://github.com/carbon-design-system/ibm-products/issues",

--- a/config/babel-preset-ibm-cloud-cognitive/package.json
+++ b/config/babel-preset-ibm-cloud-cognitive/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
     "directory": "packages/babel-preset-ibm-cloud-cognitive"
   },
-  "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
+  "bugs": "https://github.com/carbon-design-system/ibm-products/issues",
   "keywords": [
     "carbon",
     "carbon design system",

--- a/config/cli/CHANGELOG.md
+++ b/config/cli/CHANGELOG.md
@@ -3,18 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.18.35](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.34...@carbon/ibm-cloud-cognitive-cli@0.18.35) (2023-03-28)
+## [0.18.35](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.34...@carbon/ibm-cloud-cognitive-cli@0.18.35) (2023-03-28)
 
 
 ### Bug Fixes
 
-* update to Carbon v10 compatible versions to latest ([#2739](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2739)) ([7065855](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/70658550120822ab0a6dd296bc9022cc7d0856db))
+* update to Carbon v10 compatible versions to latest ([#2739](https://github.com/carbon-design-system/ibm-products/issues/2739)) ([7065855](https://github.com/carbon-design-system/ibm-products/commit/70658550120822ab0a6dd296bc9022cc7d0856db))
 
 
 
 
 
-## [0.18.34](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.33...@carbon/ibm-cloud-cognitive-cli@0.18.34) (2023-03-07)
+## [0.18.34](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.33...@carbon/ibm-cloud-cognitive-cli@0.18.34) (2023-03-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
@@ -22,7 +22,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.18.33](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.32...@carbon/ibm-cloud-cognitive-cli@0.18.33) (2023-02-07)
+## [0.18.33](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.32...@carbon/ibm-cloud-cognitive-cli@0.18.33) (2023-02-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.18.32](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.31...@carbon/ibm-cloud-cognitive-cli@0.18.32) (2023-01-10)
+## [0.18.32](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.31...@carbon/ibm-cloud-cognitive-cli@0.18.32) (2023-01-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
@@ -44,7 +44,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.18.31](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.30...@carbon/ibm-cloud-cognitive-cli@0.18.31) (2022-11-22)
+## [0.18.31](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.30...@carbon/ibm-cloud-cognitive-cli@0.18.31) (2022-11-22)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
@@ -53,7 +53,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.18.30](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.29...@carbon/ibm-cloud-cognitive-cli@0.18.30) (2022-11-08)
+## [0.18.30](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.29...@carbon/ibm-cloud-cognitive-cli@0.18.30) (2022-11-08)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
@@ -62,7 +62,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.18.29](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.28...@carbon/ibm-cloud-cognitive-cli@0.18.29) (2022-10-25)
+## [0.18.29](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.28...@carbon/ibm-cloud-cognitive-cli@0.18.29) (2022-10-25)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
@@ -71,330 +71,330 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.18.28](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.27...@carbon/ibm-cloud-cognitive-cli@0.18.28) (2022-10-11)
+## [0.18.28](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.27...@carbon/ibm-cloud-cognitive-cli@0.18.28) (2022-10-11)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#2331](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2331))
-  ([26f7bc1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/26f7bc1b05ded4d79634a06dea725746e6e381e7))
+  ([#2331](https://github.com/carbon-design-system/ibm-products/issues/2331))
+  ([26f7bc1](https://github.com/carbon-design-system/ibm-products/commit/26f7bc1b05ded4d79634a06dea725746e6e381e7))
 
-## [0.18.27](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.26...@carbon/ibm-cloud-cognitive-cli@0.18.27) (2022-09-27)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
-
-## [0.18.26](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.25...@carbon/ibm-cloud-cognitive-cli@0.18.26) (2022-09-06)
+## [0.18.27](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.26...@carbon/ibm-cloud-cognitive-cli@0.18.27) (2022-09-27)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.18.25](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.24...@carbon/ibm-cloud-cognitive-cli@0.18.25) (2022-08-16)
+## [0.18.26](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.25...@carbon/ibm-cloud-cognitive-cli@0.18.26) (2022-09-06)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.18.24](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.23...@carbon/ibm-cloud-cognitive-cli@0.18.24) (2022-08-02)
+## [0.18.25](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.24...@carbon/ibm-cloud-cognitive-cli@0.18.25) (2022-08-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.18.23](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.22...@carbon/ibm-cloud-cognitive-cli@0.18.23) (2022-07-19)
+## [0.18.24](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.23...@carbon/ibm-cloud-cognitive-cli@0.18.24) (2022-08-02)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.18.22](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.21...@carbon/ibm-cloud-cognitive-cli@0.18.22) (2022-07-12)
+## [0.18.23](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.22...@carbon/ibm-cloud-cognitive-cli@0.18.23) (2022-07-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.18.21](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.20...@carbon/ibm-cloud-cognitive-cli@0.18.21) (2022-05-17)
+## [0.18.22](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.21...@carbon/ibm-cloud-cognitive-cli@0.18.22) (2022-07-12)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.18.20](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.19...@carbon/ibm-cloud-cognitive-cli@0.18.20) (2022-05-10)
+## [0.18.21](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.20...@carbon/ibm-cloud-cognitive-cli@0.18.21) (2022-05-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.18.19](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.18...@carbon/ibm-cloud-cognitive-cli@0.18.19) (2022-05-03)
+## [0.18.20](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.19...@carbon/ibm-cloud-cognitive-cli@0.18.20) (2022-05-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.18.18](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.17...@carbon/ibm-cloud-cognitive-cli@0.18.18) (2022-04-26)
+## [0.18.19](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.18...@carbon/ibm-cloud-cognitive-cli@0.18.19) (2022-05-03)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.18.17](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.16...@carbon/ibm-cloud-cognitive-cli@0.18.17) (2022-04-19)
+## [0.18.18](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.17...@carbon/ibm-cloud-cognitive-cli@0.18.18) (2022-04-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.18.16](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.15...@carbon/ibm-cloud-cognitive-cli@0.18.16) (2022-04-12)
+## [0.18.17](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.16...@carbon/ibm-cloud-cognitive-cli@0.18.17) (2022-04-19)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
+
+## [0.18.16](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.15...@carbon/ibm-cloud-cognitive-cli@0.18.16) (2022-04-12)
 
 ### Bug Fixes
 
 - update Carbon versions to latest minor v10
-  ([#1899](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1899))
-  ([ddc7935](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ddc7935307f204956157b9cefc68f57bc72d830b))
+  ([#1899](https://github.com/carbon-design-system/ibm-products/issues/1899))
+  ([ddc7935](https://github.com/carbon-design-system/ibm-products/commit/ddc7935307f204956157b9cefc68f57bc72d830b))
 
-## [0.18.15](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.14...@carbon/ibm-cloud-cognitive-cli@0.18.15) (2022-04-05)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
-
-## [0.18.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.13...@carbon/ibm-cloud-cognitive-cli@0.18.14) (2022-03-29)
+## [0.18.15](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.14...@carbon/ibm-cloud-cognitive-cli@0.18.15) (2022-04-05)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.18.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.12...@carbon/ibm-cloud-cognitive-cli@0.18.13) (2022-03-22)
+## [0.18.14](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.13...@carbon/ibm-cloud-cognitive-cli@0.18.14) (2022-03-29)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.18.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.11...@carbon/ibm-cloud-cognitive-cli@0.18.12) (2022-03-15)
+## [0.18.13](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.12...@carbon/ibm-cloud-cognitive-cli@0.18.13) (2022-03-22)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.18.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.10...@carbon/ibm-cloud-cognitive-cli@0.18.11) (2022-03-08)
+## [0.18.12](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.11...@carbon/ibm-cloud-cognitive-cli@0.18.12) (2022-03-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.18.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.9...@carbon/ibm-cloud-cognitive-cli@0.18.10) (2022-03-01)
+## [0.18.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.10...@carbon/ibm-cloud-cognitive-cli@0.18.11) (2022-03-08)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.18.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.8...@carbon/ibm-cloud-cognitive-cli@0.18.9) (2022-02-22)
+## [0.18.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.9...@carbon/ibm-cloud-cognitive-cli@0.18.10) (2022-03-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.18.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.7...@carbon/ibm-cloud-cognitive-cli@0.18.8) (2022-02-15)
+## [0.18.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.8...@carbon/ibm-cloud-cognitive-cli@0.18.9) (2022-02-22)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.18.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.6...@carbon/ibm-cloud-cognitive-cli@0.18.7) (2022-02-01)
+## [0.18.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.7...@carbon/ibm-cloud-cognitive-cli@0.18.8) (2022-02-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.18.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.5...@carbon/ibm-cloud-cognitive-cli@0.18.6) (2022-01-25)
+## [0.18.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.6...@carbon/ibm-cloud-cognitive-cli@0.18.7) (2022-02-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.18.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.4...@carbon/ibm-cloud-cognitive-cli@0.18.5) (2022-01-11)
+## [0.18.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.5...@carbon/ibm-cloud-cognitive-cli@0.18.6) (2022-01-25)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
+
+## [0.18.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.4...@carbon/ibm-cloud-cognitive-cli@0.18.5) (2022-01-11)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1513](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1513))
-  ([505ba0e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/505ba0e13ec58bef19422835fd8ffee87c24e82a))
+  ([#1513](https://github.com/carbon-design-system/ibm-products/issues/1513))
+  ([505ba0e](https://github.com/carbon-design-system/ibm-products/commit/505ba0e13ec58bef19422835fd8ffee87c24e82a))
 - update Carbon versions and package dependencies to latest
-  ([#1518](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1518))
-  ([3ddcdf6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3ddcdf6617e0d7c9f182da91e3eb0935b34cbc05))
+  ([#1518](https://github.com/carbon-design-system/ibm-products/issues/1518))
+  ([3ddcdf6](https://github.com/carbon-design-system/ibm-products/commit/3ddcdf6617e0d7c9f182da91e3eb0935b34cbc05))
 
-## [0.18.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.3...@carbon/ibm-cloud-cognitive-cli@0.18.4) (2022-01-04)
+## [0.18.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.3...@carbon/ibm-cloud-cognitive-cli@0.18.4) (2022-01-04)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1509](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1509))
-  ([613db81](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/613db817bffec2c5b26b1fe50a337dd7bac5d963))
+  ([#1509](https://github.com/carbon-design-system/ibm-products/issues/1509))
+  ([613db81](https://github.com/carbon-design-system/ibm-products/commit/613db817bffec2c5b26b1fe50a337dd7bac5d963))
 
-## [0.18.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.2...@carbon/ibm-cloud-cognitive-cli@0.18.3) (2021-12-21)
-
-### Bug Fixes
-
-- update Carbon versions and package dependencies to latest
-  ([#1499](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1499))
-  ([8aed3d5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8aed3d53d06cc896984e6847c0450cc647e34041))
-
-## [0.18.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.1...@carbon/ibm-cloud-cognitive-cli@0.18.2) (2021-12-14)
+## [0.18.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.2...@carbon/ibm-cloud-cognitive-cli@0.18.3) (2021-12-21)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1493](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1493))
-  ([91b8238](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/91b82383e0aa74383ebb81f625a9e7b870f06c00))
+  ([#1499](https://github.com/carbon-design-system/ibm-products/issues/1499))
+  ([8aed3d5](https://github.com/carbon-design-system/ibm-products/commit/8aed3d53d06cc896984e6847c0450cc647e34041))
 
-## [0.18.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.18.0...@carbon/ibm-cloud-cognitive-cli@0.18.1) (2021-12-07)
+## [0.18.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.1...@carbon/ibm-cloud-cognitive-cli@0.18.2) (2021-12-14)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1491](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1491))
-  ([45f7b77](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/45f7b77f797c5841b9dc15bc3013f31e50244d29))
+  ([#1493](https://github.com/carbon-design-system/ibm-products/issues/1493))
+  ([91b8238](https://github.com/carbon-design-system/ibm-products/commit/91b82383e0aa74383ebb81f625a9e7b870f06c00))
 
-# [0.18.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.17.0...@carbon/ibm-cloud-cognitive-cli@0.18.0) (2021-11-30)
+## [0.18.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.18.0...@carbon/ibm-cloud-cognitive-cli@0.18.1) (2021-12-07)
+
+### Bug Fixes
+
+- update Carbon versions and package dependencies to latest
+  ([#1491](https://github.com/carbon-design-system/ibm-products/issues/1491))
+  ([45f7b77](https://github.com/carbon-design-system/ibm-products/commit/45f7b77f797c5841b9dc15bc3013f31e50244d29))
+
+# [0.18.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.17.0...@carbon/ibm-cloud-cognitive-cli@0.18.0) (2021-11-30)
 
 ### Features
 
 - update Carbon versions and dependencies to latest
-  ([#1473](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1473))
-  ([9cafbea](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9cafbea95226c46ff1732f9ad6b22c9c8837616e))
+  ([#1473](https://github.com/carbon-design-system/ibm-products/issues/1473))
+  ([9cafbea](https://github.com/carbon-design-system/ibm-products/commit/9cafbea95226c46ff1732f9ad6b22c9c8837616e))
 
-# [0.17.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.16.0...@carbon/ibm-cloud-cognitive-cli@0.17.0) (2021-11-23)
+# [0.17.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.16.0...@carbon/ibm-cloud-cognitive-cli@0.17.0) (2021-11-23)
 
 ### Features
 
 - update Carbon versions and dependencies to latest
-  ([#1465](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1465))
-  ([0c6b37f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0c6b37f5b713c54ec320d9da945fbd3f6b3f91d9))
+  ([#1465](https://github.com/carbon-design-system/ibm-products/issues/1465))
+  ([0c6b37f](https://github.com/carbon-design-system/ibm-products/commit/0c6b37f5b713c54ec320d9da945fbd3f6b3f91d9))
 
-# [0.16.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.15.0...@carbon/ibm-cloud-cognitive-cli@0.16.0) (2021-11-16)
+# [0.16.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.15.0...@carbon/ibm-cloud-cognitive-cli@0.16.0) (2021-11-16)
 
 ### Bug Fixes
 
 - replace "cloud & cognitive" with "Carbon for IBM Products" in docs
-  ([#1437](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1437))
-  ([0a58354](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0a58354ccbdd723173b2e6758907713938a7f163))
+  ([#1437](https://github.com/carbon-design-system/ibm-products/issues/1437))
+  ([0a58354](https://github.com/carbon-design-system/ibm-products/commit/0a58354ccbdd723173b2e6758907713938a7f163))
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1425](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1425))
-  ([4fd5883](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4fd5883961e0f3fc6be1c87bbe084b2cf6dc5db0)),
+  ([#1425](https://github.com/carbon-design-system/ibm-products/issues/1425))
+  ([4fd5883](https://github.com/carbon-design-system/ibm-products/commit/4fd5883961e0f3fc6be1c87bbe084b2cf6dc5db0)),
   closes
-  [#10000](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/10000)
+  [#10000](https://github.com/carbon-design-system/ibm-products/issues/10000)
 
-# [0.15.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.14.0...@carbon/ibm-cloud-cognitive-cli@0.15.0) (2021-11-09)
-
-### Features
-
-- update Carbon versions and package dependencies to latest
-  ([#1365](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1365))
-  ([ea11cf7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ea11cf7ae44b61b48142c511c16460cf7978b88c))
-
-# [0.14.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.13.0...@carbon/ibm-cloud-cognitive-cli@0.14.0) (2021-10-07)
+# [0.15.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.14.0...@carbon/ibm-cloud-cognitive-cli@0.15.0) (2021-11-09)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1309](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1309))
-  ([945bd3b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/945bd3ba5608078e961af9a04448f2abd7e7fc5e))
+  ([#1365](https://github.com/carbon-design-system/ibm-products/issues/1365))
+  ([ea11cf7](https://github.com/carbon-design-system/ibm-products/commit/ea11cf7ae44b61b48142c511c16460cf7978b88c))
 
-# [0.13.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.12.0...@carbon/ibm-cloud-cognitive-cli@0.13.0) (2021-10-02)
+# [0.14.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.13.0...@carbon/ibm-cloud-cognitive-cli@0.14.0) (2021-10-07)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1296](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1296))
-  ([f1da0bd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f1da0bd9192c4d999032df0dbe20d67b6ece89b0))
+  ([#1309](https://github.com/carbon-design-system/ibm-products/issues/1309))
+  ([945bd3b](https://github.com/carbon-design-system/ibm-products/commit/945bd3ba5608078e961af9a04448f2abd7e7fc5e))
 
-# [0.12.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.11.0...@carbon/ibm-cloud-cognitive-cli@0.12.0) (2021-09-23)
+# [0.13.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.12.0...@carbon/ibm-cloud-cognitive-cli@0.13.0) (2021-10-02)
+
+### Features
+
+- update Carbon versions and package dependencies to latest
+  ([#1296](https://github.com/carbon-design-system/ibm-products/issues/1296))
+  ([f1da0bd](https://github.com/carbon-design-system/ibm-products/commit/f1da0bd9192c4d999032df0dbe20d67b6ece89b0))
+
+# [0.12.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.11.0...@carbon/ibm-cloud-cognitive-cli@0.12.0) (2021-09-23)
 
 ### Features
 
 - update Carbon versions and dependencies to latest
-  ([#1282](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1282))
-  ([b1451cf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b1451cf5c91b75c1bd4e55ae2bdb47f025f33163))
+  ([#1282](https://github.com/carbon-design-system/ibm-products/issues/1282))
+  ([b1451cf](https://github.com/carbon-design-system/ibm-products/commit/b1451cf5c91b75c1bd4e55ae2bdb47f025f33163))
 
-# [0.11.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.10.0...@carbon/ibm-cloud-cognitive-cli@0.11.0) (2021-09-21)
-
-### Features
-
-- update Carbon versions and package dependencies to latest
-  ([#1262](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1262))
-  ([ed4dcbe](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ed4dcbe5b6d92baa6ec39240bda6996ec55f7bc4))
-
-# [0.10.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.9.0...@carbon/ibm-cloud-cognitive-cli@0.10.0) (2021-08-19)
-
-### Features
-
-- update Carbon versions and dependencies
-  ([#1168](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1168))
-  ([674017f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/674017fabc13a7737c0d16deb04ffa9872d76fe6))
-
-# [0.9.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.8.0...@carbon/ibm-cloud-cognitive-cli@0.9.0) (2021-08-11)
+# [0.11.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.10.0...@carbon/ibm-cloud-cognitive-cli@0.11.0) (2021-09-21)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1133](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1133))
-  ([4dfae1a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4dfae1a9b27f5676d0bde570e2c9ee9ce8550b52))
+  ([#1262](https://github.com/carbon-design-system/ibm-products/issues/1262))
+  ([ed4dcbe](https://github.com/carbon-design-system/ibm-products/commit/ed4dcbe5b6d92baa6ec39240bda6996ec55f7bc4))
 
-# [0.8.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.7.0...@carbon/ibm-cloud-cognitive-cli@0.8.0) (2021-08-10)
-
-### Features
-
-- update Carbon versions and dependencies
-  ([#1110](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1110))
-  ([b41f433](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b41f4331e31cbd9e41d2364b24e6ef50c7fd2d8d))
-
-# [0.7.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.6.0...@carbon/ibm-cloud-cognitive-cli@0.7.0) (2021-07-28)
+# [0.10.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.9.0...@carbon/ibm-cloud-cognitive-cli@0.10.0) (2021-08-19)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#1084](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1084))
-  ([3735ead](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3735ead9a96450015ec7aeafdb25deaa93d49aaa))
+  ([#1168](https://github.com/carbon-design-system/ibm-products/issues/1168))
+  ([674017f](https://github.com/carbon-design-system/ibm-products/commit/674017fabc13a7737c0d16deb04ffa9872d76fe6))
 
-# [0.6.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.5.1...@carbon/ibm-cloud-cognitive-cli@0.6.0) (2021-07-21)
+# [0.9.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.8.0...@carbon/ibm-cloud-cognitive-cli@0.9.0) (2021-08-11)
+
+### Features
+
+- update Carbon versions and package dependencies to latest
+  ([#1133](https://github.com/carbon-design-system/ibm-products/issues/1133))
+  ([4dfae1a](https://github.com/carbon-design-system/ibm-products/commit/4dfae1a9b27f5676d0bde570e2c9ee9ce8550b52))
+
+# [0.8.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.7.0...@carbon/ibm-cloud-cognitive-cli@0.8.0) (2021-08-10)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#1037](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1037))
-  ([8c5937a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8c5937a865d3a0cfbaf33b9eca13c4d3b4c1365d))
+  ([#1110](https://github.com/carbon-design-system/ibm-products/issues/1110))
+  ([b41f433](https://github.com/carbon-design-system/ibm-products/commit/b41f4331e31cbd9e41d2364b24e6ef50c7fd2d8d))
 
-## [0.5.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.5.0...@carbon/ibm-cloud-cognitive-cli@0.5.1) (2021-07-16)
+# [0.7.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.6.0...@carbon/ibm-cloud-cognitive-cli@0.7.0) (2021-07-28)
+
+### Features
+
+- update Carbon versions and dependencies
+  ([#1084](https://github.com/carbon-design-system/ibm-products/issues/1084))
+  ([3735ead](https://github.com/carbon-design-system/ibm-products/commit/3735ead9a96450015ec7aeafdb25deaa93d49aaa))
+
+# [0.6.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.5.1...@carbon/ibm-cloud-cognitive-cli@0.6.0) (2021-07-21)
+
+### Features
+
+- update Carbon versions and dependencies
+  ([#1037](https://github.com/carbon-design-system/ibm-products/issues/1037))
+  ([8c5937a](https://github.com/carbon-design-system/ibm-products/commit/8c5937a865d3a0cfbaf33b9eca13c4d3b4c1365d))
+
+## [0.5.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.5.0...@carbon/ibm-cloud-cognitive-cli@0.5.1) (2021-07-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-# [0.5.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.4.0...@carbon/ibm-cloud-cognitive-cli@0.5.0) (2021-07-14)
+# [0.5.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.4.0...@carbon/ibm-cloud-cognitive-cli@0.5.0) (2021-07-14)
 
 ### Features
 
 - update Carbon versions and package dependencies
-  ([#994](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/994))
-  ([2ab4845](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2ab4845511573b999d41fcf77e6d412e0d446b9d))
+  ([#994](https://github.com/carbon-design-system/ibm-products/issues/994))
+  ([2ab4845](https://github.com/carbon-design-system/ibm-products/commit/2ab4845511573b999d41fcf77e6d412e0d446b9d))
 
-# [0.4.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.3.2...@carbon/ibm-cloud-cognitive-cli@0.4.0) (2021-07-07)
-
-### Features
-
-- update Carbon versions and dependencies
-  ([#974](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/974))
-  ([555509b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/555509b5ccb147ed0d794b5816f685aa8f7ae451))
-
-## [0.3.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.3.1...@carbon/ibm-cloud-cognitive-cli@0.3.2) (2021-07-01)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
-
-## [0.3.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.3.0...@carbon/ibm-cloud-cognitive-cli@0.3.1) (2021-06-30)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
-
-# [0.3.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.2.5...@carbon/ibm-cloud-cognitive-cli@0.3.0) (2021-06-23)
+# [0.4.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.3.2...@carbon/ibm-cloud-cognitive-cli@0.4.0) (2021-07-07)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#927](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/927))
-  ([5a8f7d6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5a8f7d6b81b6da26fd0cb933c1c3de4bd27b481b))
+  ([#974](https://github.com/carbon-design-system/ibm-products/issues/974))
+  ([555509b](https://github.com/carbon-design-system/ibm-products/commit/555509b5ccb147ed0d794b5816f685aa8f7ae451))
 
-## [0.2.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.2.4...@carbon/ibm-cloud-cognitive-cli@0.2.5) (2021-06-17)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
-
-## [0.2.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.2.3...@carbon/ibm-cloud-cognitive-cli@0.2.4) (2021-06-09)
+## [0.3.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.3.1...@carbon/ibm-cloud-cognitive-cli@0.3.2) (2021-07-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.2.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.2.2...@carbon/ibm-cloud-cognitive-cli@0.2.3) (2021-06-07)
+## [0.3.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.3.0...@carbon/ibm-cloud-cognitive-cli@0.3.1) (2021-06-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.2.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.2.1...@carbon/ibm-cloud-cognitive-cli@0.2.2) (2021-05-28)
+# [0.3.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.2.5...@carbon/ibm-cloud-cognitive-cli@0.3.0) (2021-06-23)
+
+### Features
+
+- update Carbon versions and dependencies
+  ([#927](https://github.com/carbon-design-system/ibm-products/issues/927))
+  ([5a8f7d6](https://github.com/carbon-design-system/ibm-products/commit/5a8f7d6b81b6da26fd0cb933c1c3de4bd27b481b))
+
+## [0.2.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.2.4...@carbon/ibm-cloud-cognitive-cli@0.2.5) (2021-06-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.2.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.2.0...@carbon/ibm-cloud-cognitive-cli@0.2.1) (2021-04-15)
+## [0.2.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.2.3...@carbon/ibm-cloud-cognitive-cli@0.2.4) (2021-06-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-# [0.2.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.1.2...@carbon/ibm-cloud-cognitive-cli@0.2.0) (2020-12-16)
+## [0.2.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.2.2...@carbon/ibm-cloud-cognitive-cli@0.2.3) (2021-06-07)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
+
+## [0.2.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.2.1...@carbon/ibm-cloud-cognitive-cli@0.2.2) (2021-05-28)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
+
+## [0.2.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.2.0...@carbon/ibm-cloud-cognitive-cli@0.2.1) (2021-04-15)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
+
+# [0.2.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.1.2...@carbon/ibm-cloud-cognitive-cli@0.2.0) (2020-12-16)
 
 ### Features
 
 - Page header tag overflow update
-  ([#264](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/264))
-  ([ee22520](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ee225206e291fa3bca990cb2ccabfece8930fc88))
+  ([#264](https://github.com/carbon-design-system/ibm-products/issues/264))
+  ([ee22520](https://github.com/carbon-design-system/ibm-products/commit/ee225206e291fa3bca990cb2ccabfece8930fc88))
 
-## [0.1.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cli@0.1.1...@carbon/ibm-cloud-cognitive-cli@0.1.2) (2020-11-30)
+## [0.1.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cli@0.1.1...@carbon/ibm-cloud-cognitive-cli@0.1.2) (2020-11-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
-## [0.1.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cli/compare/@carbon/ibm-cloud-cognitive-cli@0.1.0...@carbon/ibm-cloud-cognitive-cli@0.1.1) (2020-11-26)
+## [0.1.1](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cli/compare/@carbon/ibm-cloud-cognitive-cli@0.1.0...@carbon/ibm-cloud-cognitive-cli@0.1.1) (2020-11-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cli
 
@@ -408,4 +408,4 @@ All notable changes to this project will be documented in this file. See
 ### Features
 
 - **project:** add support for test and builds
-  ([7b3e99a](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cli/commit/7b3e99ad75246bd03aa542563f8fdadca23a2f95))
+  ([7b3e99a](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cli/commit/7b3e99ad75246bd03aa542563f8fdadca23a2f95))

--- a/config/cli/package.json
+++ b/config/cli/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
     "directory": "packages/cli"
   },
-  "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
+  "bugs": "https://github.com/carbon-design-system/ibm-products/issues",
   "keywords": [
     "carbon",
     "carbon design system",

--- a/config/cli/package.json
+++ b/config/cli/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "url": "https://github.com/carbon-design-system/ibm-products.git",
     "directory": "packages/cli"
   },
   "bugs": "https://github.com/carbon-design-system/ibm-products/issues",

--- a/config/cli/src/commands/sync/packageJson.js
+++ b/config/cli/src/commands/sync/packageJson.js
@@ -10,8 +10,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 
-const REPO_URL_BASE =
-  'https://github.com/carbon-design-system/ibm-cloud-cognitive';
+const REPO_URL_BASE = 'https://github.com/carbon-design-system/ibm-products';
 
 // Default set of keywords to include in each `package.json`.
 const DEFAULT_KEYWORDS = [

--- a/config/cli/src/commands/sync/remark/monorepo.js
+++ b/config/cli/src/commands/sync/remark/monorepo.js
@@ -10,8 +10,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 
-const REPO_URL_BASE =
-  'https://github.com/carbon-design-system/ibm-cloud-cognitive';
+const REPO_URL_BASE = 'https://github.com/carbon-design-system/ibm-products';
 
 function monorepo() {
   async function transformer(tree, file) {

--- a/config/jest-config-ibm-cloud-cognitive/CHANGELOG.md
+++ b/config/jest-config-ibm-cloud-cognitive/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.24.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.24.13...jest-config-ibm-cloud-cognitive@0.24.14) (2023-03-28)
+## [0.24.14](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.24.13...jest-config-ibm-cloud-cognitive@0.24.14) (2023-03-28)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.24.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.24.12...jest-config-ibm-cloud-cognitive@0.24.13) (2023-03-07)
+## [0.24.13](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.24.12...jest-config-ibm-cloud-cognitive@0.24.13) (2023-03-07)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.24.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.24.11...jest-config-ibm-cloud-cognitive@0.24.12) (2023-02-07)
+## [0.24.12](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.24.11...jest-config-ibm-cloud-cognitive@0.24.12) (2023-02-07)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
@@ -32,7 +32,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.24.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.24.10...jest-config-ibm-cloud-cognitive@0.24.11) (2023-01-10)
+## [0.24.11](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.24.10...jest-config-ibm-cloud-cognitive@0.24.11) (2023-01-10)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
@@ -41,7 +41,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.24.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.24.9...jest-config-ibm-cloud-cognitive@0.24.10) (2022-11-22)
+## [0.24.10](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.24.9...jest-config-ibm-cloud-cognitive@0.24.10) (2022-11-22)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
@@ -50,7 +50,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.24.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.24.8...jest-config-ibm-cloud-cognitive@0.24.9) (2022-11-08)
+## [0.24.9](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.24.8...jest-config-ibm-cloud-cognitive@0.24.9) (2022-11-08)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
@@ -59,7 +59,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.24.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.24.7...jest-config-ibm-cloud-cognitive@0.24.8) (2022-10-25)
+## [0.24.8](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.24.7...jest-config-ibm-cloud-cognitive@0.24.8) (2022-10-25)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
@@ -68,341 +68,341 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.24.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.24.6...jest-config-ibm-cloud-cognitive@0.24.7) (2022-10-11)
+## [0.24.7](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.24.6...jest-config-ibm-cloud-cognitive@0.24.7) (2022-10-11)
 
 ### Bug Fixes
 
 - **SidePanel:** motion refactor using framer motion
-  ([#2312](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2312))
-  ([56d16e2](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/56d16e2b77399e2bc5c676cbdd27d9036aea9fd0))
+  ([#2312](https://github.com/carbon-design-system/ibm-products/issues/2312))
+  ([56d16e2](https://github.com/carbon-design-system/ibm-products/commit/56d16e2b77399e2bc5c676cbdd27d9036aea9fd0))
 
-## [0.24.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.24.5...jest-config-ibm-cloud-cognitive@0.24.6) (2022-09-27)
-
-**Note:** Version bump only for package jest-config-ibm-cloud-cognitive
-
-## [0.24.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.24.4...jest-config-ibm-cloud-cognitive@0.24.5) (2022-09-06)
+## [0.24.6](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.24.5...jest-config-ibm-cloud-cognitive@0.24.6) (2022-09-27)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-## [0.24.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.24.3...jest-config-ibm-cloud-cognitive@0.24.4) (2022-08-16)
+## [0.24.5](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.24.4...jest-config-ibm-cloud-cognitive@0.24.5) (2022-09-06)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-## [0.24.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.24.2...jest-config-ibm-cloud-cognitive@0.24.3) (2022-08-02)
+## [0.24.4](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.24.3...jest-config-ibm-cloud-cognitive@0.24.4) (2022-08-16)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-## [0.24.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.24.1...jest-config-ibm-cloud-cognitive@0.24.2) (2022-07-19)
+## [0.24.3](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.24.2...jest-config-ibm-cloud-cognitive@0.24.3) (2022-08-02)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-## [0.24.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.24.0...jest-config-ibm-cloud-cognitive@0.24.1) (2022-07-12)
+## [0.24.2](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.24.1...jest-config-ibm-cloud-cognitive@0.24.2) (2022-07-19)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-# [0.24.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.23.19...jest-config-ibm-cloud-cognitive@0.24.0) (2022-05-31)
+## [0.24.1](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.24.0...jest-config-ibm-cloud-cognitive@0.24.1) (2022-07-12)
+
+**Note:** Version bump only for package jest-config-ibm-cloud-cognitive
+
+# [0.24.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.23.19...jest-config-ibm-cloud-cognitive@0.24.0) (2022-05-31)
 
 ### Features
 
 - **cloud-cognitive:** log jest coverage to terminal
-  ([#2003](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2003))
-  ([4cc79fb](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4cc79fb06faa1869c8471272806ddb5e44ec76ea))
+  ([#2003](https://github.com/carbon-design-system/ibm-products/issues/2003))
+  ([4cc79fb](https://github.com/carbon-design-system/ibm-products/commit/4cc79fb06faa1869c8471272806ddb5e44ec76ea))
 
-## [0.23.19](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.23.18...jest-config-ibm-cloud-cognitive@0.23.19) (2022-05-17)
-
-**Note:** Version bump only for package jest-config-ibm-cloud-cognitive
-
-## [0.23.18](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.23.17...jest-config-ibm-cloud-cognitive@0.23.18) (2022-05-10)
+## [0.23.19](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.23.18...jest-config-ibm-cloud-cognitive@0.23.19) (2022-05-17)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-## [0.23.17](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.23.16...jest-config-ibm-cloud-cognitive@0.23.17) (2022-05-03)
+## [0.23.18](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.23.17...jest-config-ibm-cloud-cognitive@0.23.18) (2022-05-10)
+
+**Note:** Version bump only for package jest-config-ibm-cloud-cognitive
+
+## [0.23.17](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.23.16...jest-config-ibm-cloud-cognitive@0.23.17) (2022-05-03)
 
 ### Bug Fixes
 
 - **Datagrid:** revert react-dnd versions
-  ([#1950](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1950))
-  ([a1417b0](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a1417b0e97516826a44ae6352ada8a84200d8eb0))
+  ([#1950](https://github.com/carbon-design-system/ibm-products/issues/1950))
+  ([a1417b0](https://github.com/carbon-design-system/ibm-products/commit/a1417b0e97516826a44ae6352ada8a84200d8eb0))
 
-## [0.23.16](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.23.15...jest-config-ibm-cloud-cognitive@0.23.16) (2022-04-26)
-
-**Note:** Version bump only for package jest-config-ibm-cloud-cognitive
-
-## [0.23.15](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.23.14...jest-config-ibm-cloud-cognitive@0.23.15) (2022-04-19)
+## [0.23.16](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.23.15...jest-config-ibm-cloud-cognitive@0.23.16) (2022-04-26)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-## [0.23.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.23.13...jest-config-ibm-cloud-cognitive@0.23.14) (2022-04-05)
+## [0.23.15](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.23.14...jest-config-ibm-cloud-cognitive@0.23.15) (2022-04-19)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-## [0.23.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.23.12...jest-config-ibm-cloud-cognitive@0.23.13) (2022-03-29)
+## [0.23.14](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.23.13...jest-config-ibm-cloud-cognitive@0.23.14) (2022-04-05)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-## [0.23.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.23.11...jest-config-ibm-cloud-cognitive@0.23.12) (2022-03-22)
+## [0.23.13](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.23.12...jest-config-ibm-cloud-cognitive@0.23.13) (2022-03-29)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-## [0.23.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.23.10...jest-config-ibm-cloud-cognitive@0.23.11) (2022-03-08)
+## [0.23.12](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.23.11...jest-config-ibm-cloud-cognitive@0.23.12) (2022-03-22)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-## [0.23.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.23.9...jest-config-ibm-cloud-cognitive@0.23.10) (2022-03-01)
+## [0.23.11](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.23.10...jest-config-ibm-cloud-cognitive@0.23.11) (2022-03-08)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-## [0.23.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.23.8...jest-config-ibm-cloud-cognitive@0.23.9) (2022-02-22)
+## [0.23.10](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.23.9...jest-config-ibm-cloud-cognitive@0.23.10) (2022-03-01)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-## [0.23.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.23.7...jest-config-ibm-cloud-cognitive@0.23.8) (2022-02-15)
+## [0.23.9](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.23.8...jest-config-ibm-cloud-cognitive@0.23.9) (2022-02-22)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-## [0.23.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.23.6...jest-config-ibm-cloud-cognitive@0.23.7) (2022-02-09)
+## [0.23.8](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.23.7...jest-config-ibm-cloud-cognitive@0.23.8) (2022-02-15)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-## [0.23.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.23.5...jest-config-ibm-cloud-cognitive@0.23.6) (2022-02-01)
+## [0.23.7](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.23.6...jest-config-ibm-cloud-cognitive@0.23.7) (2022-02-09)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-## [0.23.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.23.4...jest-config-ibm-cloud-cognitive@0.23.5) (2022-01-25)
+## [0.23.6](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.23.5...jest-config-ibm-cloud-cognitive@0.23.6) (2022-02-01)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-## [0.23.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.23.3...jest-config-ibm-cloud-cognitive@0.23.4) (2022-01-11)
+## [0.23.5](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.23.4...jest-config-ibm-cloud-cognitive@0.23.5) (2022-01-25)
+
+**Note:** Version bump only for package jest-config-ibm-cloud-cognitive
+
+## [0.23.4](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.23.3...jest-config-ibm-cloud-cognitive@0.23.4) (2022-01-11)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1513](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1513))
-  ([505ba0e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/505ba0e13ec58bef19422835fd8ffee87c24e82a))
+  ([#1513](https://github.com/carbon-design-system/ibm-products/issues/1513))
+  ([505ba0e](https://github.com/carbon-design-system/ibm-products/commit/505ba0e13ec58bef19422835fd8ffee87c24e82a))
 - update Carbon versions and package dependencies to latest
-  ([#1518](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1518))
-  ([3ddcdf6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3ddcdf6617e0d7c9f182da91e3eb0935b34cbc05))
+  ([#1518](https://github.com/carbon-design-system/ibm-products/issues/1518))
+  ([3ddcdf6](https://github.com/carbon-design-system/ibm-products/commit/3ddcdf6617e0d7c9f182da91e3eb0935b34cbc05))
 
-## [0.23.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.23.2...jest-config-ibm-cloud-cognitive@0.23.3) (2021-12-21)
+## [0.23.3](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.23.2...jest-config-ibm-cloud-cognitive@0.23.3) (2021-12-21)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1499](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1499))
-  ([8aed3d5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8aed3d53d06cc896984e6847c0450cc647e34041))
+  ([#1499](https://github.com/carbon-design-system/ibm-products/issues/1499))
+  ([8aed3d5](https://github.com/carbon-design-system/ibm-products/commit/8aed3d53d06cc896984e6847c0450cc647e34041))
 
-## [0.23.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.23.1...jest-config-ibm-cloud-cognitive@0.23.2) (2021-12-14)
-
-### Bug Fixes
-
-- update Carbon versions and package dependencies to latest
-  ([#1493](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1493))
-  ([91b8238](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/91b82383e0aa74383ebb81f625a9e7b870f06c00))
-
-## [0.23.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.23.0...jest-config-ibm-cloud-cognitive@0.23.1) (2021-12-07)
+## [0.23.2](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.23.1...jest-config-ibm-cloud-cognitive@0.23.2) (2021-12-14)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1491](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1491))
-  ([45f7b77](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/45f7b77f797c5841b9dc15bc3013f31e50244d29))
+  ([#1493](https://github.com/carbon-design-system/ibm-products/issues/1493))
+  ([91b8238](https://github.com/carbon-design-system/ibm-products/commit/91b82383e0aa74383ebb81f625a9e7b870f06c00))
 
-# [0.23.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.22.0...jest-config-ibm-cloud-cognitive@0.23.0) (2021-11-30)
+## [0.23.1](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.23.0...jest-config-ibm-cloud-cognitive@0.23.1) (2021-12-07)
+
+### Bug Fixes
+
+- update Carbon versions and package dependencies to latest
+  ([#1491](https://github.com/carbon-design-system/ibm-products/issues/1491))
+  ([45f7b77](https://github.com/carbon-design-system/ibm-products/commit/45f7b77f797c5841b9dc15bc3013f31e50244d29))
+
+# [0.23.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.22.0...jest-config-ibm-cloud-cognitive@0.23.0) (2021-11-30)
 
 ### Features
 
 - update Carbon versions and dependencies to latest
-  ([#1473](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1473))
-  ([9cafbea](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9cafbea95226c46ff1732f9ad6b22c9c8837616e))
+  ([#1473](https://github.com/carbon-design-system/ibm-products/issues/1473))
+  ([9cafbea](https://github.com/carbon-design-system/ibm-products/commit/9cafbea95226c46ff1732f9ad6b22c9c8837616e))
 
-# [0.22.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.21.0...jest-config-ibm-cloud-cognitive@0.22.0) (2021-11-23)
+# [0.22.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.21.0...jest-config-ibm-cloud-cognitive@0.22.0) (2021-11-23)
 
 ### Features
 
 - update Carbon versions and dependencies to latest
-  ([#1465](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1465))
-  ([0c6b37f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0c6b37f5b713c54ec320d9da945fbd3f6b3f91d9))
+  ([#1465](https://github.com/carbon-design-system/ibm-products/issues/1465))
+  ([0c6b37f](https://github.com/carbon-design-system/ibm-products/commit/0c6b37f5b713c54ec320d9da945fbd3f6b3f91d9))
 
-# [0.21.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.20.0...jest-config-ibm-cloud-cognitive@0.21.0) (2021-11-16)
+# [0.21.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.20.0...jest-config-ibm-cloud-cognitive@0.21.0) (2021-11-16)
 
 ### Bug Fixes
 
 - replace "cloud & cognitive" with "Carbon for IBM Products" in docs
-  ([#1437](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1437))
-  ([0a58354](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0a58354ccbdd723173b2e6758907713938a7f163))
+  ([#1437](https://github.com/carbon-design-system/ibm-products/issues/1437))
+  ([0a58354](https://github.com/carbon-design-system/ibm-products/commit/0a58354ccbdd723173b2e6758907713938a7f163))
 
 ### Features
 
 - **security:** upgrade `carbon-components`, fix public API snapshot
-  ([#1389](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1389))
-  ([def48b1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/def48b1768e187c19403660f1ec2b3af961e75bf))
+  ([#1389](https://github.com/carbon-design-system/ibm-products/issues/1389))
+  ([def48b1](https://github.com/carbon-design-system/ibm-products/commit/def48b1768e187c19403660f1ec2b3af961e75bf))
 - update Carbon versions and package dependencies to latest
-  ([#1425](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1425))
-  ([4fd5883](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4fd5883961e0f3fc6be1c87bbe084b2cf6dc5db0)),
+  ([#1425](https://github.com/carbon-design-system/ibm-products/issues/1425))
+  ([4fd5883](https://github.com/carbon-design-system/ibm-products/commit/4fd5883961e0f3fc6be1c87bbe084b2cf6dc5db0)),
   closes
-  [#10000](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/10000)
+  [#10000](https://github.com/carbon-design-system/ibm-products/issues/10000)
 
-# [0.20.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.19.0...jest-config-ibm-cloud-cognitive@0.20.0) (2021-11-09)
-
-### Features
-
-- update Carbon versions and package dependencies to latest
-  ([#1365](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1365))
-  ([ea11cf7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ea11cf7ae44b61b48142c511c16460cf7978b88c))
-
-# [0.19.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.18.0...jest-config-ibm-cloud-cognitive@0.19.0) (2021-10-27)
+# [0.20.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.19.0...jest-config-ibm-cloud-cognitive@0.20.0) (2021-11-09)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1356](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1356))
-  ([946afd6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/946afd6bd5a165f35940cc1d70fc0e42fb6a4303))
+  ([#1365](https://github.com/carbon-design-system/ibm-products/issues/1365))
+  ([ea11cf7](https://github.com/carbon-design-system/ibm-products/commit/ea11cf7ae44b61b48142c511c16460cf7978b88c))
 
-# [0.18.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.17.0...jest-config-ibm-cloud-cognitive@0.18.0) (2021-10-20)
-
-### Features
-
-- update Carbon versions and package dependencies to latest
-  ([#1345](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1345))
-  ([3c7e6fe](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3c7e6fedfc46bffc38b889568133ee6c300ddb47))
-
-# [0.17.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.16.0...jest-config-ibm-cloud-cognitive@0.17.0) (2021-10-14)
+# [0.19.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.18.0...jest-config-ibm-cloud-cognitive@0.19.0) (2021-10-27)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1329](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1329))
-  ([fd3525e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fd3525ec3620b70ff19f85c300e7e0bb05577cd1))
+  ([#1356](https://github.com/carbon-design-system/ibm-products/issues/1356))
+  ([946afd6](https://github.com/carbon-design-system/ibm-products/commit/946afd6bd5a165f35940cc1d70fc0e42fb6a4303))
 
-# [0.16.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.15.0...jest-config-ibm-cloud-cognitive@0.16.0) (2021-10-07)
-
-### Features
-
-- update Carbon versions and package dependencies to latest
-  ([#1309](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1309))
-  ([945bd3b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/945bd3ba5608078e961af9a04448f2abd7e7fc5e))
-
-# [0.15.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.14.0...jest-config-ibm-cloud-cognitive@0.15.0) (2021-10-02)
+# [0.18.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.17.0...jest-config-ibm-cloud-cognitive@0.18.0) (2021-10-20)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1296](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1296))
-  ([f1da0bd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f1da0bd9192c4d999032df0dbe20d67b6ece89b0))
+  ([#1345](https://github.com/carbon-design-system/ibm-products/issues/1345))
+  ([3c7e6fe](https://github.com/carbon-design-system/ibm-products/commit/3c7e6fedfc46bffc38b889568133ee6c300ddb47))
 
-# [0.14.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.13.0...jest-config-ibm-cloud-cognitive@0.14.0) (2021-09-23)
+# [0.17.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.16.0...jest-config-ibm-cloud-cognitive@0.17.0) (2021-10-14)
+
+### Features
+
+- update Carbon versions and package dependencies to latest
+  ([#1329](https://github.com/carbon-design-system/ibm-products/issues/1329))
+  ([fd3525e](https://github.com/carbon-design-system/ibm-products/commit/fd3525ec3620b70ff19f85c300e7e0bb05577cd1))
+
+# [0.16.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.15.0...jest-config-ibm-cloud-cognitive@0.16.0) (2021-10-07)
+
+### Features
+
+- update Carbon versions and package dependencies to latest
+  ([#1309](https://github.com/carbon-design-system/ibm-products/issues/1309))
+  ([945bd3b](https://github.com/carbon-design-system/ibm-products/commit/945bd3ba5608078e961af9a04448f2abd7e7fc5e))
+
+# [0.15.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.14.0...jest-config-ibm-cloud-cognitive@0.15.0) (2021-10-02)
+
+### Features
+
+- update Carbon versions and package dependencies to latest
+  ([#1296](https://github.com/carbon-design-system/ibm-products/issues/1296))
+  ([f1da0bd](https://github.com/carbon-design-system/ibm-products/commit/f1da0bd9192c4d999032df0dbe20d67b6ece89b0))
+
+# [0.14.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.13.0...jest-config-ibm-cloud-cognitive@0.14.0) (2021-09-23)
 
 ### Features
 
 - update Carbon versions and dependencies to latest
-  ([#1282](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1282))
-  ([b1451cf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b1451cf5c91b75c1bd4e55ae2bdb47f025f33163))
+  ([#1282](https://github.com/carbon-design-system/ibm-products/issues/1282))
+  ([b1451cf](https://github.com/carbon-design-system/ibm-products/commit/b1451cf5c91b75c1bd4e55ae2bdb47f025f33163))
 
-# [0.13.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.12.0...jest-config-ibm-cloud-cognitive@0.13.0) (2021-09-21)
-
-### Features
-
-- update Carbon versions and package dependencies to latest
-  ([#1262](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1262))
-  ([ed4dcbe](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ed4dcbe5b6d92baa6ec39240bda6996ec55f7bc4))
-
-# [0.12.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.11.0...jest-config-ibm-cloud-cognitive@0.12.0) (2021-09-13)
+# [0.13.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.12.0...jest-config-ibm-cloud-cognitive@0.13.0) (2021-09-21)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1228](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1228))
-  ([4f5e24c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4f5e24cd3a36e7fa9a5cd62d1cafe75a090cf32e))
+  ([#1262](https://github.com/carbon-design-system/ibm-products/issues/1262))
+  ([ed4dcbe](https://github.com/carbon-design-system/ibm-products/commit/ed4dcbe5b6d92baa6ec39240bda6996ec55f7bc4))
 
-# [0.11.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.10.1...jest-config-ibm-cloud-cognitive@0.11.0) (2021-08-25)
-
-### Features
-
-- update Carbon versions and dependencies
-  ([#1199](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1199))
-  ([13ebf0b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/13ebf0b7bea06fa4cd2231bd613011d7717e5d03))
-
-## [0.10.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.10.0...jest-config-ibm-cloud-cognitive@0.10.1) (2021-08-19)
-
-**Note:** Version bump only for package jest-config-ibm-cloud-cognitive
-
-# [0.10.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.9.0...jest-config-ibm-cloud-cognitive@0.10.0) (2021-08-11)
+# [0.12.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.11.0...jest-config-ibm-cloud-cognitive@0.12.0) (2021-09-13)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1133](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1133))
-  ([4dfae1a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4dfae1a9b27f5676d0bde570e2c9ee9ce8550b52))
+  ([#1228](https://github.com/carbon-design-system/ibm-products/issues/1228))
+  ([4f5e24c](https://github.com/carbon-design-system/ibm-products/commit/4f5e24cd3a36e7fa9a5cd62d1cafe75a090cf32e))
 
-# [0.9.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.8.1...jest-config-ibm-cloud-cognitive@0.9.0) (2021-08-10)
+# [0.11.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.10.1...jest-config-ibm-cloud-cognitive@0.11.0) (2021-08-25)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#1110](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1110))
-  ([b41f433](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b41f4331e31cbd9e41d2364b24e6ef50c7fd2d8d))
+  ([#1199](https://github.com/carbon-design-system/ibm-products/issues/1199))
+  ([13ebf0b](https://github.com/carbon-design-system/ibm-products/commit/13ebf0b7bea06fa4cd2231bd613011d7717e5d03))
 
-## [0.8.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.8.0...jest-config-ibm-cloud-cognitive@0.8.1) (2021-08-03)
+## [0.10.1](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.10.0...jest-config-ibm-cloud-cognitive@0.10.1) (2021-08-19)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-# [0.8.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.7.0...jest-config-ibm-cloud-cognitive@0.8.0) (2021-07-28)
+# [0.10.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.9.0...jest-config-ibm-cloud-cognitive@0.10.0) (2021-08-11)
+
+### Features
+
+- update Carbon versions and package dependencies to latest
+  ([#1133](https://github.com/carbon-design-system/ibm-products/issues/1133))
+  ([4dfae1a](https://github.com/carbon-design-system/ibm-products/commit/4dfae1a9b27f5676d0bde570e2c9ee9ce8550b52))
+
+# [0.9.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.8.1...jest-config-ibm-cloud-cognitive@0.9.0) (2021-08-10)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#1084](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1084))
-  ([3735ead](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3735ead9a96450015ec7aeafdb25deaa93d49aaa))
+  ([#1110](https://github.com/carbon-design-system/ibm-products/issues/1110))
+  ([b41f433](https://github.com/carbon-design-system/ibm-products/commit/b41f4331e31cbd9e41d2364b24e6ef50c7fd2d8d))
 
-# [0.7.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.6.1...jest-config-ibm-cloud-cognitive@0.7.0) (2021-07-21)
-
-### Features
-
-- update Carbon versions and dependencies
-  ([#1037](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1037))
-  ([8c5937a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8c5937a865d3a0cfbaf33b9eca13c4d3b4c1365d))
-
-## [0.6.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.6.0...jest-config-ibm-cloud-cognitive@0.6.1) (2021-07-16)
+## [0.8.1](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.8.0...jest-config-ibm-cloud-cognitive@0.8.1) (2021-08-03)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-# [0.6.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.5.0...jest-config-ibm-cloud-cognitive@0.6.0) (2021-07-14)
+# [0.8.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.7.0...jest-config-ibm-cloud-cognitive@0.8.0) (2021-07-28)
+
+### Features
+
+- update Carbon versions and dependencies
+  ([#1084](https://github.com/carbon-design-system/ibm-products/issues/1084))
+  ([3735ead](https://github.com/carbon-design-system/ibm-products/commit/3735ead9a96450015ec7aeafdb25deaa93d49aaa))
+
+# [0.7.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.6.1...jest-config-ibm-cloud-cognitive@0.7.0) (2021-07-21)
+
+### Features
+
+- update Carbon versions and dependencies
+  ([#1037](https://github.com/carbon-design-system/ibm-products/issues/1037))
+  ([8c5937a](https://github.com/carbon-design-system/ibm-products/commit/8c5937a865d3a0cfbaf33b9eca13c4d3b4c1365d))
+
+## [0.6.1](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.6.0...jest-config-ibm-cloud-cognitive@0.6.1) (2021-07-16)
+
+**Note:** Version bump only for package jest-config-ibm-cloud-cognitive
+
+# [0.6.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.5.0...jest-config-ibm-cloud-cognitive@0.6.0) (2021-07-14)
 
 ### Features
 
 - update Carbon versions and package dependencies
-  ([#994](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/994))
-  ([2ab4845](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2ab4845511573b999d41fcf77e6d412e0d446b9d))
+  ([#994](https://github.com/carbon-design-system/ibm-products/issues/994))
+  ([2ab4845](https://github.com/carbon-design-system/ibm-products/commit/2ab4845511573b999d41fcf77e6d412e0d446b9d))
 
-# [0.5.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.4.2...jest-config-ibm-cloud-cognitive@0.5.0) (2021-07-07)
-
-### Features
-
-- update Carbon versions and dependencies
-  ([#974](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/974))
-  ([555509b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/555509b5ccb147ed0d794b5816f685aa8f7ae451))
-
-## [0.4.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.4.1...jest-config-ibm-cloud-cognitive@0.4.2) (2021-07-01)
-
-**Note:** Version bump only for package jest-config-ibm-cloud-cognitive
-
-## [0.4.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.4.0...jest-config-ibm-cloud-cognitive@0.4.1) (2021-06-30)
-
-**Note:** Version bump only for package jest-config-ibm-cloud-cognitive
-
-# [0.4.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.3.15...jest-config-ibm-cloud-cognitive@0.4.0) (2021-06-23)
+# [0.5.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.4.2...jest-config-ibm-cloud-cognitive@0.5.0) (2021-07-07)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#927](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/927))
-  ([5a8f7d6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5a8f7d6b81b6da26fd0cb933c1c3de4bd27b481b))
+  ([#974](https://github.com/carbon-design-system/ibm-products/issues/974))
+  ([555509b](https://github.com/carbon-design-system/ibm-products/commit/555509b5ccb147ed0d794b5816f685aa8f7ae451))
 
-## [0.3.15](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.3.14...jest-config-ibm-cloud-cognitive@0.3.15) (2021-06-17)
+## [0.4.2](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.4.1...jest-config-ibm-cloud-cognitive@0.4.2) (2021-07-01)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-## [0.3.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config-ibm-cloud-cognitive@0.3.13...jest-config-ibm-cloud-cognitive@0.3.14) (2021-06-09)
+## [0.4.1](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.4.0...jest-config-ibm-cloud-cognitive@0.4.1) (2021-06-30)
+
+**Note:** Version bump only for package jest-config-ibm-cloud-cognitive
+
+# [0.4.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.3.15...jest-config-ibm-cloud-cognitive@0.4.0) (2021-06-23)
+
+### Features
+
+- update Carbon versions and dependencies
+  ([#927](https://github.com/carbon-design-system/ibm-products/issues/927))
+  ([5a8f7d6](https://github.com/carbon-design-system/ibm-products/commit/5a8f7d6b81b6da26fd0cb933c1c3de4bd27b481b))
+
+## [0.3.15](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.3.14...jest-config-ibm-cloud-cognitive@0.3.15) (2021-06-17)
+
+**Note:** Version bump only for package jest-config-ibm-cloud-cognitive
+
+## [0.3.14](https://github.com/carbon-design-system/ibm-products/compare/jest-config-ibm-cloud-cognitive@0.3.13...jest-config-ibm-cloud-cognitive@0.3.14) (2021-06-09)
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
@@ -410,84 +410,84 @@ All notable changes to this project will be documented in this file. See
 
 **Note:** Version bump only for package jest-config-ibm-cloud-cognitive
 
-## [0.3.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config@0.3.11...jest-config@0.3.12) (2021-06-07)
+## [0.3.12](https://github.com/carbon-design-system/ibm-products/compare/jest-config@0.3.11...jest-config@0.3.12) (2021-06-07)
 
 **Note:** Version bump only for package jest-config
 
-## [0.3.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config@0.3.10...jest-config@0.3.11) (2021-06-04)
+## [0.3.11](https://github.com/carbon-design-system/ibm-products/compare/jest-config@0.3.10...jest-config@0.3.11) (2021-06-04)
 
 **Note:** Version bump only for package jest-config
 
-## [0.3.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config@0.3.9...jest-config@0.3.10) (2021-05-28)
+## [0.3.10](https://github.com/carbon-design-system/ibm-products/compare/jest-config@0.3.9...jest-config@0.3.10) (2021-05-28)
 
 **Note:** Version bump only for package jest-config
 
-## [0.3.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config@0.3.8...jest-config@0.3.9) (2021-05-26)
+## [0.3.9](https://github.com/carbon-design-system/ibm-products/compare/jest-config@0.3.8...jest-config@0.3.9) (2021-05-26)
 
 **Note:** Version bump only for package jest-config
 
-## [0.3.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config@0.3.7...jest-config@0.3.8) (2021-05-17)
+## [0.3.8](https://github.com/carbon-design-system/ibm-products/compare/jest-config@0.3.7...jest-config@0.3.8) (2021-05-17)
 
 **Note:** Version bump only for package jest-config
 
-## [0.3.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config@0.3.6...jest-config@0.3.7) (2021-04-21)
+## [0.3.7](https://github.com/carbon-design-system/ibm-products/compare/jest-config@0.3.6...jest-config@0.3.7) (2021-04-21)
 
 **Note:** Version bump only for package jest-config
 
-## [0.3.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config@0.3.5...jest-config@0.3.6) (2021-04-15)
+## [0.3.6](https://github.com/carbon-design-system/ibm-products/compare/jest-config@0.3.5...jest-config@0.3.6) (2021-04-15)
 
 **Note:** Version bump only for package jest-config
 
-## [0.3.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config@0.3.4...jest-config@0.3.5) (2021-04-14)
+## [0.3.5](https://github.com/carbon-design-system/ibm-products/compare/jest-config@0.3.4...jest-config@0.3.5) (2021-04-14)
 
 **Note:** Version bump only for package jest-config
 
-## [0.3.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config@0.3.3...jest-config@0.3.4) (2021-03-22)
+## [0.3.4](https://github.com/carbon-design-system/ibm-products/compare/jest-config@0.3.3...jest-config@0.3.4) (2021-03-22)
 
 **Note:** Version bump only for package jest-config
 
-## [0.3.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config@0.3.2...jest-config@0.3.3) (2021-03-16)
+## [0.3.3](https://github.com/carbon-design-system/ibm-products/compare/jest-config@0.3.2...jest-config@0.3.3) (2021-03-16)
 
 **Note:** Version bump only for package jest-config
 
-## [0.3.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config@0.3.1...jest-config@0.3.2) (2021-01-26)
+## [0.3.2](https://github.com/carbon-design-system/ibm-products/compare/jest-config@0.3.1...jest-config@0.3.2) (2021-01-26)
 
 **Note:** Version bump only for package jest-config
 
-## [0.3.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config@0.3.0...jest-config@0.3.1) (2021-01-20)
+## [0.3.1](https://github.com/carbon-design-system/ibm-products/compare/jest-config@0.3.0...jest-config@0.3.1) (2021-01-20)
 
 **Note:** Version bump only for package jest-config
 
-# [0.3.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config@0.2.2...jest-config@0.3.0) (2020-12-16)
+# [0.3.0](https://github.com/carbon-design-system/ibm-products/compare/jest-config@0.2.2...jest-config@0.3.0) (2020-12-16)
 
 ### Features
 
 - Page header tag overflow update
-  ([#264](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/264))
-  ([ee22520](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ee225206e291fa3bca990cb2ccabfece8930fc88))
+  ([#264](https://github.com/carbon-design-system/ibm-products/issues/264))
+  ([ee22520](https://github.com/carbon-design-system/ibm-products/commit/ee225206e291fa3bca990cb2ccabfece8930fc88))
 
-## [0.2.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config@0.2.1...jest-config@0.2.2) (2020-12-08)
-
-**Note:** Version bump only for package jest-config
-
-## [0.2.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/jest-config@0.2.0...jest-config@0.2.1) (2020-11-30)
+## [0.2.2](https://github.com/carbon-design-system/ibm-products/compare/jest-config@0.2.1...jest-config@0.2.2) (2020-12-08)
 
 **Note:** Version bump only for package jest-config
 
-# [0.2.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/jest-config/compare/jest-config@0.1.1...jest-config@0.2.0) (2020-11-26)
+## [0.2.1](https://github.com/carbon-design-system/ibm-products/compare/jest-config@0.2.0...jest-config@0.2.1) (2020-11-30)
+
+**Note:** Version bump only for package jest-config
+
+# [0.2.0](https://github.com/carbon-design-system/ibm-products/tree/master/packages/jest-config/compare/jest-config@0.1.1...jest-config@0.2.0) (2020-11-26)
 
 ### Features
 
 - add cdai apikey component
-  ([#223](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/jest-config/issues/223))
-  ([4c09f15](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/jest-config/commit/4c09f15c3c62c3965d98c91b9695fa7a1cba8f0b))
+  ([#223](https://github.com/carbon-design-system/ibm-products/tree/master/packages/jest-config/issues/223))
+  ([4c09f15](https://github.com/carbon-design-system/ibm-products/tree/master/packages/jest-config/commit/4c09f15c3c62c3965d98c91b9695fa7a1cba8f0b))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.1.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/jest-config/compare/jest-config@0.1.0...jest-config@0.1.1) (2020-11-17)
+## [0.1.1](https://github.com/carbon-design-system/ibm-products/tree/master/packages/jest-config/compare/jest-config@0.1.0...jest-config@0.1.1) (2020-11-17)
 
 **Note:** Version bump only for package jest-config
 
@@ -501,13 +501,13 @@ All notable changes to this project will be documented in this file. See
 ### Features
 
 - add new about screen modal component
-  ([#187](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/jest-config/issues/187))
-  ([7a8fadf](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/jest-config/commit/7a8fadf3b52bb50a733fbbbe5978051a00cf406e))
+  ([#187](https://github.com/carbon-design-system/ibm-products/tree/master/packages/jest-config/issues/187))
+  ([7a8fadf](https://github.com/carbon-design-system/ibm-products/tree/master/packages/jest-config/commit/7a8fadf3b52bb50a733fbbbe5978051a00cf406e))
 - Import component
-  ([#163](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/jest-config/issues/163))
-  ([980f4f3](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/jest-config/commit/980f4f3334610e97c0552921cdab269a6e01e6a7))
+  ([#163](https://github.com/carbon-design-system/ibm-products/tree/master/packages/jest-config/issues/163))
+  ([980f4f3](https://github.com/carbon-design-system/ibm-products/tree/master/packages/jest-config/commit/980f4f3334610e97c0552921cdab269a6e01e6a7))
 - setup testing for react components
-  ([#86](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/jest-config/issues/86))
-  ([c66c79b](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/jest-config/commit/c66c79bff039ad4a1e8fce5a2854948a80daf42e))
+  ([#86](https://github.com/carbon-design-system/ibm-products/tree/master/packages/jest-config/issues/86))
+  ([c66c79b](https://github.com/carbon-design-system/ibm-products/tree/master/packages/jest-config/commit/c66c79bff039ad4a1e8fce5a2854948a80daf42e))
 - **project:** add support for test and builds
-  ([7b3e99a](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/jest-config/commit/7b3e99ad75246bd03aa542563f8fdadca23a2f95))
+  ([7b3e99a](https://github.com/carbon-design-system/ibm-products/tree/master/packages/jest-config/commit/7b3e99ad75246bd03aa542563f8fdadca23a2f95))

--- a/config/jest-config-ibm-cloud-cognitive/package.json
+++ b/config/jest-config-ibm-cloud-cognitive/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "url": "https://github.com/carbon-design-system/ibm-products.git",
     "directory": "packages/jest-config-ibm-cloud-cognitive"
   },
   "bugs": "https://github.com/carbon-design-system/ibm-products/issues",

--- a/config/jest-config-ibm-cloud-cognitive/package.json
+++ b/config/jest-config-ibm-cloud-cognitive/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
     "directory": "packages/jest-config-ibm-cloud-cognitive"
   },
-  "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
+  "bugs": "https://github.com/carbon-design-system/ibm-products/issues",
   "keywords": [
     "carbon",
     "carbon design system",

--- a/config/storybook-addon-carbon-theme/CHANGELOG.md
+++ b/config/storybook-addon-carbon-theme/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.22.32](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.31...@carbon/storybook-addon-theme@0.22.32) (2023-03-07)
+## [0.22.32](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.31...@carbon/storybook-addon-theme@0.22.32) (2023-03-07)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.22.31](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.30...@carbon/storybook-addon-theme@0.22.31) (2023-02-07)
+## [0.22.31](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.30...@carbon/storybook-addon-theme@0.22.31) (2023-02-07)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
@@ -24,7 +24,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.22.30](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.29...@carbon/storybook-addon-theme@0.22.30) (2023-01-10)
+## [0.22.30](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.29...@carbon/storybook-addon-theme@0.22.30) (2023-01-10)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
@@ -33,7 +33,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.22.29](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.28...@carbon/storybook-addon-theme@0.22.29) (2022-11-22)
+## [0.22.29](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.28...@carbon/storybook-addon-theme@0.22.29) (2022-11-22)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
@@ -42,7 +42,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.22.28](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.27...@carbon/storybook-addon-theme@0.22.28) (2022-11-08)
+## [0.22.28](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.27...@carbon/storybook-addon-theme@0.22.28) (2022-11-08)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
@@ -51,7 +51,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.22.27](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.26...@carbon/storybook-addon-theme@0.22.27) (2022-10-25)
+## [0.22.27](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.26...@carbon/storybook-addon-theme@0.22.27) (2022-10-25)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
@@ -60,345 +60,345 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.22.26](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.25...@carbon/storybook-addon-theme@0.22.26) (2022-10-11)
+## [0.22.26](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.25...@carbon/storybook-addon-theme@0.22.26) (2022-10-11)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.25](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.24...@carbon/storybook-addon-theme@0.22.25) (2022-09-27)
+## [0.22.25](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.24...@carbon/storybook-addon-theme@0.22.25) (2022-09-27)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.24](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.23...@carbon/storybook-addon-theme@0.22.24) (2022-09-06)
+## [0.22.24](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.23...@carbon/storybook-addon-theme@0.22.24) (2022-09-06)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.23](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.22...@carbon/storybook-addon-theme@0.22.23) (2022-08-16)
+## [0.22.23](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.22...@carbon/storybook-addon-theme@0.22.23) (2022-08-16)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.22](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.21...@carbon/storybook-addon-theme@0.22.22) (2022-08-02)
+## [0.22.22](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.21...@carbon/storybook-addon-theme@0.22.22) (2022-08-02)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.21](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.20...@carbon/storybook-addon-theme@0.22.21) (2022-07-19)
+## [0.22.21](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.20...@carbon/storybook-addon-theme@0.22.21) (2022-07-19)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.20](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.19...@carbon/storybook-addon-theme@0.22.20) (2022-07-12)
+## [0.22.20](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.19...@carbon/storybook-addon-theme@0.22.20) (2022-07-12)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.19](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.18...@carbon/storybook-addon-theme@0.22.19) (2022-05-17)
+## [0.22.19](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.18...@carbon/storybook-addon-theme@0.22.19) (2022-05-17)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.18](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.17...@carbon/storybook-addon-theme@0.22.18) (2022-05-10)
+## [0.22.18](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.17...@carbon/storybook-addon-theme@0.22.18) (2022-05-10)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.17](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.16...@carbon/storybook-addon-theme@0.22.17) (2022-05-03)
+## [0.22.17](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.16...@carbon/storybook-addon-theme@0.22.17) (2022-05-03)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.16](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.15...@carbon/storybook-addon-theme@0.22.16) (2022-04-26)
+## [0.22.16](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.15...@carbon/storybook-addon-theme@0.22.16) (2022-04-26)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.15](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.14...@carbon/storybook-addon-theme@0.22.15) (2022-04-19)
+## [0.22.15](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.14...@carbon/storybook-addon-theme@0.22.15) (2022-04-19)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.13...@carbon/storybook-addon-theme@0.22.14) (2022-03-29)
+## [0.22.14](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.13...@carbon/storybook-addon-theme@0.22.14) (2022-03-29)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.12...@carbon/storybook-addon-theme@0.22.13) (2022-03-22)
+## [0.22.13](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.12...@carbon/storybook-addon-theme@0.22.13) (2022-03-22)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.11...@carbon/storybook-addon-theme@0.22.12) (2022-03-08)
+## [0.22.12](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.11...@carbon/storybook-addon-theme@0.22.12) (2022-03-08)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.10...@carbon/storybook-addon-theme@0.22.11) (2022-03-01)
+## [0.22.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.10...@carbon/storybook-addon-theme@0.22.11) (2022-03-01)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.9...@carbon/storybook-addon-theme@0.22.10) (2022-02-22)
+## [0.22.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.9...@carbon/storybook-addon-theme@0.22.10) (2022-02-22)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.8...@carbon/storybook-addon-theme@0.22.9) (2022-02-15)
+## [0.22.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.8...@carbon/storybook-addon-theme@0.22.9) (2022-02-15)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.7...@carbon/storybook-addon-theme@0.22.8) (2022-02-09)
+## [0.22.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.7...@carbon/storybook-addon-theme@0.22.8) (2022-02-09)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.6...@carbon/storybook-addon-theme@0.22.7) (2022-02-01)
+## [0.22.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.6...@carbon/storybook-addon-theme@0.22.7) (2022-02-01)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.5...@carbon/storybook-addon-theme@0.22.6) (2022-01-25)
+## [0.22.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.5...@carbon/storybook-addon-theme@0.22.6) (2022-01-25)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.22.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.4...@carbon/storybook-addon-theme@0.22.5) (2022-01-11)
+## [0.22.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.4...@carbon/storybook-addon-theme@0.22.5) (2022-01-11)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1513](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1513))
-  ([505ba0e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/505ba0e13ec58bef19422835fd8ffee87c24e82a))
+  ([#1513](https://github.com/carbon-design-system/ibm-products/issues/1513))
+  ([505ba0e](https://github.com/carbon-design-system/ibm-products/commit/505ba0e13ec58bef19422835fd8ffee87c24e82a))
 - update Carbon versions and package dependencies to latest
-  ([#1518](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1518))
-  ([3ddcdf6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3ddcdf6617e0d7c9f182da91e3eb0935b34cbc05))
+  ([#1518](https://github.com/carbon-design-system/ibm-products/issues/1518))
+  ([3ddcdf6](https://github.com/carbon-design-system/ibm-products/commit/3ddcdf6617e0d7c9f182da91e3eb0935b34cbc05))
 
-## [0.22.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.3...@carbon/storybook-addon-theme@0.22.4) (2022-01-04)
+## [0.22.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.3...@carbon/storybook-addon-theme@0.22.4) (2022-01-04)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1509](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1509))
-  ([613db81](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/613db817bffec2c5b26b1fe50a337dd7bac5d963))
+  ([#1509](https://github.com/carbon-design-system/ibm-products/issues/1509))
+  ([613db81](https://github.com/carbon-design-system/ibm-products/commit/613db817bffec2c5b26b1fe50a337dd7bac5d963))
 
-## [0.22.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.2...@carbon/storybook-addon-theme@0.22.3) (2021-12-21)
-
-### Bug Fixes
-
-- update Carbon versions and package dependencies to latest
-  ([#1499](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1499))
-  ([8aed3d5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8aed3d53d06cc896984e6847c0450cc647e34041))
-
-## [0.22.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.1...@carbon/storybook-addon-theme@0.22.2) (2021-12-14)
+## [0.22.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.2...@carbon/storybook-addon-theme@0.22.3) (2021-12-21)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1493](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1493))
-  ([91b8238](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/91b82383e0aa74383ebb81f625a9e7b870f06c00))
+  ([#1499](https://github.com/carbon-design-system/ibm-products/issues/1499))
+  ([8aed3d5](https://github.com/carbon-design-system/ibm-products/commit/8aed3d53d06cc896984e6847c0450cc647e34041))
 
-## [0.22.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.22.0...@carbon/storybook-addon-theme@0.22.1) (2021-12-07)
+## [0.22.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.1...@carbon/storybook-addon-theme@0.22.2) (2021-12-14)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1491](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1491))
-  ([45f7b77](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/45f7b77f797c5841b9dc15bc3013f31e50244d29))
+  ([#1493](https://github.com/carbon-design-system/ibm-products/issues/1493))
+  ([91b8238](https://github.com/carbon-design-system/ibm-products/commit/91b82383e0aa74383ebb81f625a9e7b870f06c00))
 
-# [0.22.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.21.0...@carbon/storybook-addon-theme@0.22.0) (2021-11-16)
+## [0.22.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.22.0...@carbon/storybook-addon-theme@0.22.1) (2021-12-07)
+
+### Bug Fixes
+
+- update Carbon versions and package dependencies to latest
+  ([#1491](https://github.com/carbon-design-system/ibm-products/issues/1491))
+  ([45f7b77](https://github.com/carbon-design-system/ibm-products/commit/45f7b77f797c5841b9dc15bc3013f31e50244d29))
+
+# [0.22.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.21.0...@carbon/storybook-addon-theme@0.22.0) (2021-11-16)
 
 ### Bug Fixes
 
 - replace "cloud & cognitive" with "Carbon for IBM Products" in docs
-  ([#1437](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1437))
-  ([0a58354](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0a58354ccbdd723173b2e6758907713938a7f163))
+  ([#1437](https://github.com/carbon-design-system/ibm-products/issues/1437))
+  ([0a58354](https://github.com/carbon-design-system/ibm-products/commit/0a58354ccbdd723173b2e6758907713938a7f163))
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1425](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1425))
-  ([4fd5883](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4fd5883961e0f3fc6be1c87bbe084b2cf6dc5db0)),
+  ([#1425](https://github.com/carbon-design-system/ibm-products/issues/1425))
+  ([4fd5883](https://github.com/carbon-design-system/ibm-products/commit/4fd5883961e0f3fc6be1c87bbe084b2cf6dc5db0)),
   closes
-  [#10000](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/10000)
+  [#10000](https://github.com/carbon-design-system/ibm-products/issues/10000)
 
-# [0.21.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.20.0...@carbon/storybook-addon-theme@0.21.0) (2021-11-09)
-
-### Features
-
-- update Carbon versions and package dependencies to latest
-  ([#1365](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1365))
-  ([ea11cf7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ea11cf7ae44b61b48142c511c16460cf7978b88c))
-
-# [0.20.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.19.0...@carbon/storybook-addon-theme@0.20.0) (2021-10-27)
+# [0.21.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.20.0...@carbon/storybook-addon-theme@0.21.0) (2021-11-09)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1356](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1356))
-  ([946afd6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/946afd6bd5a165f35940cc1d70fc0e42fb6a4303))
+  ([#1365](https://github.com/carbon-design-system/ibm-products/issues/1365))
+  ([ea11cf7](https://github.com/carbon-design-system/ibm-products/commit/ea11cf7ae44b61b48142c511c16460cf7978b88c))
 
-# [0.19.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.18.0...@carbon/storybook-addon-theme@0.19.0) (2021-10-20)
-
-### Features
-
-- update Carbon versions and package dependencies to latest
-  ([#1345](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1345))
-  ([3c7e6fe](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3c7e6fedfc46bffc38b889568133ee6c300ddb47))
-
-# [0.18.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.17.0...@carbon/storybook-addon-theme@0.18.0) (2021-10-14)
+# [0.20.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.19.0...@carbon/storybook-addon-theme@0.20.0) (2021-10-27)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1329](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1329))
-  ([fd3525e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fd3525ec3620b70ff19f85c300e7e0bb05577cd1))
+  ([#1356](https://github.com/carbon-design-system/ibm-products/issues/1356))
+  ([946afd6](https://github.com/carbon-design-system/ibm-products/commit/946afd6bd5a165f35940cc1d70fc0e42fb6a4303))
 
-# [0.17.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.16.0...@carbon/storybook-addon-theme@0.17.0) (2021-10-07)
-
-### Features
-
-- update Carbon versions and package dependencies to latest
-  ([#1309](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1309))
-  ([945bd3b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/945bd3ba5608078e961af9a04448f2abd7e7fc5e))
-
-# [0.16.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.15.0...@carbon/storybook-addon-theme@0.16.0) (2021-10-02)
+# [0.19.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.18.0...@carbon/storybook-addon-theme@0.19.0) (2021-10-20)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1296](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1296))
-  ([f1da0bd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f1da0bd9192c4d999032df0dbe20d67b6ece89b0))
+  ([#1345](https://github.com/carbon-design-system/ibm-products/issues/1345))
+  ([3c7e6fe](https://github.com/carbon-design-system/ibm-products/commit/3c7e6fedfc46bffc38b889568133ee6c300ddb47))
 
-# [0.15.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.14.0...@carbon/storybook-addon-theme@0.15.0) (2021-09-23)
+# [0.18.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.17.0...@carbon/storybook-addon-theme@0.18.0) (2021-10-14)
+
+### Features
+
+- update Carbon versions and package dependencies to latest
+  ([#1329](https://github.com/carbon-design-system/ibm-products/issues/1329))
+  ([fd3525e](https://github.com/carbon-design-system/ibm-products/commit/fd3525ec3620b70ff19f85c300e7e0bb05577cd1))
+
+# [0.17.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.16.0...@carbon/storybook-addon-theme@0.17.0) (2021-10-07)
+
+### Features
+
+- update Carbon versions and package dependencies to latest
+  ([#1309](https://github.com/carbon-design-system/ibm-products/issues/1309))
+  ([945bd3b](https://github.com/carbon-design-system/ibm-products/commit/945bd3ba5608078e961af9a04448f2abd7e7fc5e))
+
+# [0.16.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.15.0...@carbon/storybook-addon-theme@0.16.0) (2021-10-02)
+
+### Features
+
+- update Carbon versions and package dependencies to latest
+  ([#1296](https://github.com/carbon-design-system/ibm-products/issues/1296))
+  ([f1da0bd](https://github.com/carbon-design-system/ibm-products/commit/f1da0bd9192c4d999032df0dbe20d67b6ece89b0))
+
+# [0.15.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.14.0...@carbon/storybook-addon-theme@0.15.0) (2021-09-23)
 
 ### Features
 
 - update Carbon versions and dependencies to latest
-  ([#1282](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1282))
-  ([b1451cf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b1451cf5c91b75c1bd4e55ae2bdb47f025f33163))
+  ([#1282](https://github.com/carbon-design-system/ibm-products/issues/1282))
+  ([b1451cf](https://github.com/carbon-design-system/ibm-products/commit/b1451cf5c91b75c1bd4e55ae2bdb47f025f33163))
 
-# [0.14.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.13.0...@carbon/storybook-addon-theme@0.14.0) (2021-09-21)
+# [0.14.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.13.0...@carbon/storybook-addon-theme@0.14.0) (2021-09-21)
 
 ### Features
 
 - ensure prettier linting causes ci-check to fail
-  ([#1273](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1273))
-  ([ad6f347](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ad6f3479636d2b80b26338d9059429b4ae08ac6e))
+  ([#1273](https://github.com/carbon-design-system/ibm-products/issues/1273))
+  ([ad6f347](https://github.com/carbon-design-system/ibm-products/commit/ad6f3479636d2b80b26338d9059429b4ae08ac6e))
 - update Carbon versions and package dependencies to latest
-  ([#1262](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1262))
-  ([ed4dcbe](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ed4dcbe5b6d92baa6ec39240bda6996ec55f7bc4))
+  ([#1262](https://github.com/carbon-design-system/ibm-products/issues/1262))
+  ([ed4dcbe](https://github.com/carbon-design-system/ibm-products/commit/ed4dcbe5b6d92baa6ec39240bda6996ec55f7bc4))
 
-# [0.13.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.12.0...@carbon/storybook-addon-theme@0.13.0) (2021-09-13)
-
-### Features
-
-- update Carbon versions and package dependencies to latest
-  ([#1228](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1228))
-  ([4f5e24c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4f5e24cd3a36e7fa9a5cd62d1cafe75a090cf32e))
-
-# [0.12.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.11.0...@carbon/storybook-addon-theme@0.12.0) (2021-08-25)
-
-### Features
-
-- update Carbon versions and dependencies
-  ([#1199](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1199))
-  ([13ebf0b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/13ebf0b7bea06fa4cd2231bd613011d7717e5d03))
-
-# [0.11.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.10.0...@carbon/storybook-addon-theme@0.11.0) (2021-08-19)
-
-### Features
-
-- update Carbon versions and dependencies
-  ([#1168](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1168))
-  ([674017f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/674017fabc13a7737c0d16deb04ffa9872d76fe6))
-
-# [0.10.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.9.0...@carbon/storybook-addon-theme@0.10.0) (2021-08-11)
+# [0.13.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.12.0...@carbon/storybook-addon-theme@0.13.0) (2021-09-13)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1133](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1133))
-  ([4dfae1a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4dfae1a9b27f5676d0bde570e2c9ee9ce8550b52))
+  ([#1228](https://github.com/carbon-design-system/ibm-products/issues/1228))
+  ([4f5e24c](https://github.com/carbon-design-system/ibm-products/commit/4f5e24cd3a36e7fa9a5cd62d1cafe75a090cf32e))
 
-# [0.9.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.8.0...@carbon/storybook-addon-theme@0.9.0) (2021-08-10)
-
-### Features
-
-- update Carbon versions and dependencies
-  ([#1110](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1110))
-  ([b41f433](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b41f4331e31cbd9e41d2364b24e6ef50c7fd2d8d))
-
-# [0.8.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.7.0...@carbon/storybook-addon-theme@0.8.0) (2021-07-28)
+# [0.12.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.11.0...@carbon/storybook-addon-theme@0.12.0) (2021-08-25)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#1084](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1084))
-  ([3735ead](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3735ead9a96450015ec7aeafdb25deaa93d49aaa))
+  ([#1199](https://github.com/carbon-design-system/ibm-products/issues/1199))
+  ([13ebf0b](https://github.com/carbon-design-system/ibm-products/commit/13ebf0b7bea06fa4cd2231bd613011d7717e5d03))
 
-# [0.7.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.6.0...@carbon/storybook-addon-theme@0.7.0) (2021-07-21)
+# [0.11.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.10.0...@carbon/storybook-addon-theme@0.11.0) (2021-08-19)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#1037](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1037))
-  ([8c5937a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8c5937a865d3a0cfbaf33b9eca13c4d3b4c1365d))
+  ([#1168](https://github.com/carbon-design-system/ibm-products/issues/1168))
+  ([674017f](https://github.com/carbon-design-system/ibm-products/commit/674017fabc13a7737c0d16deb04ffa9872d76fe6))
 
-# [0.6.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.5.0...@carbon/storybook-addon-theme@0.6.0) (2021-07-14)
+# [0.10.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.9.0...@carbon/storybook-addon-theme@0.10.0) (2021-08-11)
+
+### Features
+
+- update Carbon versions and package dependencies to latest
+  ([#1133](https://github.com/carbon-design-system/ibm-products/issues/1133))
+  ([4dfae1a](https://github.com/carbon-design-system/ibm-products/commit/4dfae1a9b27f5676d0bde570e2c9ee9ce8550b52))
+
+# [0.9.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.8.0...@carbon/storybook-addon-theme@0.9.0) (2021-08-10)
+
+### Features
+
+- update Carbon versions and dependencies
+  ([#1110](https://github.com/carbon-design-system/ibm-products/issues/1110))
+  ([b41f433](https://github.com/carbon-design-system/ibm-products/commit/b41f4331e31cbd9e41d2364b24e6ef50c7fd2d8d))
+
+# [0.8.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.7.0...@carbon/storybook-addon-theme@0.8.0) (2021-07-28)
+
+### Features
+
+- update Carbon versions and dependencies
+  ([#1084](https://github.com/carbon-design-system/ibm-products/issues/1084))
+  ([3735ead](https://github.com/carbon-design-system/ibm-products/commit/3735ead9a96450015ec7aeafdb25deaa93d49aaa))
+
+# [0.7.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.6.0...@carbon/storybook-addon-theme@0.7.0) (2021-07-21)
+
+### Features
+
+- update Carbon versions and dependencies
+  ([#1037](https://github.com/carbon-design-system/ibm-products/issues/1037))
+  ([8c5937a](https://github.com/carbon-design-system/ibm-products/commit/8c5937a865d3a0cfbaf33b9eca13c4d3b4c1365d))
+
+# [0.6.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.5.0...@carbon/storybook-addon-theme@0.6.0) (2021-07-14)
 
 ### Features
 
 - update Carbon versions and package dependencies
-  ([#994](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/994))
-  ([2ab4845](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2ab4845511573b999d41fcf77e6d412e0d446b9d))
+  ([#994](https://github.com/carbon-design-system/ibm-products/issues/994))
+  ([2ab4845](https://github.com/carbon-design-system/ibm-products/commit/2ab4845511573b999d41fcf77e6d412e0d446b9d))
 
-# [0.5.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.4.2...@carbon/storybook-addon-theme@0.5.0) (2021-07-07)
-
-### Features
-
-- update Carbon versions and dependencies
-  ([#974](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/974))
-  ([555509b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/555509b5ccb147ed0d794b5816f685aa8f7ae451))
-
-## [0.4.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.4.1...@carbon/storybook-addon-theme@0.4.2) (2021-07-01)
-
-**Note:** Version bump only for package @carbon/storybook-addon-theme
-
-## [0.4.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.4.0...@carbon/storybook-addon-theme@0.4.1) (2021-06-30)
-
-**Note:** Version bump only for package @carbon/storybook-addon-theme
-
-# [0.4.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.3.6...@carbon/storybook-addon-theme@0.4.0) (2021-06-23)
+# [0.5.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.4.2...@carbon/storybook-addon-theme@0.5.0) (2021-07-07)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#927](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/927))
-  ([5a8f7d6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5a8f7d6b81b6da26fd0cb933c1c3de4bd27b481b))
+  ([#974](https://github.com/carbon-design-system/ibm-products/issues/974))
+  ([555509b](https://github.com/carbon-design-system/ibm-products/commit/555509b5ccb147ed0d794b5816f685aa8f7ae451))
 
-## [0.3.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.3.5...@carbon/storybook-addon-theme@0.3.6) (2021-06-17)
-
-**Note:** Version bump only for package @carbon/storybook-addon-theme
-
-## [0.3.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.3.4...@carbon/storybook-addon-theme@0.3.5) (2021-06-09)
+## [0.4.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.4.1...@carbon/storybook-addon-theme@0.4.2) (2021-07-01)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.3.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.3.3...@carbon/storybook-addon-theme@0.3.4) (2021-06-07)
+## [0.4.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.4.0...@carbon/storybook-addon-theme@0.4.1) (2021-06-30)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.3.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.3.2...@carbon/storybook-addon-theme@0.3.3) (2021-06-04)
+# [0.4.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.3.6...@carbon/storybook-addon-theme@0.4.0) (2021-06-23)
+
+### Features
+
+- update Carbon versions and dependencies
+  ([#927](https://github.com/carbon-design-system/ibm-products/issues/927))
+  ([5a8f7d6](https://github.com/carbon-design-system/ibm-products/commit/5a8f7d6b81b6da26fd0cb933c1c3de4bd27b481b))
+
+## [0.3.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.3.5...@carbon/storybook-addon-theme@0.3.6) (2021-06-17)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.3.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.3.1...@carbon/storybook-addon-theme@0.3.2) (2021-05-28)
+## [0.3.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.3.4...@carbon/storybook-addon-theme@0.3.5) (2021-06-09)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-## [0.3.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.3.0...@carbon/storybook-addon-theme@0.3.1) (2021-04-15)
+## [0.3.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.3.3...@carbon/storybook-addon-theme@0.3.4) (2021-06-07)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 
-# [0.3.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.2.3...@carbon/storybook-addon-theme@0.3.0) (2020-12-16)
+## [0.3.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.3.2...@carbon/storybook-addon-theme@0.3.3) (2021-06-04)
+
+**Note:** Version bump only for package @carbon/storybook-addon-theme
+
+## [0.3.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.3.1...@carbon/storybook-addon-theme@0.3.2) (2021-05-28)
+
+**Note:** Version bump only for package @carbon/storybook-addon-theme
+
+## [0.3.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.3.0...@carbon/storybook-addon-theme@0.3.1) (2021-04-15)
+
+**Note:** Version bump only for package @carbon/storybook-addon-theme
+
+# [0.3.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.2.3...@carbon/storybook-addon-theme@0.3.0) (2020-12-16)
 
 ### Features
 
 - Page header tag overflow update
-  ([#264](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/264))
-  ([ee22520](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ee225206e291fa3bca990cb2ccabfece8930fc88))
+  ([#264](https://github.com/carbon-design-system/ibm-products/issues/264))
+  ([ee22520](https://github.com/carbon-design-system/ibm-products/commit/ee225206e291fa3bca990cb2ccabfece8930fc88))
 
-## [0.2.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.2.2...@carbon/storybook-addon-theme@0.2.3) (2020-12-10)
+## [0.2.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.2.2...@carbon/storybook-addon-theme@0.2.3) (2020-12-10)
 
 ### Bug Fixes
 
 - stylelint plugin readme
-  ([#270](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/270))
-  ([0aa1985](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0aa19854c442c8d09ee3e9e482a019955c63282e))
+  ([#270](https://github.com/carbon-design-system/ibm-products/issues/270))
+  ([0aa1985](https://github.com/carbon-design-system/ibm-products/commit/0aa19854c442c8d09ee3e9e482a019955c63282e))
 
-## [0.2.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/storybook-addon-theme@0.2.1...@carbon/storybook-addon-theme@0.2.2) (2020-11-30)
+## [0.2.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/storybook-addon-theme@0.2.1...@carbon/storybook-addon-theme@0.2.2) (2020-11-30)
 
 **Note:** Version bump only for package @carbon/storybook-addon-theme
 

--- a/config/storybook-addon-carbon-theme/README.md
+++ b/config/storybook-addon-carbon-theme/README.md
@@ -24,7 +24,7 @@ npm install @carbon/storybook-addon-theme
 We are always looking for contributors to help us fix bugs, build new features,
 or help us improve the project documentation. If you're interested, definitely
 check out our
-[Contributing Guide](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/.github/CONTRIBUTING.md)
+[Contributing Guide](https://github.com/carbon-design-system/ibm-products/blob/master/.github/CONTRIBUTING.md)
 and
 [Carbon's Developer Handbook](https://github.com/carbon-design-system/carbon/blob/master/docs/developer-handbook.md)!
 👀

--- a/config/storybook-addon-carbon-theme/package.json
+++ b/config/storybook-addon-carbon-theme/package.json
@@ -6,7 +6,7 @@
   "main": "dist/react.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "url": "https://github.com/carbon-design-system/ibm-products.git",
     "directory": "packages/storybook-addon-carbon-theme"
   },
   "bugs": "https://github.com/carbon-design-system/ibm-products/issues",

--- a/config/storybook-addon-carbon-theme/package.json
+++ b/config/storybook-addon-carbon-theme/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
     "directory": "packages/storybook-addon-carbon-theme"
   },
-  "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
+  "bugs": "https://github.com/carbon-design-system/ibm-products/issues",
   "homepage": "https://github.com/storybookjs/storybook#readme",
   "files": [
     "dist/**/*",

--- a/config/stylelint-config-ibm-products/CHANGELOG.md
+++ b/config/stylelint-config-ibm-products/CHANGELOG.md
@@ -3,53 +3,31 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.0.29](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.28...stylelint-config-ibm-products@0.0.29) (2023-03-28)
+## [0.0.29](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.28...stylelint-config-ibm-products@0.0.29) (2023-03-28)
 
 
 ### Bug Fixes
 
-* update to Carbon v10 compatible versions to latest ([#2739](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2739)) ([7065855](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/70658550120822ab0a6dd296bc9022cc7d0856db))
+* update to Carbon v10 compatible versions to latest ([#2739](https://github.com/carbon-design-system/ibm-products/issues/2739)) ([7065855](https://github.com/carbon-design-system/ibm-products/commit/70658550120822ab0a6dd296bc9022cc7d0856db))
 
 
 
 
 
-## [0.0.28](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.27...stylelint-config-ibm-products@0.0.28) (2023-03-07)
-
-**Note:** Version bump only for package stylelint-config-ibm-products
-
-
-
-
-
-# Change Log
-
-All notable changes to this project will be documented in this file. See
-[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-## [0.0.27](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.26...stylelint-config-ibm-products@0.0.27) (2023-01-10)
+## [0.0.28](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.27...stylelint-config-ibm-products@0.0.28) (2023-03-07)
 
 **Note:** Version bump only for package stylelint-config-ibm-products
 
-# Change Log
 
-All notable changes to this project will be documented in this file. See
-[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.0.26](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.25...stylelint-config-ibm-products@0.0.26) (2022-12-20)
 
-### Bug Fixes
-
-- update to Carbon v10 compatible versions to latest
-  ([#2572](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2572))
-  ([4040e09](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4040e0925bcf5c3276a42248b35e0737adc8c36e))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.0.25](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.24...stylelint-config-ibm-products@0.0.25) (2022-11-22)
+## [0.0.27](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.26...stylelint-config-ibm-products@0.0.27) (2023-01-10)
 
 **Note:** Version bump only for package stylelint-config-ibm-products
 
@@ -58,122 +36,144 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.0.24](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.23...stylelint-config-ibm-products@0.0.24) (2022-11-08)
-
-**Note:** Version bump only for package stylelint-config-ibm-products
-
-# Change Log
-
-All notable changes to this project will be documented in this file. See
-[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-## [0.0.23](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.22...stylelint-config-ibm-products@0.0.23) (2022-10-25)
-
-**Note:** Version bump only for package stylelint-config-ibm-products
-
-# Change Log
-
-All notable changes to this project will be documented in this file. See
-[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-## [0.0.22](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.21...stylelint-config-ibm-products@0.0.22) (2022-10-11)
+## [0.0.26](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.25...stylelint-config-ibm-products@0.0.26) (2022-12-20)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#2331](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2331))
-  ([26f7bc1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/26f7bc1b05ded4d79634a06dea725746e6e381e7))
+  ([#2572](https://github.com/carbon-design-system/ibm-products/issues/2572))
+  ([4040e09](https://github.com/carbon-design-system/ibm-products/commit/4040e0925bcf5c3276a42248b35e0737adc8c36e))
 
-## [0.0.21](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.20...stylelint-config-ibm-products@0.0.21) (2022-09-27)
+# Change Log
 
-**Note:** Version bump only for package stylelint-config-ibm-products
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.0.20](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.19...stylelint-config-ibm-products@0.0.20) (2022-09-06)
-
-**Note:** Version bump only for package stylelint-config-ibm-products
-
-## [0.0.19](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.18...stylelint-config-ibm-products@0.0.19) (2022-08-30)
+## [0.0.25](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.24...stylelint-config-ibm-products@0.0.25) (2022-11-22)
 
 **Note:** Version bump only for package stylelint-config-ibm-products
 
-## [0.0.18](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.17...stylelint-config-ibm-products@0.0.18) (2022-08-16)
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.0.24](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.23...stylelint-config-ibm-products@0.0.24) (2022-11-08)
 
 **Note:** Version bump only for package stylelint-config-ibm-products
 
-## [0.0.17](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.16...stylelint-config-ibm-products@0.0.17) (2022-08-02)
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.0.23](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.22...stylelint-config-ibm-products@0.0.23) (2022-10-25)
 
 **Note:** Version bump only for package stylelint-config-ibm-products
 
-## [0.0.16](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.15...stylelint-config-ibm-products@0.0.16) (2022-07-27)
+# Change Log
 
-**Note:** Version bump only for package stylelint-config-ibm-products
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.0.15](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.14...stylelint-config-ibm-products@0.0.15) (2022-07-19)
+## [0.0.22](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.21...stylelint-config-ibm-products@0.0.22) (2022-10-11)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#2101](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2101))
-  ([feebce3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/feebce38ac474917e29d201d9198e3baf9452a97))
+  ([#2331](https://github.com/carbon-design-system/ibm-products/issues/2331))
+  ([26f7bc1](https://github.com/carbon-design-system/ibm-products/commit/26f7bc1b05ded4d79634a06dea725746e6e381e7))
 
-## [0.0.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.13...stylelint-config-ibm-products@0.0.14) (2022-07-12)
-
-**Note:** Version bump only for package stylelint-config-ibm-products
-
-## [0.0.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.12...stylelint-config-ibm-products@0.0.13) (2022-05-31)
+## [0.0.21](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.20...stylelint-config-ibm-products@0.0.21) (2022-09-27)
 
 **Note:** Version bump only for package stylelint-config-ibm-products
 
-## [0.0.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.11...stylelint-config-ibm-products@0.0.12) (2022-05-10)
+## [0.0.20](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.19...stylelint-config-ibm-products@0.0.20) (2022-09-06)
 
 **Note:** Version bump only for package stylelint-config-ibm-products
 
-## [0.0.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.10...stylelint-config-ibm-products@0.0.11) (2022-05-03)
+## [0.0.19](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.18...stylelint-config-ibm-products@0.0.19) (2022-08-30)
 
 **Note:** Version bump only for package stylelint-config-ibm-products
 
-## [0.0.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.9...stylelint-config-ibm-products@0.0.10) (2022-04-26)
+## [0.0.18](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.17...stylelint-config-ibm-products@0.0.18) (2022-08-16)
 
 **Note:** Version bump only for package stylelint-config-ibm-products
 
-## [0.0.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.8...stylelint-config-ibm-products@0.0.9) (2022-04-05)
+## [0.0.17](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.16...stylelint-config-ibm-products@0.0.17) (2022-08-02)
 
 **Note:** Version bump only for package stylelint-config-ibm-products
 
-## [0.0.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.7...stylelint-config-ibm-products@0.0.8) (2022-03-29)
+## [0.0.16](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.15...stylelint-config-ibm-products@0.0.16) (2022-07-27)
 
 **Note:** Version bump only for package stylelint-config-ibm-products
 
-## [0.0.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.6...stylelint-config-ibm-products@0.0.7) (2022-03-22)
+## [0.0.15](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.14...stylelint-config-ibm-products@0.0.15) (2022-07-19)
+
+### Bug Fixes
+
+- update to Carbon v10 compatible versions to latest
+  ([#2101](https://github.com/carbon-design-system/ibm-products/issues/2101))
+  ([feebce3](https://github.com/carbon-design-system/ibm-products/commit/feebce38ac474917e29d201d9198e3baf9452a97))
+
+## [0.0.14](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.13...stylelint-config-ibm-products@0.0.14) (2022-07-12)
+
+**Note:** Version bump only for package stylelint-config-ibm-products
+
+## [0.0.13](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.12...stylelint-config-ibm-products@0.0.13) (2022-05-31)
+
+**Note:** Version bump only for package stylelint-config-ibm-products
+
+## [0.0.12](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.11...stylelint-config-ibm-products@0.0.12) (2022-05-10)
+
+**Note:** Version bump only for package stylelint-config-ibm-products
+
+## [0.0.11](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.10...stylelint-config-ibm-products@0.0.11) (2022-05-03)
+
+**Note:** Version bump only for package stylelint-config-ibm-products
+
+## [0.0.10](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.9...stylelint-config-ibm-products@0.0.10) (2022-04-26)
+
+**Note:** Version bump only for package stylelint-config-ibm-products
+
+## [0.0.9](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.8...stylelint-config-ibm-products@0.0.9) (2022-04-05)
+
+**Note:** Version bump only for package stylelint-config-ibm-products
+
+## [0.0.8](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.7...stylelint-config-ibm-products@0.0.8) (2022-03-29)
+
+**Note:** Version bump only for package stylelint-config-ibm-products
+
+## [0.0.7](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.6...stylelint-config-ibm-products@0.0.7) (2022-03-22)
 
 ### Bug Fixes
 
 - update Carbon versions to latest
-  ([#1793](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1793))
-  ([9943926](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9943926b5234ce0690417d16483da4caa84790cf)),
+  ([#1793](https://github.com/carbon-design-system/ibm-products/issues/1793))
+  ([9943926](https://github.com/carbon-design-system/ibm-products/commit/9943926b5234ce0690417d16483da4caa84790cf)),
   closes
-  [#1738](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1738)
-  [#1791](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1791)
-  [#1738](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1738)
-  [#1790](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1790)
+  [#1738](https://github.com/carbon-design-system/ibm-products/issues/1738)
+  [#1791](https://github.com/carbon-design-system/ibm-products/issues/1791)
+  [#1738](https://github.com/carbon-design-system/ibm-products/issues/1738)
+  [#1790](https://github.com/carbon-design-system/ibm-products/issues/1790)
 
-## [0.0.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.5...stylelint-config-ibm-products@0.0.6) (2022-03-08)
+## [0.0.6](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.5...stylelint-config-ibm-products@0.0.6) (2022-03-08)
 
 ### Bug Fixes
 
 - update Carbon versions to latest
-  ([#1733](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1733))
-  ([9783faa](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9783faac23d8f03598ef0e5994743c4c5f915705))
+  ([#1733](https://github.com/carbon-design-system/ibm-products/issues/1733))
+  ([9783faa](https://github.com/carbon-design-system/ibm-products/commit/9783faac23d8f03598ef0e5994743c4c5f915705))
 
-## [0.0.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.4...stylelint-config-ibm-products@0.0.5) (2022-03-01)
-
-**Note:** Version bump only for package stylelint-config-ibm-products
-
-## [0.0.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.3...stylelint-config-ibm-products@0.0.4) (2022-02-22)
+## [0.0.5](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.4...stylelint-config-ibm-products@0.0.5) (2022-03-01)
 
 **Note:** Version bump only for package stylelint-config-ibm-products
 
-## [0.0.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/stylelint-config-ibm-products@0.0.2...stylelint-config-ibm-products@0.0.3) (2022-02-15)
+## [0.0.4](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.3...stylelint-config-ibm-products@0.0.4) (2022-02-22)
+
+**Note:** Version bump only for package stylelint-config-ibm-products
+
+## [0.0.3](https://github.com/carbon-design-system/ibm-products/compare/stylelint-config-ibm-products@0.0.2...stylelint-config-ibm-products@0.0.3) (2022-02-15)
 
 **Note:** Version bump only for package stylelint-config-ibm-products
 
@@ -182,5 +182,5 @@ All notable changes to this project will be documented in this file. See
 ### Bug Fixes
 
 - update stylelint to latest version
-  ([#1597](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1597))
-  ([13d8f9e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/13d8f9eb2885e687ba23f66b019a5629fffa2a85))
+  ([#1597](https://github.com/carbon-design-system/ibm-products/issues/1597))
+  ([13d8f9e](https://github.com/carbon-design-system/ibm-products/commit/13d8f9eb2885e687ba23f66b019a5629fffa2a85))

--- a/config/stylelint-config-ibm-products/package.json
+++ b/config/stylelint-config-ibm-products/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
     "directory": "config/stylelint-config-ibm-products"
   },
-  "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
+  "bugs": "https://github.com/carbon-design-system/ibm-products/issues",
   "scripts": {
     "//upgrade-dependencies": "# don't upgrade carbon (done globally)",
     "upgrade-dependencies": "npm-check-updates -u --dep dev,peer,prod --color --reject '/(carbon$)/'"

--- a/config/stylelint-config-ibm-products/package.json
+++ b/config/stylelint-config-ibm-products/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "url": "https://github.com/carbon-design-system/ibm-products.git",
     "directory": "config/stylelint-config-ibm-products"
   },
   "bugs": "https://github.com/carbon-design-system/ibm-products/issues",

--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -151,7 +151,7 @@ unclear.
 - Ensure all code is neatly formatted (use `yarn format` and/or a prettier
   plugin for an editor to follow the prettier rules set up in the project), and
   that code is clear, maintainable and follows standard React practices and the
-  [contributing guidelines](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/.github/CONTRIBUTING.md).
+  [contributing guidelines](https://github.com/carbon-design-system/ibm-products/blob/master/.github/CONTRIBUTING.md).
 
 ## Component SCSS code
 

--- a/docs/MAINTAINER_GUIDELINES.md
+++ b/docs/MAINTAINER_GUIDELINES.md
@@ -4,7 +4,7 @@
 
 Pull requests are automatically assigned to the IBM Cloud & Cognitive
 Development team. (Pull requests related to the
-[`security` package](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/main/packages/security)
+[`security` package](https://github.com/carbon-design-system/ibm-products/tree/main/packages/security)
 are assigned the individual maintainers of that package.)
 
 ## Reviewing code
@@ -12,7 +12,7 @@ are assigned the individual maintainers of that package.)
 Pull requests should be reviewed in a timely manner.
 
 Code review should follow the process and standards documented in our
-[PR review guidelines](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/main/docs/reviews/PR_REVIEW_GUIDELINES.md).
+[PR review guidelines](https://github.com/carbon-design-system/ibm-products/blob/main/docs/reviews/PR_REVIEW_GUIDELINES.md).
 
 Once a PR is approved, you can add the label **`status: ready to merge`**, to
 allow Kodiak to handle automatic updates and merging. PRs can be merged by their
@@ -22,7 +22,7 @@ team, you may also merge and delete the branches on their behalf.
 ## Performing release reviews
 
 As described in the
-[release review guidelines](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/main/docs/reviews/RELEASE_REVIEW_GUIDELINES.md),
+[release review guidelines](https://github.com/carbon-design-system/ibm-products/blob/main/docs/reviews/RELEASE_REVIEW_GUIDELINES.md),
 the core contribution team is responsible for performing release reviews.
 
 In most cases, a new maintainer will partner with an experienced contributor for
@@ -48,4 +48,4 @@ After each release, our contributors should announce the latest version of
 `@carbon/ibm-products` in the `ibmproducts-pal-dev` Slack channel.
 
 For more detail on publishing releases, please see our guidelines on
-[publishing releases](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/main/docs/PUBLISHING_RELEASES.md)
+[publishing releases](https://github.com/carbon-design-system/ibm-products/blob/main/docs/PUBLISHING_RELEASES.md)

--- a/docs/PUBLISHING_RELEASES.md
+++ b/docs/PUBLISHING_RELEASES.md
@@ -51,7 +51,7 @@ the following should be done:
   version of @carbon/ibm-products.
 
   To do this, share the initial part of the release summary from the
-  [releases page on GitHub](https://github.com/carbon-design-system/ibm-cloud-cognitive/releases)
+  [releases page on GitHub](https://github.com/carbon-design-system/ibm-products/releases)
   that shows the package name, version number, and any features and bug fixes
   but stopping before the assets (there is no need to post those into the Slack
   message).

--- a/docs/guides/CARBON_V10_AND_V11_SUPPORT.md
+++ b/docs/guides/CARBON_V10_AND_V11_SUPPORT.md
@@ -35,9 +35,9 @@ following command:
 ```sh
 $ mkdir ibm-cloud-cognitive-v11
 $ cd ibm-cloud-cognitive-v11
-$ git clone --branch carbon-v11 git@github.com:carbon-design-system/ibm-cloud-cognitive.git . // will clone from `carbon-v11` inside of the new v11 project directory that was just created
+$ git clone --branch carbon-v11 git@github.com:carbon-design-system/ibm-products.git . // will clone from `carbon-v11` inside of the new v11 project directory that was just created
 $ git remote set-url origin <ADD YOUR ORIGIN URL>
-$ git remote add upstream git@github.com:carbon-design-system/ibm-cloud-cognitive.git
+$ git remote add upstream git@github.com:carbon-design-system/ibm-products.git
 ```
 
 Afterwards, confirm that your remote urls are properly configured.

--- a/docs/guides/VARIANT_COMPONENT_GUIDELINES.md
+++ b/docs/guides/VARIANT_COMPONENT_GUIDELINES.md
@@ -134,8 +134,8 @@ There should only be two things to remember with storybook implementation.
 ## Conclusion
 
 If you want to see this pattern in use feel free to refer to the
-[Card](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cloud-cognitive/src/components/Card),
-[ExpressiveCard](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cloud-cognitive/src/components/ExpressiveCard),
+[Card](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cloud-cognitive/src/components/Card),
+[ExpressiveCard](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cloud-cognitive/src/components/ExpressiveCard),
 and
-[ProductiveCard](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cloud-cognitive/src/components/ProductiveCard)
+[ProductiveCard](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cloud-cognitive/src/components/ProductiveCard)
 code.

--- a/docs/reviews/PR_REVIEW_GUIDELINES.md
+++ b/docs/reviews/PR_REVIEW_GUIDELINES.md
@@ -1,9 +1,9 @@
 # PR reviews
 
 When reviewing a PR, check that our
-[code guidelines](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/docs/CODE_GUIDELINES.md)
+[code guidelines](https://github.com/carbon-design-system/ibm-products/blob/master/docs/CODE_GUIDELINES.md)
 are followed, and keep an eye on the
-[release review guidelines](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/docs/reviews/RELEASE_REVIEW_GUIDELINES.md).
+[release review guidelines](https://github.com/carbon-design-system/ibm-products/blob/master/docs/reviews/RELEASE_REVIEW_GUIDELINES.md).
 
 Each PR should be reviewed based on these criteria where applicable.
 

--- a/docs/reviews/RELEASE_REVIEW_GUIDELINES.md
+++ b/docs/reviews/RELEASE_REVIEW_GUIDELINES.md
@@ -52,7 +52,7 @@ responds to the currently set Carbon theme.\
 `- [ ]` Components are functional components using hooks.\
 `- [ ]` Public components which produce DOM structures support className.\
 `- [ ]` Public components support a ref (via React.forwardRef).\
-`- [ ]` Public component supports a [Devtools attribute](https://github.com/carbon-design-system/ibm-cloud-cognitive/search?l=JavaScript&q=devtools&type=)
+`- [ ]` Public component supports a [Devtools attribute](https://github.com/carbon-design-system/ibm-products/search?l=JavaScript&q=devtools&type=)
 \
 `- [ ]` All significant DOM elements have meaningful classes.\
 `- [ ]` Additional attributes that are not identified as props (such as title, aria-\*,
@@ -75,7 +75,7 @@ accessibility purposes -
 [read more here](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion).\
 `- [ ]` Code is formatted according to prettier rules (no use of //prettier-ignore).\
 `- [ ]` Code is clear, maintainable and follows standard React practices and the
-[code guidelines](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/docs/CODE_GUIDELINES.md).\
+[code guidelines](https://github.com/carbon-design-system/ibm-products/blob/master/docs/CODE_GUIDELINES.md).\
 `- [ ]` Copyright header in every source file (js, css, scss etc.) with the appropriate
 years.
 

--- a/examples/carbon-for-ibm-products/example-gallery/src/gallery-config/index.js
+++ b/examples/carbon-for-ibm-products/example-gallery/src/gallery-config/index.js
@@ -11,19 +11,19 @@ const defaultOrNot = (item) => item.default || item;
 const config = [
   {
     label: 'API Key Modal',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/APIKeyModal',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/APIKeyModal',
     thumbnail:
       'url( ' + defaultOrNot(require('./APIKeyModal--thumbnail.png')) + ')',
   },
   {
     label: 'About Modal',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/AboutModal',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/AboutModal',
     thumbnail:
       'url( ' + defaultOrNot(require('./AboutModal--thumbnail.png')) + ')',
   },
   {
     label: 'Carbon v11 template',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/Carbon-v11-template',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/Carbon-v11-template',
     thumbnail:
       'url( ' +
       defaultOrNot(require('./Carbon-v11-template--thumbnail.png')) +
@@ -31,37 +31,37 @@ const config = [
   },
   {
     label: 'Cascade',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/Cascade',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/Cascade',
     thumbnail:
       'url( ' + defaultOrNot(require('./Cascade--thumbnail.png')) + ')',
   },
   {
     label: 'Create Full Page',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/CreateFullPage',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/CreateFullPage',
     thumbnail:
       'url( ' + defaultOrNot(require('./CreateFullPage--thumbnail.png')) + ')',
   },
   {
     label: 'Create Modal',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/CreateModal',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/CreateModal',
     thumbnail:
       'url( ' + defaultOrNot(require('./CreateModal--thumbnail.png')) + ')',
   },
   {
     label: 'Create Side Panel',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/CreateSidePanel',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/CreateSidePanel',
     thumbnail:
       'url( ' + defaultOrNot(require('./CreateSidePanel--thumbnail.png')) + ')',
   },
   {
     label: 'Tearsheet',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/CreateTearsheet',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/CreateTearsheet',
     thumbnail:
       'url( ' + defaultOrNot(require('./CreateTearsheet--thumbnail.png')) + ')',
   },
   {
     label: 'Tearsheet Narrow',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/CreateTearsheetNarrow',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/CreateTearsheetNarrow',
     thumbnail:
       'url( ' +
       defaultOrNot(require('./CreateTearsheetNarrow--thumbnail.png')) +
@@ -69,61 +69,61 @@ const config = [
   },
   {
     label: 'DataSpreadsheet',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/DataSpreadsheet',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/DataSpreadsheet',
     thumbnail:
       'url( ' + defaultOrNot(require('./DataSpreadsheet--thumbnail.png')) + ')',
   },
   {
     label: 'Datagrid',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/Datagrid',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/Datagrid',
     thumbnail:
       'url( ' + defaultOrNot(require('./Datagrid--thumbnail.png')) + ')',
   },
   {
     label: 'Empty State',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/EmptyStates',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/EmptyStates',
     thumbnail:
       'url( ' + defaultOrNot(require('./EmptyStates--thumbnail.png')) + ')',
   },
   {
     label: 'Export Modal',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/ExportModal',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/ExportModal',
     thumbnail:
       'url( ' + defaultOrNot(require('./ExportModal--thumbnail.png')) + ')',
   },
   {
     label: 'Expressive Card',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/ExpressiveCard',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/ExpressiveCard',
     thumbnail:
       'url( ' + defaultOrNot(require('./ExpressiveCard--thumbnail.png')) + ')',
   },
   {
     label: 'HTTP Error',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/HTTPErrors',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/HTTPErrors',
     thumbnail:
       'url( ' + defaultOrNot(require('./HTTPErrors--thumbnail.png')) + ')',
   },
   {
     label: 'Import Modal',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/ImportModal',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/ImportModal',
     thumbnail:
       'url( ' + defaultOrNot(require('./ImportModal--thumbnail.png')) + ')',
   },
   {
     label: 'InlineEdit',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/InlineEdit',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/InlineEdit',
     thumbnail:
       'url( ' + defaultOrNot(require('./InlineEdit--thumbnail.png')) + ')',
   },
   {
     label: 'Multi Add Select',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/MultiAddSelect',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/MultiAddSelect',
     thumbnail:
       'url( ' + defaultOrNot(require('./MultiAddSelect--thumbnail.png')) + ')',
   },
   {
     label: 'Notifications Panel',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/NotificationsPanel',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/NotificationsPanel',
     thumbnail:
       'url( ' +
       defaultOrNot(require('./NotificationsPanel--thumbnail.png')) +
@@ -131,65 +131,65 @@ const config = [
   },
   {
     label: 'OptionsTile',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/OptionsTile',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/OptionsTile',
     thumbnail:
       'url( ' + defaultOrNot(require('./OptionsTile--thumbnail.png')) + ')',
   },
   {
     label: 'Page Header Example',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/PageHeader',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/PageHeader',
     thumbnail:
       'url( ' + defaultOrNot(require('./PageHeader--thumbnail.png')) + ')',
   },
   {
     label: 'ProductiveCard',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/ProductiveCard',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/ProductiveCard',
     thumbnail:
       'url( ' + defaultOrNot(require('./ProductiveCard--thumbnail.png')) + ')',
   },
   {
     label: 'RemoveModal',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/RemoveModal',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/RemoveModal',
     thumbnail:
       'url( ' + defaultOrNot(require('./RemoveModal--thumbnail.png')) + ')',
   },
   {
     label: 'Saving',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/Saving',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/Saving',
     thumbnail: 'url( ' + defaultOrNot(require('./Saving--thumbnail.png')) + ')',
   },
   {
     label: 'SidePanel',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/SidePanel',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/SidePanel',
     thumbnail:
       'url( ' + defaultOrNot(require('./SidePanel--thumbnail.png')) + ')',
   },
   {
     label: 'Single Add Select',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/SingleAddSelect',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/SingleAddSelect',
     thumbnail:
       'url( ' + defaultOrNot(require('./SingleAddSelect--thumbnail.png')) + ')',
   },
   {
     label: 'StatusIcon',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/StatusIcon',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/StatusIcon',
     thumbnail:
       'url( ' + defaultOrNot(require('./StatusIcon--thumbnail.png')) + ')',
   },
   {
     label: 'TagSet',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/TagSet',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/TagSet',
     thumbnail: 'url( ' + defaultOrNot(require('./TagSet--thumbnail.png')) + ')',
   },
   {
     label: 'Tearsheet',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/Tearsheet',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/Tearsheet',
     thumbnail:
       'url( ' + defaultOrNot(require('./Tearsheet--thumbnail.png')) + ')',
   },
   {
     label: 'UserProfileImage',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/UserProfileImage',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/UserProfileImage',
     thumbnail:
       'url( ' +
       defaultOrNot(require('./UserProfileImage--thumbnail.png')) +
@@ -197,13 +197,13 @@ const config = [
   },
   {
     label: 'WebTerminal',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/WebTerminal',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/WebTerminal',
     thumbnail:
       'url( ' + defaultOrNot(require('./WebTerminal--thumbnail.png')) + ')',
   },
   {
     label: 'React 16 usage',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/ccs-base-react-16',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/ccs-base-react-16',
     thumbnail:
       'url( ' +
       defaultOrNot(require('./ccs-base-react-16--thumbnail.png')) +
@@ -211,7 +211,7 @@ const config = [
   },
   {
     label: 'React 17 usage',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/ccs-base-react-17',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/ccs-base-react-17',
     thumbnail:
       'url( ' +
       defaultOrNot(require('./ccs-base-react-17--thumbnail.png')) +
@@ -219,7 +219,7 @@ const config = [
   },
   {
     label: 'Prefix CSS/JS Example',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/prefix-example',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/prefix-example',
     thumbnail:
       'url( ' + defaultOrNot(require('./prefix-example--thumbnail.png')) + ')',
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ibm-cloud-cognitive",
   "private": true,
   "version": "0.0.0",
-  "repository": "git@github.com:carbon-design-system/ibm-cloud-cognitive.git",
+  "repository": "git@github.com:carbon-design-system/ibm-products.git",
   "license": "Apache-2.0",
   "workspaces": {
     "packages": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ibm-cloud-cognitive",
+  "name": "ibm-products",
   "private": true,
   "version": "0.0.0",
   "repository": "git@github.com:carbon-design-system/ibm-products.git",

--- a/packages/cdai/CHANGELOG.md
+++ b/packages/cdai/CHANGELOG.md
@@ -3,18 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.24.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.24.3...@carbon/ibm-cloud-cognitive-cdai@1.24.4) (2023-03-28)
+## [1.24.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.24.3...@carbon/ibm-cloud-cognitive-cdai@1.24.4) (2023-03-28)
 
 
 ### Bug Fixes
 
-* update to Carbon v10 compatible versions to latest ([#2739](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2739)) ([7065855](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/70658550120822ab0a6dd296bc9022cc7d0856db))
+* update to Carbon v10 compatible versions to latest ([#2739](https://github.com/carbon-design-system/ibm-products/issues/2739)) ([7065855](https://github.com/carbon-design-system/ibm-products/commit/70658550120822ab0a6dd296bc9022cc7d0856db))
 
 
 
 
 
-## [1.24.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.24.2...@carbon/ibm-cloud-cognitive-cdai@1.24.3) (2023-03-07)
+## [1.24.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.24.2...@carbon/ibm-cloud-cognitive-cdai@1.24.3) (2023-03-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
@@ -22,18 +22,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [1.24.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.24.1...@carbon/ibm-cloud-cognitive-cdai@1.24.2) (2023-02-24)
+## [1.24.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.24.1...@carbon/ibm-cloud-cognitive-cdai@1.24.2) (2023-02-24)
 
 
 ### Bug Fixes
 
-* Replace `react-highlighter` ([#2698](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2698)) ([ca6a718](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ca6a718b58322980bd31451c11ba5d64b03c4f8f))
+* Replace `react-highlighter` ([#2698](https://github.com/carbon-design-system/ibm-products/issues/2698)) ([ca6a718](https://github.com/carbon-design-system/ibm-products/commit/ca6a718b58322980bd31451c11ba5d64b03c4f8f))
 
 
 
 
 
-## [1.24.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.24.0...@carbon/ibm-cloud-cognitive-cdai@1.24.1) (2023-02-07)
+## [1.24.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.24.0...@carbon/ibm-cloud-cognitive-cdai@1.24.1) (2023-02-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
@@ -46,20 +46,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.24.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.23.1...@carbon/ibm-cloud-cognitive-cdai@1.24.0) (2023-01-31)
+# [1.24.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.23.1...@carbon/ibm-cloud-cognitive-cdai@1.24.0) (2023-01-31)
 
 ### Features
 
 - add a custom onClick function and other props in IdeEmptyState …
-  ([#2626](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2626))
-  ([7fcde6b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7fcde6b26f9f79158ed74483b185dd030ee0ffac))
+  ([#2626](https://github.com/carbon-design-system/ibm-products/issues/2626))
+  ([7fcde6b](https://github.com/carbon-design-system/ibm-products/commit/7fcde6b26f9f79158ed74483b185dd030ee0ffac))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.23.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.23.0...@carbon/ibm-cloud-cognitive-cdai@1.23.1) (2023-01-10)
+## [1.23.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.23.0...@carbon/ibm-cloud-cognitive-cdai@1.23.1) (2023-01-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
@@ -68,33 +68,33 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.23.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.25...@carbon/ibm-cloud-cognitive-cdai@1.23.0) (2022-12-06)
+# [1.23.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.25...@carbon/ibm-cloud-cognitive-cdai@1.23.0) (2022-12-06)
 
 ### Features
 
 - **Datagrid:** Filter flyout
-  ([#2406](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2406))
-  ([d375308](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d3753083154f1c48b52164e2d2ae56d53dc0be7a))
+  ([#2406](https://github.com/carbon-design-system/ibm-products/issues/2406))
+  ([d375308](https://github.com/carbon-design-system/ibm-products/commit/d3753083154f1c48b52164e2d2ae56d53dc0be7a))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.22.25](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.24...@carbon/ibm-cloud-cognitive-cdai@1.22.25) (2022-11-22)
+## [1.22.25](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.24...@carbon/ibm-cloud-cognitive-cdai@1.22.25) (2022-11-22)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#2462](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2462))
-  ([4353991](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/43539912353a965549f0f2e5f8245168d2ce1c98))
+  ([#2462](https://github.com/carbon-design-system/ibm-products/issues/2462))
+  ([4353991](https://github.com/carbon-design-system/ibm-products/commit/43539912353a965549f0f2e5f8245168d2ce1c98))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.22.24](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.23...@carbon/ibm-cloud-cognitive-cdai@1.22.24) (2022-11-08)
+## [1.22.24](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.23...@carbon/ibm-cloud-cognitive-cdai@1.22.24) (2022-11-08)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
@@ -103,7 +103,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.22.23](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.22...@carbon/ibm-cloud-cognitive-cdai@1.22.23) (2022-10-25)
+## [1.22.23](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.22...@carbon/ibm-cloud-cognitive-cdai@1.22.23) (2022-10-25)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
@@ -112,676 +112,676 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.22.22](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.21...@carbon/ibm-cloud-cognitive-cdai@1.22.22) (2022-10-18)
+## [1.22.22](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.21...@carbon/ibm-cloud-cognitive-cdai@1.22.22) (2022-10-18)
 
 ### Bug Fixes
 
 - update Carbon v10 compatible versions to latest
-  ([#2362](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2362))
-  ([e328904](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e328904b20bdc0c652661de829c0d1bfcb8738b6))
+  ([#2362](https://github.com/carbon-design-system/ibm-products/issues/2362))
+  ([e328904](https://github.com/carbon-design-system/ibm-products/commit/e328904b20bdc0c652661de829c0d1bfcb8738b6))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.22.21](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.20...@carbon/ibm-cloud-cognitive-cdai@1.22.21) (2022-10-11)
+## [1.22.21](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.20...@carbon/ibm-cloud-cognitive-cdai@1.22.21) (2022-10-11)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#2331](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2331))
-  ([26f7bc1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/26f7bc1b05ded4d79634a06dea725746e6e381e7))
+  ([#2331](https://github.com/carbon-design-system/ibm-products/issues/2331))
+  ([26f7bc1](https://github.com/carbon-design-system/ibm-products/commit/26f7bc1b05ded4d79634a06dea725746e6e381e7))
 
-## [1.22.20](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.19...@carbon/ibm-cloud-cognitive-cdai@1.22.20) (2022-09-27)
+## [1.22.20](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.19...@carbon/ibm-cloud-cognitive-cdai@1.22.20) (2022-09-27)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#2276](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2276))
-  ([c35a363](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c35a3630ecb0dd60d920e57d81bd8f6e84aae008))
+  ([#2276](https://github.com/carbon-design-system/ibm-products/issues/2276))
+  ([c35a363](https://github.com/carbon-design-system/ibm-products/commit/c35a3630ecb0dd60d920e57d81bd8f6e84aae008))
 
-## [1.22.19](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.18...@carbon/ibm-cloud-cognitive-cdai@1.22.19) (2022-09-06)
+## [1.22.19](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.18...@carbon/ibm-cloud-cognitive-cdai@1.22.19) (2022-09-06)
 
 ### Bug Fixes
 
 - Remove `@carbon/elements` from `@carbon/ibm-cloud-cognitive-cdai`'s peer
   dependencies
-  ([#2242](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2242))
-  ([4aa2736](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4aa27361acb6cbf9a59b167f8543c000ae183310))
+  ([#2242](https://github.com/carbon-design-system/ibm-products/issues/2242))
+  ([4aa2736](https://github.com/carbon-design-system/ibm-products/commit/4aa27361acb6cbf9a59b167f8543c000ae183310))
 - Require only one of `arial-label` or `aria-labelledby` in `<IdeNavigation>`
-  ([#2243](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2243))
-  ([0b798ab](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0b798aba8b3073de854ad8848c17f0aff6091ae0))
+  ([#2243](https://github.com/carbon-design-system/ibm-products/issues/2243))
+  ([0b798ab](https://github.com/carbon-design-system/ibm-products/commit/0b798aba8b3073de854ad8848c17f0aff6091ae0))
 - Update IdeCard.js
-  ([#2244](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2244))
-  ([6eba115](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6eba115ce5717119b7a5836753f764d26ca72956))
+  ([#2244](https://github.com/carbon-design-system/ibm-products/issues/2244))
+  ([6eba115](https://github.com/carbon-design-system/ibm-products/commit/6eba115ce5717119b7a5836753f764d26ca72956))
 - update to Carbon v10 compatible versions to latest
-  ([#2249](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2249))
-  ([2a2ccfa](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2a2ccfaef41d5247724aed978fb62567932ea6dc))
+  ([#2249](https://github.com/carbon-design-system/ibm-products/issues/2249))
+  ([2a2ccfa](https://github.com/carbon-design-system/ibm-products/commit/2a2ccfaef41d5247724aed978fb62567932ea6dc))
 
-## [1.22.18](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.17...@carbon/ibm-cloud-cognitive-cdai@1.22.18) (2022-08-30)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
-
-## [1.22.17](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.16...@carbon/ibm-cloud-cognitive-cdai@1.22.17) (2022-08-16)
+## [1.22.18](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.17...@carbon/ibm-cloud-cognitive-cdai@1.22.18) (2022-08-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [1.22.16](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.15...@carbon/ibm-cloud-cognitive-cdai@1.22.16) (2022-08-02)
+## [1.22.17](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.16...@carbon/ibm-cloud-cognitive-cdai@1.22.17) (2022-08-16)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
+
+## [1.22.16](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.15...@carbon/ibm-cloud-cognitive-cdai@1.22.16) (2022-08-02)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#2144](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2144))
-  ([c67ce20](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c67ce20cf586218f28d2ad7bba4de6fd4d21efae))
+  ([#2144](https://github.com/carbon-design-system/ibm-products/issues/2144))
+  ([c67ce20](https://github.com/carbon-design-system/ibm-products/commit/c67ce20cf586218f28d2ad7bba4de6fd4d21efae))
 
-## [1.22.15](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.14...@carbon/ibm-cloud-cognitive-cdai@1.22.15) (2022-07-27)
+## [1.22.15](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.14...@carbon/ibm-cloud-cognitive-cdai@1.22.15) (2022-07-27)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [1.22.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.13...@carbon/ibm-cloud-cognitive-cdai@1.22.14) (2022-07-19)
+## [1.22.14](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.13...@carbon/ibm-cloud-cognitive-cdai@1.22.14) (2022-07-19)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#2101](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2101))
-  ([feebce3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/feebce38ac474917e29d201d9198e3baf9452a97))
+  ([#2101](https://github.com/carbon-design-system/ibm-products/issues/2101))
+  ([feebce3](https://github.com/carbon-design-system/ibm-products/commit/feebce38ac474917e29d201d9198e3baf9452a97))
 
-## [1.22.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.12...@carbon/ibm-cloud-cognitive-cdai@1.22.13) (2022-07-12)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
-
-## [1.22.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.11...@carbon/ibm-cloud-cognitive-cdai@1.22.12) (2022-05-31)
+## [1.22.13](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.12...@carbon/ibm-cloud-cognitive-cdai@1.22.13) (2022-07-12)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [1.22.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.10...@carbon/ibm-cloud-cognitive-cdai@1.22.11) (2022-05-17)
+## [1.22.12](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.11...@carbon/ibm-cloud-cognitive-cdai@1.22.12) (2022-05-31)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [1.22.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.9...@carbon/ibm-cloud-cognitive-cdai@1.22.10) (2022-05-10)
+## [1.22.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.10...@carbon/ibm-cloud-cognitive-cdai@1.22.11) (2022-05-17)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
+
+## [1.22.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.9...@carbon/ibm-cloud-cognitive-cdai@1.22.10) (2022-05-10)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#1971](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1971))
-  ([95374b8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/95374b89a15b1a76d18fb29c40e161a54720c447)),
+  ([#1971](https://github.com/carbon-design-system/ibm-products/issues/1971))
+  ([95374b8](https://github.com/carbon-design-system/ibm-products/commit/95374b89a15b1a76d18fb29c40e161a54720c447)),
   closes
-  [#1970](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1970)
-  [#1972](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1972)
+  [#1970](https://github.com/carbon-design-system/ibm-products/issues/1970)
+  [#1972](https://github.com/carbon-design-system/ibm-products/issues/1972)
 
-## [1.22.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.8...@carbon/ibm-cloud-cognitive-cdai@1.22.9) (2022-05-03)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
-
-## [1.22.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.7...@carbon/ibm-cloud-cognitive-cdai@1.22.8) (2022-04-26)
+## [1.22.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.8...@carbon/ibm-cloud-cognitive-cdai@1.22.9) (2022-05-03)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [1.22.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.6...@carbon/ibm-cloud-cognitive-cdai@1.22.7) (2022-04-19)
+## [1.22.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.7...@carbon/ibm-cloud-cognitive-cdai@1.22.8) (2022-04-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [1.22.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.5...@carbon/ibm-cloud-cognitive-cdai@1.22.6) (2022-04-05)
+## [1.22.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.6...@carbon/ibm-cloud-cognitive-cdai@1.22.7) (2022-04-19)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
+
+## [1.22.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.5...@carbon/ibm-cloud-cognitive-cdai@1.22.6) (2022-04-05)
 
 ### Bug Fixes
 
 - update Carbon versions to latest
-  ([#1862](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1862))
-  ([c0e8024](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c0e8024cf060cec0262c79628077810a92a56619))
+  ([#1862](https://github.com/carbon-design-system/ibm-products/issues/1862))
+  ([c0e8024](https://github.com/carbon-design-system/ibm-products/commit/c0e8024cf060cec0262c79628077810a92a56619))
 
-## [1.22.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.4...@carbon/ibm-cloud-cognitive-cdai@1.22.5) (2022-03-29)
-
-### Bug Fixes
-
-- update Carbon versions to latest
-  ([#1835](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1835))
-  ([b9152d1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b9152d15813b7feab937092bbbf46439305aab50))
-
-## [1.22.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.3...@carbon/ibm-cloud-cognitive-cdai@1.22.4) (2022-03-22)
+## [1.22.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.4...@carbon/ibm-cloud-cognitive-cdai@1.22.5) (2022-03-29)
 
 ### Bug Fixes
 
 - update Carbon versions to latest
-  ([#1793](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1793))
-  ([9943926](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9943926b5234ce0690417d16483da4caa84790cf)),
+  ([#1835](https://github.com/carbon-design-system/ibm-products/issues/1835))
+  ([b9152d1](https://github.com/carbon-design-system/ibm-products/commit/b9152d15813b7feab937092bbbf46439305aab50))
+
+## [1.22.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.3...@carbon/ibm-cloud-cognitive-cdai@1.22.4) (2022-03-22)
+
+### Bug Fixes
+
+- update Carbon versions to latest
+  ([#1793](https://github.com/carbon-design-system/ibm-products/issues/1793))
+  ([9943926](https://github.com/carbon-design-system/ibm-products/commit/9943926b5234ce0690417d16483da4caa84790cf)),
   closes
-  [#1738](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1738)
-  [#1791](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1791)
-  [#1738](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1738)
-  [#1790](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1790)
+  [#1738](https://github.com/carbon-design-system/ibm-products/issues/1738)
+  [#1791](https://github.com/carbon-design-system/ibm-products/issues/1791)
+  [#1738](https://github.com/carbon-design-system/ibm-products/issues/1738)
+  [#1790](https://github.com/carbon-design-system/ibm-products/issues/1790)
 
-## [1.22.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.2...@carbon/ibm-cloud-cognitive-cdai@1.22.3) (2022-03-08)
+## [1.22.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.2...@carbon/ibm-cloud-cognitive-cdai@1.22.3) (2022-03-08)
 
 ### Bug Fixes
 
 - update Carbon versions to latest
-  ([#1733](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1733))
-  ([9783faa](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9783faac23d8f03598ef0e5994743c4c5f915705))
+  ([#1733](https://github.com/carbon-design-system/ibm-products/issues/1733))
+  ([9783faa](https://github.com/carbon-design-system/ibm-products/commit/9783faac23d8f03598ef0e5994743c4c5f915705))
 
-## [1.22.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.1...@carbon/ibm-cloud-cognitive-cdai@1.22.2) (2022-03-01)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
-
-## [1.22.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.0...@carbon/ibm-cloud-cognitive-cdai@1.22.1) (2022-02-22)
+## [1.22.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.1...@carbon/ibm-cloud-cognitive-cdai@1.22.2) (2022-03-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-# [1.22.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.21.9...@carbon/ibm-cloud-cognitive-cdai@1.22.0) (2022-02-16)
+## [1.22.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.22.0...@carbon/ibm-cloud-cognitive-cdai@1.22.1) (2022-02-22)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
+
+# [1.22.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.21.9...@carbon/ibm-cloud-cognitive-cdai@1.22.0) (2022-02-16)
 
 ### Features
 
 - update Carbon versions to latest
-  ([#1646](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1646))
-  ([e323739](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e323739ac9a6155aa0fddf39b13e4440d04117fc))
+  ([#1646](https://github.com/carbon-design-system/ibm-products/issues/1646))
+  ([e323739](https://github.com/carbon-design-system/ibm-products/commit/e323739ac9a6155aa0fddf39b13e4440d04117fc))
 
-## [1.21.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.21.8...@carbon/ibm-cloud-cognitive-cdai@1.21.9) (2022-02-15)
+## [1.21.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.21.8...@carbon/ibm-cloud-cognitive-cdai@1.21.9) (2022-02-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [1.21.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.21.7...@carbon/ibm-cloud-cognitive-cdai@1.21.8) (2022-02-09)
+## [1.21.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.21.7...@carbon/ibm-cloud-cognitive-cdai@1.21.8) (2022-02-09)
 
 ### Bug Fixes
 
 - update Carbon versions to latest
-  ([#1587](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1587))
-  ([d4b5ccc](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d4b5cccd9ef4a9df2966063c21f49fe7810245a8))
+  ([#1587](https://github.com/carbon-design-system/ibm-products/issues/1587))
+  ([d4b5ccc](https://github.com/carbon-design-system/ibm-products/commit/d4b5cccd9ef4a9df2966063c21f49fe7810245a8))
 - update stylelint to latest version
-  ([#1597](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1597))
-  ([13d8f9e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/13d8f9eb2885e687ba23f66b019a5629fffa2a85))
+  ([#1597](https://github.com/carbon-design-system/ibm-products/issues/1597))
+  ([13d8f9e](https://github.com/carbon-design-system/ibm-products/commit/13d8f9eb2885e687ba23f66b019a5629fffa2a85))
 
-## [1.21.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.21.6...@carbon/ibm-cloud-cognitive-cdai@1.21.7) (2022-02-01)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
-
-## [1.21.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.21.5...@carbon/ibm-cloud-cognitive-cdai@1.21.6) (2022-01-25)
+## [1.21.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.21.6...@carbon/ibm-cloud-cognitive-cdai@1.21.7) (2022-02-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [1.21.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.21.4...@carbon/ibm-cloud-cognitive-cdai@1.21.5) (2022-01-11)
-
-### Bug Fixes
-
-- update Carbon versions and package dependencies to latest
-  ([#1513](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1513))
-  ([505ba0e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/505ba0e13ec58bef19422835fd8ffee87c24e82a))
-- update Carbon versions and package dependencies to latest
-  ([#1518](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1518))
-  ([3ddcdf6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3ddcdf6617e0d7c9f182da91e3eb0935b34cbc05))
-
-## [1.21.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.21.3...@carbon/ibm-cloud-cognitive-cdai@1.21.4) (2021-12-21)
-
-### Bug Fixes
-
-- update Carbon versions and package dependencies to latest
-  ([#1499](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1499))
-  ([8aed3d5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8aed3d53d06cc896984e6847c0450cc647e34041))
-
-## [1.21.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.21.2...@carbon/ibm-cloud-cognitive-cdai@1.21.3) (2021-12-14)
-
-### Bug Fixes
-
-- update Carbon versions and package dependencies to latest
-  ([#1493](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1493))
-  ([91b8238](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/91b82383e0aa74383ebb81f625a9e7b870f06c00))
-
-## [1.21.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.21.1...@carbon/ibm-cloud-cognitive-cdai@1.21.2) (2021-12-07)
-
-### Bug Fixes
-
-- update Carbon versions and package dependencies to latest
-  ([#1491](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1491))
-  ([45f7b77](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/45f7b77f797c5841b9dc15bc3013f31e50244d29))
-
-## [1.21.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.21.0...@carbon/ibm-cloud-cognitive-cdai@1.21.1) (2021-11-30)
+## [1.21.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.21.5...@carbon/ibm-cloud-cognitive-cdai@1.21.6) (2022-01-25)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-# [1.21.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.20.0...@carbon/ibm-cloud-cognitive-cdai@1.21.0) (2021-11-23)
+## [1.21.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.21.4...@carbon/ibm-cloud-cognitive-cdai@1.21.5) (2022-01-11)
+
+### Bug Fixes
+
+- update Carbon versions and package dependencies to latest
+  ([#1513](https://github.com/carbon-design-system/ibm-products/issues/1513))
+  ([505ba0e](https://github.com/carbon-design-system/ibm-products/commit/505ba0e13ec58bef19422835fd8ffee87c24e82a))
+- update Carbon versions and package dependencies to latest
+  ([#1518](https://github.com/carbon-design-system/ibm-products/issues/1518))
+  ([3ddcdf6](https://github.com/carbon-design-system/ibm-products/commit/3ddcdf6617e0d7c9f182da91e3eb0935b34cbc05))
+
+## [1.21.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.21.3...@carbon/ibm-cloud-cognitive-cdai@1.21.4) (2021-12-21)
+
+### Bug Fixes
+
+- update Carbon versions and package dependencies to latest
+  ([#1499](https://github.com/carbon-design-system/ibm-products/issues/1499))
+  ([8aed3d5](https://github.com/carbon-design-system/ibm-products/commit/8aed3d53d06cc896984e6847c0450cc647e34041))
+
+## [1.21.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.21.2...@carbon/ibm-cloud-cognitive-cdai@1.21.3) (2021-12-14)
+
+### Bug Fixes
+
+- update Carbon versions and package dependencies to latest
+  ([#1493](https://github.com/carbon-design-system/ibm-products/issues/1493))
+  ([91b8238](https://github.com/carbon-design-system/ibm-products/commit/91b82383e0aa74383ebb81f625a9e7b870f06c00))
+
+## [1.21.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.21.1...@carbon/ibm-cloud-cognitive-cdai@1.21.2) (2021-12-07)
+
+### Bug Fixes
+
+- update Carbon versions and package dependencies to latest
+  ([#1491](https://github.com/carbon-design-system/ibm-products/issues/1491))
+  ([45f7b77](https://github.com/carbon-design-system/ibm-products/commit/45f7b77f797c5841b9dc15bc3013f31e50244d29))
+
+## [1.21.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.21.0...@carbon/ibm-cloud-cognitive-cdai@1.21.1) (2021-11-30)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
+
+# [1.21.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.20.0...@carbon/ibm-cloud-cognitive-cdai@1.21.0) (2021-11-23)
 
 ### Features
 
 - update Carbon versions and dependencies to latest
-  ([#1465](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1465))
-  ([0c6b37f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0c6b37f5b713c54ec320d9da945fbd3f6b3f91d9))
+  ([#1465](https://github.com/carbon-design-system/ibm-products/issues/1465))
+  ([0c6b37f](https://github.com/carbon-design-system/ibm-products/commit/0c6b37f5b713c54ec320d9da945fbd3f6b3f91d9))
 
-# [1.20.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.19.0...@carbon/ibm-cloud-cognitive-cdai@1.20.0) (2021-11-16)
+# [1.20.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.19.0...@carbon/ibm-cloud-cognitive-cdai@1.20.0) (2021-11-16)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1425](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1425))
-  ([4fd5883](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4fd5883961e0f3fc6be1c87bbe084b2cf6dc5db0)),
+  ([#1425](https://github.com/carbon-design-system/ibm-products/issues/1425))
+  ([4fd5883](https://github.com/carbon-design-system/ibm-products/commit/4fd5883961e0f3fc6be1c87bbe084b2cf6dc5db0)),
   closes
-  [#10000](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/10000)
+  [#10000](https://github.com/carbon-design-system/ibm-products/issues/10000)
 
-# [1.19.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.18.1...@carbon/ibm-cloud-cognitive-cdai@1.19.0) (2021-11-09)
+# [1.19.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.18.1...@carbon/ibm-cloud-cognitive-cdai@1.19.0) (2021-11-09)
 
 ### Bug Fixes
 
 - improve tree-shaking optimisation by importing icons directly from
   @carbons/icons-react
-  ([#1379](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1379))
-  ([9110484](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9110484d7860a95a858a5e1931015b853769c3a9))
+  ([#1379](https://github.com/carbon-design-system/ibm-products/issues/1379))
+  ([9110484](https://github.com/carbon-design-system/ibm-products/commit/9110484d7860a95a858a5e1931015b853769c3a9))
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1365](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1365))
-  ([ea11cf7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ea11cf7ae44b61b48142c511c16460cf7978b88c))
+  ([#1365](https://github.com/carbon-design-system/ibm-products/issues/1365))
+  ([ea11cf7](https://github.com/carbon-design-system/ibm-products/commit/ea11cf7ae44b61b48142c511c16460cf7978b88c))
 
-## [1.18.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.18.0...@carbon/ibm-cloud-cognitive-cdai@1.18.1) (2021-10-27)
+## [1.18.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.18.0...@carbon/ibm-cloud-cognitive-cdai@1.18.1) (2021-10-27)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-# [1.18.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.17.1...@carbon/ibm-cloud-cognitive-cdai@1.18.0) (2021-10-20)
+# [1.18.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.17.1...@carbon/ibm-cloud-cognitive-cdai@1.18.0) (2021-10-20)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1345](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1345))
-  ([3c7e6fe](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3c7e6fedfc46bffc38b889568133ee6c300ddb47))
+  ([#1345](https://github.com/carbon-design-system/ibm-products/issues/1345))
+  ([3c7e6fe](https://github.com/carbon-design-system/ibm-products/commit/3c7e6fedfc46bffc38b889568133ee6c300ddb47))
 
-## [1.17.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.17.0...@carbon/ibm-cloud-cognitive-cdai@1.17.1) (2021-10-14)
+## [1.17.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.17.0...@carbon/ibm-cloud-cognitive-cdai@1.17.1) (2021-10-14)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-# [1.17.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.16.0...@carbon/ibm-cloud-cognitive-cdai@1.17.0) (2021-10-14)
+# [1.17.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.16.0...@carbon/ibm-cloud-cognitive-cdai@1.17.0) (2021-10-14)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1329](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1329))
-  ([fd3525e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fd3525ec3620b70ff19f85c300e7e0bb05577cd1))
+  ([#1329](https://github.com/carbon-design-system/ibm-products/issues/1329))
+  ([fd3525e](https://github.com/carbon-design-system/ibm-products/commit/fd3525ec3620b70ff19f85c300e7e0bb05577cd1))
 
-# [1.16.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.15.0...@carbon/ibm-cloud-cognitive-cdai@1.16.0) (2021-10-07)
-
-### Features
-
-- update Carbon versions and package dependencies to latest
-  ([#1309](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1309))
-  ([945bd3b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/945bd3ba5608078e961af9a04448f2abd7e7fc5e))
-
-# [1.15.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.14.0...@carbon/ibm-cloud-cognitive-cdai@1.15.0) (2021-10-02)
+# [1.16.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.15.0...@carbon/ibm-cloud-cognitive-cdai@1.16.0) (2021-10-07)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1296](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1296))
-  ([f1da0bd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f1da0bd9192c4d999032df0dbe20d67b6ece89b0))
+  ([#1309](https://github.com/carbon-design-system/ibm-products/issues/1309))
+  ([945bd3b](https://github.com/carbon-design-system/ibm-products/commit/945bd3ba5608078e961af9a04448f2abd7e7fc5e))
 
-# [1.14.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.13.0...@carbon/ibm-cloud-cognitive-cdai@1.14.0) (2021-09-23)
+# [1.15.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.14.0...@carbon/ibm-cloud-cognitive-cdai@1.15.0) (2021-10-02)
+
+### Features
+
+- update Carbon versions and package dependencies to latest
+  ([#1296](https://github.com/carbon-design-system/ibm-products/issues/1296))
+  ([f1da0bd](https://github.com/carbon-design-system/ibm-products/commit/f1da0bd9192c4d999032df0dbe20d67b6ece89b0))
+
+# [1.14.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.13.0...@carbon/ibm-cloud-cognitive-cdai@1.14.0) (2021-09-23)
 
 ### Features
 
 - update Carbon versions and dependencies to latest
-  ([#1282](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1282))
-  ([b1451cf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b1451cf5c91b75c1bd4e55ae2bdb47f025f33163))
+  ([#1282](https://github.com/carbon-design-system/ibm-products/issues/1282))
+  ([b1451cf](https://github.com/carbon-design-system/ibm-products/commit/b1451cf5c91b75c1bd4e55ae2bdb47f025f33163))
 
-# [1.13.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.12.0...@carbon/ibm-cloud-cognitive-cdai@1.13.0) (2021-09-21)
+# [1.13.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.12.0...@carbon/ibm-cloud-cognitive-cdai@1.13.0) (2021-09-21)
 
 ### Features
 
 - ensure prettier linting causes ci-check to fail
-  ([#1273](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1273))
-  ([ad6f347](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ad6f3479636d2b80b26338d9059429b4ae08ac6e))
+  ([#1273](https://github.com/carbon-design-system/ibm-products/issues/1273))
+  ([ad6f347](https://github.com/carbon-design-system/ibm-products/commit/ad6f3479636d2b80b26338d9059429b4ae08ac6e))
 - update Carbon versions and package dependencies to latest
-  ([#1262](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1262))
-  ([ed4dcbe](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ed4dcbe5b6d92baa6ec39240bda6996ec55f7bc4))
+  ([#1262](https://github.com/carbon-design-system/ibm-products/issues/1262))
+  ([ed4dcbe](https://github.com/carbon-design-system/ibm-products/commit/ed4dcbe5b6d92baa6ec39240bda6996ec55f7bc4))
 
-# [1.12.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.11.1...@carbon/ibm-cloud-cognitive-cdai@1.12.0) (2021-09-13)
+# [1.12.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.11.1...@carbon/ibm-cloud-cognitive-cdai@1.12.0) (2021-09-13)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1228](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1228))
-  ([4f5e24c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4f5e24cd3a36e7fa9a5cd62d1cafe75a090cf32e))
+  ([#1228](https://github.com/carbon-design-system/ibm-products/issues/1228))
+  ([4f5e24c](https://github.com/carbon-design-system/ibm-products/commit/4f5e24cd3a36e7fa9a5cd62d1cafe75a090cf32e))
 
-## [1.11.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.11.0...@carbon/ibm-cloud-cognitive-cdai@1.11.1) (2021-08-27)
+## [1.11.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.11.0...@carbon/ibm-cloud-cognitive-cdai@1.11.1) (2021-08-27)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-# [1.11.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.10.1...@carbon/ibm-cloud-cognitive-cdai@1.11.0) (2021-08-19)
+# [1.11.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.10.1...@carbon/ibm-cloud-cognitive-cdai@1.11.0) (2021-08-19)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#1168](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1168))
-  ([674017f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/674017fabc13a7737c0d16deb04ffa9872d76fe6))
+  ([#1168](https://github.com/carbon-design-system/ibm-products/issues/1168))
+  ([674017f](https://github.com/carbon-design-system/ibm-products/commit/674017fabc13a7737c0d16deb04ffa9872d76fe6))
 
-## [1.10.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.10.0...@carbon/ibm-cloud-cognitive-cdai@1.10.1) (2021-08-18)
+## [1.10.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.10.0...@carbon/ibm-cloud-cognitive-cdai@1.10.1) (2021-08-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-# [1.10.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.9.0...@carbon/ibm-cloud-cognitive-cdai@1.10.0) (2021-08-11)
+# [1.10.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.9.0...@carbon/ibm-cloud-cognitive-cdai@1.10.0) (2021-08-11)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1133](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1133))
-  ([4dfae1a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4dfae1a9b27f5676d0bde570e2c9ee9ce8550b52))
+  ([#1133](https://github.com/carbon-design-system/ibm-products/issues/1133))
+  ([4dfae1a](https://github.com/carbon-design-system/ibm-products/commit/4dfae1a9b27f5676d0bde570e2c9ee9ce8550b52))
 
-# [1.9.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.8.0...@carbon/ibm-cloud-cognitive-cdai@1.9.0) (2021-08-10)
-
-### Features
-
-- update Carbon versions and dependencies
-  ([#1110](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1110))
-  ([b41f433](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b41f4331e31cbd9e41d2364b24e6ef50c7fd2d8d))
-
-# [1.8.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.7.0...@carbon/ibm-cloud-cognitive-cdai@1.8.0) (2021-07-28)
+# [1.9.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.8.0...@carbon/ibm-cloud-cognitive-cdai@1.9.0) (2021-08-10)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#1084](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1084))
-  ([3735ead](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3735ead9a96450015ec7aeafdb25deaa93d49aaa))
+  ([#1110](https://github.com/carbon-design-system/ibm-products/issues/1110))
+  ([b41f433](https://github.com/carbon-design-system/ibm-products/commit/b41f4331e31cbd9e41d2364b24e6ef50c7fd2d8d))
 
-# [1.7.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.6.0...@carbon/ibm-cloud-cognitive-cdai@1.7.0) (2021-07-21)
+# [1.8.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.7.0...@carbon/ibm-cloud-cognitive-cdai@1.8.0) (2021-07-28)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#1037](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1037))
-  ([8c5937a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8c5937a865d3a0cfbaf33b9eca13c4d3b4c1365d))
+  ([#1084](https://github.com/carbon-design-system/ibm-products/issues/1084))
+  ([3735ead](https://github.com/carbon-design-system/ibm-products/commit/3735ead9a96450015ec7aeafdb25deaa93d49aaa))
 
-# [1.6.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.5.0...@carbon/ibm-cloud-cognitive-cdai@1.6.0) (2021-07-14)
+# [1.7.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.6.0...@carbon/ibm-cloud-cognitive-cdai@1.7.0) (2021-07-21)
+
+### Features
+
+- update Carbon versions and dependencies
+  ([#1037](https://github.com/carbon-design-system/ibm-products/issues/1037))
+  ([8c5937a](https://github.com/carbon-design-system/ibm-products/commit/8c5937a865d3a0cfbaf33b9eca13c4d3b4c1365d))
+
+# [1.6.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.5.0...@carbon/ibm-cloud-cognitive-cdai@1.6.0) (2021-07-14)
 
 ### Features
 
 - update Carbon versions and package dependencies
-  ([#994](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/994))
-  ([2ab4845](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2ab4845511573b999d41fcf77e6d412e0d446b9d))
+  ([#994](https://github.com/carbon-design-system/ibm-products/issues/994))
+  ([2ab4845](https://github.com/carbon-design-system/ibm-products/commit/2ab4845511573b999d41fcf77e6d412e0d446b9d))
 
-# [1.5.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.4.2...@carbon/ibm-cloud-cognitive-cdai@1.5.0) (2021-07-07)
-
-### Features
-
-- update Carbon versions and dependencies
-  ([#974](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/974))
-  ([555509b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/555509b5ccb147ed0d794b5816f685aa8f7ae451))
-
-## [1.4.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.4.1...@carbon/ibm-cloud-cognitive-cdai@1.4.2) (2021-07-06)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
-
-## [1.4.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.4.0...@carbon/ibm-cloud-cognitive-cdai@1.4.1) (2021-06-30)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
-
-# [1.4.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.3.3...@carbon/ibm-cloud-cognitive-cdai@1.4.0) (2021-06-23)
+# [1.5.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.4.2...@carbon/ibm-cloud-cognitive-cdai@1.5.0) (2021-07-07)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#927](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/927))
-  ([5a8f7d6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5a8f7d6b81b6da26fd0cb933c1c3de4bd27b481b))
+  ([#974](https://github.com/carbon-design-system/ibm-products/issues/974))
+  ([555509b](https://github.com/carbon-design-system/ibm-products/commit/555509b5ccb147ed0d794b5816f685aa8f7ae451))
 
-## [1.3.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.3.2...@carbon/ibm-cloud-cognitive-cdai@1.3.3) (2021-06-17)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
-
-## [1.3.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.3.1...@carbon/ibm-cloud-cognitive-cdai@1.3.2) (2021-06-10)
+## [1.4.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.4.1...@carbon/ibm-cloud-cognitive-cdai@1.4.2) (2021-07-06)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [1.3.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.3.0...@carbon/ibm-cloud-cognitive-cdai@1.3.1) (2021-06-09)
+## [1.4.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.4.0...@carbon/ibm-cloud-cognitive-cdai@1.4.1) (2021-06-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-# [1.3.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.2.9...@carbon/ibm-cloud-cognitive-cdai@1.3.0) (2021-06-09)
+# [1.4.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.3.3...@carbon/ibm-cloud-cognitive-cdai@1.4.0) (2021-06-23)
+
+### Features
+
+- update Carbon versions and dependencies
+  ([#927](https://github.com/carbon-design-system/ibm-products/issues/927))
+  ([5a8f7d6](https://github.com/carbon-design-system/ibm-products/commit/5a8f7d6b81b6da26fd0cb933c1c3de4bd27b481b))
+
+## [1.3.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.3.2...@carbon/ibm-cloud-cognitive-cdai@1.3.3) (2021-06-17)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
+
+## [1.3.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.3.1...@carbon/ibm-cloud-cognitive-cdai@1.3.2) (2021-06-10)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
+
+## [1.3.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.3.0...@carbon/ibm-cloud-cognitive-cdai@1.3.1) (2021-06-09)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
+
+# [1.3.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.2.9...@carbon/ibm-cloud-cognitive-cdai@1.3.0) (2021-06-09)
 
 ### Features
 
 - match Carbon peer deps for react
-  ([#869](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/869))
-  ([8f42118](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8f42118754a904554acee9ec3af2e1fae8143817))
+  ([#869](https://github.com/carbon-design-system/ibm-products/issues/869))
+  ([8f42118](https://github.com/carbon-design-system/ibm-products/commit/8f42118754a904554acee9ec3af2e1fae8143817))
 
-## [1.2.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.2.8...@carbon/ibm-cloud-cognitive-cdai@1.2.9) (2021-06-07)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
-
-## [1.2.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.2.7...@carbon/ibm-cloud-cognitive-cdai@1.2.8) (2021-06-04)
+## [1.2.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.2.8...@carbon/ibm-cloud-cognitive-cdai@1.2.9) (2021-06-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [1.2.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.2.6...@carbon/ibm-cloud-cognitive-cdai@1.2.7) (2021-06-03)
+## [1.2.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.2.7...@carbon/ibm-cloud-cognitive-cdai@1.2.8) (2021-06-04)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
+
+## [1.2.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.2.6...@carbon/ibm-cloud-cognitive-cdai@1.2.7) (2021-06-03)
 
 ### Bug Fixes
 
 - add fallback selector for focus trap
-  ([#853](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/853))
-  ([59b23f4](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/59b23f41073fa58534202fadd3e98fbc42b248a4))
+  ([#853](https://github.com/carbon-design-system/ibm-products/issues/853))
+  ([59b23f4](https://github.com/carbon-design-system/ibm-products/commit/59b23f41073fa58534202fadd3e98fbc42b248a4))
 
-## [1.2.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.2.5...@carbon/ibm-cloud-cognitive-cdai@1.2.6) (2021-05-28)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
-
-## [1.2.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.2.4...@carbon/ibm-cloud-cognitive-cdai@1.2.5) (2021-05-27)
+## [1.2.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.2.5...@carbon/ibm-cloud-cognitive-cdai@1.2.6) (2021-05-28)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [1.2.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.2.3...@carbon/ibm-cloud-cognitive-cdai@1.2.4) (2021-05-26)
+## [1.2.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.2.4...@carbon/ibm-cloud-cognitive-cdai@1.2.5) (2021-05-27)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [1.2.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.2.2...@carbon/ibm-cloud-cognitive-cdai@1.2.3) (2021-05-26)
+## [1.2.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.2.3...@carbon/ibm-cloud-cognitive-cdai@1.2.4) (2021-05-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [1.2.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.2.1...@carbon/ibm-cloud-cognitive-cdai@1.2.2) (2021-05-10)
+## [1.2.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.2.2...@carbon/ibm-cloud-cognitive-cdai@1.2.3) (2021-05-26)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
+
+## [1.2.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.2.1...@carbon/ibm-cloud-cognitive-cdai@1.2.2) (2021-05-10)
 
 ### Bug Fixes
 
 - ide filter close buttons, expose new props
-  ([#720](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/720))
-  ([83dd53d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/83dd53d4e22b1b3aeef6878eb2cec6ab8806ea5e))
+  ([#720](https://github.com/carbon-design-system/ibm-products/issues/720))
+  ([83dd53d](https://github.com/carbon-design-system/ibm-products/commit/83dd53d4e22b1b3aeef6878eb2cec6ab8806ea5e))
 
-## [1.2.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.1.8...@carbon/ibm-cloud-cognitive-cdai@1.2.1) (2021-05-06)
+## [1.2.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.1.8...@carbon/ibm-cloud-cognitive-cdai@1.2.1) (2021-05-06)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [1.1.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.1.7...@carbon/ibm-cloud-cognitive-cdai@1.1.8) (2021-04-26)
+## [1.1.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.1.7...@carbon/ibm-cloud-cognitive-cdai@1.1.8) (2021-04-26)
 
 ### Bug Fixes
 
 - increase specificity
-  ([#655](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/655))
-  ([5181532](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/518153282a9016cf8106d05b169acbd6dfd5e6ae))
+  ([#655](https://github.com/carbon-design-system/ibm-products/issues/655))
+  ([5181532](https://github.com/carbon-design-system/ibm-products/commit/518153282a9016cf8106d05b169acbd6dfd5e6ae))
 
-## [1.1.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.1.6...@carbon/ibm-cloud-cognitive-cdai@1.1.7) (2021-04-15)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
-
-## [1.1.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.1.5...@carbon/ibm-cloud-cognitive-cdai@1.1.6) (2021-04-09)
+## [1.1.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.1.6...@carbon/ibm-cloud-cognitive-cdai@1.1.7) (2021-04-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [1.1.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.1.4...@carbon/ibm-cloud-cognitive-cdai@1.1.5) (2021-03-26)
+## [1.1.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.1.5...@carbon/ibm-cloud-cognitive-cdai@1.1.6) (2021-04-09)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
+
+## [1.1.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.1.4...@carbon/ibm-cloud-cognitive-cdai@1.1.5) (2021-03-26)
 
 ### Bug Fixes
 
 - ideStoryError
-  ([#529](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/529))
-  ([cd0c428](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/cd0c428df5a8ebfdaab8dc7b898118365e435089))
+  ([#529](https://github.com/carbon-design-system/ibm-products/issues/529))
+  ([cd0c428](https://github.com/carbon-design-system/ibm-products/commit/cd0c428df5a8ebfdaab8dc7b898118365e435089))
 
-## [1.1.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.1.3...@carbon/ibm-cloud-cognitive-cdai@1.1.4) (2021-03-19)
+## [1.1.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.1.3...@carbon/ibm-cloud-cognitive-cdai@1.1.4) (2021-03-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [1.1.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.1.2...@carbon/ibm-cloud-cognitive-cdai@1.1.3) (2021-03-18)
+## [1.1.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.1.2...@carbon/ibm-cloud-cognitive-cdai@1.1.3) (2021-03-18)
 
 ### Bug Fixes
 
 - linter warnings for CDAI
-  ([#474](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/474))
-  ([6a79fdb](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6a79fdbafa211ec1fee7fc95f3613801bfd55086))
+  ([#474](https://github.com/carbon-design-system/ibm-products/issues/474))
+  ([6a79fdb](https://github.com/carbon-design-system/ibm-products/commit/6a79fdbafa211ec1fee7fc95f3613801bfd55086))
 
-## [1.1.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.1.1...@carbon/ibm-cloud-cognitive-cdai@1.1.2) (2021-02-25)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
-
-## [1.1.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.1.0...@carbon/ibm-cloud-cognitive-cdai@1.1.1) (2021-02-17)
+## [1.1.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.1.1...@carbon/ibm-cloud-cognitive-cdai@1.1.2) (2021-02-25)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-# [1.1.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.0.4...@carbon/ibm-cloud-cognitive-cdai@1.1.0) (2021-01-28)
+## [1.1.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.1.0...@carbon/ibm-cloud-cognitive-cdai@1.1.1) (2021-02-17)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
+
+# [1.1.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.0.4...@carbon/ibm-cloud-cognitive-cdai@1.1.0) (2021-01-28)
 
 ### Features
 
 - update carbon to 10-27
-  ([#311](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/311))
-  ([b7569b8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b7569b8e3a339b8886175ed224164030e036b36c))
+  ([#311](https://github.com/carbon-design-system/ibm-products/issues/311))
+  ([b7569b8](https://github.com/carbon-design-system/ibm-products/commit/b7569b8e3a339b8886175ed224164030e036b36c))
 
-## [1.0.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.0.3...@carbon/ibm-cloud-cognitive-cdai@1.0.4) (2021-01-20)
+## [1.0.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.0.3...@carbon/ibm-cloud-cognitive-cdai@1.0.4) (2021-01-20)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [1.0.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.0.2...@carbon/ibm-cloud-cognitive-cdai@1.0.3) (2021-01-07)
+## [1.0.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.0.2...@carbon/ibm-cloud-cognitive-cdai@1.0.3) (2021-01-07)
 
 ### Bug Fixes
 
 - increase zindex in header
-  ([#287](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/287))
-  ([c4b70c9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c4b70c94735f6a5e8edbda2dc81ab6c0cda05aed))
+  ([#287](https://github.com/carbon-design-system/ibm-products/issues/287))
+  ([c4b70c9](https://github.com/carbon-design-system/ibm-products/commit/c4b70c94735f6a5e8edbda2dc81ab6c0cda05aed))
 
-## [1.0.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@1.0.1...@carbon/ibm-cloud-cognitive-cdai@1.0.2) (2021-01-05)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
-
-## [1.0.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@0.5.7...@carbon/ibm-cloud-cognitive-cdai@1.0.1) (2020-12-18)
+## [1.0.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@1.0.1...@carbon/ibm-cloud-cognitive-cdai@1.0.2) (2021-01-05)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [0.5.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@0.5.6...@carbon/ibm-cloud-cognitive-cdai@0.5.7) (2020-12-17)
+## [1.0.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@0.5.7...@carbon/ibm-cloud-cognitive-cdai@1.0.1) (2020-12-18)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
+
+## [0.5.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@0.5.6...@carbon/ibm-cloud-cognitive-cdai@0.5.7) (2020-12-17)
 
 ### Bug Fixes
 
 - migrate focus trap fix for slideover
-  ([#285](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/285))
-  ([8a29cce](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8a29cce724f4c47e702d3406f4afa43d50edaf2b))
+  ([#285](https://github.com/carbon-design-system/ibm-products/issues/285))
+  ([8a29cce](https://github.com/carbon-design-system/ibm-products/commit/8a29cce724f4c47e702d3406f4afa43d50edaf2b))
 
-## [0.5.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@0.5.5...@carbon/ibm-cloud-cognitive-cdai@0.5.6) (2020-12-16)
+## [0.5.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@0.5.5...@carbon/ibm-cloud-cognitive-cdai@0.5.6) (2020-12-16)
 
 ### Bug Fixes
 
 - move to peerDependencies
-  ([#281](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/281))
-  ([8c1a108](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8c1a1082181078058d52ceb23892b616a1f61b08))
+  ([#281](https://github.com/carbon-design-system/ibm-products/issues/281))
+  ([8c1a108](https://github.com/carbon-design-system/ibm-products/commit/8c1a1082181078058d52ceb23892b616a1f61b08))
 
-## [0.5.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@0.5.4...@carbon/ibm-cloud-cognitive-cdai@0.5.5) (2020-12-15)
+## [0.5.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@0.5.4...@carbon/ibm-cloud-cognitive-cdai@0.5.5) (2020-12-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [0.5.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@0.5.3...@carbon/ibm-cloud-cognitive-cdai@0.5.4) (2020-12-11)
+## [0.5.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@0.5.3...@carbon/ibm-cloud-cognitive-cdai@0.5.4) (2020-12-11)
 
 ### Bug Fixes
 
 - missing tilde in import
-  ([#274](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/274))
-  ([155812a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/155812a1678aa36043431cd44ae14aaec7b8d029))
+  ([#274](https://github.com/carbon-design-system/ibm-products/issues/274))
+  ([155812a](https://github.com/carbon-design-system/ibm-products/commit/155812a1678aa36043431cd44ae14aaec7b8d029))
 
-## [0.5.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@0.5.2...@carbon/ibm-cloud-cognitive-cdai@0.5.3) (2020-12-11)
+## [0.5.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@0.5.2...@carbon/ibm-cloud-cognitive-cdai@0.5.3) (2020-12-11)
 
 ### Bug Fixes
 
 - missing grid scss
-  ([#273](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/273))
-  ([edc1acd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/edc1acd123758ce071b252a7252a17b4ab8a6154))
+  ([#273](https://github.com/carbon-design-system/ibm-products/issues/273))
+  ([edc1acd](https://github.com/carbon-design-system/ibm-products/commit/edc1acd123758ce071b252a7252a17b4ab8a6154))
 
-## [0.5.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@0.5.1...@carbon/ibm-cloud-cognitive-cdai@0.5.2) (2020-12-09)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
-
-## [0.5.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@0.5.0...@carbon/ibm-cloud-cognitive-cdai@0.5.1) (2020-12-09)
+## [0.5.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@0.5.1...@carbon/ibm-cloud-cognitive-cdai@0.5.2) (2020-12-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-# [0.5.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@0.4.6...@carbon/ibm-cloud-cognitive-cdai@0.5.0) (2020-12-01)
+## [0.5.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@0.5.0...@carbon/ibm-cloud-cognitive-cdai@0.5.1) (2020-12-09)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
+
+# [0.5.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@0.4.6...@carbon/ibm-cloud-cognitive-cdai@0.5.0) (2020-12-01)
 
 ### Features
 
 - **lang:** <IdeImporting> hides the file drop area after uploading
-  ([#248](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/248))
-  ([c90a47b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c90a47bb9d24d25c3209fb3783dae6f86823f6f4))
+  ([#248](https://github.com/carbon-design-system/ibm-products/issues/248))
+  ([c90a47b](https://github.com/carbon-design-system/ibm-products/commit/c90a47bb9d24d25c3209fb3783dae6f86823f6f4))
 
-## [0.4.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-cdai@0.4.5...@carbon/ibm-cloud-cognitive-cdai@0.4.6) (2020-11-30)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
-
-## [0.4.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/compare/@carbon/ibm-cloud-cognitive-cdai@0.4.4...@carbon/ibm-cloud-cognitive-cdai@0.4.5) (2020-11-27)
+## [0.4.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-cdai@0.4.5...@carbon/ibm-cloud-cognitive-cdai@0.4.6) (2020-11-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [0.4.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/compare/@carbon/ibm-cloud-cognitive-cdai@0.4.3...@carbon/ibm-cloud-cognitive-cdai@0.4.4) (2020-11-25)
+## [0.4.5](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/compare/@carbon/ibm-cloud-cognitive-cdai@0.4.4...@carbon/ibm-cloud-cognitive-cdai@0.4.5) (2020-11-27)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
+
+## [0.4.4](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/compare/@carbon/ibm-cloud-cognitive-cdai@0.4.3...@carbon/ibm-cloud-cognitive-cdai@0.4.4) (2020-11-25)
 
 ### Bug Fixes
 
 - use tilde for node_module imports 2
-  ([#232](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/issues/232))
-  ([6ace505](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/commit/6ace505c18b6d722a80b64e815a6a2fed989a788))
+  ([#232](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/issues/232))
+  ([6ace505](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/commit/6ace505c18b6d722a80b64e815a6a2fed989a788))
 
-## [0.4.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/compare/@carbon/ibm-cloud-cognitive-cdai@0.4.2...@carbon/ibm-cloud-cognitive-cdai@0.4.3) (2020-11-24)
+## [0.4.3](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/compare/@carbon/ibm-cloud-cognitive-cdai@0.4.2...@carbon/ibm-cloud-cognitive-cdai@0.4.3) (2020-11-24)
 
 ### Bug Fixes
 
 - use tilde for node_module imports
-  ([#231](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/issues/231))
-  ([06a33de](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/commit/06a33de8a429404995b534283c49ae6670f13cc1))
+  ([#231](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/issues/231))
+  ([06a33de](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/commit/06a33de8a429404995b534283c49ae6670f13cc1))
 
-## [0.4.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/compare/@carbon/ibm-cloud-cognitive-cdai@0.4.1...@carbon/ibm-cloud-cognitive-cdai@0.4.2) (2020-11-23)
+## [0.4.2](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/compare/@carbon/ibm-cloud-cognitive-cdai@0.4.1...@carbon/ibm-cloud-cognitive-cdai@0.4.2) (2020-11-23)
 
 ### Bug Fixes
 
 - updates deps for cdai
-  ([#227](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/issues/227))
-  ([380b707](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/commit/380b707c748bc6565b95708b9a32eaa3adf53cda))
+  ([#227](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/issues/227))
+  ([380b707](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/commit/380b707c748bc6565b95708b9a32eaa3adf53cda))
 
-## [0.4.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/compare/@carbon/ibm-cloud-cognitive-cdai@0.3.0...@carbon/ibm-cloud-cognitive-cdai@0.4.1) (2020-11-23)
+## [0.4.1](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/compare/@carbon/ibm-cloud-cognitive-cdai@0.3.0...@carbon/ibm-cloud-cognitive-cdai@0.4.1) (2020-11-23)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-# [0.3.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/compare/@carbon/ibm-cloud-cognitive-cdai@0.2.0...@carbon/ibm-cloud-cognitive-cdai@0.3.0) (2020-11-23)
+# [0.3.0](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/compare/@carbon/ibm-cloud-cognitive-cdai@0.2.0...@carbon/ibm-cloud-cognitive-cdai@0.3.0) (2020-11-23)
 
 ### Features
 
 - add cdai apikey component
-  ([#223](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/issues/223))
-  ([4c09f15](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/commit/4c09f15c3c62c3965d98c91b9695fa7a1cba8f0b))
+  ([#223](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/issues/223))
+  ([4c09f15](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/commit/4c09f15c3c62c3965d98c91b9695fa7a1cba8f0b))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.2.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/compare/@carbon/ibm-cloud-cognitive-cdai@0.1.3...@carbon/ibm-cloud-cognitive-cdai@0.2.0) (2020-11-17)
+# [0.2.0](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/compare/@carbon/ibm-cloud-cognitive-cdai@0.1.3...@carbon/ibm-cloud-cognitive-cdai@0.2.0) (2020-11-17)
 
 ### Features
 
 - update to carbon 10.24.0
-  ([#217](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/issues/217))
-  ([76839f3](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/commit/76839f36eca23132559c47f61d9efa0cfcd8414d))
+  ([#217](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/issues/217))
+  ([76839f3](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/commit/76839f36eca23132559c47f61d9efa0cfcd8414d))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.1.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/compare/@carbon/ibm-cloud-cognitive-cdai@0.1.2...@carbon/ibm-cloud-cognitive-cdai@0.1.3) (2020-11-17)
+## [0.1.3](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/compare/@carbon/ibm-cloud-cognitive-cdai@0.1.2...@carbon/ibm-cloud-cognitive-cdai@0.1.3) (2020-11-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [0.1.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/compare/@carbon/ibm-cloud-cognitive-cdai@0.1.1...@carbon/ibm-cloud-cognitive-cdai@0.1.2) (2020-11-17)
+## [0.1.2](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/compare/@carbon/ibm-cloud-cognitive-cdai@0.1.1...@carbon/ibm-cloud-cognitive-cdai@0.1.2) (2020-11-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-cdai
 
-## [0.1.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/compare/@carbon/ibm-cloud-cognitive-cdai@0.1.0...@carbon/ibm-cloud-cognitive-cdai@0.1.1) (2020-11-13)
+## [0.1.1](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/compare/@carbon/ibm-cloud-cognitive-cdai@0.1.0...@carbon/ibm-cloud-cognitive-cdai@0.1.1) (2020-11-13)
 
 ### Bug Fixes
 
 - update readmes
-  ([#206](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/issues/206))
-  ([9b26eb6](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/commit/9b26eb6188984ba68a4e9e839328e2d219f49e71))
+  ([#206](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/issues/206))
+  ([9b26eb6](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/commit/9b26eb6188984ba68a4e9e839328e2d219f49e71))
 
 # Change Log
 
@@ -793,26 +793,26 @@ All notable changes to this project will be documented in this file. See
 ### Bug Fixes
 
 - build copying stories prevents storybook
-  ([#129](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/issues/129))
-  ([0e48a56](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/commit/0e48a5611080746bc121a2308a6b14bd4c402bc4))
+  ([#129](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/issues/129))
+  ([0e48a56](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/commit/0e48a5611080746bc121a2308a6b14bd4c402bc4))
 
 ### Features
 
 - add IdeButton
-  ([#114](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/issues/114))
-  ([48bed50](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/commit/48bed505ecdb5cef905ace39c77c7dda7ffa8b30))
+  ([#114](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/issues/114))
+  ([48bed50](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/commit/48bed505ecdb5cef905ace39c77c7dda7ffa8b30))
 - add saving component
-  ([#162](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/issues/162))
-  ([17ee5ba](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/commit/17ee5ba28036d8b7177b69a217110b3f368a6c2e))
+  ([#162](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/issues/162))
+  ([17ee5ba](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/commit/17ee5ba28036d8b7177b69a217110b3f368a6c2e))
 - ide-create
-  ([#195](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/issues/195))
-  ([c762592](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/commit/c7625928c8e2eec030e4c549b2a4691714c552a5))
+  ([#195](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/issues/195))
+  ([c762592](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/commit/c7625928c8e2eec030e4c549b2a4691714c552a5))
 - ide-remove
-  ([#186](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/issues/186))
-  ([fa980af](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/commit/fa980afc326172ad9cbaa1815e5b614cc291d7a3))
+  ([#186](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/issues/186))
+  ([fa980af](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/commit/fa980afc326172ad9cbaa1815e5b614cc291d7a3))
 - **cdai:** add build setup
-  ([#127](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/issues/127))
-  ([ce526f2](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/commit/ce526f245d54d0898e5a744eae10d5072c64b7de))
+  ([#127](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/issues/127))
+  ([ce526f2](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/commit/ce526f245d54d0898e5a744eae10d5072c64b7de))
 - use latest carbon token linter
-  ([#128](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/issues/128))
-  ([d3617fc](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai/commit/d3617fc85e916068169c696abd92565f6f203685))
+  ([#128](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/issues/128))
+  ([d3617fc](https://github.com/carbon-design-system/ibm-products/tree/master/packages/cdai/commit/d3617fc85e916068169c696abd92565f6f203685))

--- a/packages/cdai/README.md
+++ b/packages/cdai/README.md
@@ -23,7 +23,7 @@ yarn add @carbon/ibm-cloud-cognitive-cdai
 We're always looking for contributors to help us fix bugs, build new features,
 or help us improve the project documentation. If you're interested, definitely
 check out our
-[Contributing Guide](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/.github/CONTRIBUTING.md)
+[Contributing Guide](https://github.com/carbon-design-system/ibm-products/blob/master/.github/CONTRIBUTING.md)
 and
 [Carbon's Developer Handbook](https://github.com/carbon-design-system/carbon/blob/master/docs/developer-handbook.md)!
 👀
@@ -31,4 +31,4 @@ and
 ## 📝 License
 
 Licensed under the
-[Apache-2.0 License](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/LICENSE).
+[Apache-2.0 License](https://github.com/carbon-design-system/ibm-products/blob/master/LICENSE).

--- a/packages/cdai/package.json
+++ b/packages/cdai/package.json
@@ -7,7 +7,7 @@
   "module": "es/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "url": "https://github.com/carbon-design-system/ibm-products.git",
     "directory": "packages/cdai"
   },
   "bugs": "https://github.com/carbon-design-system/ibm-products/issues",

--- a/packages/cdai/package.json
+++ b/packages/cdai/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
     "directory": "packages/cdai"
   },
-  "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
+  "bugs": "https://github.com/carbon-design-system/ibm-products/issues",
   "files": [
     "es",
     "lib",

--- a/packages/cloud-cognitive/CHANGELOG.md
+++ b/packages/cloud-cognitive/CHANGELOG.md
@@ -3,208 +3,208 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.53.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.53.0...@carbon/ibm-products@1.53.1) (2023-05-11)
+## [1.53.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.53.0...@carbon/ibm-products@1.53.1) (2023-05-11)
 
 
 ### Bug Fixes
 
-* add missing dependency ([#2954](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2954)) ([1375c1a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1375c1a0e5fc176332ba64875f5e475cf819493c))
+* add missing dependency ([#2954](https://github.com/carbon-design-system/ibm-products/issues/2954)) ([1375c1a](https://github.com/carbon-design-system/ibm-products/commit/1375c1a0e5fc176332ba64875f5e475cf819493c))
 
 
 
 
 
-# [1.53.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.52.0...@carbon/ibm-products@1.53.0) (2023-05-09)
+# [1.53.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.52.0...@carbon/ibm-products@1.53.0) (2023-05-09)
 
 
 ### Features
 
-* **datagrid:** adds table of contents links for extensions ([#2956](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2956)) ([e81c478](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e81c4781c1581386f3fbbb52625178d9db03f91b))
+* **datagrid:** adds table of contents links for extensions ([#2956](https://github.com/carbon-design-system/ibm-products/issues/2956)) ([e81c478](https://github.com/carbon-design-system/ibm-products/commit/e81c4781c1581386f3fbbb52625178d9db03f91b))
 
 
 
 
 
-# [1.52.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.51.0...@carbon/ibm-products@1.52.0) (2023-05-04)
+# [1.52.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.51.0...@carbon/ibm-products@1.52.0) (2023-05-04)
 
 
 ### Bug Fixes
 
-* additional coverage testing for data spreadsheet ([#2769](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2769)) ([5959308](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/595930810ef45181a0fe13ee486b40aad490d568))
-* make deprecated component log only on use ([#2944](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2944)) ([220d700](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/220d700d96348944cd8987db7dce1747fc91cec1))
-* **nonlinear:** update styling ([#2907](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2907)) ([6fdaac3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6fdaac394eae9d298e116002a35e0ea26c326a81))
+* additional coverage testing for data spreadsheet ([#2769](https://github.com/carbon-design-system/ibm-products/issues/2769)) ([5959308](https://github.com/carbon-design-system/ibm-products/commit/595930810ef45181a0fe13ee486b40aad490d568))
+* make deprecated component log only on use ([#2944](https://github.com/carbon-design-system/ibm-products/issues/2944)) ([220d700](https://github.com/carbon-design-system/ibm-products/commit/220d700d96348944cd8987db7dce1747fc91cec1))
+* **nonlinear:** update styling ([#2907](https://github.com/carbon-design-system/ibm-products/issues/2907)) ([6fdaac3](https://github.com/carbon-design-system/ibm-products/commit/6fdaac394eae9d298e116002a35e0ea26c326a81))
 
 
 ### Features
 
-* **Datagrid:** add feature flag to select hooks until fully released ([#2937](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2937)) ([387b593](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/387b5938ebd469708dae997d5d4701ebb1215edb))
-* feature flagging in v1 with example ([#2928](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2928)) ([8da8deb](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8da8deb337772162aa74d686e76fc178e05a2dfc))
-* Remove react resize detector ([#2957](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2957)) ([a3a89b0](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a3a89b057e7663b009c13977515ac15d20360c09)), closes [#2744](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2744) [#2744](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2744)
+* **Datagrid:** add feature flag to select hooks until fully released ([#2937](https://github.com/carbon-design-system/ibm-products/issues/2937)) ([387b593](https://github.com/carbon-design-system/ibm-products/commit/387b5938ebd469708dae997d5d4701ebb1215edb))
+* feature flagging in v1 with example ([#2928](https://github.com/carbon-design-system/ibm-products/issues/2928)) ([8da8deb](https://github.com/carbon-design-system/ibm-products/commit/8da8deb337772162aa74d686e76fc178e05a2dfc))
+* Remove react resize detector ([#2957](https://github.com/carbon-design-system/ibm-products/issues/2957)) ([a3a89b0](https://github.com/carbon-design-system/ibm-products/commit/a3a89b057e7663b009c13977515ac15d20360c09)), closes [#2744](https://github.com/carbon-design-system/ibm-products/issues/2744) [#2744](https://github.com/carbon-design-system/ibm-products/issues/2744)
 
 
 
 
 
-# [1.51.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.50.0...@carbon/ibm-products@1.51.0) (2023-05-02)
-
-
-### Features
-
-* add ellipsis to inline-edit v2 pkg v1 ([#2931](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2931)) ([9f60ac9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9f60ac97b31245ba3e51230d567c947ae52183fc))
-* **Datagrid:** add keyboard support for clickable rows ([#2914](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2914)) ([cbdecd8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/cbdecd8e23ef37c9f679ea93c4e69121399d36e3))
-* **Datagrid:** adds FilterPanel stories ([#2942](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2942)) ([0eb800a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0eb800a620d9a8de199e3caed73a5a480c3dd69a))
-* **datagrid:** adds initial filters support ([#2934](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2934)) ([d1f7d2e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d1f7d2ec3880e13e16260a98b6de50a747a325e6))
-* Rename inline edit (V1) ([#2881](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2881)) ([cff465d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/cff465d845d0bdf5835a4dfe2fa87aa75e658578))
-* update InlineEditV2 ([#2918](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2918)) ([121dbf1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/121dbf1123462f2bfd618a6ac75a3ac30127bff6))
-
-
-
-
-
-# [1.50.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.49.0...@carbon/ibm-products@1.50.0) (2023-04-25)
-
-
-### Bug Fixes
-
-* allow nodes to be passed to additional card props ([#2885](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2885)) ([c8499bf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c8499bf4b6d262938c8585ac3b1cefb711b00d26))
-* **Datagrid:** invalid aria role ([#2882](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2882)) ([9c788fe](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9c788fef290f7a30c3d0d62da8e660a356851bca))
-* **TagSet:** removed border radius to show descenders ([#2707](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2707)) ([bb75256](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/bb75256049a08c29451a847f583d9c3ffa9d5fcd))
+# [1.51.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.50.0...@carbon/ibm-products@1.51.0) (2023-05-02)
 
 
 ### Features
 
-* **Datagrid:** add support for NotFound empty state ([#2887](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2887)) ([8a3651b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8a3651b7e004b112911c1068007e88b65a02b193))
+* add ellipsis to inline-edit v2 pkg v1 ([#2931](https://github.com/carbon-design-system/ibm-products/issues/2931)) ([9f60ac9](https://github.com/carbon-design-system/ibm-products/commit/9f60ac97b31245ba3e51230d567c947ae52183fc))
+* **Datagrid:** add keyboard support for clickable rows ([#2914](https://github.com/carbon-design-system/ibm-products/issues/2914)) ([cbdecd8](https://github.com/carbon-design-system/ibm-products/commit/cbdecd8e23ef37c9f679ea93c4e69121399d36e3))
+* **Datagrid:** adds FilterPanel stories ([#2942](https://github.com/carbon-design-system/ibm-products/issues/2942)) ([0eb800a](https://github.com/carbon-design-system/ibm-products/commit/0eb800a620d9a8de199e3caed73a5a480c3dd69a))
+* **datagrid:** adds initial filters support ([#2934](https://github.com/carbon-design-system/ibm-products/issues/2934)) ([d1f7d2e](https://github.com/carbon-design-system/ibm-products/commit/d1f7d2ec3880e13e16260a98b6de50a747a325e6))
+* Rename inline edit (V1) ([#2881](https://github.com/carbon-design-system/ibm-products/issues/2881)) ([cff465d](https://github.com/carbon-design-system/ibm-products/commit/cff465d845d0bdf5835a4dfe2fa87aa75e658578))
+* update InlineEditV2 ([#2918](https://github.com/carbon-design-system/ibm-products/issues/2918)) ([121dbf1](https://github.com/carbon-design-system/ibm-products/commit/121dbf1123462f2bfd618a6ac75a3ac30127bff6))
 
 
 
 
 
-# [1.49.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.48.0...@carbon/ibm-products@1.49.0) (2023-04-18)
+# [1.50.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.49.0...@carbon/ibm-products@1.50.0) (2023-04-25)
 
 
 ### Bug Fixes
 
-* **Datagrid:** filtering number empty tag bug ([#2879](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2879)) ([8ad3a7e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8ad3a7ea177a2a080fb93620b4ad75867c766799))
-* **Datagrid:** fix batch action logic to show one/two actions ([#2816](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2816)) ([9e7cc70](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9e7cc70ec9dd3b1aa6c5284028fc4c21f5f4de3c))
-* **Datagrid:** fix how `RowSizeDropdown` open state value is set ([#2864](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2864)) ([751503d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/751503d087671ee6f63306da66616d7a3e41422b))
-* **Datagrid:** sortable and customizable columns work together now ([#2840](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2840)) ([d6fd58d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d6fd58d55dd70221c77b26586c02842384d01082))
-* inline edit fixes package v1 ([#2870](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2870)) ([bd76e86](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/bd76e86407cd6b5e50d20f005566fe7637ff84e0))
-* **side-panel:** fix close button hover state ([#2835](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2835)) ([8735ecf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8735ecf8876acd971dc3b6e5bd91e04ec7a2efdf))
-* **sidepanel toolbar:** tooltip truncate issue fix ([#2786](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2786)) ([c9ba2b8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c9ba2b8ea3cefd99ac97ca791df6a5962af0a733))
+* allow nodes to be passed to additional card props ([#2885](https://github.com/carbon-design-system/ibm-products/issues/2885)) ([c8499bf](https://github.com/carbon-design-system/ibm-products/commit/c8499bf4b6d262938c8585ac3b1cefb711b00d26))
+* **Datagrid:** invalid aria role ([#2882](https://github.com/carbon-design-system/ibm-products/issues/2882)) ([9c788fe](https://github.com/carbon-design-system/ibm-products/commit/9c788fef290f7a30c3d0d62da8e660a356851bca))
+* **TagSet:** removed border radius to show descenders ([#2707](https://github.com/carbon-design-system/ibm-products/issues/2707)) ([bb75256](https://github.com/carbon-design-system/ibm-products/commit/bb75256049a08c29451a847f583d9c3ffa9d5fcd))
 
 
 ### Features
 
-* adds i18n support and change overflow-y ([#2869](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2869)) ([5bbb20a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5bbb20ac3df0c9e6f7e6ff8e2ab90e91835ec824))
-* **Datagrid:** add auto size column support ([#2859](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2859)) ([373366d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/373366df70f1d80bfb24f9c1ed031550e7d242bf))
-* **storybook:** new fn getSelectedCarbonTheme ([#2799](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2799)) ([caa98ff](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/caa98ff69604e2f1ed61786db8837f30f0a9959c))
+* **Datagrid:** add support for NotFound empty state ([#2887](https://github.com/carbon-design-system/ibm-products/issues/2887)) ([8a3651b](https://github.com/carbon-design-system/ibm-products/commit/8a3651b7e004b112911c1068007e88b65a02b193))
 
 
 
 
 
-# [1.48.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.47.0...@carbon/ibm-products@1.48.0) (2023-04-11)
+# [1.49.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.48.0...@carbon/ibm-products@1.49.0) (2023-04-18)
 
 
 ### Bug Fixes
 
-* add select keyboard accessibility fixes ([#2803](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2803)) ([1c3b930](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1c3b930733cb6b4dd2bb0552e27626c68548a41f))
-* **create-full-page:** focus modal secondary button ([#2790](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2790)) ([7332357](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7332357147c6f13b15d47b998f77cda014f60ba1))
-* **Datagrid:** add background to virtual body header, fix svg scoping ([#2828](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2828)) ([867dc23](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/867dc23fdf24335f4ec47ace2ec204e88ef05d62))
-* **Datagrid:** address bug with keyboard interaction for inline edit ([#2804](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2804)) ([4a4e4fa](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4a4e4fa92490c0b4899a4dcd78b93011fa3fd8d0))
-* **Datagrid:** filter from Columns component to prevent ordering issues ([#2826](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2826)) ([1301ccd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1301ccd36e75cbcd45770ef5049e3d08508cf18a))
-* **side-panel:** fix icon button alignment ([#2814](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2814)) ([45764ca](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/45764cabaf907bc7cd4208ad87de3580b3e503a9))
+* **Datagrid:** filtering number empty tag bug ([#2879](https://github.com/carbon-design-system/ibm-products/issues/2879)) ([8ad3a7e](https://github.com/carbon-design-system/ibm-products/commit/8ad3a7ea177a2a080fb93620b4ad75867c766799))
+* **Datagrid:** fix batch action logic to show one/two actions ([#2816](https://github.com/carbon-design-system/ibm-products/issues/2816)) ([9e7cc70](https://github.com/carbon-design-system/ibm-products/commit/9e7cc70ec9dd3b1aa6c5284028fc4c21f5f4de3c))
+* **Datagrid:** fix how `RowSizeDropdown` open state value is set ([#2864](https://github.com/carbon-design-system/ibm-products/issues/2864)) ([751503d](https://github.com/carbon-design-system/ibm-products/commit/751503d087671ee6f63306da66616d7a3e41422b))
+* **Datagrid:** sortable and customizable columns work together now ([#2840](https://github.com/carbon-design-system/ibm-products/issues/2840)) ([d6fd58d](https://github.com/carbon-design-system/ibm-products/commit/d6fd58d55dd70221c77b26586c02842384d01082))
+* inline edit fixes package v1 ([#2870](https://github.com/carbon-design-system/ibm-products/issues/2870)) ([bd76e86](https://github.com/carbon-design-system/ibm-products/commit/bd76e86407cd6b5e50d20f005566fe7637ff84e0))
+* **side-panel:** fix close button hover state ([#2835](https://github.com/carbon-design-system/ibm-products/issues/2835)) ([8735ecf](https://github.com/carbon-design-system/ibm-products/commit/8735ecf8876acd971dc3b6e5bd91e04ec7a2efdf))
+* **sidepanel toolbar:** tooltip truncate issue fix ([#2786](https://github.com/carbon-design-system/ibm-products/issues/2786)) ([c9ba2b8](https://github.com/carbon-design-system/ibm-products/commit/c9ba2b8ea3cefd99ac97ca791df6a5962af0a733))
 
 
 ### Features
 
-* add new NonLinearReading component ([#2793](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2793)) ([2516844](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/251684484022517ccf4c6d829b63a5e8b7949c86))
+* adds i18n support and change overflow-y ([#2869](https://github.com/carbon-design-system/ibm-products/issues/2869)) ([5bbb20a](https://github.com/carbon-design-system/ibm-products/commit/5bbb20ac3df0c9e6f7e6ff8e2ab90e91835ec824))
+* **Datagrid:** add auto size column support ([#2859](https://github.com/carbon-design-system/ibm-products/issues/2859)) ([373366d](https://github.com/carbon-design-system/ibm-products/commit/373366df70f1d80bfb24f9c1ed031550e7d242bf))
+* **storybook:** new fn getSelectedCarbonTheme ([#2799](https://github.com/carbon-design-system/ibm-products/issues/2799)) ([caa98ff](https://github.com/carbon-design-system/ibm-products/commit/caa98ff69604e2f1ed61786db8837f30f0a9959c))
 
 
 
 
 
-# [1.47.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.46.2...@carbon/ibm-products@1.47.0) (2023-03-28)
+# [1.48.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.47.0...@carbon/ibm-products@1.48.0) (2023-04-11)
 
 
 ### Bug Fixes
 
-* datagrid inline edit focus background color ([#2680](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2680)) ([aebe0a2](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/aebe0a26cf73d4ca8bdeb6d4c63dfbd261359494))
-* **Datagrid:** hide columns with no header title ([#2745](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2745)) ([4885222](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4885222da1939b46ec679aa6c6c8825074c1ac2f))
-* **empty-state:** update header spacing ([#2766](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2766)) ([a739980](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a739980442aff2eef6810809f38c01332c7b092e))
-* **expandable row:** content added with controls ([#2675](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2675)) ([ebbe5c9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ebbe5c91dabac69b2a9fc76cbb52bb76486543b2))
-* **TearsheetNarrow:** increase description width to 80% ([#2738](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2738)) ([4de6e35](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4de6e35e6892bad036a57adc73fc9ccd66939945))
-* update to Carbon v10 compatible versions to latest ([#2739](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2739)) ([7065855](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/70658550120822ab0a6dd296bc9022cc7d0856db))
+* add select keyboard accessibility fixes ([#2803](https://github.com/carbon-design-system/ibm-products/issues/2803)) ([1c3b930](https://github.com/carbon-design-system/ibm-products/commit/1c3b930733cb6b4dd2bb0552e27626c68548a41f))
+* **create-full-page:** focus modal secondary button ([#2790](https://github.com/carbon-design-system/ibm-products/issues/2790)) ([7332357](https://github.com/carbon-design-system/ibm-products/commit/7332357147c6f13b15d47b998f77cda014f60ba1))
+* **Datagrid:** add background to virtual body header, fix svg scoping ([#2828](https://github.com/carbon-design-system/ibm-products/issues/2828)) ([867dc23](https://github.com/carbon-design-system/ibm-products/commit/867dc23fdf24335f4ec47ace2ec204e88ef05d62))
+* **Datagrid:** address bug with keyboard interaction for inline edit ([#2804](https://github.com/carbon-design-system/ibm-products/issues/2804)) ([4a4e4fa](https://github.com/carbon-design-system/ibm-products/commit/4a4e4fa92490c0b4899a4dcd78b93011fa3fd8d0))
+* **Datagrid:** filter from Columns component to prevent ordering issues ([#2826](https://github.com/carbon-design-system/ibm-products/issues/2826)) ([1301ccd](https://github.com/carbon-design-system/ibm-products/commit/1301ccd36e75cbcd45770ef5049e3d08508cf18a))
+* **side-panel:** fix icon button alignment ([#2814](https://github.com/carbon-design-system/ibm-products/issues/2814)) ([45764ca](https://github.com/carbon-design-system/ibm-products/commit/45764cabaf907bc7cd4208ad87de3580b3e503a9))
 
 
 ### Features
 
-* **SidePanel:** expose tooltip props ([#2756](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2756)) ([ee63cae](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ee63cae21978ab502a4c914e9c0177a3bb8a6b72))
+* add new NonLinearReading component ([#2793](https://github.com/carbon-design-system/ibm-products/issues/2793)) ([2516844](https://github.com/carbon-design-system/ibm-products/commit/251684484022517ccf4c6d829b63a5e8b7949c86))
 
 
 
 
 
-## [1.46.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.46.1...@carbon/ibm-products@1.46.2) (2023-03-21)
-
-
-### Bug Fixes
-
-* cardfooter button icon props update ([#2729](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2729)) ([5d7f4d2](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5d7f4d2ef11e46d14b2726b69ef9cdc559800c32))
-* **DataGrid:** design review horizontal scrolling ([#2657](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2657)) ([99685c0](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/99685c0bd98630a8f67383e0698d9ede98493a71))
-* **nested row:** border color and align fixed ([#2621](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2621)) ([3b81a0e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3b81a0ec56d829f65bf4092a971098811d7b8bc2))
-
-
-
-
-
-## [1.46.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.46.0...@carbon/ibm-products@1.46.1) (2023-03-14)
+# [1.47.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.46.2...@carbon/ibm-products@1.47.0) (2023-03-28)
 
 
 ### Bug Fixes
 
-* **DataGrid:** dense header alignment ([#2711](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2711)) ([ac94837](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ac9483798d7479ba127242f88e228b6aea81314e))
-* **options-tile:** add safe area around toggle ([#2705](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2705)) ([2f290d8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2f290d8665ed7a73a94f743e80d5463766efa07c))
-
-
-
-
-
-# [1.46.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.45.0...@carbon/ibm-products@1.46.0) (2023-03-07)
-
-
-### Bug Fixes
-
-* **DataGrid:** sort column focus ([#2673](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2673)) ([92ef4ff](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/92ef4ffc5152846c0618622814b55290d3aa7933))
+* datagrid inline edit focus background color ([#2680](https://github.com/carbon-design-system/ibm-products/issues/2680)) ([aebe0a2](https://github.com/carbon-design-system/ibm-products/commit/aebe0a26cf73d4ca8bdeb6d4c63dfbd261359494))
+* **Datagrid:** hide columns with no header title ([#2745](https://github.com/carbon-design-system/ibm-products/issues/2745)) ([4885222](https://github.com/carbon-design-system/ibm-products/commit/4885222da1939b46ec679aa6c6c8825074c1ac2f))
+* **empty-state:** update header spacing ([#2766](https://github.com/carbon-design-system/ibm-products/issues/2766)) ([a739980](https://github.com/carbon-design-system/ibm-products/commit/a739980442aff2eef6810809f38c01332c7b092e))
+* **expandable row:** content added with controls ([#2675](https://github.com/carbon-design-system/ibm-products/issues/2675)) ([ebbe5c9](https://github.com/carbon-design-system/ibm-products/commit/ebbe5c91dabac69b2a9fc76cbb52bb76486543b2))
+* **TearsheetNarrow:** increase description width to 80% ([#2738](https://github.com/carbon-design-system/ibm-products/issues/2738)) ([4de6e35](https://github.com/carbon-design-system/ibm-products/commit/4de6e35e6892bad036a57adc73fc9ccd66939945))
+* update to Carbon v10 compatible versions to latest ([#2739](https://github.com/carbon-design-system/ibm-products/issues/2739)) ([7065855](https://github.com/carbon-design-system/ibm-products/commit/70658550120822ab0a6dd296bc9022cc7d0856db))
 
 
 ### Features
 
-* **Datagrid:** Extracts Filtering logic into `useFilters` hook ([#2690](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2690)) ([7dd1b49](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7dd1b49c487517d57f467817f2ddafcb38d2a7f1))
+* **SidePanel:** expose tooltip props ([#2756](https://github.com/carbon-design-system/ibm-products/issues/2756)) ([ee63cae](https://github.com/carbon-design-system/ibm-products/commit/ee63cae21978ab502a4c914e9c0177a3bb8a6b72))
 
 
 
 
 
-# [1.45.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.44.1...@carbon/ibm-products@1.45.0) (2023-02-28)
+## [1.46.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.46.1...@carbon/ibm-products@1.46.2) (2023-03-21)
 
 
 ### Bug Fixes
 
-* datagrid design review row height settings ([#2625](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2625)) ([b3b4384](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b3b4384bd9f44f0c1d3b22c1c64909a7c7878e3b))
-* **DataGrid:** any option in filter panel flyout ([#2687](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2687)) ([2b01061](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2b0106113cbed4e70ead3744abb37b1e0adf38cd))
-* **DataGrid:** restore toolbar responsiveness ([#2692](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2692)) ([12a0538](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/12a0538fb3a85baadae81c8fa127e64ab8b1a753))
+* cardfooter button icon props update ([#2729](https://github.com/carbon-design-system/ibm-products/issues/2729)) ([5d7f4d2](https://github.com/carbon-design-system/ibm-products/commit/5d7f4d2ef11e46d14b2726b69ef9cdc559800c32))
+* **DataGrid:** design review horizontal scrolling ([#2657](https://github.com/carbon-design-system/ibm-products/issues/2657)) ([99685c0](https://github.com/carbon-design-system/ibm-products/commit/99685c0bd98630a8f67383e0698d9ede98493a71))
+* **nested row:** border color and align fixed ([#2621](https://github.com/carbon-design-system/ibm-products/issues/2621)) ([3b81a0e](https://github.com/carbon-design-system/ibm-products/commit/3b81a0ec56d829f65bf4092a971098811d7b8bc2))
+
+
+
+
+
+## [1.46.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.46.0...@carbon/ibm-products@1.46.1) (2023-03-14)
+
+
+### Bug Fixes
+
+* **DataGrid:** dense header alignment ([#2711](https://github.com/carbon-design-system/ibm-products/issues/2711)) ([ac94837](https://github.com/carbon-design-system/ibm-products/commit/ac9483798d7479ba127242f88e228b6aea81314e))
+* **options-tile:** add safe area around toggle ([#2705](https://github.com/carbon-design-system/ibm-products/issues/2705)) ([2f290d8](https://github.com/carbon-design-system/ibm-products/commit/2f290d8665ed7a73a94f743e80d5463766efa07c))
+
+
+
+
+
+# [1.46.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.45.0...@carbon/ibm-products@1.46.0) (2023-03-07)
+
+
+### Bug Fixes
+
+* **DataGrid:** sort column focus ([#2673](https://github.com/carbon-design-system/ibm-products/issues/2673)) ([92ef4ff](https://github.com/carbon-design-system/ibm-products/commit/92ef4ffc5152846c0618622814b55290d3aa7933))
 
 
 ### Features
 
-* **Datagrid:** Custom hook to handle `ActionSet` disabled state for `FilterPanel` & `FilterFlyout` ([#2676](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2676)) ([461d1ea](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/461d1ea675d6c3eed0cd55f89f12d2eaf9cc501a))
+* **Datagrid:** Extracts Filtering logic into `useFilters` hook ([#2690](https://github.com/carbon-design-system/ibm-products/issues/2690)) ([7dd1b49](https://github.com/carbon-design-system/ibm-products/commit/7dd1b49c487517d57f467817f2ddafcb38d2a7f1))
 
 
 
 
 
-## [1.44.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.44.0...@carbon/ibm-products@1.44.1) (2023-02-24)
+# [1.45.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.44.1...@carbon/ibm-products@1.45.0) (2023-02-28)
+
+
+### Bug Fixes
+
+* datagrid design review row height settings ([#2625](https://github.com/carbon-design-system/ibm-products/issues/2625)) ([b3b4384](https://github.com/carbon-design-system/ibm-products/commit/b3b4384bd9f44f0c1d3b22c1c64909a7c7878e3b))
+* **DataGrid:** any option in filter panel flyout ([#2687](https://github.com/carbon-design-system/ibm-products/issues/2687)) ([2b01061](https://github.com/carbon-design-system/ibm-products/commit/2b0106113cbed4e70ead3744abb37b1e0adf38cd))
+* **DataGrid:** restore toolbar responsiveness ([#2692](https://github.com/carbon-design-system/ibm-products/issues/2692)) ([12a0538](https://github.com/carbon-design-system/ibm-products/commit/12a0538fb3a85baadae81c8fa127e64ab8b1a753))
+
+
+### Features
+
+* **Datagrid:** Custom hook to handle `ActionSet` disabled state for `FilterPanel` & `FilterFlyout` ([#2676](https://github.com/carbon-design-system/ibm-products/issues/2676)) ([461d1ea](https://github.com/carbon-design-system/ibm-products/commit/461d1ea675d6c3eed0cd55f89f12d2eaf9cc501a))
+
+
+
+
+
+## [1.44.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.44.0...@carbon/ibm-products@1.44.1) (2023-02-24)
 
 **Note:** Version bump only for package @carbon/ibm-products
 
@@ -212,46 +212,46 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [1.44.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.43.0...@carbon/ibm-products@1.44.0) (2023-02-21)
+# [1.44.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.43.0...@carbon/ibm-products@1.44.0) (2023-02-21)
 
 
 ### Features
 
-* **Datagrid:** show fixed columns in column customization ([#2665](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2665)) ([05c8bad](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/05c8bad8607fcab4b98ee467ceaae0d27f869844))
+* **Datagrid:** show fixed columns in column customization ([#2665](https://github.com/carbon-design-system/ibm-products/issues/2665)) ([05c8bad](https://github.com/carbon-design-system/ibm-products/commit/05c8bad8607fcab4b98ee467ceaae0d27f869844))
 
 
 ### Reverts
 
-* Revert "chore: add select release (#2664)" (#2684) ([5a8afca](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5a8afca33ed1469a4d6e258d638a5433f471455c)), closes [#2664](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2664) [#2684](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2684)
+* Revert "chore: add select release (#2664)" (#2684) ([5a8afca](https://github.com/carbon-design-system/ibm-products/commit/5a8afca33ed1469a4d6e258d638a5433f471455c)), closes [#2664](https://github.com/carbon-design-system/ibm-products/issues/2664) [#2684](https://github.com/carbon-design-system/ibm-products/issues/2684)
 
 
 
 
 
-# [1.43.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.42.1...@carbon/ibm-products@1.43.0) (2023-02-14)
+# [1.43.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.42.1...@carbon/ibm-products@1.43.0) (2023-02-14)
 
 
 ### Bug Fixes
 
-* datagrid inline edit review fixes ([#2640](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2640)) ([e181ed8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e181ed878286730fc92c195d6063da93ce7bd917))
-* **Datagrid:** column customization styles ([#2660](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2660)) ([c11951d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c11951db317fea77926c67656883adadd93c7164))
+* datagrid inline edit review fixes ([#2640](https://github.com/carbon-design-system/ibm-products/issues/2640)) ([e181ed8](https://github.com/carbon-design-system/ibm-products/commit/e181ed878286730fc92c195d6063da93ce7bd917))
+* **Datagrid:** column customization styles ([#2660](https://github.com/carbon-design-system/ibm-products/issues/2660)) ([c11951d](https://github.com/carbon-design-system/ibm-products/commit/c11951db317fea77926c67656883adadd93c7164))
 
 
 ### Features
 
-* **Datagrid:** adds FilterPanel (v10) ([#2586](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2586)) ([3974e0d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3974e0deaaab616f46367c081bac052d2fc23f2f)), closes [#2474](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2474)
+* **Datagrid:** adds FilterPanel (v10) ([#2586](https://github.com/carbon-design-system/ibm-products/issues/2586)) ([3974e0d](https://github.com/carbon-design-system/ibm-products/commit/3974e0deaaab616f46367c081bac052d2fc23f2f)), closes [#2474](https://github.com/carbon-design-system/ibm-products/issues/2474)
 
 
 
 
 
-## [1.42.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.42.0...@carbon/ibm-products@1.42.1) (2023-02-07)
+## [1.42.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.42.0...@carbon/ibm-products@1.42.1) (2023-02-07)
 
 
 ### Bug Fixes
 
-* **DataGrid:** filter summary add heights options ([#2644](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2644)) ([24b393d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/24b393dd71b08bb9082d420f9a87568a3f7c08ec))
-* **Tearsheet:** prevent description breaking ([#2645](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2645)) ([46055ec](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/46055ec2cf6528d4a6e0510508eaa127856b27ed))
+* **DataGrid:** filter summary add heights options ([#2644](https://github.com/carbon-design-system/ibm-products/issues/2644)) ([24b393d](https://github.com/carbon-design-system/ibm-products/commit/24b393dd71b08bb9082d420f9a87568a3f7c08ec))
+* **Tearsheet:** prevent description breaking ([#2645](https://github.com/carbon-design-system/ibm-products/issues/2645)) ([46055ec](https://github.com/carbon-design-system/ibm-products/commit/46055ec2cf6528d4a6e0510508eaa127856b27ed))
 
 
 
@@ -262,5498 +262,5498 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.42.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.41.4...@carbon/ibm-products@1.42.0) (2023-02-01)
+# [1.42.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.41.4...@carbon/ibm-products@1.42.0) (2023-02-01)
 
 ### Bug Fixes
 
 - **Datagrid:** export useColumnCenterAlign
-  ([#2631](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2631))
-  ([028a012](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/028a01211640da0d5603ee301beca93c1acc9832))
+  ([#2631](https://github.com/carbon-design-system/ibm-products/issues/2631))
+  ([028a012](https://github.com/carbon-design-system/ibm-products/commit/028a01211640da0d5603ee301beca93c1acc9832))
 
 ### Features
 
 - **Datagrid:** exports FilterFlyout through datagridState
-  ([#2638](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2638))
-  ([11b9588](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/11b95883db76f7ce323fa6036f37cab255e4c620))
+  ([#2638](https://github.com/carbon-design-system/ibm-products/issues/2638))
+  ([11b9588](https://github.com/carbon-design-system/ibm-products/commit/11b95883db76f7ce323fa6036f37cab255e4c620))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.41.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.41.3...@carbon/ibm-products@1.41.4) (2023-01-31)
+## [1.41.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.41.3...@carbon/ibm-products@1.41.4) (2023-01-31)
 
 ### Bug Fixes
 
 - **DataGrid:** date input support typing date
-  ([#2619](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2619))
-  ([d808b9f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d808b9f4f1e0f03bc2b89ebf76bf93b362d72ba3))
+  ([#2619](https://github.com/carbon-design-system/ibm-products/issues/2619))
+  ([d808b9f](https://github.com/carbon-design-system/ibm-products/commit/d808b9f4f1e0f03bc2b89ebf76bf93b362d72ba3))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.41.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.41.2...@carbon/ibm-products@1.41.3) (2023-01-24)
+## [1.41.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.41.2...@carbon/ibm-products@1.41.3) (2023-01-24)
 
 ### Bug Fixes
 
 - tagset overflow first open
-  ([#2611](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2611))
-  ([9d5e4c2](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9d5e4c26c43451fb7a5581b05139529318bf09b6))
+  ([#2611](https://github.com/carbon-design-system/ibm-products/issues/2611))
+  ([9d5e4c2](https://github.com/carbon-design-system/ibm-products/commit/9d5e4c26c43451fb7a5581b05139529318bf09b6))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.41.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.41.1...@carbon/ibm-products@1.41.2) (2023-01-17)
+## [1.41.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.41.1...@carbon/ibm-products@1.41.2) (2023-01-17)
 
 ### Bug Fixes
 
 - **ButtonMenu:** update lg size
-  ([#2609](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2609))
-  ([de53c03](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/de53c03fd2db9dd2fc0d62496b806c4a32d824e5))
+  ([#2609](https://github.com/carbon-design-system/ibm-products/issues/2609))
+  ([de53c03](https://github.com/carbon-design-system/ibm-products/commit/de53c03fd2db9dd2fc0d62496b806c4a32d824e5))
 - **DataGrid:** date input to accept string date
-  ([#2592](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2592))
-  ([b9704bd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b9704bdc55b2e04500a3a7a3cdcc651a4059b918))
+  ([#2592](https://github.com/carbon-design-system/ibm-products/issues/2592))
+  ([b9704bd](https://github.com/carbon-design-system/ibm-products/commit/b9704bdc55b2e04500a3a7a3cdcc651a4059b918))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.41.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.41.0...@carbon/ibm-products@1.41.1) (2023-01-10)
+## [1.41.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.41.0...@carbon/ibm-products@1.41.1) (2023-01-10)
 
 ### Bug Fixes
 
 - **CreateTearsheet:** Add firstFocusElement
-  ([#2551](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2551))
-  ([dc3e4c0](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/dc3e4c06ed7a451617d30c3db0298be3aea440a5))
+  ([#2551](https://github.com/carbon-design-system/ibm-products/issues/2551))
+  ([dc3e4c0](https://github.com/carbon-design-system/ibm-products/commit/dc3e4c06ed7a451617d30c3db0298be3aea440a5))
 - **Datagrid:** ColumnCustomizationModal to Tearsheet Narrow
-  ([#2582](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2582))
-  ([04075a9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/04075a937814bbb3e6fc2acd2b559b133e85490b))
+  ([#2582](https://github.com/carbon-design-system/ibm-products/issues/2582))
+  ([04075a9](https://github.com/carbon-design-system/ibm-products/commit/04075a937814bbb3e6fc2acd2b559b133e85490b))
 - **DataGrid:** customize column focus and search highlight
-  ([#2518](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2518))
-  ([cad8d19](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/cad8d1919f86ad8068b3affd23bcc7c3ede7c6b3))
+  ([#2518](https://github.com/carbon-design-system/ibm-products/issues/2518))
+  ([cad8d19](https://github.com/carbon-design-system/ibm-products/commit/cad8d1919f86ad8068b3affd23bcc7c3ede7c6b3))
 - exports useFiltering (v10)
-  ([#2597](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2597))
-  ([f306e43](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f306e4397b8da48890692e55e18bfa8f4f672ec6))
+  ([#2597](https://github.com/carbon-design-system/ibm-products/issues/2597))
+  ([f306e43](https://github.com/carbon-design-system/ibm-products/commit/f306e4397b8da48890692e55e18bfa8f4f672ec6))
 - single add select review fixes
-  ([#2583](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2583))
-  ([c7211b9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c7211b99383af7fe6351e132dc02e85ce14a28fd))
+  ([#2583](https://github.com/carbon-design-system/ibm-products/issues/2583))
+  ([c7211b9](https://github.com/carbon-design-system/ibm-products/commit/c7211b99383af7fe6351e132dc02e85ce14a28fd))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.41.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.40.0...@carbon/ibm-products@1.41.0) (2022-12-20)
+# [1.41.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.40.0...@carbon/ibm-products@1.41.0) (2022-12-20)
 
 ### Bug Fixes
 
 - **DataGrid:** empty state with action and link
-  ([#2561](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2561))
-  ([a9fc689](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a9fc6893f46e17a11ceee25812b586b53e9a7cd9))
+  ([#2561](https://github.com/carbon-design-system/ibm-products/issues/2561))
+  ([a9fc689](https://github.com/carbon-design-system/ibm-products/commit/a9fc6893f46e17a11ceee25812b586b53e9a7cd9))
 - **Datagrid:** fixes bugs and issues for design review
-  ([#2559](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2559))
-  ([471c46e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/471c46eaeb078df04372bf94b470e68ba9732293))
+  ([#2559](https://github.com/carbon-design-system/ibm-products/issues/2559))
+  ([471c46e](https://github.com/carbon-design-system/ibm-products/commit/471c46eaeb078df04372bf94b470e68ba9732293))
 - **Datagrid:** resolve react hook error from datagrid row
-  ([#2574](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2574))
-  ([b2ce873](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b2ce87370cd5db83cda56a208ed38b597c7b7de0))
+  ([#2574](https://github.com/carbon-design-system/ibm-products/issues/2574))
+  ([b2ce873](https://github.com/carbon-design-system/ibm-products/commit/b2ce87370cd5db83cda56a208ed38b597c7b7de0))
 - **DataGrid:** virtual scrollbar not visible
-  ([#2451](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2451))
-  ([719a881](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/719a88161b1e18a7cf7c7bb635280d53785796ae))
+  ([#2451](https://github.com/carbon-design-system/ibm-products/issues/2451))
+  ([719a881](https://github.com/carbon-design-system/ibm-products/commit/719a88161b1e18a7cf7c7bb635280d53785796ae))
 
 ### Features
 
 - **Datagrid:** makes seperate story file and adds docs for FilterFlyout (v10)
-  ([#2568](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2568))
-  ([1ed3a18](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1ed3a18d22e3368d11d26270681e815b560cba87))
+  ([#2568](https://github.com/carbon-design-system/ibm-products/issues/2568))
+  ([1ed3a18](https://github.com/carbon-design-system/ibm-products/commit/1ed3a18d22e3368d11d26270681e815b560cba87))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.40.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.39.0...@carbon/ibm-products@1.40.0) (2022-12-10)
+# [1.40.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.39.0...@carbon/ibm-products@1.40.0) (2022-12-10)
 
 ### Bug Fixes
 
 - adds primaryButtonDisabled prop
-  ([#2532](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2532))
-  ([1424a5a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1424a5aa2e3d3815f135acbb17f59258fc5085f5))
+  ([#2532](https://github.com/carbon-design-system/ibm-products/issues/2532))
+  ([1424a5a](https://github.com/carbon-design-system/ibm-products/commit/1424a5aa2e3d3815f135acbb17f59258fc5085f5))
 - **ButtonMenu:** Revert back to OverflowMenu
-  ([#2521](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2521))
-  ([19b3277](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/19b3277d897f86a8c26f383b553c5cd706912e0e))
+  ([#2521](https://github.com/carbon-design-system/ibm-products/issues/2521))
+  ([19b3277](https://github.com/carbon-design-system/ibm-products/commit/19b3277d897f86a8c26f383b553c5cd706912e0e))
 - card action bug fix
-  ([#2549](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2549))
-  ([1307c38](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1307c3819c6180382eb483927ddb50124ac3932d))
+  ([#2549](https://github.com/carbon-design-system/ibm-products/issues/2549))
+  ([1307c38](https://github.com/carbon-design-system/ibm-products/commit/1307c3819c6180382eb483927ddb50124ac3932d))
 - **Datagrid:** address date issue with clickable row side panel
-  ([#2544](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2544))
-  ([6559047](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6559047a988869651c3cc59104004e1c9d3a9909))
+  ([#2544](https://github.com/carbon-design-system/ibm-products/issues/2544))
+  ([6559047](https://github.com/carbon-design-system/ibm-products/commit/6559047a988869651c3cc59104004e1c9d3a9909))
 - **Datagrid:** fixed some issues in filter flyout
-  ([#2528](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2528))
-  ([52d33d3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/52d33d34b98ca7c237b9d5cf0f58ba9f8e7f8dc5))
+  ([#2528](https://github.com/carbon-design-system/ibm-products/issues/2528))
+  ([52d33d3](https://github.com/carbon-design-system/ibm-products/commit/52d33d34b98ca7c237b9d5cf0f58ba9f8e7f8dc5))
 - **Datagrid:** update inline edit selection type to support string items
-  ([#2546](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2546))
-  ([fbb85f5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fbb85f5482927b4f1b21e9eb7bc3d8bae9ea3f83))
+  ([#2546](https://github.com/carbon-design-system/ibm-products/issues/2546))
+  ([fbb85f5](https://github.com/carbon-design-system/ibm-products/commit/fbb85f5482927b4f1b21e9eb7bc3d8bae9ea3f83))
 - **InlineEdit:** move warning inside component
-  ([#2531](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2531))
-  ([ccbf36d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ccbf36d6876ddf06eeb9d5ff7946a10f8921b667))
+  ([#2531](https://github.com/carbon-design-system/ibm-products/issues/2531))
+  ([ccbf36d](https://github.com/carbon-design-system/ibm-products/commit/ccbf36d6876ddf06eeb9d5ff7946a10f8921b667))
 
 ### Features
 
 - **Datagrid:** add empty state type option
-  ([#2558](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2558))
-  ([05bae71](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/05bae710bdf91967d2e976b5c0b77c458a388c12))
+  ([#2558](https://github.com/carbon-design-system/ibm-products/issues/2558))
+  ([05bae71](https://github.com/carbon-design-system/ibm-products/commit/05bae710bdf91967d2e976b5c0b77c458a388c12))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.39.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.38.0...@carbon/ibm-products@1.39.0) (2022-12-06)
+# [1.39.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.38.0...@carbon/ibm-products@1.39.0) (2022-12-06)
 
 ### Bug Fixes
 
 - **ActionBar:** overflow menu item onClick
-  ([#2511](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2511))
-  ([d8f0f08](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d8f0f08b7d7dd5ccfc89b49174e63d267d1548eb))
+  ([#2511](https://github.com/carbon-design-system/ibm-products/issues/2511))
+  ([d8f0f08](https://github.com/carbon-design-system/ibm-products/commit/d8f0f08b7d7dd5ccfc89b49174e63d267d1548eb))
 - **create full page:** modal close issue fixed
-  ([#2488](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2488))
-  ([567b4cf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/567b4cfe47f70997b3565e994d9f63e9ed0bde6a))
+  ([#2488](https://github.com/carbon-design-system/ibm-products/issues/2488))
+  ([567b4cf](https://github.com/carbon-design-system/ibm-products/commit/567b4cfe47f70997b3565e994d9f63e9ed0bde6a))
 
 ### Features
 
 - **Datagrid:** Filter flyout
-  ([#2406](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2406))
-  ([d375308](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d3753083154f1c48b52164e2d2ae56d53dc0be7a))
+  ([#2406](https://github.com/carbon-design-system/ibm-products/issues/2406))
+  ([d375308](https://github.com/carbon-design-system/ibm-products/commit/d3753083154f1c48b52164e2d2ae56d53dc0be7a))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.38.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.37.0...@carbon/ibm-products@1.38.0) (2022-11-29)
+# [1.38.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.37.0...@carbon/ibm-products@1.38.0) (2022-11-29)
 
 ### Bug Fixes
 
 - Multi add select review fixes
-  ([#2487](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2487))
-  ([9555e77](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9555e779cb105e891135503c6b2c1b52b8607d44))
+  ([#2487](https://github.com/carbon-design-system/ibm-products/issues/2487))
+  ([9555e77](https://github.com/carbon-design-system/ibm-products/commit/9555e779cb105e891135503c6b2c1b52b8607d44))
 
 ### Features
 
 - inline edit v2 release
-  ([#2482](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2482))
-  ([80b1a8e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/80b1a8ee315de86a80bc898d48b0b4131d764e4e))
+  ([#2482](https://github.com/carbon-design-system/ibm-products/issues/2482))
+  ([80b1a8e](https://github.com/carbon-design-system/ibm-products/commit/80b1a8ee315de86a80bc898d48b0b4131d764e4e))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.37.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.36.0...@carbon/ibm-products@1.37.0) (2022-11-22)
+# [1.37.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.36.0...@carbon/ibm-products@1.37.0) (2022-11-22)
 
 ### Bug Fixes
 
 - **DataSpreadsheet:** prevent delete error from header
-  ([#2476](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2476))
-  ([aab2809](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/aab28099e43f336722b642b3532a07ea51c9d135))
+  ([#2476](https://github.com/carbon-design-system/ibm-products/issues/2476))
+  ([aab2809](https://github.com/carbon-design-system/ibm-products/commit/aab28099e43f336722b642b3532a07ea51c9d135))
 - **PageHeader:** Page header title truncation
-  ([#2472](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2472))
-  ([78a9251](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/78a925170f6131d454f4488e0943f41248419f56))
+  ([#2472](https://github.com/carbon-design-system/ibm-products/issues/2472))
+  ([78a9251](https://github.com/carbon-design-system/ibm-products/commit/78a925170f6131d454f4488e0943f41248419f56))
 - update to Carbon v10 compatible versions to latest
-  ([#2462](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2462))
-  ([4353991](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/43539912353a965549f0f2e5f8245168d2ce1c98))
+  ([#2462](https://github.com/carbon-design-system/ibm-products/issues/2462))
+  ([4353991](https://github.com/carbon-design-system/ibm-products/commit/43539912353a965549f0f2e5f8245168d2ce1c98))
 
 ### Features
 
 - adds FilterSummary
-  ([#2466](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2466))
-  ([46dd712](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/46dd7120f088d3f05ecd653d44058f3e51d76c9c))
+  ([#2466](https://github.com/carbon-design-system/ibm-products/issues/2466))
+  ([46dd712](https://github.com/carbon-design-system/ibm-products/commit/46dd7120f088d3f05ecd653d44058f3e51d76c9c))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.36.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.35.2...@carbon/ibm-products@1.36.0) (2022-11-15)
+# [1.36.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.35.2...@carbon/ibm-products@1.36.0) (2022-11-15)
 
 ### Bug Fixes
 
 - **ActionSet:** allow for non expressive buttons
-  ([#2447](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2447))
-  ([e297a36](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e297a366df420c87905463bf61678c248d16c5b7))
+  ([#2447](https://github.com/carbon-design-system/ibm-products/issues/2447))
+  ([e297a36](https://github.com/carbon-design-system/ibm-products/commit/e297a366df420c87905463bf61678c248d16c5b7))
 - add select filter fix
-  ([#2455](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2455))
-  ([19ac075](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/19ac075aa88a6f3f0a964f670ca4168dba0afb47))
+  ([#2455](https://github.com/carbon-design-system/ibm-products/issues/2455))
+  ([19ac075](https://github.com/carbon-design-system/ibm-products/commit/19ac075aa88a6f3f0a964f670ca4168dba0afb47))
 - **Datagrid:**
-  [#2291](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2291)
+  [#2291](https://github.com/carbon-design-system/ibm-products/issues/2291)
   extend last nested row border
-  ([#2443](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2443))
-  ([a8311a8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a8311a8f0c4e547d2ad06f80c8c2f8071ca569f4))
+  ([#2443](https://github.com/carbon-design-system/ibm-products/issues/2443))
+  ([a8311a8](https://github.com/carbon-design-system/ibm-products/commit/a8311a8f0c4e547d2ad06f80c8c2f8071ca569f4))
 
 ### Features
 
 - **OptionsTile:** add onChange prop and useContrallableState hook
-  ([#2456](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2456))
-  ([ab2c5bc](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ab2c5bc9958557c6a4541d76cf8eb07d230cf4da))
+  ([#2456](https://github.com/carbon-design-system/ibm-products/issues/2456))
+  ([ab2c5bc](https://github.com/carbon-design-system/ibm-products/commit/ab2c5bc9958557c6a4541d76cf8eb07d230cf4da))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.35.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.35.1...@carbon/ibm-products@1.35.2) (2022-11-08)
+## [1.35.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.35.1...@carbon/ibm-products@1.35.2) (2022-11-08)
 
 ### Bug Fixes
 
 - add inline edit wrapper component
-  ([#2404](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2404))
-  ([53dc96c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/53dc96c6a85f0e0c501799ab3715ab83057f746d))
+  ([#2404](https://github.com/carbon-design-system/ibm-products/issues/2404))
+  ([53dc96c](https://github.com/carbon-design-system/ibm-products/commit/53dc96c6a85f0e0c501799ab3715ab83057f746d))
 - **Datagrid:**
-  [#2417](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2417)
+  [#2417](https://github.com/carbon-design-system/ibm-products/issues/2417)
   datagrid select rows filter issue
-  ([#2440](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2440))
-  ([4d361cc](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4d361cc9ba0dbfea11e374c44765a64599e4740e))
+  ([#2440](https://github.com/carbon-design-system/ibm-products/issues/2440))
+  ([4d361cc](https://github.com/carbon-design-system/ibm-products/commit/4d361cc9ba0dbfea11e374c44765a64599e4740e))
 - **Datagrid:** allow keyboard interaction with row expander
-  ([#2434](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2434))
-  ([762103f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/762103f960e9aed8b2d652ff0e388092775a2d42))
+  ([#2434](https://github.com/carbon-design-system/ibm-products/issues/2434))
+  ([762103f](https://github.com/carbon-design-system/ibm-products/commit/762103f960e9aed8b2d652ff0e388092775a2d42))
 - **Datagrid:** CustomizeColumns flyout offset fix
-  ([#2433](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2433))
-  ([b8d85fd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b8d85fdde05a6a3763f026cff933950465aa443f))
+  ([#2433](https://github.com/carbon-design-system/ibm-products/issues/2433))
+  ([b8d85fd](https://github.com/carbon-design-system/ibm-products/commit/b8d85fdde05a6a3763f026cff933950465aa443f))
 - remove read only
-  ([#2429](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2429))
-  ([0297d79](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0297d7988b569a292b0109bb2a6fa51bbe5e7bad))
+  ([#2429](https://github.com/carbon-design-system/ibm-products/issues/2429))
+  ([0297d79](https://github.com/carbon-design-system/ibm-products/commit/0297d7988b569a292b0109bb2a6fa51bbe5e7bad))
 - various updates from release review
-  ([#2436](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2436))
-  ([756c4a8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/756c4a82b75ade40475ed837c833ecd435203480))
+  ([#2436](https://github.com/carbon-design-system/ibm-products/issues/2436))
+  ([756c4a8](https://github.com/carbon-design-system/ibm-products/commit/756c4a82b75ade40475ed837c833ecd435203480))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.35.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.35.0...@carbon/ibm-products@1.35.1) (2022-11-01)
+## [1.35.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.35.0...@carbon/ibm-products@1.35.1) (2022-11-01)
 
 ### Bug Fixes
 
 - **CreateTearsheet:** fix initialStep issue when open=true
-  ([#2353](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2353))
-  ([09e5ea9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/09e5ea9b59a0e706a716ca7b904b57e992bab061))
+  ([#2353](https://github.com/carbon-design-system/ibm-products/issues/2353))
+  ([09e5ea9](https://github.com/carbon-design-system/ibm-products/commit/09e5ea9b59a0e706a716ca7b904b57e992bab061))
 - **Datagrid:** render pagination as component
-  ([#2415](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2415))
-  ([15f8db4](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/15f8db4851252f735e5dee1ba090f2e8ea64f481))
+  ([#2415](https://github.com/carbon-design-system/ibm-products/issues/2415))
+  ([15f8db4](https://github.com/carbon-design-system/ibm-products/commit/15f8db4851252f735e5dee1ba090f2e8ea64f481))
 - **PageHeader:** button alignment logic based on variable value
-  ([#2391](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2391))
-  ([0e2055a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0e2055aa930fcdd9635a9e2249b1b56cb42d5200))
+  ([#2391](https://github.com/carbon-design-system/ibm-products/issues/2391))
+  ([0e2055a](https://github.com/carbon-design-system/ibm-products/commit/0e2055aa930fcdd9635a9e2249b1b56cb42d5200))
 - **PageHeader:** restrict useEffect logic to prevent scroll
-  ([#2410](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2410))
-  ([ecc11df](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ecc11dff50d377ae69c4bd990a8aa2fa952e8cc7))
+  ([#2410](https://github.com/carbon-design-system/ibm-products/issues/2410))
+  ([ecc11df](https://github.com/carbon-design-system/ibm-products/commit/ecc11dff50d377ae69c4bd990a8aa2fa952e8cc7))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.35.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.34.1...@carbon/ibm-products@1.35.0) (2022-10-25)
+# [1.35.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.34.1...@carbon/ibm-products@1.35.0) (2022-10-25)
 
 ### Bug Fixes
 
 - **Datagrid:** get default table height for inifinite scroll
-  ([#2369](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2369))
-  ([720221a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/720221ac4c7e52ab8fac9394aa661a4a8c8c9e34))
+  ([#2369](https://github.com/carbon-design-system/ibm-products/issues/2369))
+  ([720221a](https://github.com/carbon-design-system/ibm-products/commit/720221ac4c7e52ab8fac9394aa661a4a8c8c9e34))
 - design review fixes
-  ([#2376](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2376))
-  ([8bbd7b1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8bbd7b1c0af7cf02a2630b8c391abaa87ea49bc1))
+  ([#2376](https://github.com/carbon-design-system/ibm-products/issues/2376))
+  ([8bbd7b1](https://github.com/carbon-design-system/ibm-products/commit/8bbd7b1c0af7cf02a2630b8c391abaa87ea49bc1))
 - Inline edit v2 design review
-  ([#2397](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2397))
-  ([643f900](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/643f900bd29135383371580fd29b5252c9301f99))
+  ([#2397](https://github.com/carbon-design-system/ibm-products/issues/2397))
+  ([643f900](https://github.com/carbon-design-system/ibm-products/commit/643f900bd29135383371580fd29b5252c9301f99))
 - **SidePanel:** address positioning in static version
-  ([#2395](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2395))
-  ([1c9ae8c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1c9ae8c347352f4ffbd2d68f1c7f1fe6177478cf))
+  ([#2395](https://github.com/carbon-design-system/ibm-products/issues/2395))
+  ([1c9ae8c](https://github.com/carbon-design-system/ibm-products/commit/1c9ae8c347352f4ffbd2d68f1c7f1fe6177478cf))
 
 ### Features
 
 - **Datagrid:** allow for customizable virtual height
-  ([#2381](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2381))
-  ([b083c4b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b083c4bd6a597d917e90e2befc2c795139c6890c))
+  ([#2381](https://github.com/carbon-design-system/ibm-products/issues/2381))
+  ([b083c4b](https://github.com/carbon-design-system/ibm-products/commit/b083c4bd6a597d917e90e2befc2c795139c6890c))
 - **EditUpdateCards:** Edit and update cards
-  ([#2212](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2212))
-  ([ac140f8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ac140f8f8320f4985d95a8a270a440fd7b5cb2cf))
+  ([#2212](https://github.com/carbon-design-system/ibm-products/issues/2212))
+  ([ac140f8](https://github.com/carbon-design-system/ibm-products/commit/ac140f8f8320f4985d95a8a270a440fd7b5cb2cf))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.34.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.34.0...@carbon/ibm-products@1.34.1) (2022-10-18)
+## [1.34.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.34.0...@carbon/ibm-products@1.34.1) (2022-10-18)
 
 ### Bug Fixes
 
 - **builds:** add script to fix `node_modules` path in sass source maps
-  ([#2358](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2358))
-  ([c450dc8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c450dc848108921f58ae190d1c109918c337965d))
+  ([#2358](https://github.com/carbon-design-system/ibm-products/issues/2358))
+  ([c450dc8](https://github.com/carbon-design-system/ibm-products/commit/c450dc848108921f58ae190d1c109918c337965d))
 - update Carbon v10 compatible versions to latest
-  ([#2362](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2362))
-  ([e328904](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e328904b20bdc0c652661de829c0d1bfcb8738b6))
+  ([#2362](https://github.com/carbon-design-system/ibm-products/issues/2362))
+  ([e328904](https://github.com/carbon-design-system/ibm-products/commit/e328904b20bdc0c652661de829c0d1bfcb8738b6))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.34.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.33.0...@carbon/ibm-products@1.34.0) (2022-10-11)
+# [1.34.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.33.0...@carbon/ibm-products@1.34.0) (2022-10-11)
 
 ### Bug Fixes
 
 - add inline edit v2 stories
-  ([#2340](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2340))
-  ([7aa0efd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7aa0efdc3aa241b45094c7b7250c22dcc6b61dd9))
+  ([#2340](https://github.com/carbon-design-system/ibm-products/issues/2340))
+  ([7aa0efd](https://github.com/carbon-design-system/ibm-products/commit/7aa0efdc3aa241b45094c7b7250c22dcc6b61dd9))
 - added actions to inline edit v2
-  ([#2339](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2339))
-  ([c8de30c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c8de30ce0e08e1ead4185fc24b22aa102c0fc79f))
+  ([#2339](https://github.com/carbon-design-system/ibm-products/issues/2339))
+  ([c8de30c](https://github.com/carbon-design-system/ibm-products/commit/c8de30ce0e08e1ead4185fc24b22aa102c0fc79f))
 - **PageHeader:** Update page header to use h1
-  ([#2325](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2325))
-  ([1f4cb98](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1f4cb980d790bd0a447aa13338df96f167ea4e1f))
+  ([#2325](https://github.com/carbon-design-system/ibm-products/issues/2325))
+  ([1f4cb98](https://github.com/carbon-design-system/ibm-products/commit/1f4cb980d790bd0a447aa13338df96f167ea4e1f))
 - **SidePanel:** motion refactor using framer motion
-  ([#2312](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2312))
-  ([56d16e2](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/56d16e2b77399e2bc5c676cbdd27d9036aea9fd0))
+  ([#2312](https://github.com/carbon-design-system/ibm-products/issues/2312))
+  ([56d16e2](https://github.com/carbon-design-system/ibm-products/commit/56d16e2b77399e2bc5c676cbdd27d9036aea9fd0))
 - update to Carbon v10 compatible versions to latest
-  ([#2331](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2331))
-  ([26f7bc1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/26f7bc1b05ded4d79634a06dea725746e6e381e7))
+  ([#2331](https://github.com/carbon-design-system/ibm-products/issues/2331))
+  ([26f7bc1](https://github.com/carbon-design-system/ibm-products/commit/26f7bc1b05ded4d79634a06dea725746e6e381e7))
 
 ### Features
 
 - inline edit refactor
-  ([#2330](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2330))
-  ([ecd7b6d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ecd7b6dbc0174c0a06d3540a02c19e1881d85a59))
+  ([#2330](https://github.com/carbon-design-system/ibm-products/issues/2330))
+  ([ecd7b6d](https://github.com/carbon-design-system/ibm-products/commit/ecd7b6dbc0174c0a06d3540a02c19e1881d85a59))
 
-# [1.33.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.32.1...@carbon/ibm-products@1.33.0) (2022-10-04)
+# [1.33.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.32.1...@carbon/ibm-products@1.33.0) (2022-10-04)
 
 ### Bug Fixes
 
 - **CreateTearsheetNarrow:** Update formTitle prop as optional
-  ([#2315](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2315))
-  ([5b3e946](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5b3e946f9b6f8a819b37bbe9b527d36ecf0751e1))
+  ([#2315](https://github.com/carbon-design-system/ibm-products/issues/2315))
+  ([5b3e946](https://github.com/carbon-design-system/ibm-products/commit/5b3e946f9b6f8a819b37bbe9b527d36ecf0751e1))
 - **InlineEdit:** fix calc interpolation issue
-  ([#2311](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2311))
-  ([55f526a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/55f526a299007fa520e4f3022556c7709cb77e64))
+  ([#2311](https://github.com/carbon-design-system/ibm-products/issues/2311))
+  ([55f526a](https://github.com/carbon-design-system/ibm-products/commit/55f526a299007fa520e4f3022556c7709cb77e64))
 
 ### Features
 
 - **Datagrid:** add validation to inline editing
-  ([#2316](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2316))
-  ([3e572d6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3e572d630c6632d2c8a383f46dcb877978d63553))
+  ([#2316](https://github.com/carbon-design-system/ibm-products/issues/2316))
+  ([3e572d6](https://github.com/carbon-design-system/ibm-products/commit/3e572d630c6632d2c8a383f46dcb877978d63553))
 
-## [1.32.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.32.0...@carbon/ibm-products@1.32.1) (2022-09-27)
+## [1.32.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.32.0...@carbon/ibm-products@1.32.1) (2022-09-27)
 
 ### Bug Fixes
 
 - **Data Grid:** review feedback fix
-  ([#2282](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2282))
-  ([690a7c6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/690a7c64ea8b506fbc2ccc18c546332deea05226))
+  ([#2282](https://github.com/carbon-design-system/ibm-products/issues/2282))
+  ([690a7c6](https://github.com/carbon-design-system/ibm-products/commit/690a7c64ea8b506fbc2ccc18c546332deea05226))
 - **Datagrid:** allow row settings menu to work with inline edit
-  ([#2299](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2299))
-  ([e840378](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e840378246ad9179c03c7b1110c59d8f30d03bec))
+  ([#2299](https://github.com/carbon-design-system/ibm-products/issues/2299))
+  ([e840378](https://github.com/carbon-design-system/ibm-products/commit/e840378246ad9179c03c7b1110c59d8f30d03bec))
 - **Datagrid:** allow sticky columns to stick again
-  ([#2281](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2281))
-  ([66b0b14](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/66b0b142297bb0844de1d4ddaf7811221be554bb))
+  ([#2281](https://github.com/carbon-design-system/ibm-products/issues/2281))
+  ([66b0b14](https://github.com/carbon-design-system/ibm-products/commit/66b0b142297bb0844de1d4ddaf7811221be554bb))
 - **Datagrid:** row size drop down alignment
-  ([#2288](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2288))
-  ([00b6a4a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/00b6a4af6e394bae502b8af24d553b111d3ee23a))
+  ([#2288](https://github.com/carbon-design-system/ibm-products/issues/2288))
+  ([00b6a4a](https://github.com/carbon-design-system/ibm-products/commit/00b6a4af6e394bae502b8af24d553b111d3ee23a))
 - inline edit newline fix
-  ([#2298](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2298))
-  ([0dbcbdf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0dbcbdf2b9f1530a9efa6075159cdbbed5c13a08))
+  ([#2298](https://github.com/carbon-design-system/ibm-products/issues/2298))
+  ([0dbcbdf](https://github.com/carbon-design-system/ibm-products/commit/0dbcbdf2b9f1530a9efa6075159cdbbed5c13a08))
 - update option title trucation issue
-  ([#2313](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2313))
-  ([73d6059](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/73d605946ac19e4ec965b07223ec93c84b1f39f9))
+  ([#2313](https://github.com/carbon-design-system/ibm-products/issues/2313))
+  ([73d6059](https://github.com/carbon-design-system/ibm-products/commit/73d605946ac19e4ec965b07223ec93c84b1f39f9))
 - update to Carbon v10 compatible versions to latest
-  ([#2276](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2276))
-  ([c35a363](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c35a3630ecb0dd60d920e57d81bd8f6e84aae008))
+  ([#2276](https://github.com/carbon-design-system/ibm-products/issues/2276))
+  ([c35a363](https://github.com/carbon-design-system/ibm-products/commit/c35a3630ecb0dd60d920e57d81bd8f6e84aae008))
 
-# [1.32.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.31.0...@carbon/ibm-products@1.32.0) (2022-09-20)
+# [1.32.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.31.0...@carbon/ibm-products@1.32.0) (2022-09-20)
 
 ### Features
 
 - **Datagrid:** add inline edit keyboard shortcuts
-  ([#2269](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2269))
-  ([3d38e70](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3d38e706f68ecbec72bcd9b9db3213a9f68e26c2))
+  ([#2269](https://github.com/carbon-design-system/ibm-products/issues/2269))
+  ([3d38e70](https://github.com/carbon-design-system/ibm-products/commit/3d38e706f68ecbec72bcd9b9db3213a9f68e26c2))
 
-# [1.31.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.30.0...@carbon/ibm-products@1.31.0) (2022-09-13)
+# [1.31.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.30.0...@carbon/ibm-products@1.31.0) (2022-09-13)
 
 ### Features
 
 - **Datagrid:**
-  [#2237](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2237)
+  [#2237](https://github.com/carbon-design-system/ibm-products/issues/2237)
   datagrid inline edit `date` type
-  ([#2238](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2238))
-  ([835dd48](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/835dd48f439b87610f0722c420f56ce6c0385daf))
+  ([#2238](https://github.com/carbon-design-system/ibm-products/issues/2238))
+  ([835dd48](https://github.com/carbon-design-system/ibm-products/commit/835dd48f439b87610f0722c420f56ce6c0385daf))
 
-# [1.30.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.29.0...@carbon/ibm-products@1.30.0) (2022-09-13)
+# [1.30.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.29.0...@carbon/ibm-products@1.30.0) (2022-09-13)
 
 ### Features
 
 - **Datagrid:** inline edit - useInlineEdit hook, text and number types
-  ([#2228](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2228))
-  ([4d6c839](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4d6c839e7130c841f58367c221953cb51785b16f))
+  ([#2228](https://github.com/carbon-design-system/ibm-products/issues/2228))
+  ([4d6c839](https://github.com/carbon-design-system/ibm-products/commit/4d6c839e7130c841f58367c221953cb51785b16f))
 - **DataSpreadsheet:** add cell deletion and theme prop for designs
-  ([#2220](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2220))
-  ([3acddc5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3acddc598017c9afa453ec217154ebfe7b683dfb))
+  ([#2220](https://github.com/carbon-design-system/ibm-products/issues/2220))
+  ([3acddc5](https://github.com/carbon-design-system/ibm-products/commit/3acddc598017c9afa453ec217154ebfe7b683dfb))
 - **ProductiveCard:** include ghost button in the Action Bar
-  ([#2253](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2253))
-  ([865e3c0](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/865e3c0216832f209d0c0492d4dbd332d3daabb2))
+  ([#2253](https://github.com/carbon-design-system/ibm-products/issues/2253))
+  ([865e3c0](https://github.com/carbon-design-system/ibm-products/commit/865e3c0216832f209d0c0492d4dbd332d3daabb2))
 
-# [1.29.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.28.0...@carbon/ibm-products@1.29.0) (2022-09-06)
+# [1.29.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.28.0...@carbon/ibm-products@1.29.0) (2022-09-06)
 
 ### Bug Fixes
 
 - **Datagrid:** add withSelectColumns when using useSelectRows
-  ([#2241](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2241))
-  ([2a5e194](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2a5e1948a16aa6cf4f1ba5126a58f1f99d1ec69d))
+  ([#2241](https://github.com/carbon-design-system/ibm-products/issues/2241))
+  ([2a5e194](https://github.com/carbon-design-system/ibm-products/commit/2a5e1948a16aa6cf4f1ba5126a58f1f99d1ec69d))
 - **removeModal:** Edit small inconsistencies from pal
-  ([#2245](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2245))
-  ([5cb4b4e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5cb4b4ee6f3fc6ab69512811bb1dddca18e60194))
+  ([#2245](https://github.com/carbon-design-system/ibm-products/issues/2245))
+  ([5cb4b4e](https://github.com/carbon-design-system/ibm-products/commit/5cb4b4ee6f3fc6ab69512811bb1dddca18e60194))
 - **SidePanel:** style update for title truncation issue
-  ([#2239](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2239))
-  ([c88b085](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c88b085c542fb10a12a844f2b5c419e2e4676db4))
+  ([#2239](https://github.com/carbon-design-system/ibm-products/issues/2239))
+  ([c88b085](https://github.com/carbon-design-system/ibm-products/commit/c88b085c542fb10a12a844f2b5c419e2e4676db4))
 - update to Carbon v10 compatible versions to latest
-  ([#2249](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2249))
-  ([2a2ccfa](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2a2ccfaef41d5247724aed978fb62567932ea6dc))
+  ([#2249](https://github.com/carbon-design-system/ibm-products/issues/2249))
+  ([2a2ccfa](https://github.com/carbon-design-system/ibm-products/commit/2a2ccfaef41d5247724aed978fb62567932ea6dc))
 
 ### Features
 
 - **WebTerminal:** Releases the WebTerminal 🚀
-  ([#2246](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2246))
-  ([2afe754](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2afe7542b29224574234ef9552dc3f62cb160dc6))
+  ([#2246](https://github.com/carbon-design-system/ibm-products/issues/2246))
+  ([2afe754](https://github.com/carbon-design-system/ibm-products/commit/2afe7542b29224574234ef9552dc3f62cb160dc6))
 
-# [1.28.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.27.0...@carbon/ibm-products@1.28.0) (2022-08-30)
+# [1.28.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.27.0...@carbon/ibm-products@1.28.0) (2022-08-30)
 
 ### Bug Fixes
 
 - add select design review updates
-  ([#2195](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2195))
-  ([c6e2625](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c6e2625f8ebdc732445c4daea2bb3bdfe0bcc89e))
+  ([#2195](https://github.com/carbon-design-system/ibm-products/issues/2195))
+  ([c6e2625](https://github.com/carbon-design-system/ibm-products/commit/c6e2625f8ebdc732445c4daea2bb3bdfe0bcc89e))
 - **Datagrid:** export useColumnOrder hook
-  ([#2214](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2214))
-  ([094cc6f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/094cc6f55bf6e493f4c56fe4a63fb8e70a2c6221))
+  ([#2214](https://github.com/carbon-design-system/ibm-products/issues/2214))
+  ([094cc6f](https://github.com/carbon-design-system/ibm-products/commit/094cc6f55bf6e493f4c56fe4a63fb8e70a2c6221))
 - **DataSpreadsheet:** add missing aria labels and update arialabelled-by
-  ([#2211](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2211))
-  ([840864e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/840864ec3bac68f643fa87d5c9b35b09246b70c9))
+  ([#2211](https://github.com/carbon-design-system/ibm-products/issues/2211))
+  ([840864e](https://github.com/carbon-design-system/ibm-products/commit/840864ec3bac68f643fa87d5c9b35b09246b70c9))
 - **ImportModal:** empty accepts array & adds "." to extension variable
-  ([#2218](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2218))
-  ([6cdd78b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6cdd78bb8586eb94db283eb65e52f4eb50de2321))
+  ([#2218](https://github.com/carbon-design-system/ibm-products/issues/2218))
+  ([6cdd78b](https://github.com/carbon-design-system/ibm-products/commit/6cdd78bb8586eb94db283eb65e52f4eb50de2321))
 - Inline edit 2107
-  ([#2222](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2222))
-  ([76cfb89](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/76cfb894e2c8472a8da3a06f96dca7a09c26e57e))
+  ([#2222](https://github.com/carbon-design-system/ibm-products/issues/2222))
+  ([76cfb89](https://github.com/carbon-design-system/ibm-products/commit/76cfb894e2c8472a8da3a06f96dca7a09c26e57e))
 - reset state on submit or close
-  ([#2219](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2219))
-  ([a18e538](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a18e5381b22a0a64c74e3545c773251c89de4dab))
+  ([#2219](https://github.com/carbon-design-system/ibm-products/issues/2219))
+  ([a18e538](https://github.com/carbon-design-system/ibm-products/commit/a18e5381b22a0a64c74e3545c773251c89de4dab))
 
 ### Features
 
 - **Datagrid:**
-  [#2070](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2070)
+  [#2070](https://github.com/carbon-design-system/ibm-products/issues/2070)
   add datagrid actions dropdown example
-  ([#2210](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2210))
-  ([08f1bd5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/08f1bd55073abe398134430c06fa432c43e1208a))
+  ([#2210](https://github.com/carbon-design-system/ibm-products/issues/2210))
+  ([08f1bd5](https://github.com/carbon-design-system/ibm-products/commit/08f1bd55073abe398134430c06fa432c43e1208a))
 - **Datagrid:** add frozen left column support
-  ([#2194](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2194))
-  ([d469476](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d469476e0f60d376f0989c7a5cb335e3d9525a36))
+  ([#2194](https://github.com/carbon-design-system/ibm-products/issues/2194))
+  ([d469476](https://github.com/carbon-design-system/ibm-products/commit/d469476e0f60d376f0989c7a5cb335e3d9525a36))
 - **Datagrid:** added select all button to customize columns modal; added
   styles; revised instruction text
-  ([#2221](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2221))
-  ([fd90950](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fd909502b7f9c69024f6a43543ffb496bd7875ce))
+  ([#2221](https://github.com/carbon-design-system/ibm-products/issues/2221))
+  ([fd90950](https://github.com/carbon-design-system/ibm-products/commit/fd909502b7f9c69024f6a43543ffb496bd7875ce))
 
-# [1.27.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.26.0...@carbon/ibm-products@1.27.0) (2022-08-23)
+# [1.27.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.26.0...@carbon/ibm-products@1.27.0) (2022-08-23)
 
 ### Features
 
 - **Datagrid:** add multi line wrap option
-  ([#2196](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2196))
-  ([537d93b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/537d93be2fa3997b71debe4f6fd27094c37c6935))
+  ([#2196](https://github.com/carbon-design-system/ibm-products/issues/2196))
+  ([537d93b](https://github.com/carbon-design-system/ibm-products/commit/537d93be2fa3997b71debe4f6fd27094c37c6935))
 - **WebTerminal:** A11y test, iconDescription tests, and storybook
-  ([#2162](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2162))
-  ([090470e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/090470e8f1eaba5ddde6751f5ad53338642d0015))
+  ([#2162](https://github.com/carbon-design-system/ibm-products/issues/2162))
+  ([090470e](https://github.com/carbon-design-system/ibm-products/commit/090470e8f1eaba5ddde6751f5ad53338642d0015))
 
-# [1.26.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.25.1...@carbon/ibm-products@1.26.0) (2022-08-16)
+# [1.26.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.25.1...@carbon/ibm-products@1.26.0) (2022-08-16)
 
 ### Bug Fixes
 
 - **InlineEdit:** fix sass calc issue with carbon token
-  ([#2158](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2158))
-  ([ac258e6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ac258e664f700819da467ff8d0fc80ad428e6ac4))
+  ([#2158](https://github.com/carbon-design-system/ibm-products/issues/2158))
+  ([ac258e6](https://github.com/carbon-design-system/ibm-products/commit/ac258e664f700819da467ff8d0fc80ad428e6ac4))
 
 ### Features
 
 - Add Row Action Buttons
-  ([#2168](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2168))
-  ([d0635bc](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d0635bc637a7133eba6321a1b4f597ba3d60d8a4))
+  ([#2168](https://github.com/carbon-design-system/ibm-products/issues/2168))
+  ([d0635bc](https://github.com/carbon-design-system/ibm-products/commit/d0635bc637a7133eba6321a1b4f597ba3d60d8a4))
 - **Datagrid:** Batch actions
-  ([#2022](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2022))
-  ([bb7e71b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/bb7e71b3a6b333c8b9ea6c0fb90d02e280042dc0))
+  ([#2022](https://github.com/carbon-design-system/ibm-products/issues/2022))
+  ([bb7e71b](https://github.com/carbon-design-system/ibm-products/commit/bb7e71b3a6b333c8b9ea6c0fb90d02e280042dc0))
 
-## [1.25.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.25.0...@carbon/ibm-products@1.25.1) (2022-08-08)
+## [1.25.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.25.0...@carbon/ibm-products@1.25.1) (2022-08-08)
 
 ### Bug Fixes
 
 - change datagrid style files to partials
-  ([#2153](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2153))
-  ([c8cfe3f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c8cfe3f3b38367a9d1ceed6203f9f72d8a050e1e))
+  ([#2153](https://github.com/carbon-design-system/ibm-products/issues/2153))
+  ([c8cfe3f](https://github.com/carbon-design-system/ibm-products/commit/c8cfe3f3b38367a9d1ceed6203f9f72d8a050e1e))
 - **Datagrid:** fix style issues between Datagrid and Carbon data table
-  ([#2156](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2156))
-  ([082877e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/082877e8f9204c74f0d5ca644a80e15a6b17016e))
+  ([#2156](https://github.com/carbon-design-system/ibm-products/issues/2156))
+  ([082877e](https://github.com/carbon-design-system/ibm-products/commit/082877e8f9204c74f0d5ca644a80e15a6b17016e))
 - single add select css updates
-  ([#2149](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2149))
-  ([b09524b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b09524bb1953e69f7b6cdb7d762434b4b9dec7b5))
+  ([#2149](https://github.com/carbon-design-system/ibm-products/issues/2149))
+  ([b09524b](https://github.com/carbon-design-system/ibm-products/commit/b09524bb1953e69f7b6cdb7d762434b4b9dec7b5))
 
-# [1.25.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.24.0...@carbon/ibm-products@1.25.0) (2022-08-02)
+# [1.25.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.24.0...@carbon/ibm-products@1.25.0) (2022-08-02)
 
 ### Bug Fixes
 
 - **EmptyState:** update text-styles, spacing and button-size
-  ([#2133](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2133))
-  ([1c27e3a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1c27e3add89734cee222174484c27d4d1d6e86eb))
+  ([#2133](https://github.com/carbon-design-system/ibm-products/issues/2133))
+  ([1c27e3a](https://github.com/carbon-design-system/ibm-products/commit/1c27e3add89734cee222174484c27d4d1d6e86eb))
 - update to Carbon v10 compatible versions to latest
-  ([#2144](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2144))
-  ([c67ce20](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c67ce20cf586218f28d2ad7bba4de6fd4d21efae))
+  ([#2144](https://github.com/carbon-design-system/ibm-products/issues/2144))
+  ([c67ce20](https://github.com/carbon-design-system/ibm-products/commit/c67ce20cf586218f28d2ad7bba4de6fd4d21efae))
 
 ### Features
 
 - **ImportModal:** render icon for import by url button
-  ([#2146](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2146))
-  ([c707b8b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c707b8b23265909917794b0f31b4f93097dfbc05))
+  ([#2146](https://github.com/carbon-design-system/ibm-products/issues/2146))
+  ([c707b8b](https://github.com/carbon-design-system/ibm-products/commit/c707b8b23265909917794b0f31b4f93097dfbc05))
 - **WebTerminal:** refactors code to useContext and custom hooks
-  ([#2097](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2097))
-  ([e71e21b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e71e21b66782fa99edccaf230ec8365c27f6192e))
+  ([#2097](https://github.com/carbon-design-system/ibm-products/issues/2097))
+  ([e71e21b](https://github.com/carbon-design-system/ibm-products/commit/e71e21b66782fa99edccaf230ec8365c27f6192e))
 
-# [1.24.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.23.1...@carbon/ibm-products@1.24.0) (2022-07-27)
+# [1.24.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.23.1...@carbon/ibm-products@1.24.0) (2022-07-27)
 
 ### Bug Fixes
 
 - **Datagrid:** fix issue in StickActionColumn tests
-  ([#2135](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2135))
-  ([ff37a8e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ff37a8eabb13ebd256058e0404bde3a70d84c46f))
+  ([#2135](https://github.com/carbon-design-system/ibm-products/issues/2135))
+  ([ff37a8e](https://github.com/carbon-design-system/ibm-products/commit/ff37a8eabb13ebd256058e0404bde3a70d84c46f))
 - inline edit overflow to right
-  ([#2104](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2104))
-  ([9392372](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/939237279f94330752c69bb93a814eaef5dfd9a0))
+  ([#2104](https://github.com/carbon-design-system/ibm-products/issues/2104))
+  ([9392372](https://github.com/carbon-design-system/ibm-products/commit/939237279f94330752c69bb93a814eaef5dfd9a0))
 - **PageHeader:** solved unexpected scrollbar issue
-  ([#2119](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2119))
-  ([15daeee](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/15daeee4ee744df5ddee2f0c8fe579383dfc4451))
+  ([#2119](https://github.com/carbon-design-system/ibm-products/issues/2119))
+  ([15daeee](https://github.com/carbon-design-system/ibm-products/commit/15daeee4ee744df5ddee2f0c8fe579383dfc4451))
 - select all duplicates in add select columns
-  ([#2136](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2136))
-  ([fb16ab3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fb16ab33c6a6a6920ca8b27c84382046ea0e3764))
+  ([#2136](https://github.com/carbon-design-system/ibm-products/issues/2136))
+  ([fb16ab3](https://github.com/carbon-design-system/ibm-products/commit/fb16ab33c6a6a6920ca8b27c84382046ea0e3764))
 
 ### Features
 
 - **Datatable:** table header
-  ([#1973](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1973))
-  ([f9166ad](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f9166adacbda3851e20f710cb196e2db01388107))
+  ([#1973](https://github.com/carbon-design-system/ibm-products/issues/1973))
+  ([f9166ad](https://github.com/carbon-design-system/ibm-products/commit/f9166adacbda3851e20f710cb196e2db01388107))
 - **edit and update:** edit and update tearsheet
-  ([#1975](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1975))
-  ([cd09bab](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/cd09babac9f862339760acd64fc24340c06423ae))
+  ([#1975](https://github.com/carbon-design-system/ibm-products/issues/1975))
+  ([cd09bab](https://github.com/carbon-design-system/ibm-products/commit/cd09babac9f862339760acd64fc24340c06423ae))
 
-## [1.23.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.23.0...@carbon/ibm-products@1.23.1) (2022-07-19)
+## [1.23.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.23.0...@carbon/ibm-products@1.23.1) (2022-07-19)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#2101](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2101))
-  ([feebce3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/feebce38ac474917e29d201d9198e3baf9452a97))
+  ([#2101](https://github.com/carbon-design-system/ibm-products/issues/2101))
+  ([feebce3](https://github.com/carbon-design-system/ibm-products/commit/feebce38ac474917e29d201d9198e3baf9452a97))
 - **web-terminal:** spans 100% when less than 640px
-  ([#2087](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2087))
-  ([c012d30](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c012d306c0df936ef4916e5b31e7dd8517ebb3ca))
+  ([#2087](https://github.com/carbon-design-system/ibm-products/issues/2087))
+  ([c012d30](https://github.com/carbon-design-system/ibm-products/commit/c012d306c0df936ef4916e5b31e7dd8517ebb3ca))
 - **WebTerminal:** small fixes for release review
-  ([#2106](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2106))
-  ([6eb3346](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6eb3346efaae41a1c38972620c4f9222419cce36))
+  ([#2106](https://github.com/carbon-design-system/ibm-products/issues/2106))
+  ([6eb3346](https://github.com/carbon-design-system/ibm-products/commit/6eb3346efaae41a1c38972620c4f9222419cce36))
 
-# [1.23.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.22.0...@carbon/ibm-products@1.23.0) (2022-07-12)
+# [1.23.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.22.0...@carbon/ibm-products@1.23.0) (2022-07-12)
 
 ### Bug Fixes
 
 - add select refactor
-  ([#2068](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2068))
-  ([b7aa521](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b7aa5217902ae4ca29c998692f8d7b2823c90f69))
+  ([#2068](https://github.com/carbon-design-system/ibm-products/issues/2068))
+  ([b7aa521](https://github.com/carbon-design-system/ibm-products/commit/b7aa5217902ae4ca29c998692f8d7b2823c90f69))
 
 ### Features
 
 - add multiline attribute to tagset
-  ([#2079](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2079))
-  ([6c3286a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6c3286ae43f8e4996badf20dc4582b8133a36d0f))
+  ([#2079](https://github.com/carbon-design-system/ibm-products/issues/2079))
+  ([6c3286a](https://github.com/carbon-design-system/ibm-products/commit/6c3286ae43f8e4996badf20dc4582b8133a36d0f))
 - align expandable rows
-  ([#2039](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2039))
-  ([853176f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/853176f951d13ab867bee63cb2b2a562fd7ce7a7))
+  ([#2039](https://github.com/carbon-design-system/ibm-products/issues/2039))
+  ([853176f](https://github.com/carbon-design-system/ibm-products/commit/853176f951d13ab867bee63cb2b2a562fd7ce7a7))
 - index cloud cognitive
-  ([#2063](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2063))
-  ([a743a20](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a743a206a016685f3a8a2644bbdce054ad84ead1))
+  ([#2063](https://github.com/carbon-design-system/ibm-products/issues/2063))
+  ([a743a20](https://github.com/carbon-design-system/ibm-products/commit/a743a206a016685f3a8a2644bbdce054ad84ead1))
 - merged left panel content and datagrid on same horizontal level
-  ([#2064](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2064))
-  ([356b101](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/356b10107055a8f72ee68f07851357405306b99e))
+  ([#2064](https://github.com/carbon-design-system/ibm-products/issues/2064))
+  ([356b101](https://github.com/carbon-design-system/ibm-products/commit/356b10107055a8f72ee68f07851357405306b99e))
 
-# [1.22.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.21.0...@carbon/ibm-products@1.22.0) (2022-07-05)
+# [1.22.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.21.0...@carbon/ibm-products@1.22.0) (2022-07-05)
 
 ### Features
 
 - added center aligned columns component and centered new columns
-  ([#2056](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2056))
-  ([9178df2](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9178df24c2f54370ab4064ab659c77a9ac459377))
+  ([#2056](https://github.com/carbon-design-system/ibm-products/issues/2056))
+  ([9178df2](https://github.com/carbon-design-system/ibm-products/commit/9178df24c2f54370ab4064ab659c77a9ac459377))
 
-# [1.21.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.20.3...@carbon/ibm-products@1.21.0) (2022-06-28)
+# [1.21.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.20.3...@carbon/ibm-products@1.21.0) (2022-06-28)
 
 ### Features
 
 - **WebTerminal:** Changes width to 640px
-  ([#2066](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2066))
-  ([b741316](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b741316b74dd8be0af2f4cfc61ad28c0a672e46b))
+  ([#2066](https://github.com/carbon-design-system/ibm-products/issues/2066))
+  ([b741316](https://github.com/carbon-design-system/ibm-products/commit/b741316b74dd8be0af2f4cfc61ad28c0a672e46b))
 
-## [1.20.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.20.2...@carbon/ibm-products@1.20.3) (2022-06-21)
+## [1.20.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.20.2...@carbon/ibm-products@1.20.3) (2022-06-21)
 
 **Note:** Version bump only for package @carbon/ibm-products
 
-## [1.20.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.20.1...@carbon/ibm-products@1.20.2) (2022-06-15)
+## [1.20.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.20.1...@carbon/ibm-products@1.20.2) (2022-06-15)
 
 ### Bug Fixes
 
 - **Datagrid:** use checkbox in place of inline checkbox
-  ([#2037](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2037))
-  ([1859ccf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1859ccf5f1f7181ed83aad0125268042fb5a7ca1))
+  ([#2037](https://github.com/carbon-design-system/ibm-products/issues/2037))
+  ([1859ccf](https://github.com/carbon-design-system/ibm-products/commit/1859ccf5f1f7181ed83aad0125268042fb5a7ca1))
 
-## [1.20.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.20.0...@carbon/ibm-products@1.20.1) (2022-06-14)
+## [1.20.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.20.0...@carbon/ibm-products@1.20.1) (2022-06-14)
 
 ### Bug Fixes
 
 - **Datagrid:** export datagrid hooks
-  ([#2036](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2036))
-  ([44be0e1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/44be0e1e31cf5061296238026901280bdd49bc75))
+  ([#2036](https://github.com/carbon-design-system/ibm-products/issues/2036))
+  ([44be0e1](https://github.com/carbon-design-system/ibm-products/commit/44be0e1e31cf5061296238026901280bdd49bc75))
 
-# [1.20.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.19.1...@carbon/ibm-products@1.20.0) (2022-06-13)
+# [1.20.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.19.1...@carbon/ibm-products@1.20.0) (2022-06-13)
 
 ### Bug Fixes
 
 - **ComboButton:** remove getInstanceId and use our internal uuid util
-  ([#2028](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2028))
-  ([c482bbd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c482bbd1378ad4b774a118e677e05ccad88c4675))
+  ([#2028](https://github.com/carbon-design-system/ibm-products/issues/2028))
+  ([c482bbd](https://github.com/carbon-design-system/ibm-products/commit/c482bbd1378ad4b774a118e677e05ccad88c4675))
 - **CreateSidePanel:** use actions prop instead of ActionSet directly
-  ([#2033](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2033))
-  ([8dbeabd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8dbeabdc3a2829e9a60207c9a36da58d9817add0))
+  ([#2033](https://github.com/carbon-design-system/ibm-products/issues/2033))
+  ([8dbeabd](https://github.com/carbon-design-system/ibm-products/commit/8dbeabdc3a2829e9a60207c9a36da58d9817add0))
 - header row horizontal scroll and scrollbar style
-  ([#2032](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2032))
-  ([f6ea8d8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f6ea8d88ca11cc959d1c36c5d309f23414cc03e3))
+  ([#2032](https://github.com/carbon-design-system/ibm-products/issues/2032))
+  ([f6ea8d8](https://github.com/carbon-design-system/ibm-products/commit/f6ea8d88ca11cc959d1c36c5d309f23414cc03e3))
 - hooked up add select modifier functionality
-  ([#2019](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2019))
-  ([2cbda09](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2cbda091755b6c1dde20e892c5b8568c0ab18e11))
+  ([#2019](https://github.com/carbon-design-system/ibm-products/issues/2019))
+  ([2cbda09](https://github.com/carbon-design-system/ibm-products/commit/2cbda091755b6c1dde20e892c5b8568c0ab18e11))
 - **SidePanel:** check if window exists for reduced motion logic
-  ([#2029](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2029))
-  ([6bc2b29](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6bc2b29a3dc35ee7952cf8683e5f8a9e46e59e2c))
+  ([#2029](https://github.com/carbon-design-system/ibm-products/issues/2029))
+  ([6bc2b29](https://github.com/carbon-design-system/ibm-products/commit/6bc2b29a3dc35ee7952cf8683e5f8a9e46e59e2c))
 
 ### Features
 
 - inline edit release
-  ([#2025](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2025))
-  ([028a58f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/028a58fc10fab8cd2f7e8846d0ef7611e15862ca))
+  ([#2025](https://github.com/carbon-design-system/ibm-products/issues/2025))
+  ([028a58f](https://github.com/carbon-design-system/ibm-products/commit/028a58fc10fab8cd2f7e8846d0ef7611e15862ca))
 
-## [1.19.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.19.0...@carbon/ibm-products@1.19.1) (2022-06-06)
+## [1.19.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.19.0...@carbon/ibm-products@1.19.1) (2022-06-06)
 
 ### Bug Fixes
 
 - Added styles to datagrid drag and drop pattern
-  ([#2009](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2009))
-  ([0dc0bf8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0dc0bf84a794960bbf1bf08e1ebb6ba23de6e027))
+  ([#2009](https://github.com/carbon-design-system/ibm-products/issues/2009))
+  ([0dc0bf8](https://github.com/carbon-design-system/ibm-products/commit/0dc0bf84a794960bbf1bf08e1ebb6ba23de6e027))
 - **ComboButton:** change import of overflow menu and fix styles
-  ([#2010](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2010))
-  ([564de7d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/564de7d01dadb1c504e9a4add866a6698c152ccc))
+  ([#2010](https://github.com/carbon-design-system/ibm-products/issues/2010))
+  ([564de7d](https://github.com/carbon-design-system/ibm-products/commit/564de7d01dadb1c504e9a4add866a6698c152ccc))
 
-# [1.19.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.18.2...@carbon/ibm-products@1.19.0) (2022-05-31)
+# [1.19.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.18.2...@carbon/ibm-products@1.19.0) (2022-05-31)
 
 ### Bug Fixes
 
 - add select global filter styles
-  ([#2005](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2005))
-  ([34951a7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/34951a75d7d09cdfe6e61e0ccb41de04fec30d57))
+  ([#2005](https://github.com/carbon-design-system/ibm-products/issues/2005))
+  ([34951a7](https://github.com/carbon-design-system/ibm-products/commit/34951a75d7d09cdfe6e61e0ccb41de04fec30d57))
 - add select sidebar bug
-  ([#2007](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2007))
-  ([9f587c8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9f587c8824a0222634266e8532e64a6b42436713))
+  ([#2007](https://github.com/carbon-design-system/ibm-products/issues/2007))
+  ([9f587c8](https://github.com/carbon-design-system/ibm-products/commit/9f587c8824a0222634266e8532e64a6b42436713))
 
 ### Features
 
 - **DataSpreadsheet:** add multiple column reordering
-  ([#2002](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2002))
-  ([3f3588f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3f3588f5521d23e8bd74fb5fdd56101ea2952e34))
+  ([#2002](https://github.com/carbon-design-system/ibm-products/issues/2002))
+  ([3f3588f](https://github.com/carbon-design-system/ibm-products/commit/3f3588f5521d23e8bd74fb5fdd56101ea2952e34))
 
-## [1.18.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.18.1...@carbon/ibm-products@1.18.2) (2022-05-24)
+## [1.18.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.18.1...@carbon/ibm-products@1.18.2) (2022-05-24)
 
 ### Bug Fixes
 
 - **DataSpreadsheet:** support reordering columns with horizontal scroll
-  ([#1993](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1993))
-  ([e4a9b28](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e4a9b280df30ad5ca80777fd46a9acd058436bf1))
+  ([#1993](https://github.com/carbon-design-system/ibm-products/issues/1993))
+  ([e4a9b28](https://github.com/carbon-design-system/ibm-products/commit/e4a9b280df30ad5ca80777fd46a9acd058436bf1))
 - **DataSpreadsheet:** update active cell location after cellSize change
-  ([#1992](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1992))
-  ([9c103c6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9c103c6d7a55748cfcd9c22ef99d8308dfc9393a))
+  ([#1992](https://github.com/carbon-design-system/ibm-products/issues/1992))
+  ([9c103c6](https://github.com/carbon-design-system/ibm-products/commit/9c103c6d7a55748cfcd9c22ef99d8308dfc9393a))
 - **DataSpreadsheet:** update header cell border colors
-  ([#1997](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1997))
-  ([97c99f7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/97c99f7a80669b103840b8f1595de28d76915804))
+  ([#1997](https://github.com/carbon-design-system/ibm-products/issues/1997))
+  ([97c99f7](https://github.com/carbon-design-system/ibm-products/commit/97c99f7a80669b103840b8f1595de28d76915804))
 - when export modal closes the input should be reset
-  ([#1998](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1998))
-  ([7980610](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7980610d65fa42c509024325b40778bf8b0a3b82))
+  ([#1998](https://github.com/carbon-design-system/ibm-products/issues/1998))
+  ([7980610](https://github.com/carbon-design-system/ibm-products/commit/7980610d65fa42c509024325b40778bf8b0a3b82))
 
-## [1.18.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.18.0...@carbon/ibm-products@1.18.1) (2022-05-17)
+## [1.18.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.18.0...@carbon/ibm-products@1.18.1) (2022-05-17)
 
 ### Bug Fixes
 
 - add select meta panel
-  ([#1983](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1983))
-  ([5d06c18](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5d06c180a1e9236e53c6b7d9c738b52f299153a1))
+  ([#1983](https://github.com/carbon-design-system/ibm-products/issues/1983))
+  ([5d06c18](https://github.com/carbon-design-system/ibm-products/commit/5d06c180a1e9236e53c6b7d9c738b52f299153a1))
 - converts chevron in add select to button
-  ([#1988](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1988))
-  ([69c9b72](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/69c9b722a3f20afe89a4ebec13da10fe845650e3))
+  ([#1988](https://github.com/carbon-design-system/ibm-products/issues/1988))
+  ([69c9b72](https://github.com/carbon-design-system/ibm-products/commit/69c9b722a3f20afe89a4ebec13da10fe845650e3))
 - data table empty state
-  ([#1969](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1969))
-  ([512655d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/512655d8eb887436d61a8417b275994f14e34567))
+  ([#1969](https://github.com/carbon-design-system/ibm-products/issues/1969))
+  ([512655d](https://github.com/carbon-design-system/ibm-products/commit/512655d8eb887436d61a8417b275994f14e34567))
 - **DataSpreadsheet:** spreadsheet total visible columns fix
-  ([#1991](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1991))
-  ([10e931a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/10e931a6fe933e17674fb76a79cc2c467120eb19))
+  ([#1991](https://github.com/carbon-design-system/ibm-products/issues/1991))
+  ([10e931a](https://github.com/carbon-design-system/ibm-products/commit/10e931a6fe933e17674fb76a79cc2c467120eb19))
 - **DataSpreadsheet:** selected row/column cell header fixes
-  ([#1990](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1990))
-  ([9ccc157](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9ccc157b9062ba3b0165bfe08899e95e0dd1c87a))
+  ([#1990](https://github.com/carbon-design-system/ibm-products/issues/1990))
+  ([9ccc157](https://github.com/carbon-design-system/ibm-products/commit/9ccc157b9062ba3b0165bfe08899e95e0dd1c87a))
 
-# [1.18.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.17.0...@carbon/ibm-products@1.18.0) (2022-05-10)
+# [1.18.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.17.0...@carbon/ibm-products@1.18.0) (2022-05-10)
 
 ### Bug Fixes
 
 - **DataSpreadsheet:** address cell editing after reorder
-  ([#1962](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1962))
-  ([07530c6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/07530c6be2d57cc686e8081cebf06a225b016468))
+  ([#1962](https://github.com/carbon-design-system/ibm-products/issues/1962))
+  ([07530c6](https://github.com/carbon-design-system/ibm-products/commit/07530c6be2d57cc686e8081cebf06a225b016468))
 - **DataSpreadsheet:** spreadsheet column reordering indicator line and fix
   selection width issue
-  ([#1960](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1960))
-  ([4c2efde](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4c2efde39848742900a786bf62a63a0b4bdcb0f2))
+  ([#1960](https://github.com/carbon-design-system/ibm-products/issues/1960))
+  ([4c2efde](https://github.com/carbon-design-system/ibm-products/commit/4c2efde39848742900a786bf62a63a0b4bdcb0f2))
 - global filter functionality for add select
-  ([#1970](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1970))
-  ([7f3f7ea](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7f3f7eab5cf27a42ec808fd9eea08df894dbb071))
+  ([#1970](https://github.com/carbon-design-system/ibm-products/issues/1970))
+  ([7f3f7ea](https://github.com/carbon-design-system/ibm-products/commit/7f3f7eab5cf27a42ec808fd9eea08df894dbb071))
 - update to Carbon v10 compatible versions to latest
-  ([#1971](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1971))
-  ([95374b8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/95374b89a15b1a76d18fb29c40e161a54720c447)),
+  ([#1971](https://github.com/carbon-design-system/ibm-products/issues/1971))
+  ([95374b8](https://github.com/carbon-design-system/ibm-products/commit/95374b89a15b1a76d18fb29c40e161a54720c447)),
   closes
-  [#1970](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1970)
-  [#1972](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1972)
+  [#1970](https://github.com/carbon-design-system/ibm-products/issues/1970)
+  [#1972](https://github.com/carbon-design-system/ibm-products/issues/1972)
 
 ### Features
 
 - **DataSpreadsheet:** add spreadsheet column reordering
-  ([#1959](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1959))
-  ([b4d876b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b4d876bf9d804a48ecb965f94ff7c942e16490e1))
+  ([#1959](https://github.com/carbon-design-system/ibm-products/issues/1959))
+  ([b4d876b](https://github.com/carbon-design-system/ibm-products/commit/b4d876bf9d804a48ecb965f94ff7c942e16490e1))
 
-# [1.17.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.16.0...@carbon/ibm-products@1.17.0) (2022-05-03)
+# [1.17.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.16.0...@carbon/ibm-products@1.17.0) (2022-05-03)
 
 ### Bug Fixes
 
 - **Datagrid:** revert react-dnd versions
-  ([#1950](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1950))
-  ([a1417b0](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a1417b0e97516826a44ae6352ada8a84200d8eb0))
+  ([#1950](https://github.com/carbon-design-system/ibm-products/issues/1950))
+  ([a1417b0](https://github.com/carbon-design-system/ibm-products/commit/a1417b0e97516826a44ae6352ada8a84200d8eb0))
 - filename and extension default state
-  ([#1947](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1947))
-  ([87eaf33](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/87eaf33e72371f301a5c7c4a5f2f61a2b448bdf5))
+  ([#1947](https://github.com/carbon-design-system/ibm-products/issues/1947))
+  ([87eaf33](https://github.com/carbon-design-system/ibm-products/commit/87eaf33e72371f301a5c7c4a5f2f61a2b448bdf5))
 - **SidePanel:** fix static panel height without actions
-  ([#1943](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1943))
-  ([1092125](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/10921258ecd9dc460492e785a69b82a49a34ba50))
+  ([#1943](https://github.com/carbon-design-system/ibm-products/issues/1943))
+  ([1092125](https://github.com/carbon-design-system/ibm-products/commit/10921258ecd9dc460492e785a69b82a49a34ba50))
 
 ### Features
 
 - **DataSpreadsheet:** add selected row/column header state
-  ([#1954](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1954))
-  ([b9184cb](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b9184cbefeb02cec3c1a7577ea3168a7919ae343))
+  ([#1954](https://github.com/carbon-design-system/ibm-products/issues/1954))
+  ([b9184cb](https://github.com/carbon-design-system/ibm-products/commit/b9184cbefeb02cec3c1a7577ea3168a7919ae343))
 - **DataSpreadsheet:** support variable column width
-  ([#1945](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1945))
-  ([0ab2ae7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0ab2ae779032c073deedfbcd6ba42fda6ea73176))
+  ([#1945](https://github.com/carbon-design-system/ibm-products/issues/1945))
+  ([0ab2ae7](https://github.com/carbon-design-system/ibm-products/commit/0ab2ae779032c073deedfbcd6ba42fda6ea73176))
 - **WebTerminal:** 1914 reduce motion web terminal
-  ([#1951](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1951))
-  ([d26face](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d26facef16657a9bc43b7b09ac50cf3f173999f5))
+  ([#1951](https://github.com/carbon-design-system/ibm-products/issues/1951))
+  ([d26face](https://github.com/carbon-design-system/ibm-products/commit/d26facef16657a9bc43b7b09ac50cf3f173999f5))
 
-# [1.16.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.15.0...@carbon/ibm-products@1.16.0) (2022-04-26)
+# [1.16.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.15.0...@carbon/ibm-products@1.16.0) (2022-04-26)
 
 ### Bug Fixes
 
 - adds global filter tags to add select
-  ([#1938](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1938))
-  ([3a66201](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3a66201a23b7577d6abff7d575c5950ddfd9bc1a))
+  ([#1938](https://github.com/carbon-design-system/ibm-products/issues/1938))
+  ([3a66201](https://github.com/carbon-design-system/ibm-products/commit/3a66201a23b7577d6abff7d575c5950ddfd9bc1a))
 
 ### Features
 
 - **DataSpreadsheet:** support horizontal scrolling/add sticky headers
-  ([#1934](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1934))
-  ([987cecc](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/987cecc2d13a13958615fe229b2e290e7a69295d))
+  ([#1934](https://github.com/carbon-design-system/ibm-products/issues/1934))
+  ([987cecc](https://github.com/carbon-design-system/ibm-products/commit/987cecc2d13a13958615fe229b2e290e7a69295d))
 
-# [1.15.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.14.0...@carbon/ibm-products@1.15.0) (2022-04-19)
+# [1.15.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.14.0...@carbon/ibm-products@1.15.0) (2022-04-19)
 
 ### Bug Fixes
 
 - **AboutModal:** scrolling content fade visible
-  ([#1919](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1919))
-  ([5b2fa8b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5b2fa8bf61b65300ce3cd05327ee8f865bcabf7f))
+  ([#1919](https://github.com/carbon-design-system/ibm-products/issues/1919))
+  ([5b2fa8b](https://github.com/carbon-design-system/ibm-products/commit/5b2fa8bf61b65300ce3cd05327ee8f865bcabf7f))
 - add outline tag type and test
-  ([#1888](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1888))
-  ([4d8d3e3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4d8d3e3c686a4ab3be743eda4b7a370d076ee711))
+  ([#1888](https://github.com/carbon-design-system/ibm-products/issues/1888))
+  ([4d8d3e3](https://github.com/carbon-design-system/ibm-products/commit/4d8d3e3c686a4ab3be743eda4b7a370d076ee711))
 - **Datagrid:** revert namor package version
-  ([#1909](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1909))
-  ([abc6584](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/abc65849db6d8f785cc5cd286ff4065be3c29ae4))
+  ([#1909](https://github.com/carbon-design-system/ibm-products/issues/1909))
+  ([abc6584](https://github.com/carbon-design-system/ibm-products/commit/abc65849db6d8f785cc5cd286ff4065be3c29ae4))
 - **DataSpreadsheet:** updates to keys pressed custom hook
-  ([#1900](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1900))
-  ([2b79850](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2b79850ee7157bab15e19be9e79f68a4d2c1a9dc))
+  ([#1900](https://github.com/carbon-design-system/ibm-products/issues/1900))
+  ([2b79850](https://github.com/carbon-design-system/ibm-products/commit/2b79850ee7157bab15e19be9e79f68a4d2c1a9dc))
 - show export modal close icon
-  ([#1903](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1903))
-  ([aeaf40f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/aeaf40fe29cae18a0c66b270d4c799046097f1b5))
+  ([#1903](https://github.com/carbon-design-system/ibm-products/issues/1903))
+  ([aeaf40f](https://github.com/carbon-design-system/ibm-products/commit/aeaf40fe29cae18a0c66b270d4c799046097f1b5))
 
 ### Features
 
 - add portal target prop to tearsheet shell
-  ([#1905](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1905))
-  ([05808e4](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/05808e4776ad713c0865cfaf29741924ecd23d5a))
+  ([#1905](https://github.com/carbon-design-system/ibm-products/issues/1905))
+  ([05808e4](https://github.com/carbon-design-system/ibm-products/commit/05808e4776ad713c0865cfaf29741924ecd23d5a))
 - **DataSpreadsheet:**
-  [#1884](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1884)
+  [#1884](https://github.com/carbon-design-system/ibm-products/issues/1884)
   spreadsheet more shortcuts
-  ([#1898](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1898))
-  ([b349ce2](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b349ce2597db9236f979b82d77fdaa6e022f1799))
+  ([#1898](https://github.com/carbon-design-system/ibm-products/issues/1898))
+  ([b349ce2](https://github.com/carbon-design-system/ibm-products/commit/b349ce2597db9236f979b82d77fdaa6e022f1799))
 - **DataSpreadsheet:** add select all button functionality
-  ([#1910](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1910))
-  ([e580376](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e58037612988de851a58e13b9536ff5b31b41082))
+  ([#1910](https://github.com/carbon-design-system/ibm-products/issues/1910))
+  ([e580376](https://github.com/carbon-design-system/ibm-products/commit/e58037612988de851a58e13b9536ff5b31b41082))
 - **DataSpreadsheet:** add support for multi row/column selections
-  ([#1915](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1915))
-  ([f41513c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f41513c5c61d825137198100d7abeb4c90e938a9))
+  ([#1915](https://github.com/carbon-design-system/ibm-products/issues/1915))
+  ([f41513c](https://github.com/carbon-design-system/ibm-products/commit/f41513c5c61d825137198100d7abeb4c90e938a9))
 - **DataSpreadsheet:** move active cell within selection area with tab
-  ([#1927](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1927))
-  ([4ef8a7c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4ef8a7cd95209042d9c5f0344264c636ba06fc49))
+  ([#1927](https://github.com/carbon-design-system/ibm-products/issues/1927))
+  ([4ef8a7c](https://github.com/carbon-design-system/ibm-products/commit/4ef8a7cd95209042d9c5f0344264c636ba06fc49))
 - **DataSpreadsheet:** move active cell within selection areas
-  ([#1921](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1921))
-  ([50e3006](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/50e3006bc21bb46b53279af967231fb2baedff1a))
+  ([#1921](https://github.com/carbon-design-system/ibm-products/issues/1921))
+  ([50e3006](https://github.com/carbon-design-system/ibm-products/commit/50e3006bc21bb46b53279af967231fb2baedff1a))
 - **DataSpreadsheet:** support windows keyboards with shortcuts
-  ([#1917](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1917))
-  ([7866c1b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7866c1b6a65f664d44a1225e23411c772f25ec31))
+  ([#1917](https://github.com/carbon-design-system/ibm-products/issues/1917))
+  ([7866c1b](https://github.com/carbon-design-system/ibm-products/commit/7866c1b6a65f664d44a1225e23411c772f25ec31))
 
-# [1.14.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.13.0...@carbon/ibm-products@1.14.0) (2022-04-12)
+# [1.14.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.13.0...@carbon/ibm-products@1.14.0) (2022-04-12)
 
 ### Bug Fixes
 
 - add select global filter
-  ([#1894](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1894))
-  ([5f7f47a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5f7f47a3810b9b4ec1f32b16c432a7e1c7c7f9d6))
+  ([#1894](https://github.com/carbon-design-system/ibm-products/issues/1894))
+  ([5f7f47a](https://github.com/carbon-design-system/ibm-products/commit/5f7f47a3810b9b4ec1f32b16c432a7e1c7c7f9d6))
 - **DataSpreadsheet:** correct cursor placement
-  ([#1883](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1883))
-  ([4f52dbd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4f52dbd78caab9528134464a40afae90a7270acd))
+  ([#1883](https://github.com/carbon-design-system/ibm-products/issues/1883))
+  ([4f52dbd](https://github.com/carbon-design-system/ibm-products/commit/4f52dbd78caab9528134464a40afae90a7270acd))
 - **select:** inline background color on tearsheet
-  ([#1901](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1901))
-  ([6f67090](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6f67090a0a18839c64c20a2271fc93b864745ac3))
+  ([#1901](https://github.com/carbon-design-system/ibm-products/issues/1901))
+  ([6f67090](https://github.com/carbon-design-system/ibm-products/commit/6f67090a0a18839c64c20a2271fc93b864745ac3))
 
 ### Features
 
 - Datagrid component
-  ([#1877](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1877))
-  ([f9dd8ce](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f9dd8ce0ab87cea39e91603fdb542091fa757cbe))
+  ([#1877](https://github.com/carbon-design-system/ibm-products/issues/1877))
+  ([f9dd8ce](https://github.com/carbon-design-system/ibm-products/commit/f9dd8ce0ab87cea39e91603fdb542091fa757cbe))
 - **DataSpreadsheet:** a11y updates and keyboard shortcuts
-  ([#1892](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1892))
-  ([aed603a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/aed603abe10de815f8216ee7acc65f1f36deff9d))
+  ([#1892](https://github.com/carbon-design-system/ibm-products/issues/1892))
+  ([aed603a](https://github.com/carbon-design-system/ibm-products/commit/aed603abe10de815f8216ee7acc65f1f36deff9d))
 
-# [1.13.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.12.0...@carbon/ibm-products@1.13.0) (2022-04-05)
+# [1.13.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.12.0...@carbon/ibm-products@1.13.0) (2022-04-05)
 
 ### Bug Fixes
 
 - add select avatar and userprofileimage update
-  ([#1853](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1853))
-  ([cab0621](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/cab0621605f252ba908aa0e85dff1fb5079b8c57))
+  ([#1853](https://github.com/carbon-design-system/ibm-products/issues/1853))
+  ([cab0621](https://github.com/carbon-design-system/ibm-products/commit/cab0621605f252ba908aa0e85dff1fb5079b8c57))
 - add select icon support
-  ([#1860](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1860))
-  ([d11f2b5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d11f2b5e7b59881324658c2d4ad3eaadbfa503d2))
+  ([#1860](https://github.com/carbon-design-system/ibm-products/issues/1860))
+  ([d11f2b5](https://github.com/carbon-design-system/ibm-products/commit/d11f2b5e7b59881324658c2d4ad3eaadbfa503d2))
 - **DataSpreadsheet:** browser fix, update selectionArea on cell updates
-  ([#1861](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1861))
-  ([8e5764b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8e5764bdf86e2f34ea2c6432b928897d26d83afd))
+  ([#1861](https://github.com/carbon-design-system/ibm-products/issues/1861))
+  ([8e5764b](https://github.com/carbon-design-system/ibm-products/commit/8e5764bdf86e2f34ea2c6432b928897d26d83afd))
 - **HTTP errors:** responsive behaviour
-  ([#1828](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1828))
-  ([9d4b025](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9d4b025971bf913e811b4807f7eb67186a457f6a)),
+  ([#1828](https://github.com/carbon-design-system/ibm-products/issues/1828))
+  ([9d4b025](https://github.com/carbon-design-system/ibm-products/commit/9d4b025971bf913e811b4807f7eb67186a457f6a)),
   closes
-  [#1826](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1826)
-  [#1780](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1780)
-  [#1829](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1829)
-  [#1831](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1831)
-  [#1830](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1830)
-  [#1827](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1827)
-  [#1834](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1834)
-  [#1758](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1758)
-  [#1840](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1840)
-  [#1839](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1839)
-  [#1838](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1838)
-  [#1842](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1842)
-  [#1841](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1841)
-  [#1835](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1835)
+  [#1826](https://github.com/carbon-design-system/ibm-products/issues/1826)
+  [#1780](https://github.com/carbon-design-system/ibm-products/issues/1780)
+  [#1829](https://github.com/carbon-design-system/ibm-products/issues/1829)
+  [#1831](https://github.com/carbon-design-system/ibm-products/issues/1831)
+  [#1830](https://github.com/carbon-design-system/ibm-products/issues/1830)
+  [#1827](https://github.com/carbon-design-system/ibm-products/issues/1827)
+  [#1834](https://github.com/carbon-design-system/ibm-products/issues/1834)
+  [#1758](https://github.com/carbon-design-system/ibm-products/issues/1758)
+  [#1840](https://github.com/carbon-design-system/ibm-products/issues/1840)
+  [#1839](https://github.com/carbon-design-system/ibm-products/issues/1839)
+  [#1838](https://github.com/carbon-design-system/ibm-products/issues/1838)
+  [#1842](https://github.com/carbon-design-system/ibm-products/issues/1842)
+  [#1841](https://github.com/carbon-design-system/ibm-products/issues/1841)
+  [#1835](https://github.com/carbon-design-system/ibm-products/issues/1835)
 - issue 1737 page header example
-  ([#1880](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1880))
-  ([79d0a8e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/79d0a8ef7085666f69e4c3eec7bee36c44937fbf))
+  ([#1880](https://github.com/carbon-design-system/ibm-products/issues/1880))
+  ([79d0a8e](https://github.com/carbon-design-system/ibm-products/commit/79d0a8ef7085666f69e4c3eec7bee36c44937fbf))
 - **PageHeader:** issue1789 a11y issues BreadcrumbWithOverflow & ActionBar
-  ([#1854](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1854))
-  ([10d3bcc](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/10d3bcc868a5415dd95588870f320079c480f778))
+  ([#1854](https://github.com/carbon-design-system/ibm-products/issues/1854))
+  ([10d3bcc](https://github.com/carbon-design-system/ibm-products/commit/10d3bcc868a5415dd95588870f320079c480f778))
 - ssr maybe - moves document.body inside useEffect
-  ([#1881](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1881))
-  ([5bc6602](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5bc66027aaa2f98685d0702e99f4e42494491d05))
+  ([#1881](https://github.com/carbon-design-system/ibm-products/issues/1881))
+  ([5bc6602](https://github.com/carbon-design-system/ibm-products/commit/5bc66027aaa2f98685d0702e99f4e42494491d05))
 - update Carbon versions to latest
-  ([#1862](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1862))
-  ([c0e8024](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c0e8024cf060cec0262c79628077810a92a56619))
+  ([#1862](https://github.com/carbon-design-system/ibm-products/issues/1862))
+  ([c0e8024](https://github.com/carbon-design-system/ibm-products/commit/c0e8024cf060cec0262c79628077810a92a56619))
 
 ### Features
 
 - **DataSpreadsheet:** add edit mode overflow enhancements
-  ([#1857](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1857))
-  ([458933a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/458933a00276062ae189cb1ed51dae5c531feb31))
+  ([#1857](https://github.com/carbon-design-system/ibm-products/issues/1857))
+  ([458933a](https://github.com/carbon-design-system/ibm-products/commit/458933a00276062ae189cb1ed51dae5c531feb31))
 - **DataSpreadsheet:** support empty spreadsheets
-  ([#1848](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1848))
-  ([5010ca7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5010ca794d0ae9bb8f105c702ba6e30b84346836))
+  ([#1848](https://github.com/carbon-design-system/ibm-products/issues/1848))
+  ([5010ca7](https://github.com/carbon-design-system/ibm-products/commit/5010ca794d0ae9bb8f105c702ba6e30b84346836))
 
-# [1.12.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.11.2...@carbon/ibm-products@1.12.0) (2022-03-29)
+# [1.12.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.11.2...@carbon/ibm-products@1.12.0) (2022-03-29)
 
 ### Bug Fixes
 
 - add select global search
-  ([#1834](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1834))
-  ([ee4ac9e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ee4ac9ef78a05ed362535c8a9d25b3bbe31747c8))
+  ([#1834](https://github.com/carbon-design-system/ibm-products/issues/1834))
+  ([ee4ac9e](https://github.com/carbon-design-system/ibm-products/commit/ee4ac9ef78a05ed362535c8a9d25b3bbe31747c8))
 - **DataSpreadsheet:**
-  [#1758](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1758)
+  [#1758](https://github.com/carbon-design-system/ibm-products/issues/1758)
   spreadsheet single cell selection area
-  ([#1840](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1840))
-  ([f7b388d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f7b388dd1a79f45b17e210360a49cc9f37c1ec7f))
+  ([#1840](https://github.com/carbon-design-system/ibm-products/issues/1840))
+  ([f7b388d](https://github.com/carbon-design-system/ibm-products/commit/f7b388dd1a79f45b17e210360a49cc9f37c1ec7f))
 - **DataSpreadsheet:** address header scrollbar issue
-  ([#1780](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1780))
-  ([c42819c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c42819c01c8e5ae3dabac4f3540b2689b01af37c))
+  ([#1780](https://github.com/carbon-design-system/ibm-products/issues/1780))
+  ([c42819c](https://github.com/carbon-design-system/ibm-products/commit/c42819c01c8e5ae3dabac4f3540b2689b01af37c))
 - **DataSpreadsheet:** use type token for cells/cell editor/active cell
-  ([#1831](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1831))
-  ([abf6d3d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/abf6d3d8fdfa2059b5eeb52a0f02a51e0ee563ef))
+  ([#1831](https://github.com/carbon-design-system/ibm-products/issues/1831))
+  ([abf6d3d](https://github.com/carbon-design-system/ibm-products/commit/abf6d3d8fdfa2059b5eeb52a0f02a51e0ee563ef))
 - text alignment in tagset overflow
-  ([#1829](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1829))
-  ([4f651f0](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4f651f0ea8bcd80953df54fee22a94f70c815537))
+  ([#1829](https://github.com/carbon-design-system/ibm-products/issues/1829))
+  ([4f651f0](https://github.com/carbon-design-system/ibm-products/commit/4f651f0ea8bcd80953df54fee22a94f70c815537))
 - update Carbon versions to latest
-  ([#1835](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1835))
-  ([b9152d1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b9152d15813b7feab937092bbbf46439305aab50))
+  ([#1835](https://github.com/carbon-design-system/ibm-products/issues/1835))
+  ([b9152d1](https://github.com/carbon-design-system/ibm-products/commit/b9152d15813b7feab937092bbbf46439305aab50))
 
 ### Features
 
 - **DataSpreadsheet:** add onSelectionAreaChange prop
-  ([#1830](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1830))
-  ([626f6ba](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/626f6ba2e717a755088cc835a4d1fc76c30a6580))
+  ([#1830](https://github.com/carbon-design-system/ibm-products/issues/1830))
+  ([626f6ba](https://github.com/carbon-design-system/ibm-products/commit/626f6ba2e717a755088cc835a4d1fc76c30a6580))
 
-## [1.11.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.11.1...@carbon/ibm-products@1.11.2) (2022-03-22)
+## [1.11.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.11.1...@carbon/ibm-products@1.11.2) (2022-03-22)
 
 ### Bug Fixes
 
 - **CreateTearsheet:** change onNext initialization
-  ([#1823](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1823))
-  ([15d5181](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/15d51813b4a415591b19d6dcf3b1d0e4e5bf58d6))
+  ([#1823](https://github.com/carbon-design-system/ibm-products/issues/1823))
+  ([15d5181](https://github.com/carbon-design-system/ibm-products/commit/15d51813b4a415591b19d6dcf3b1d0e4e5bf58d6))
 
-## [1.11.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.11.0...@carbon/ibm-products@1.11.1) (2022-03-22)
+## [1.11.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.11.0...@carbon/ibm-products@1.11.1) (2022-03-22)
 
 ### Bug Fixes
 
 - adds column select functionality in add select
-  ([#1788](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1788))
-  ([72c2d29](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/72c2d29ccb2c357982c2f7b1153aeca53e8f40f6))
+  ([#1788](https://github.com/carbon-design-system/ibm-products/issues/1788))
+  ([72c2d29](https://github.com/carbon-design-system/ibm-products/commit/72c2d29ccb2c357982c2f7b1153aeca53e8f40f6))
 - **ButtonMenu:** doesn't support ghost kind
-  ([#1779](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1779))
-  ([30b9d0f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/30b9d0f8cde01b20fe150eff1c0c0dd4209d49b2))
+  ([#1779](https://github.com/carbon-design-system/ibm-products/issues/1779))
+  ([30b9d0f](https://github.com/carbon-design-system/ibm-products/commit/30b9d0f8cde01b20fe150eff1c0c0dd4209d49b2))
 - **LoadingBar:** remove loadingbar component
-  [#1738](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1738)
-  ([#1791](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1791))
-  ([80c93a6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/80c93a6bd4787ed0e1eed518c08e0ea6466ad0d5))
+  [#1738](https://github.com/carbon-design-system/ibm-products/issues/1738)
+  ([#1791](https://github.com/carbon-design-system/ibm-products/issues/1791))
+  ([80c93a6](https://github.com/carbon-design-system/ibm-products/commit/80c93a6bd4787ed0e1eed518c08e0ea6466ad0d5))
 - update Carbon versions to latest
-  ([#1793](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1793))
-  ([9943926](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9943926b5234ce0690417d16483da4caa84790cf)),
+  ([#1793](https://github.com/carbon-design-system/ibm-products/issues/1793))
+  ([9943926](https://github.com/carbon-design-system/ibm-products/commit/9943926b5234ce0690417d16483da4caa84790cf)),
   closes
-  [#1738](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1738)
-  [#1791](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1791)
-  [#1738](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1738)
-  [#1790](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1790)
+  [#1738](https://github.com/carbon-design-system/ibm-products/issues/1738)
+  [#1791](https://github.com/carbon-design-system/ibm-products/issues/1791)
+  [#1738](https://github.com/carbon-design-system/ibm-products/issues/1738)
+  [#1790](https://github.com/carbon-design-system/ibm-products/issues/1790)
 
-# [1.11.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.10.0...@carbon/ibm-products@1.11.0) (2022-03-15)
+# [1.11.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.10.0...@carbon/ibm-products@1.11.0) (2022-03-15)
 
 ### Bug Fixes
 
 - add select cleanup
-  ([#1774](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1774))
-  ([6f6d954](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6f6d9544de911a05b46257617404abc7886382ef))
+  ([#1774](https://github.com/carbon-design-system/ibm-products/issues/1774))
+  ([6f6d954](https://github.com/carbon-design-system/ibm-products/commit/6f6d9544de911a05b46257617404abc7886382ef))
 - adds sort and filter functionality to add select columns
-  ([#1765](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1765))
-  ([e9cd868](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e9cd86893f7a514ff2269b39caa8466f2af56361))
+  ([#1765](https://github.com/carbon-design-system/ibm-products/issues/1765))
+  ([e9cd868](https://github.com/carbon-design-system/ibm-products/commit/e9cd86893f7a514ff2269b39caa8466f2af56361))
 - adds the filter and sort buttons to add select columns
-  ([#1753](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1753))
-  ([29ac82a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/29ac82a27ca801e2615b147c730a15b88a20724d))
+  ([#1753](https://github.com/carbon-design-system/ibm-products/issues/1753))
+  ([29ac82a](https://github.com/carbon-design-system/ibm-products/commit/29ac82a27ca801e2615b147c730a15b88a20724d))
 - breadcrumb overflow z-index
-  ([#1769](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1769))
-  ([662adfa](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/662adfa5d6ad95839b8dcdded4ca369e144d0d60))
+  ([#1769](https://github.com/carbon-design-system/ibm-products/issues/1769))
+  ([662adfa](https://github.com/carbon-design-system/ibm-products/commit/662adfa5d6ad95839b8dcdded4ca369e144d0d60))
 - edit sidepanel footer align issue
-  ([#1751](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1751))
-  ([13098ed](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/13098ede436a711dcefd41f6f06d7a1e008f35d7))
+  ([#1751](https://github.com/carbon-design-system/ibm-products/issues/1751))
+  ([13098ed](https://github.com/carbon-design-system/ibm-products/commit/13098ede436a711dcefd41f6f06d7a1e008f35d7))
 - **InlineEdit:** test coverage update
-  ([#1772](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1772))
-  ([dd5f5b4](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/dd5f5b493ff05a790dda1df2f468ea5f37f10459))
+  ([#1772](https://github.com/carbon-design-system/ibm-products/issues/1772))
+  ([dd5f5b4](https://github.com/carbon-design-system/ibm-products/commit/dd5f5b493ff05a790dda1df2f468ea5f37f10459))
 - **PageHeader:** test coverage
-  ([#1773](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1773))
-  ([7e36775](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7e367751f850c92ad8272f0dc0efa8ed03cc4b63))
+  ([#1773](https://github.com/carbon-design-system/ibm-products/issues/1773))
+  ([7e36775](https://github.com/carbon-design-system/ibm-products/commit/7e367751f850c92ad8272f0dc0efa8ed03cc4b63))
 - **PageHeader:** various fixes
-  ([#1761](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1761))
-  ([30e90b5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/30e90b51d0b91d0d5a6909295c769fa09d5735c7))
+  ([#1761](https://github.com/carbon-design-system/ibm-products/issues/1761))
+  ([30e90b5](https://github.com/carbon-design-system/ibm-products/commit/30e90b51d0b91d0d5a6909295c769fa09d5735c7))
 - **SidePanel:** .bx replace with #{$carbon-prefix}
-  ([#1760](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1760))
-  ([1044685](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1044685a20f55c7871d88af9050609e75a38dde3))
+  ([#1760](https://github.com/carbon-design-system/ibm-products/issues/1760))
+  ([1044685](https://github.com/carbon-design-system/ibm-products/commit/1044685a20f55c7871d88af9050609e75a38dde3))
 
 ### Features
 
 - add inline edit tip position
-  ([#1730](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1730))
-  ([9985b94](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9985b94f975f16f661fe07d54093492b8fdf3972))
+  ([#1730](https://github.com/carbon-design-system/ibm-products/issues/1730))
+  ([9985b94](https://github.com/carbon-design-system/ibm-products/commit/9985b94f975f16f661fe07d54093492b8fdf3972))
 - **DataSpreadsheet:**
-  [#1703](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1703)
+  [#1703](https://github.com/carbon-design-system/ibm-products/issues/1703)
   add spreadsheet row/column selections
-  ([#1777](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1777))
-  ([81e1bc5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/81e1bc5942b71f7c5d3d725cf54b60a8ee7ad4b9))
+  ([#1777](https://github.com/carbon-design-system/ibm-products/issues/1777))
+  ([81e1bc5](https://github.com/carbon-design-system/ibm-products/commit/81e1bc5942b71f7c5d3d725cf54b60a8ee7ad4b9))
 - **DataSpreadsheet:** add cell editing
-  ([#1755](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1755))
-  ([349c9f1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/349c9f1b5fc25f2961fbfcd7961022cef114fdda))
+  ([#1755](https://github.com/carbon-design-system/ibm-products/issues/1755))
+  ([349c9f1](https://github.com/carbon-design-system/ibm-products/commit/349c9f1b5fc25f2961fbfcd7961022cef114fdda))
 
-# [1.10.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.9.0...@carbon/ibm-products@1.10.0) (2022-03-08)
+# [1.10.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.9.0...@carbon/ibm-products@1.10.0) (2022-03-08)
 
 ### Bug Fixes
 
 - add select multi select filtering
-  ([#1714](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1714))
-  ([7c4b469](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7c4b469fb3c40f3601dd6c46a65be2e7618700db))
+  ([#1714](https://github.com/carbon-design-system/ibm-products/issues/1714))
+  ([7c4b469](https://github.com/carbon-design-system/ibm-products/commit/7c4b469fb3c40f3601dd6c46a65be2e7618700db))
 - **DataSpreadsheet:** prevent check on coords that do not exist
-  ([#1716](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1716))
-  ([236fcfc](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/236fcfccc557342a2a736d7418cd59449b4d089e))
+  ([#1716](https://github.com/carbon-design-system/ibm-products/issues/1716))
+  ([236fcfc](https://github.com/carbon-design-system/ibm-products/commit/236fcfccc557342a2a736d7418cd59449b4d089e))
 - move show all modal to document body
-  ([#1747](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1747))
-  ([b94e75d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b94e75d7e11fa1338871c7d8a1aab4a96be568c0))
+  ([#1747](https://github.com/carbon-design-system/ibm-products/issues/1747))
+  ([b94e75d](https://github.com/carbon-design-system/ibm-products/commit/b94e75d7e11fa1338871c7d8a1aab4a96be568c0))
 - **options-tile:** fix summary behaviour
-  ([#1726](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1726))
-  ([1c0aa1a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1c0aa1a255e67e2544b3b443860d31e8a43509f7))
+  ([#1726](https://github.com/carbon-design-system/ibm-products/issues/1726))
+  ([1c0aa1a](https://github.com/carbon-design-system/ibm-products/commit/1c0aa1a255e67e2544b3b443860d31e8a43509f7))
 - remove reserved space for invalid icon
-  ([#1710](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1710))
-  ([5590ce7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5590ce7e7b0ccb510f32bdc24b910e785760d063))
+  ([#1710](https://github.com/carbon-design-system/ibm-products/issues/1710))
+  ([5590ce7](https://github.com/carbon-design-system/ibm-products/commit/5590ce7e7b0ccb510f32bdc24b910e785760d063))
 - SidePanel (enhancement): mobile responsiveness of panels
-  ([#1735](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1735))
-  ([6a5d94a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6a5d94a5856c27230574c49dcceb23a0a7afc6a3))
+  ([#1735](https://github.com/carbon-design-system/ibm-products/issues/1735))
+  ([6a5d94a](https://github.com/carbon-design-system/ibm-products/commit/6a5d94a5856c27230574c49dcceb23a0a7afc6a3))
 - update Carbon versions to latest
-  ([#1733](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1733))
-  ([9783faa](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9783faac23d8f03598ef0e5994743c4c5f915705))
+  ([#1733](https://github.com/carbon-design-system/ibm-products/issues/1733))
+  ([9783faa](https://github.com/carbon-design-system/ibm-products/commit/9783faac23d8f03598ef0e5994743c4c5f915705))
 - **UserProfileImage:** fix tooltip version of user profile image
-  ([#1745](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1745))
-  ([b89c73a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b89c73aa92598ad39b3436c77a973e999a50bec8))
+  ([#1745](https://github.com/carbon-design-system/ibm-products/issues/1745))
+  ([b89c73a](https://github.com/carbon-design-system/ibm-products/commit/b89c73aa92598ad39b3436c77a973e999a50bec8))
 
 ### Features
 
 - **DataSpreadsheet:**
-  [#1704](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1704)
+  [#1704](https://github.com/carbon-design-system/ibm-products/issues/1704)
   add spreadsheet shift click behavior
-  ([#1723](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1723))
-  ([3126859](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/312685957a08fc4bf7f8aec530520a2c9a685ec3))
+  ([#1723](https://github.com/carbon-design-system/ibm-products/issues/1723))
+  ([3126859](https://github.com/carbon-design-system/ibm-products/commit/312685957a08fc4bf7f8aec530520a2c9a685ec3))
 - **DataSpreadsheet:**
-  [#1731](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1731)
+  [#1731](https://github.com/carbon-design-system/ibm-products/issues/1731)
   add active highlight to column/row headers
-  ([#1744](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1744))
-  ([3bac3f9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3bac3f9924a29c4d20ddf8a9f7f619597578db6a))
+  ([#1744](https://github.com/carbon-design-system/ibm-products/issues/1744))
+  ([3bac3f9](https://github.com/carbon-design-system/ibm-products/commit/3bac3f9924a29c4d20ddf8a9f7f619597578db6a))
 - **DataSpreadsheet:** add keyboard support to cell selections
-  ([#1719](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1719))
-  ([812ade5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/812ade5669136cd73670566d079a8be5a1159ea8))
+  ([#1719](https://github.com/carbon-design-system/ibm-products/issues/1719))
+  ([812ade5](https://github.com/carbon-design-system/ibm-products/commit/812ade5669136cd73670566d079a8be5a1159ea8))
 - **DataSpreadsheet:** highlight row/column header on active cell change
-  ([#1732](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1732))
-  ([b828e9b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b828e9b809bf9349e473830a29c9aef70df1cd08))
+  ([#1732](https://github.com/carbon-design-system/ibm-products/issues/1732))
+  ([b828e9b](https://github.com/carbon-design-system/ibm-products/commit/b828e9b809bf9349e473830a29c9aef70df1cd08))
 - **DataSpreadsheet:** remove cell selection in certain case
-  ([#1706](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1706))
-  ([712ac00](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/712ac00e60151b101fc9375e21bb80c4b28f28f7))
+  ([#1706](https://github.com/carbon-design-system/ibm-products/issues/1706))
+  ([712ac00](https://github.com/carbon-design-system/ibm-products/commit/712ac00e60151b101fc9375e21bb80c4b28f28f7))
 - **PageHeader:** prevent breadcrumb scroll by default
-  ([#1748](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1748))
-  ([4179840](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/41798401e3625a0850612819573d60010b6a3a32))
+  ([#1748](https://github.com/carbon-design-system/ibm-products/issues/1748))
+  ([4179840](https://github.com/carbon-design-system/ibm-products/commit/41798401e3625a0850612819573d60010b6a3a32))
 - **TagSet:** add allTagsModalTarget prop
-  ([#1749](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1749))
-  ([69c3a20](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/69c3a204dda1962d08ad91fab5bf9adde37e2a27))
+  ([#1749](https://github.com/carbon-design-system/ibm-products/issues/1749))
+  ([69c3a20](https://github.com/carbon-design-system/ibm-products/commit/69c3a204dda1962d08ad91fab5bf9adde37e2a27))
 
-# [1.9.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.8.0...@carbon/ibm-products@1.9.0) (2022-03-01)
+# [1.9.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.8.0...@carbon/ibm-products@1.9.0) (2022-03-01)
 
 ### Bug Fixes
 
 - adds mutli select hierarchy support
-  ([#1659](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1659))
-  ([743938b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/743938b26215859c345b1d26b86e3a2fcc8fe6d5))
+  ([#1659](https://github.com/carbon-design-system/ibm-products/issues/1659))
+  ([743938b](https://github.com/carbon-design-system/ibm-products/commit/743938b26215859c345b1d26b86e3a2fcc8fe6d5))
 - Using padding instead of margin to prevent border to being cut
-  ([#1683](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1683))
-  ([991f865](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/991f8657c19fe19d2797ae731970d4272f4aada0))
+  ([#1683](https://github.com/carbon-design-system/ibm-products/issues/1683))
+  ([991f865](https://github.com/carbon-design-system/ibm-products/commit/991f8657c19fe19d2797ae731970d4272f4aada0))
 
 ### Features
 
 - **DataSpreadsheet:**
-  [#1674](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1674)
+  [#1674](https://github.com/carbon-design-system/ibm-products/issues/1674)
   add support for cell selection areas
-  ([#1689](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1689))
-  ([6c5bf94](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6c5bf948249cf9a3e97120d8ab068793c308aeba))
+  ([#1689](https://github.com/carbon-design-system/ibm-products/issues/1689))
+  ([6c5bf94](https://github.com/carbon-design-system/ibm-products/commit/6c5bf948249cf9a3e97120d8ab068793c308aeba))
 - **InlineEdit:** add cancel on use of escape key
-  ([#1679](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1679))
-  ([fee29cd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fee29cda483a8a54fea29e05aeda11254ff024b1))
+  ([#1679](https://github.com/carbon-design-system/ibm-products/issues/1679))
+  ([fee29cd](https://github.com/carbon-design-system/ibm-products/commit/fee29cda483a8a54fea29e05aeda11254ff024b1))
 - match design for edit button visibility
-  ([#1676](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1676))
-  ([ba88bf9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ba88bf97f3c431187bd5bd28c6cebcbc938e57fa))
+  ([#1676](https://github.com/carbon-design-system/ibm-products/issues/1676))
+  ([ba88bf9](https://github.com/carbon-design-system/ibm-products/commit/ba88bf97f3c431187bd5bd28c6cebcbc938e57fa))
 
-# [1.8.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.7.0...@carbon/ibm-products@1.8.0) (2022-02-22)
+# [1.8.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.7.0...@carbon/ibm-products@1.8.0) (2022-02-22)
 
 ### Bug Fixes
 
 - inline edit placeholder blocking input click
-  ([#1675](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1675))
-  ([277c133](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/277c133f5dfcf91ab20df52bb798b7266974b8c8))
+  ([#1675](https://github.com/carbon-design-system/ibm-products/issues/1675))
+  ([277c133](https://github.com/carbon-design-system/ibm-products/commit/277c133f5dfcf91ab20df52bb798b7266974b8c8))
 - make inline edit story validation more robust
-  ([#1678](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1678))
-  ([75d7628](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/75d762859d34628e1afd62428ffd6e8ff533eda3))
+  ([#1678](https://github.com/carbon-design-system/ibm-products/issues/1678))
+  ([75d7628](https://github.com/carbon-design-system/ibm-products/commit/75d762859d34628e1afd62428ffd6e8ff533eda3))
 
 ### Features
 
 - **DataSpreadsheet:**
-  [#1652](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1652)
+  [#1652](https://github.com/carbon-design-system/ibm-products/issues/1652)
   spreadsheet keyboard active cell
-  ([#1663](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1663))
-  ([c64b953](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c64b95312ee1ea863e396b3021c8c75c2eed5fc2))
+  ([#1663](https://github.com/carbon-design-system/ibm-products/issues/1663))
+  ([c64b953](https://github.com/carbon-design-system/ibm-products/commit/c64b95312ee1ea863e396b3021c8c75c2eed5fc2))
 - **DataSpreadsheet:** data spreadsheet active cell
-  ([#1648](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1648))
-  ([902cc03](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/902cc039935f6b962aa5601427db1adda3da896a))
+  ([#1648](https://github.com/carbon-design-system/ibm-products/issues/1648))
+  ([902cc03](https://github.com/carbon-design-system/ibm-products/commit/902cc039935f6b962aa5601427db1adda3da896a))
 
-# [1.7.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.6.1...@carbon/ibm-products@1.7.0) (2022-02-16)
+# [1.7.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.6.1...@carbon/ibm-products@1.7.0) (2022-02-16)
 
 ### Bug Fixes
 
 - adds remove item from add select sidebar
-  ([#1639](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1639))
-  ([f061a4c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f061a4c84071b4afbd16ee83d829f6446538a2d5))
+  ([#1639](https://github.com/carbon-design-system/ibm-products/issues/1639))
+  ([f061a4c](https://github.com/carbon-design-system/ibm-products/commit/f061a4c84071b4afbd16ee83d829f6446538a2d5))
 - avoid relying on defaultProps in carbon components
-  ([#1645](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1645))
-  ([85718dc](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/85718dc0b7b8aff8e73b2e36b5e64e13ea773539))
+  ([#1645](https://github.com/carbon-design-system/ibm-products/issues/1645))
+  ([85718dc](https://github.com/carbon-design-system/ibm-products/commit/85718dc0b7b8aff8e73b2e36b5e64e13ea773539))
 - **Tearsheet:** replace useLayoutEffect with useEffect (issue
-  [#1640](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1640))
-  ([#1647](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1647))
-  ([f05f92e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f05f92e819d300ee60d3da04a21f61b0c4563a9c))
+  [#1640](https://github.com/carbon-design-system/ibm-products/issues/1640))
+  ([#1647](https://github.com/carbon-design-system/ibm-products/issues/1647))
+  ([f05f92e](https://github.com/carbon-design-system/ibm-products/commit/f05f92e819d300ee60d3da04a21f61b0c4563a9c))
 
 ### Features
 
 - **DataSpreadsheet:** add initial component
-  ([#1606](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1606))
-  ([331a087](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/331a08757d0715aea156027e4f62772febdcf059))
+  ([#1606](https://github.com/carbon-design-system/ibm-products/issues/1606))
+  ([331a087](https://github.com/carbon-design-system/ibm-products/commit/331a08757d0715aea156027e4f62772febdcf059))
 - **InlineEdit:** add validation
-  ([#1641](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1641))
-  ([7e75fad](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7e75fadd9ebac18da0faf791ab70582f11418bcc))
+  ([#1641](https://github.com/carbon-design-system/ibm-products/issues/1641))
+  ([7e75fad](https://github.com/carbon-design-system/ibm-products/commit/7e75fadd9ebac18da0faf791ab70582f11418bcc))
 - update Carbon versions to latest
-  ([#1646](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1646))
-  ([e323739](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e323739ac9a6155aa0fddf39b13e4440d04117fc))
+  ([#1646](https://github.com/carbon-design-system/ibm-products/issues/1646))
+  ([e323739](https://github.com/carbon-design-system/ibm-products/commit/e323739ac9a6155aa0fddf39b13e4440d04117fc))
 
-## [1.6.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.6.0...@carbon/ibm-products@1.6.1) (2022-02-15)
+## [1.6.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.6.0...@carbon/ibm-products@1.6.1) (2022-02-15)
 
 ### Bug Fixes
 
 - add select sidebar flatten
-  ([#1619](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1619))
-  ([c95ea64](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c95ea64397e0bd9d0671f6261301837672f17f08))
+  ([#1619](https://github.com/carbon-design-system/ibm-products/issues/1619))
+  ([c95ea64](https://github.com/carbon-design-system/ibm-products/commit/c95ea64397e0bd9d0671f6261301837672f17f08))
 - **EmptyState:** make subtitle optional
-  ([#1620](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1620))
-  ([508182a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/508182a01d469817d07e487664adc6fb21270abc)),
+  ([#1620](https://github.com/carbon-design-system/ibm-products/issues/1620))
+  ([508182a](https://github.com/carbon-design-system/ibm-products/commit/508182a01d469817d07e487664adc6fb21270abc)),
   closes
-  [#1605](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1605)
-  [#1605](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1605)
+  [#1605](https://github.com/carbon-design-system/ibm-products/issues/1605)
+  [#1605](https://github.com/carbon-design-system/ibm-products/issues/1605)
 - inline edit validation presentation
-  ([#1622](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1622))
-  ([7fdafcb](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7fdafcbafac59b144278363cc358913eb91cc77d))
+  ([#1622](https://github.com/carbon-design-system/ibm-products/issues/1622))
+  ([7fdafcb](https://github.com/carbon-design-system/ibm-products/commit/7fdafcbafac59b144278363cc358913eb91cc77d))
 - **PageHeader:** Page header title edit transition
-  ([#1601](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1601))
-  ([e7fd2a7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e7fd2a76077c3512ffdae29bcf7c467230c0e8f5))
+  ([#1601](https://github.com/carbon-design-system/ibm-products/issues/1601))
+  ([e7fd2a7](https://github.com/carbon-design-system/ibm-products/commit/e7fd2a76077c3512ffdae29bcf7c467230c0e8f5))
 
-# [1.6.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.5.0...@carbon/ibm-products@1.6.0) (2022-02-09)
+# [1.6.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.5.0...@carbon/ibm-products@1.6.0) (2022-02-09)
 
 ### Bug Fixes
 
 - adds nested lists
-  ([#1591](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1591))
-  ([c091c55](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c091c5505c1143f0e506af2c29b48de99cdd8dc9))
+  ([#1591](https://github.com/carbon-design-system/ibm-products/issues/1591))
+  ([c091c55](https://github.com/carbon-design-system/ibm-products/commit/c091c5505c1143f0e506af2c29b48de99cdd8dc9))
 - adds selection functionality to add select
-  ([#1579](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1579))
-  ([1b5b624](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1b5b62422563d3909a8f30683cf7611fa630af28))
+  ([#1579](https://github.com/carbon-design-system/ibm-products/issues/1579))
+  ([1b5b624](https://github.com/carbon-design-system/ibm-products/commit/1b5b62422563d3909a8f30683cf7611fa630af28))
 - **AddSelect:** refactor custom filter and init navigation
-  ([#1583](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1583))
-  ([8d53206](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8d53206c8627151d22565631aad8369d721e4af8))
+  ([#1583](https://github.com/carbon-design-system/ibm-products/issues/1583))
+  ([8d53206](https://github.com/carbon-design-system/ibm-products/commit/8d53206c8627151d22565631aad8369d721e4af8))
 - breakup add select into multiple components
-  ([#1602](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1602))
-  ([2a271ff](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2a271ff6b18e776cc5bcae8d5f963f9ce049c634))
+  ([#1602](https://github.com/carbon-design-system/ibm-products/issues/1602))
+  ([2a271ff](https://github.com/carbon-design-system/ibm-products/commit/2a271ff6b18e776cc5bcae8d5f963f9ce049c634))
 - **PageHeader:** title without breadcrumb and action bar remains visible on
   scroll
-  ([#1562](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1562))
-  ([1b62c0b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1b62c0b9890ce00107dff2e465bda072f8c4e6c8))
+  ([#1562](https://github.com/carbon-design-system/ibm-products/issues/1562))
+  ([1b62c0b](https://github.com/carbon-design-system/ibm-products/commit/1b62c0b9890ce00107dff2e465bda072f8c4e6c8))
 - productive card button size and props spread
-  ([#1581](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1581))
-  ([a33b3d8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a33b3d896b010a8305ad9b27e17fa733af7ce7c6))
+  ([#1581](https://github.com/carbon-design-system/ibm-products/issues/1581))
+  ([a33b3d8](https://github.com/carbon-design-system/ibm-products/commit/a33b3d896b010a8305ad9b27e17fa733af7ce7c6))
 - update Carbon versions to latest
-  ([#1587](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1587))
-  ([d4b5ccc](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d4b5cccd9ef4a9df2966063c21f49fe7810245a8))
+  ([#1587](https://github.com/carbon-design-system/ibm-products/issues/1587))
+  ([d4b5ccc](https://github.com/carbon-design-system/ibm-products/commit/d4b5cccd9ef4a9df2966063c21f49fe7810245a8))
 - update stylelint to latest version
-  ([#1597](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1597))
-  ([13d8f9e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/13d8f9eb2885e687ba23f66b019a5629fffa2a85))
+  ([#1597](https://github.com/carbon-design-system/ibm-products/issues/1597))
+  ([13d8f9e](https://github.com/carbon-design-system/ibm-products/commit/13d8f9eb2885e687ba23f66b019a5629fffa2a85))
 
 ### Features
 
 - **NotificationsPanel:** support reduced motion
-  ([#1598](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1598))
-  ([f614e52](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f614e52216fb44769250e60d1a6cb17cc68b7f88))
+  ([#1598](https://github.com/carbon-design-system/ibm-products/issues/1598))
+  ([f614e52](https://github.com/carbon-design-system/ibm-products/commit/f614e52216fb44769250e60d1a6cb17cc68b7f88))
 - **SidePanel:** add prefers-reduced-motion support for SidePanel animations
-  ([#1586](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1586))
-  ([8e53e1b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8e53e1b8ba8a0ae75434a78714d1647d1452c4c3))
+  ([#1586](https://github.com/carbon-design-system/ibm-products/issues/1586))
+  ([8e53e1b](https://github.com/carbon-design-system/ibm-products/commit/8e53e1b8ba8a0ae75434a78714d1647d1452c4c3))
 
-# [1.5.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.4.0...@carbon/ibm-products@1.5.0) (2022-02-01)
+# [1.5.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.4.0...@carbon/ibm-products@1.5.0) (2022-02-01)
 
 ### Bug Fixes
 
 - remove changes to security snapshot
-  ([#1569](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1569))
-  ([efa0557](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/efa0557cb886f57414b65fad2cf6e090bc0aaa7d))
+  ([#1569](https://github.com/carbon-design-system/ibm-products/issues/1569))
+  ([efa0557](https://github.com/carbon-design-system/ibm-products/commit/efa0557cb886f57414b65fad2cf6e090bc0aaa7d))
 - **Tearsheet,SidePanel:** enable danger button kinds as actions
-  ([#1572](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1572))
-  ([9b0acc9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9b0acc96ac16eea4085e559f30b184af5e593631))
+  ([#1572](https://github.com/carbon-design-system/ibm-products/issues/1572))
+  ([9b0acc9](https://github.com/carbon-design-system/ibm-products/commit/9b0acc96ac16eea4085e559f30b184af5e593631))
 
 ### Features
 
 - **CreateTearsheet/FullPage:**
-  [#1538](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1538)
+  [#1538](https://github.com/carbon-design-system/ibm-products/issues/1538)
   add support for dynamic steps
-  ([#1576](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1576))
-  ([cdd0880](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/cdd0880e2bdf07e488c7bd74c60b1dd2b44d2dc0))
+  ([#1576](https://github.com/carbon-design-system/ibm-products/issues/1576))
+  ([cdd0880](https://github.com/carbon-design-system/ibm-products/commit/cdd0880e2bdf07e488c7bd74c60b1dd2b44d2dc0))
 - password input option for export modal
-  ([#1574](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1574))
-  ([d5384da](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d5384da13e69ec6566ffff720f0616f116521e4a))
+  ([#1574](https://github.com/carbon-design-system/ibm-products/issues/1574))
+  ([d5384da](https://github.com/carbon-design-system/ibm-products/commit/d5384da13e69ec6566ffff720f0616f116521e4a))
 
-# [1.4.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.3.0...@carbon/ibm-products@1.4.0) (2022-01-25)
+# [1.4.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.3.0...@carbon/ibm-products@1.4.0) (2022-01-25)
 
 ### Bug Fixes
 
 - fixes for modal focus
-  ([#1552](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1552))
-  ([cc23b0f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/cc23b0f6b87d082239f013020410e2af534441d0))
+  ([#1552](https://github.com/carbon-design-system/ibm-products/issues/1552))
+  ([cc23b0f](https://github.com/carbon-design-system/ibm-products/commit/cc23b0f6b87d082239f013020410e2af534441d0))
 - issue1508
-  ([#1557](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1557))
-  ([f08ed89](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f08ed89216edf6aaccf446abf1da45f0d5cc00ed))
+  ([#1557](https://github.com/carbon-design-system/ibm-products/issues/1557))
+  ([f08ed89](https://github.com/carbon-design-system/ibm-products/commit/f08ed89216edf6aaccf446abf1da45f0d5cc00ed))
 - Prevent id duplication in page header
-  ([#1537](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1537))
-  ([dff0887](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/dff088791920c32f52ae7d915076b0af2ffb5828))
+  ([#1537](https://github.com/carbon-design-system/ibm-products/issues/1537))
+  ([dff0887](https://github.com/carbon-design-system/ibm-products/commit/dff088791920c32f52ae7d915076b0af2ffb5828))
 - Rework breadcrumb back button
-  ([#1545](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1545))
-  ([46fcfc2](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/46fcfc2db159613afff049d74f8afc49c58aed07))
+  ([#1545](https://github.com/carbon-design-system/ibm-products/issues/1545))
+  ([46fcfc2](https://github.com/carbon-design-system/ibm-products/commit/46fcfc2db159613afff049d74f8afc49c58aed07))
 
 ### Features
 
 - add new step tracking approach allowing for custom steps
-  ([#1524](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1524))
-  ([a4b44f5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a4b44f5d1b0f99c2ed5fcbf3314c2e96c61c5aef))
+  ([#1524](https://github.com/carbon-design-system/ibm-products/issues/1524))
+  ([a4b44f5](https://github.com/carbon-design-system/ibm-products/commit/a4b44f5d1b0f99c2ed5fcbf3314c2e96c61c5aef))
 - add search filter to add select
-  ([#1547](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1547))
-  ([96a1874](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/96a1874bfe6343620175c5de4ba40c6000bd2c68))
+  ([#1547](https://github.com/carbon-design-system/ibm-products/issues/1547))
+  ([96a1874](https://github.com/carbon-design-system/ibm-products/commit/96a1874bfe6343620175c5de4ba40c6000bd2c68))
 - initial inline edit to page-header
-  ([#1533](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1533))
-  ([dffbba6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/dffbba6a761237a3fa1aa92d8f3b07c8de88fe0d))
+  ([#1533](https://github.com/carbon-design-system/ibm-products/issues/1533))
+  ([dffbba6](https://github.com/carbon-design-system/ibm-products/commit/dffbba6a761237a3fa1aa92d8f3b07c8de88fe0d))
 - **OptionsTile:** add open prop
-  ([#1534](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1534))
-  ([e99d208](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e99d2081a4d7986030878092e890ebe158e26691)),
+  ([#1534](https://github.com/carbon-design-system/ibm-products/issues/1534))
+  ([e99d208](https://github.com/carbon-design-system/ibm-products/commit/e99d2081a4d7986030878092e890ebe158e26691)),
   closes
-  [#1521](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1521)
-  [#1521](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1521)
+  [#1521](https://github.com/carbon-design-system/ibm-products/issues/1521)
+  [#1521](https://github.com/carbon-design-system/ibm-products/issues/1521)
 - split addselect into multiple exports
-  ([#1542](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1542))
-  ([b9de902](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b9de9024b7e5e422119fc90ef0258a1314a62124))
+  ([#1542](https://github.com/carbon-design-system/ibm-products/issues/1542))
+  ([b9de902](https://github.com/carbon-design-system/ibm-products/commit/b9de9024b7e5e422119fc90ef0258a1314a62124))
 - **toolbar:** add keyboard accessibility
-  ([#1514](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1514))
-  ([709c10a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/709c10afaf0845aa8209ad7dffc598e1f9ce12e6))
+  ([#1514](https://github.com/carbon-design-system/ibm-products/issues/1514))
+  ([709c10a](https://github.com/carbon-design-system/ibm-products/commit/709c10afaf0845aa8209ad7dffc598e1f9ce12e6))
 
-# [1.3.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.2.5...@carbon/ibm-products@1.3.0) (2022-01-18)
+# [1.3.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.2.5...@carbon/ibm-products@1.3.0) (2022-01-18)
 
 ### Features
 
 - add select component init
-  ([#1523](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1523))
-  ([3c61353](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3c613539ce6334be13dbf2b5d09b5f7b73f87a20))
+  ([#1523](https://github.com/carbon-design-system/ibm-products/issues/1523))
+  ([3c61353](https://github.com/carbon-design-system/ibm-products/commit/3c613539ce6334be13dbf2b5d09b5f7b73f87a20))
 
-## [1.2.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.2.4...@carbon/ibm-products@1.2.5) (2022-01-11)
-
-### Bug Fixes
-
-- update Carbon versions and package dependencies to latest
-  ([#1513](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1513))
-  ([505ba0e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/505ba0e13ec58bef19422835fd8ffee87c24e82a))
-- update Carbon versions and package dependencies to latest
-  ([#1518](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1518))
-  ([3ddcdf6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3ddcdf6617e0d7c9f182da91e3eb0935b34cbc05))
-
-## [1.2.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.2.3...@carbon/ibm-products@1.2.4) (2022-01-04)
+## [1.2.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.2.4...@carbon/ibm-products@1.2.5) (2022-01-11)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1509](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1509))
-  ([613db81](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/613db817bffec2c5b26b1fe50a337dd7bac5d963))
+  ([#1513](https://github.com/carbon-design-system/ibm-products/issues/1513))
+  ([505ba0e](https://github.com/carbon-design-system/ibm-products/commit/505ba0e13ec58bef19422835fd8ffee87c24e82a))
+- update Carbon versions and package dependencies to latest
+  ([#1518](https://github.com/carbon-design-system/ibm-products/issues/1518))
+  ([3ddcdf6](https://github.com/carbon-design-system/ibm-products/commit/3ddcdf6617e0d7c9f182da91e3eb0935b34cbc05))
 
-## [1.2.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.2.2...@carbon/ibm-products@1.2.3) (2021-12-21)
+## [1.2.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.2.3...@carbon/ibm-products@1.2.4) (2022-01-04)
+
+### Bug Fixes
+
+- update Carbon versions and package dependencies to latest
+  ([#1509](https://github.com/carbon-design-system/ibm-products/issues/1509))
+  ([613db81](https://github.com/carbon-design-system/ibm-products/commit/613db817bffec2c5b26b1fe50a337dd7bac5d963))
+
+## [1.2.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.2.2...@carbon/ibm-products@1.2.3) (2021-12-21)
 
 ### Bug Fixes
 
 - **PageHeader:** adjust CSS for clarity and to avoid webpack reordering glitch
-  ([#1498](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1498))
-  ([48b48c2](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/48b48c214c202a78846519767c3a41a7d661c771))
+  ([#1498](https://github.com/carbon-design-system/ibm-products/issues/1498))
+  ([48b48c2](https://github.com/carbon-design-system/ibm-products/commit/48b48c214c202a78846519767c3a41a7d661c771))
 - update Carbon versions and package dependencies to latest
-  ([#1499](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1499))
-  ([8aed3d5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8aed3d53d06cc896984e6847c0450cc647e34041))
+  ([#1499](https://github.com/carbon-design-system/ibm-products/issues/1499))
+  ([8aed3d5](https://github.com/carbon-design-system/ibm-products/commit/8aed3d53d06cc896984e6847c0450cc647e34041))
 
-## [1.2.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.2.1...@carbon/ibm-products@1.2.2) (2021-12-14)
+## [1.2.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.2.1...@carbon/ibm-products@1.2.2) (2021-12-14)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1493](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1493))
-  ([91b8238](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/91b82383e0aa74383ebb81f625a9e7b870f06c00))
+  ([#1493](https://github.com/carbon-design-system/ibm-products/issues/1493))
+  ([91b8238](https://github.com/carbon-design-system/ibm-products/commit/91b82383e0aa74383ebb81f625a9e7b870f06c00))
 
-## [1.2.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.2.0...@carbon/ibm-products@1.2.1) (2021-12-07)
+## [1.2.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.2.0...@carbon/ibm-products@1.2.1) (2021-12-07)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1491](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1491))
-  ([45f7b77](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/45f7b77f797c5841b9dc15bc3013f31e50244d29))
+  ([#1491](https://github.com/carbon-design-system/ibm-products/issues/1491))
+  ([45f7b77](https://github.com/carbon-design-system/ibm-products/commit/45f7b77f797c5841b9dc15bc3013f31e50244d29))
 
-# [1.2.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.1.0...@carbon/ibm-products@1.2.0) (2021-12-03)
+# [1.2.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.1.0...@carbon/ibm-products@1.2.0) (2021-12-03)
 
 ### Bug Fixes
 
 - **Tearsheet:** don't apply modal 80% width limit to influencer content
-  ([#1482](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1482))
-  ([ee87da6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ee87da6b938c06e11a8928a68fef19799b36bd2d))
+  ([#1482](https://github.com/carbon-design-system/ibm-products/issues/1482))
+  ([ee87da6](https://github.com/carbon-design-system/ibm-products/commit/ee87da6b938c06e11a8928a68fef19799b36bd2d))
 
 ### Features
 
 - adds svg support to buttons in productive card
-  ([#1481](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1481))
-  ([8722de8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8722de80fc775cfb675da12110e4efb373253a60))
+  ([#1481](https://github.com/carbon-design-system/ibm-products/issues/1481))
+  ([8722de8](https://github.com/carbon-design-system/ibm-products/commit/8722de80fc775cfb675da12110e4efb373253a60))
 - icon href support for cards
-  ([#1487](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1487))
-  ([173016e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/173016e4894820d49a1b07a573d3ce08412617c6))
+  ([#1487](https://github.com/carbon-design-system/ibm-products/issues/1487))
+  ([173016e](https://github.com/carbon-design-system/ibm-products/commit/173016e4894820d49a1b07a573d3ce08412617c6))
 
-# [1.1.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@1.0.1...@carbon/ibm-products@1.1.0) (2021-11-30)
+# [1.1.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@1.0.1...@carbon/ibm-products@1.1.0) (2021-11-30)
 
 ### Features
 
 - **pageHeader:** rename property to withoutBackground following design review
-  ([#1455](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1455))
-  ([91ab444](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/91ab444b757cc03b07a7b58bdbbb4cf2a49b74f4))
+  ([#1455](https://github.com/carbon-design-system/ibm-products/issues/1455))
+  ([91ab444](https://github.com/carbon-design-system/ibm-products/commit/91ab444b757cc03b07a7b58bdbbb4cf2a49b74f4))
 - update Carbon versions and dependencies to latest
-  ([#1473](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1473))
-  ([9cafbea](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9cafbea95226c46ff1732f9ad6b22c9c8837616e))
+  ([#1473](https://github.com/carbon-design-system/ibm-products/issues/1473))
+  ([9cafbea](https://github.com/carbon-design-system/ibm-products/commit/9cafbea95226c46ff1732f9ad6b22c9c8837616e))
 
-## [1.0.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@0.99.1...@carbon/ibm-products@1.0.1) (2021-11-23)
+## [1.0.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@0.99.1...@carbon/ibm-products@1.0.1) (2021-11-23)
 
 ### Bug Fixes
 
 - page header withotu background shadow
-  ([#1457](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1457))
-  ([fa4df10](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fa4df103451adcb411e61a08c923c717bd9520be))
+  ([#1457](https://github.com/carbon-design-system/ibm-products/issues/1457))
+  ([fa4df10](https://github.com/carbon-design-system/ibm-products/commit/fa4df103451adcb411e61a08c923c717bd9520be))
 - **PageHeader:** user defined page action space
-  ([#1470](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1470))
-  ([e9f79e9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e9f79e95da701b2064cca5ab5f56be93b8510a1b))
+  ([#1470](https://github.com/carbon-design-system/ibm-products/issues/1470))
+  ([e9f79e9](https://github.com/carbon-design-system/ibm-products/commit/e9f79e95da701b2064cca5ab5f56be93b8510a1b))
 
-# [1.0.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-products@0.99.1...@carbon/ibm-products@1.0.0) (2021-11-18)
+# [1.0.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@0.99.1...@carbon/ibm-products@1.0.0) (2021-11-18)
 
 ### Bug Fixes
 
 - page header withotu background shadow
-  ([#1457](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1457))
-  ([fa4df10](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fa4df103451adcb411e61a08c923c717bd9520be))
+  ([#1457](https://github.com/carbon-design-system/ibm-products/issues/1457))
+  ([fa4df10](https://github.com/carbon-design-system/ibm-products/commit/fa4df103451adcb411e61a08c923c717bd9520be))
 
 ## 0.99.1 (2021-11-18)
 
 ### Bug Fixes
 
 - **about-modal:** align copyright and legal text color with design
-  ([#1038](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1038))
-  ([6dbd605](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6dbd605aca7f6bc0218f5a5489d2c657399f2dc0))
+  ([#1038](https://github.com/carbon-design-system/ibm-products/issues/1038))
+  ([6dbd605](https://github.com/carbon-design-system/ibm-products/commit/6dbd605aca7f6bc0218f5a5489d2c657399f2dc0))
 - **about-modal:** prevent `p` browser defaults with no CSS reset
-  ([#1034](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1034))
-  ([cf0ae3a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/cf0ae3a5a20295c6889b20d1023d6334b8482f6d))
+  ([#1034](https://github.com/carbon-design-system/ibm-products/issues/1034))
+  ([cf0ae3a](https://github.com/carbon-design-system/ibm-products/commit/cf0ae3a5a20295c6889b20d1023d6334b8482f6d))
 - action bar crash when no space for overflow
-  ([#556](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/556))
-  ([74d1718](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/74d1718771dffb434512905a4c5ab2ed518a9a35))
+  ([#556](https://github.com/carbon-design-system/ibm-products/issues/556))
+  ([74d1718](https://github.com/carbon-design-system/ibm-products/commit/74d1718771dffb434512905a4c5ab2ed518a9a35))
 - **ActionSet:** ensure action set buttons have max width none
-  ([#859](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/859))
-  ([5aba160](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5aba1609193c241d86d2a2cda99ae6dfc6f43717))
+  ([#859](https://github.com/carbon-design-system/ibm-products/issues/859))
+  ([5aba160](https://github.com/carbon-design-system/ibm-products/commit/5aba1609193c241d86d2a2cda99ae6dfc6f43717))
 - add interactive tag styling to overflow tag in TagSet
-  ([#1022](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1022))
-  ([ae5c656](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ae5c656c88703a5ec50cb6bcad8541c00a78f737))
+  ([#1022](https://github.com/carbon-design-system/ibm-products/issues/1022))
+  ([ae5c656](https://github.com/carbon-design-system/ibm-products/commit/ae5c656c88703a5ec50cb6bcad8541c00a78f737))
 - add side effect for props-helper to package.json
-  ([#1434](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1434))
-  ([f9f6a65](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f9f6a656f4e1e563460a8b4159b9c13c26101a06))
+  ([#1434](https://github.com/carbon-design-system/ibm-products/issues/1434))
+  ([f9f6a65](https://github.com/carbon-design-system/ibm-products/commit/f9f6a656f4e1e563460a8b4159b9c13c26101a06))
 - add tag set tests n tidy
-  ([#642](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/642))
-  ([cfeeaf9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/cfeeaf943fe0bb70d543e962cb51e3303c6debb4))
+  ([#642](https://github.com/carbon-design-system/ibm-products/issues/642))
+  ([cfeeaf9](https://github.com/carbon-design-system/ibm-products/commit/cfeeaf943fe0bb70d543e962cb51e3303c6debb4))
 - add tests to PageActionItem
-  ([#516](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/516))
-  ([f1e5de2](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f1e5de288720be43f411b173486b5ed5ebe33759))
+  ([#516](https://github.com/carbon-design-system/ibm-products/issues/516))
+  ([f1e5de2](https://github.com/carbon-design-system/ibm-products/commit/f1e5de288720be43f411b173486b5ed5ebe33759))
 - added additional apikeymodal tests
-  ([#1098](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1098))
-  ([e680415](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e680415bbf998584910eb9ed92eff62a71913ebe))
+  ([#1098](https://github.com/carbon-design-system/ibm-products/issues/1098))
+  ([e680415](https://github.com/carbon-design-system/ibm-products/commit/e680415bbf998584910eb9ed92eff62a71913ebe))
 - added additional import modal tests
-  ([#673](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/673))
-  ([f6a9a2f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f6a9a2fba7519415eb5df0b3e8485c5e6bd8c6b4))
+  ([#673](https://github.com/carbon-design-system/ibm-products/issues/673))
+  ([f6a9a2f](https://github.com/carbon-design-system/ibm-products/commit/f6a9a2fba7519415eb5df0b3e8485c5e6bd8c6b4))
 - added button icon props for cards
-  ([#1336](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1336))
-  ([4974632](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4974632c7e5e691e16749a4935da2753148bfbb8))
+  ([#1336](https://github.com/carbon-design-system/ibm-products/issues/1336))
+  ([4974632](https://github.com/carbon-design-system/ibm-products/commit/4974632c7e5e691e16749a4935da2753148bfbb8))
 - added sideEffects field to package.json
-  ([#1251](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1251))
-  ([a54554b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a54554b8b8b940e9049ad8dcca481dec6f54c354))
+  ([#1251](https://github.com/carbon-design-system/ibm-products/issues/1251))
+  ([a54554b](https://github.com/carbon-design-system/ibm-products/commit/a54554b8b8b940e9049ad8dcca481dec6f54c354))
 - added testing for export release review
-  ([#635](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/635))
-  ([eff717e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/eff717e88c024fc671ece9d8963924e5495772a0))
+  ([#635](https://github.com/carbon-design-system/ibm-products/issues/635))
+  ([eff717e](https://github.com/carbon-design-system/ibm-products/commit/eff717e88c024fc671ece9d8963924e5495772a0))
 - adds additional check for copy
-  ([#1258](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1258))
-  ([b69cca1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b69cca1314e2cca7d99351fa7f91069687d64b72))
+  ([#1258](https://github.com/carbon-design-system/ibm-products/issues/1258))
+  ([b69cca1](https://github.com/carbon-design-system/ibm-products/commit/b69cca1314e2cca7d99351fa7f91069687d64b72))
 - adds and improves testing to several components
-  ([#649](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/649))
-  ([b336afa](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b336afac9a9c8f730393a38e53f1d383911c36f3))
+  ([#649](https://github.com/carbon-design-system/ibm-products/issues/649))
+  ([b336afa](https://github.com/carbon-design-system/ibm-products/commit/b336afac9a9c8f730393a38e53f1d383911c36f3))
 - adds tests and updates docs for saving
-  ([#591](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/591))
-  ([d873051](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d8730510c08edd79f3b70a15a7fc4c323f684175))
+  ([#591](https://github.com/carbon-design-system/ibm-products/issues/591))
+  ([d873051](https://github.com/carbon-design-system/ibm-products/commit/d8730510c08edd79f3b70a15a7fc4c323f684175))
 - apikey modal pre release updates
-  ([#906](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/906))
-  ([6ae80e4](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6ae80e4ba115acb0ed534ccdf5efe6faa15f80e5))
+  ([#906](https://github.com/carbon-design-system/ibm-products/issues/906))
+  ([6ae80e4](https://github.com/carbon-design-system/ibm-products/commit/6ae80e4ba115acb0ed534ccdf5efe6faa15f80e5))
 - apikey story fix
-  ([#1081](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1081))
-  ([a225b3a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a225b3a291734d1d29d564708ae267aa4a202134))
+  ([#1081](https://github.com/carbon-design-system/ibm-products/issues/1081))
+  ([a225b3a](https://github.com/carbon-design-system/ibm-products/commit/a225b3a291734d1d29d564708ae267aa4a202134))
 - available space dep and copyright
-  ([#1039](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1039))
-  ([e6e9a42](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e6e9a4222ec6f9920689b5cd74fbf03b27430781))
+  ([#1039](https://github.com/carbon-design-system/ibm-products/issues/1039))
+  ([e6e9a42](https://github.com/carbon-design-system/ibm-products/commit/e6e9a4222ec6f9920689b5cd74fbf03b27430781))
 - back arrow tooltip
-  ([#778](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/778))
-  ([b7c6dde](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b7c6dde284bb681ebcfc1474738b9280ecab82ed))
+  ([#778](https://github.com/carbon-design-system/ibm-products/issues/778))
+  ([b7c6dde](https://github.com/carbon-design-system/ibm-products/commit/b7c6dde284bb681ebcfc1474738b9280ecab82ed))
 - better warnings when deprecated-usage props have invalid values
-  ([#1198](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1198))
-  ([6ec8777](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6ec8777b66b4f45d47ed1060051b8bf9ec8692d8))
+  ([#1198](https://github.com/carbon-design-system/ibm-products/issues/1198))
+  ([6ec8777](https://github.com/carbon-design-system/ibm-products/commit/6ec8777b66b4f45d47ed1060051b8bf9ec8692d8))
 - breadcrumb overflow in page header
-  ([#880](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/880))
-  ([fa71aa3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fa71aa39c4666efadb47c02fd85c6bfe97515284))
+  ([#880](https://github.com/carbon-design-system/ibm-products/issues/880))
+  ([fa71aa3](https://github.com/carbon-design-system/ibm-products/commit/fa71aa39c4666efadb47c02fd85c6bfe97515284))
 - breadcrumb styling
-  ([#723](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/723))
-  ([65ac371](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/65ac371a0f48406acb1d6193dd9a45cefa8f9a57))
+  ([#723](https://github.com/carbon-design-system/ibm-products/issues/723))
+  ([65ac371](https://github.com/carbon-design-system/ibm-products/commit/65ac371a0f48406acb1d6193dd9a45cefa8f9a57))
 - button and tag set block class errors
-  ([#879](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/879))
-  ([d26966d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d26966dee8ef21d002c3d524914a1d2f8ff31818))
+  ([#879](https://github.com/carbon-design-system/ibm-products/issues/879))
+  ([d26966d](https://github.com/carbon-design-system/ibm-products/commit/d26966dee8ef21d002c3d524914a1d2f8ff31818))
 - card design feedback
-  ([#561](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/561))
-  ([7668278](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/76682786f4422cf9267a84b7e6f1409043758537))
+  ([#561](https://github.com/carbon-design-system/ibm-products/issues/561))
+  ([7668278](https://github.com/carbon-design-system/ibm-products/commit/76682786f4422cf9267a84b7e6f1409043758537))
 - card refactor to multiple exports
-  ([#949](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/949))
-  ([e60fa76](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e60fa76963b3027aafa4a8a87e188c9dd5ab54b0))
+  ([#949](https://github.com/carbon-design-system/ibm-products/issues/949))
+  ([e60fa76](https://github.com/carbon-design-system/ibm-products/commit/e60fa76963b3027aafa4a8a87e188c9dd5ab54b0))
 - card updates
-  ([#1013](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1013))
-  ([2e14d8e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2e14d8e101f73e8dfb9518c783e282c2365ef850))
+  ([#1013](https://github.com/carbon-design-system/ibm-products/issues/1013))
+  ([2e14d8e](https://github.com/carbon-design-system/ibm-products/commit/2e14d8e101f73e8dfb9518c783e282c2365ef850))
 - cascade release
-  ([#1242](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1242))
-  ([144af3f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/144af3f2c9a32b9621418e505ae3e5df9428fdc8))
+  ([#1242](https://github.com/carbon-design-system/ibm-products/issues/1242))
+  ([144af3f](https://github.com/carbon-design-system/ibm-products/commit/144af3f2c9a32b9621418e505ae3e5df9428fdc8))
 - contributors
-  ([#960](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/960))
-  ([02966c3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/02966c30bf253a4bf4eb601fd928d1970c55a76f))
+  ([#960](https://github.com/carbon-design-system/ibm-products/issues/960))
+  ([02966c3](https://github.com/carbon-design-system/ibm-products/commit/02966c30bf253a4bf4eb601fd928d1970c55a76f))
 - **CreateFullPage:** explicitly set bg color for page content
-  ([#1249](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1249))
-  ([776d2d3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/776d2d35a4549815312f5b3a89be2da045271eee))
+  ([#1249](https://github.com/carbon-design-system/ibm-products/issues/1249))
+  ([776d2d3](https://github.com/carbon-design-system/ibm-products/commit/776d2d35a4549815312f5b3a89be2da045271eee))
 - **CreateModal:** ensure closing the modal calls onRequestClose handler
-  ([#1147](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1147))
-  ([73cd1a4](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/73cd1a4e99d6ad5da326b0509f115268b5696a55))
+  ([#1147](https://github.com/carbon-design-system/ibm-products/issues/1147))
+  ([73cd1a4](https://github.com/carbon-design-system/ibm-products/commit/73cd1a4e99d6ad5da326b0509f115268b5696a55))
 - **CreateSidePanel:** design fixes and side panel header/scrolling work
-  ([#1141](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1141))
-  ([be67abc](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/be67abc89964816d447d3f0c24cbc0fcbaf61c6f))
+  ([#1141](https://github.com/carbon-design-system/ibm-products/issues/1141))
+  ([be67abc](https://github.com/carbon-design-system/ibm-products/commit/be67abc89964816d447d3f0c24cbc0fcbaf61c6f))
 - **CreateSidePanel:** scoping issue for create side panel
-  ([#1303](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1303))
-  ([3a198ea](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3a198eaf807af9401885c6b7841de65ce39b88e6))
+  ([#1303](https://github.com/carbon-design-system/ibm-products/issues/1303))
+  ([3a198ea](https://github.com/carbon-design-system/ibm-products/commit/3a198eaf807af9401885c6b7841de65ce39b88e6))
 - **CreateSidePanel:** title and subtitle padding is correct now
-  ([#1080](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1080))
-  ([9fcbe91](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9fcbe9185c403f2b8bc76f79ed3b687ada9da254))
+  ([#1080](https://github.com/carbon-design-system/ibm-products/issues/1080))
+  ([9fcbe91](https://github.com/carbon-design-system/ibm-products/commit/9fcbe9185c403f2b8bc76f79ed3b687ada9da254))
 - **CreateTearsheet:**
-  [#987](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/987)
+  [#987](https://github.com/carbon-design-system/ibm-products/issues/987)
   create tearsheet resizing
-  ([#988](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/988))
-  ([5f3550e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5f3550ef12665cef85b13409d438b312cb72e50b))
+  ([#988](https://github.com/carbon-design-system/ibm-products/issues/988))
+  ([5f3550e](https://github.com/carbon-design-system/ibm-products/commit/5f3550ef12665cef85b13409d438b312cb72e50b))
 - **CreateTearsheet:** add grid usage to step component and storybook
-  ([#1214](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1214))
-  ([8f49008](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8f490080cda913bc099a03b1e4bd97ecd93b394c))
+  ([#1214](https://github.com/carbon-design-system/ibm-products/issues/1214))
+  ([8f49008](https://github.com/carbon-design-system/ibm-products/commit/8f490080cda913bc099a03b1e4bd97ecd93b394c))
 - **CreateTearsheet:** allow progress steps to receive a secondary label
-  ([#945](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/945))
-  ([ff0ba7f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ff0ba7fb442e879541dbb268bc6c5ba3eff46786))
+  ([#945](https://github.com/carbon-design-system/ibm-products/issues/945))
+  ([ff0ba7f](https://github.com/carbon-design-system/ibm-products/commit/ff0ba7fb442e879541dbb268bc6c5ba3eff46786))
 - **CreateTearsheet:** fix console error in tests from timeout issue
-  ([#793](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/793))
-  ([18cab39](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/18cab399c921972d5b8b3eb90222f1a744a53a54))
+  ([#793](https://github.com/carbon-design-system/ibm-products/issues/793))
+  ([18cab39](https://github.com/carbon-design-system/ibm-products/commit/18cab399c921972d5b8b3eb90222f1a744a53a54))
 - **CreateTearsheet:** import components together
-  ([#856](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/856))
-  ([65e23ad](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/65e23adfe83c9f9652e60e00cdd19e2a696a7f32))
+  ([#856](https://github.com/carbon-design-system/ibm-products/issues/856))
+  ([65e23ad](https://github.com/carbon-design-system/ibm-products/commit/65e23adfe83c9f9652e60e00cdd19e2a696a7f32))
 - **CreateTearsheetNarrow:** add tests and address onRequestClose issue
-  ([#1143](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1143))
-  ([87ed826](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/87ed826da64825cf7f1a3f860baed4cbae1b8a54))
+  ([#1143](https://github.com/carbon-design-system/ibm-products/issues/1143))
+  ([87ed826](https://github.com/carbon-design-system/ibm-products/commit/87ed826da64825cf7f1a3f860baed4cbae1b8a54))
 - **CreateTearsheet:** remove grid margin
-  ([#1170](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1170))
-  ([75bfb54](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/75bfb5462ec364d86970fc142a99b91d0c5a185b))
+  ([#1170](https://github.com/carbon-design-system/ibm-products/issues/1170))
+  ([75bfb54](https://github.com/carbon-design-system/ibm-products/commit/75bfb5462ec364d86970fc142a99b91d0c5a185b))
 - **CreateTearsheet:** remove overflow styles
-  ([#924](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/924))
-  ([369329a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/369329a34cd3ea45ae8e4c21938d358a78fd92cb))
+  ([#924](https://github.com/carbon-design-system/ibm-products/issues/924))
+  ([369329a](https://github.com/carbon-design-system/ibm-products/commit/369329a34cd3ea45ae8e4c21938d358a78fd92cb))
 - **CreateTearsheet:** stories should receive args as expected now
-  ([#1099](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1099))
-  ([ec43a08](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ec43a0891c472a554228bd2bc11bb83a0fa090ce))
+  ([#1099](https://github.com/carbon-design-system/ibm-products/issues/1099))
+  ([ec43a08](https://github.com/carbon-design-system/ibm-products/commit/ec43a0891c472a554228bd2bc11bb83a0fa090ce))
 - **CreateTearsheet:** story component updates
-  ([#1091](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1091))
-  ([62f7fbc](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/62f7fbc0b0c4d62d68cbaf288bbd5ae0170a4605))
+  ([#1091](https://github.com/carbon-design-system/ibm-products/issues/1091))
+  ([62f7fbc](https://github.com/carbon-design-system/ibm-products/commit/62f7fbc0b0c4d62d68cbaf288bbd5ae0170a4605))
 - **CreateTearsheet:** toggle spacing is correct now
-  ([#1025](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1025))
-  ([a662106](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a6621069d2a08c620f96c20aad4aaf431c8061bf))
+  ([#1025](https://github.com/carbon-design-system/ibm-products/issues/1025))
+  ([a662106](https://github.com/carbon-design-system/ibm-products/commit/a6621069d2a08c620f96c20aad4aaf431c8061bf))
 - **CreateTearsheet:** updates based on release review
-  ([#1233](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1233))
-  ([f50e78a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f50e78ab7f7a6b12d14b779954cad5ef4f91f6eb))
+  ([#1233](https://github.com/carbon-design-system/ibm-products/issues/1233))
+  ([f50e78a](https://github.com/carbon-design-system/ibm-products/commit/f50e78ab7f7a6b12d14b779954cad5ef4f91f6eb))
 - **CreateTearsheet:** use default button separator color variable
-  ([#802](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/802))
-  ([8594e69](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8594e69852c746b6108b778cdc88b7b56fbd6838))
+  ([#802](https://github.com/carbon-design-system/ibm-products/issues/802))
+  ([8594e69](https://github.com/carbon-design-system/ibm-products/commit/8594e69852c746b6108b778cdc88b7b56fbd6838))
 - desdign review niggles
-  ([#765](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/765))
-  ([46a353b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/46a353b8ba9f30657f1b7cd3808a978e5cc3869c))
+  ([#765](https://github.com/carbon-design-system/ibm-products/issues/765))
+  ([46a353b](https://github.com/carbon-design-system/ibm-products/commit/46a353b8ba9f30657f1b7cd3808a978e5cc3869c))
 - **EmptyState:** fix error logs by not having defaults for shared props
-  ([#535](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/535))
-  ([3de7429](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3de7429a8bb841c97df37d2711bc4a97f0241064))
+  ([#535](https://github.com/carbon-design-system/ibm-products/issues/535))
+  ([3de7429](https://github.com/carbon-design-system/ibm-products/commit/3de7429a8bb841c97df37d2711bc4a97f0241064))
 - **EmptyStates:** give svg elements unique ids to avoid display issues
-  ([#1290](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1290))
-  ([72deea8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/72deea83d493930ba03ee938c4aa1f588662407f))
+  ([#1290](https://github.com/carbon-design-system/ibm-products/issues/1290))
+  ([72deea8](https://github.com/carbon-design-system/ibm-products/commit/72deea83d493930ba03ee938c4aa1f588662407f))
 - **EmptyStates:** update stories and rename size prop
-  ([#753](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/753))
-  ([c5e6bfb](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c5e6bfb912b5d8bc2ab143df87f2b615f35939ac))
+  ([#753](https://github.com/carbon-design-system/ibm-products/issues/753))
+  ([c5e6bfb](https://github.com/carbon-design-system/ibm-products/commit/c5e6bfb912b5d8bc2ab143df87f2b615f35939ac))
 - ensure internal components don't render as canary placeholders
-  ([#1167](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1167))
-  ([0b557b6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0b557b6163692e796058e7d2bc3b991d019b62d9))
+  ([#1167](https://github.com/carbon-design-system/ibm-products/issues/1167))
+  ([0b557b6](https://github.com/carbon-design-system/ibm-products/commit/0b557b6163692e796058e7d2bc3b991d019b62d9))
 - Ensure PageActions can be clicked, on scroll
-  ([#1347](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1347))
-  ([96183e2](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/96183e2d1e54ef9f8b6b110fdfb731cac737c181))
+  ([#1347](https://github.com/carbon-design-system/ibm-products/issues/1347))
+  ([96183e2](https://github.com/carbon-design-system/ibm-products/commit/96183e2d1e54ef9f8b6b110fdfb731cac737c181))
 - Ensure SCSS for all components and stories sets required carbon and project
   settings
-  ([#1166](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1166))
-  ([5c77105](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5c77105891df498f26d3f8f6214f8d7f7fa68267))
+  ([#1166](https://github.com/carbon-design-system/ibm-products/issues/1166))
+  ([5c77105](https://github.com/carbon-design-system/ibm-products/commit/5c77105891df498f26d3f8f6214f8d7f7fa68267))
 - export cards
-  ([#1120](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1120))
-  ([7227aeb](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7227aebcc0c31c2f9a3076692c5a3b3913a6a2e0))
+  ([#1120](https://github.com/carbon-design-system/ibm-products/issues/1120))
+  ([7227aeb](https://github.com/carbon-design-system/ibm-products/commit/7227aebcc0c31c2f9a3076692c5a3b3913a6a2e0))
 - fixes card href support
-  ([#1353](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1353))
-  ([30a89cb](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/30a89cb682189f2844a3d36c88bf9f40b3e33532))
+  ([#1353](https://github.com/carbon-design-system/ibm-products/issues/1353))
+  ([30a89cb](https://github.com/carbon-design-system/ibm-products/commit/30a89cb682189f2844a3d36c88bf9f40b3e33532))
 - forgot to add onclose to export modal
-  ([#776](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/776))
-  ([c381d93](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c381d93e123c33a600e7bf8dee0f3fd8c75767e6))
+  ([#776](https://github.com/carbon-design-system/ibm-products/issues/776))
+  ([c381d93](https://github.com/carbon-design-system/ibm-products/commit/c381d93e123c33a600e7bf8dee0f3fd8c75767e6))
 - html element method mock
-  ([#833](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/833))
-  ([fccb061](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fccb061fafaf42b9c91c309c9363b2e745ed1b11))
+  ([#833](https://github.com/carbon-design-system/ibm-products/issues/833))
+  ([fccb061](https://github.com/carbon-design-system/ibm-products/commit/fccb061fafaf42b9c91c309c9363b2e745ed1b11))
 - **HTTPErrors:** addresses review findings
-  ([#789](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/789))
-  ([1f8c9d9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1f8c9d9c26ec1635b96f7c8d13925ff3ed8213af))
+  ([#789](https://github.com/carbon-design-system/ibm-products/issues/789))
+  ([1f8c9d9](https://github.com/carbon-design-system/ibm-products/commit/1f8c9d9c26ec1635b96f7c8d13925ff3ed8213af))
 - **HTTPErrors:** explicitly set text color and update snapshot
-  ([#1155](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1155))
-  ([bd37ca6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/bd37ca69a1489c55ebb94e7c9f5f4858d3ad3923))
+  ([#1155](https://github.com/carbon-design-system/ibm-products/issues/1155))
+  ([bd37ca6](https://github.com/carbon-design-system/ibm-products/commit/bd37ca69a1489c55ebb94e7c9f5f4858d3ad3923))
 - **HTTPErrors:** fix centering issue with css
-  ([#543](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/543))
-  ([3783d62](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3783d627b5626fe6077a317c15f1b6542e23e8ff))
+  ([#543](https://github.com/carbon-design-system/ibm-products/issues/543))
+  ([3783d62](https://github.com/carbon-design-system/ibm-products/commit/3783d627b5626fe6077a317c15f1b6542e23e8ff))
 - **HTTPErrors:** remove canary check on http error content component
-  ([#900](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/900))
-  ([e6e394a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e6e394a4e90d3bfda58489a9a5687e0499215fb9))
+  ([#900](https://github.com/carbon-design-system/ibm-products/issues/900))
+  ([e6e394a](https://github.com/carbon-design-system/ibm-products/commit/e6e394a4e90d3bfda58489a9a5687e0499215fb9))
 - import modal style updates
-  ([#624](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/624))
-  ([bf94094](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/bf94094c7d0dfa4c6b60ecc248f7da514f24a47b))
+  ([#624](https://github.com/carbon-design-system/ibm-products/issues/624))
+  ([bf94094](https://github.com/carbon-design-system/ibm-products/commit/bf94094c7d0dfa4c6b60ecc248f7da514f24a47b))
 - import review updates
-  ([#872](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/872))
-  ([fbe0ce6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fbe0ce61a5435061255e4a30bee3b3a785b7659f))
+  ([#872](https://github.com/carbon-design-system/ibm-products/issues/872))
+  ([fbe0ce6](https://github.com/carbon-design-system/ibm-products/commit/fbe0ce61a5435061255e4a30bee3b3a785b7659f))
 - improve AboutModal stories
-  ([#875](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/875))
-  ([5faf934](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5faf93494a33d523330e536b150013f4e339c5ec))
+  ([#875](https://github.com/carbon-design-system/ibm-products/issues/875))
+  ([5faf934](https://github.com/carbon-design-system/ibm-products/commit/5faf93494a33d523330e536b150013f4e339c5ec))
 - improve tree-shaking optimisation by importing icons directly from
   @carbons/icons-react
-  ([#1379](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1379))
-  ([9110484](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9110484d7860a95a858a5e1931015b853769c3a9))
+  ([#1379](https://github.com/carbon-design-system/ibm-products/issues/1379))
+  ([9110484](https://github.com/carbon-design-system/ibm-products/commit/9110484d7860a95a858a5e1931015b853769c3a9))
 - issues raised in page header design review
-  ([#754](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/754))
-  ([13c5085](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/13c5085b6de50c01a942f71b66e80a9516167c42))
+  ([#754](https://github.com/carbon-design-system/ibm-products/issues/754))
+  ([13c5085](https://github.com/carbon-design-system/ibm-products/commit/13c5085b6de50c01a942f71b66e80a9516167c42))
 - keep page header above content on scroll
-  ([#1281](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1281))
-  ([f2d95e4](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f2d95e434f37945d6d249631f44f8ce4789b7a58))
+  ([#1281](https://github.com/carbon-design-system/ibm-products/issues/1281))
+  ([f2d95e4](https://github.com/carbon-design-system/ibm-products/commit/f2d95e434f37945d6d249631f44f8ce4789b7a58))
 - long tag rendering in TagSet overflow
-  ([#1301](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1301))
-  ([722aa8b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/722aa8bd3504b3050784daeffedff07d057f57ee))
+  ([#1301](https://github.com/carbon-design-system/ibm-products/issues/1301))
+  ([722aa8b](https://github.com/carbon-design-system/ibm-products/commit/722aa8bd3504b3050784daeffedff07d057f57ee))
 - lower page header z-index for sidenav
-  ([#1343](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1343))
-  ([03d2743](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/03d2743e895c832bfb1486f1672af272510a85c8))
+  ([#1343](https://github.com/carbon-design-system/ibm-products/issues/1343))
+  ([03d2743](https://github.com/carbon-design-system/ibm-products/commit/03d2743e895c832bfb1486f1672af272510a85c8))
 - minor fix to make AboutModal stories switch more smoothly
-  ([#609](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/609))
-  ([b3fe083](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b3fe083c411a3d627031094fe608c57bd378990d))
+  ([#609](https://github.com/carbon-design-system/ibm-products/issues/609))
+  ([b3fe083](https://github.com/carbon-design-system/ibm-products/commit/b3fe083c411a3d627031094fe608c57bd378990d))
 - more card design feedback
-  ([#576](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/576))
-  ([cd73a79](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/cd73a794a17b5b2e4784effd45744a07bc5b3351))
+  ([#576](https://github.com/carbon-design-system/ibm-products/issues/576))
+  ([cd73a79](https://github.com/carbon-design-system/ibm-products/commit/cd73a794a17b5b2e4784effd45744a07bc5b3351))
 - **Notifications:** new notifications get sorted as expected now
-  ([#527](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/527))
-  ([2f762e8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2f762e812c9728525721b2480e3bdd86f533bbc0))
+  ([#527](https://github.com/carbon-design-system/ibm-products/issues/527))
+  ([2f762e8](https://github.com/carbon-design-system/ibm-products/commit/2f762e812c9728525721b2480e3bdd86f533bbc0))
 - **NotificationsPanel:** add prop to set defaultToggled value
-  ([#956](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/956))
-  ([4f92e2a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4f92e2a537bc210b86c2682bd8899a95e2693e5d))
+  ([#956](https://github.com/carbon-design-system/ibm-products/issues/956))
+  ([4f92e2a](https://github.com/carbon-design-system/ibm-products/commit/4f92e2a537bc210b86c2682bd8899a95e2693e5d))
 - **NotificationsPanel:** address review findings and add more tests
-  ([#613](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/613))
-  ([a8e6bb4](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a8e6bb47f7b298ab00c077442c3ea3c85f7f3525))
+  ([#613](https://github.com/carbon-design-system/ibm-products/issues/613))
+  ([a8e6bb4](https://github.com/carbon-design-system/ibm-products/commit/a8e6bb47f7b298ab00c077442c3ea3c85f7f3525))
 - **NotificationsPanel:** fix z index issue in bottom actions
-  ([#629](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/629))
-  ([8700e7d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8700e7d7f09c33f39395ca76540db66cd9052d2d))
+  ([#629](https://github.com/carbon-design-system/ibm-products/issues/629))
+  ([8700e7d](https://github.com/carbon-design-system/ibm-products/commit/8700e7d7f09c33f39395ca76540db66cd9052d2d))
 - **NotificationsPanel:** release review fixes
-  ([#584](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/584))
-  ([7c9af63](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7c9af63a6c1b258f1b8743bcfccc47e0bd6eb1ca))
+  ([#584](https://github.com/carbon-design-system/ibm-products/issues/584))
+  ([7c9af63](https://github.com/carbon-design-system/ibm-products/commit/7c9af63a6c1b258f1b8743bcfccc47e0bd6eb1ca))
 - out dated canary instruction
-  ([#578](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/578))
-  ([#579](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/579))
-  ([97bb6a6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/97bb6a6721cdac8c6b6c7cb98452a0025d64faeb))
+  ([#578](https://github.com/carbon-design-system/ibm-products/issues/578))
+  ([#579](https://github.com/carbon-design-system/ibm-products/issues/579))
+  ([97bb6a6](https://github.com/carbon-design-system/ibm-products/commit/97bb6a6721cdac8c6b6c7cb98452a0025d64faeb))
 - overflwo z-indexes in page header
-  ([#1361](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1361))
-  ([21cc33d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/21cc33d4bde5f252d95f1e6fd3c5941031b67097))
+  ([#1361](https://github.com/carbon-design-system/ibm-products/issues/1361))
+  ([21cc33d](https://github.com/carbon-design-system/ibm-products/commit/21cc33d4bde5f252d95f1e6fd3c5941031b67097))
 - page header action bar usage
-  ([#622](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/622))
-  ([bfa4370](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/bfa437079b68ea8583e0ea5a9df5ce344936d85c))
+  ([#622](https://github.com/carbon-design-system/ibm-products/issues/622))
+  ([bfa4370](https://github.com/carbon-design-system/ibm-products/commit/bfa437079b68ea8583e0ea5a9df5ce344936d85c))
 - page header background over lays
-  ([#1418](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1418))
-  ([40a3531](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/40a3531536fbe1dcda4e551bdad32f77fad440ff))
+  ([#1418](https://github.com/carbon-design-system/ibm-products/issues/1418))
+  ([40a3531](https://github.com/carbon-design-system/ibm-products/commit/40a3531536fbe1dcda4e551bdad32f77fad440ff))
 - page header deprecations
-  ([#697](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/697))
-  ([ee559f9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ee559f93896a416c01d0e790864835542726d44a))
+  ([#697](https://github.com/carbon-design-system/ibm-products/issues/697))
+  ([ee559f9](https://github.com/carbon-design-system/ibm-products/commit/ee559f93896a416c01d0e790864835542726d44a))
 - page header performance glitches
-  ([#896](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/896))
-  ([57eae46](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/57eae4653f3b9efbe1218ad947ff6141760f0c14))
+  ([#896](https://github.com/carbon-design-system/ibm-products/issues/896))
+  ([57eae46](https://github.com/carbon-design-system/ibm-products/commit/57eae4653f3b9efbe1218ad947ff6141760f0c14))
 - page header styling on scroll
-  ([#881](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/881))
-  ([da5a472](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/da5a472e0ecef94be5d6157dcb55b640c76bbf23))
+  ([#881](https://github.com/carbon-design-system/ibm-products/issues/881))
+  ([da5a472](https://github.com/carbon-design-system/ibm-products/commit/da5a472e0ecef94be5d6157dcb55b640c76bbf23))
 - page header test coverage 100%
-  ([#788](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/788))
-  ([5a1d2d7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5a1d2d7bdfff4d1cfc0a187f8a82992dfa946c75))
+  ([#788](https://github.com/carbon-design-system/ibm-products/issues/788))
+  ([5a1d2d7](https://github.com/carbon-design-system/ibm-products/commit/5a1d2d7bdfff4d1cfc0a187f8a82992dfa946c75))
 - page header tests 100 percent
-  ([#1069](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1069))
-  ([3d025eb](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3d025ebf81dc4efd87b573490f87ed8969710466))
+  ([#1069](https://github.com/carbon-design-system/ibm-products/issues/1069))
+  ([3d025eb](https://github.com/carbon-design-system/ibm-products/commit/3d025ebf81dc4efd87b573490f87ed8969710466))
 - page header title breadcrumb
-  ([#1063](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1063))
-  ([fe5291f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fe5291f52e42d6d0532264f866e8d53602f0b8d3))
+  ([#1063](https://github.com/carbon-design-system/ibm-products/issues/1063))
+  ([fe5291f](https://github.com/carbon-design-system/ibm-products/commit/fe5291f52e42d6d0532264f866e8d53602f0b8d3))
 - pageheader styles either side of md breakpt
-  ([#554](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/554))
-  ([6abab44](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6abab440845b9919dbdd7e4a3b2c6d021f6477b8))
+  ([#554](https://github.com/carbon-design-system/ibm-products/issues/554))
+  ([6abab44](https://github.com/carbon-design-system/ibm-products/commit/6abab440845b9919dbdd7e4a3b2c6d021f6477b8))
 - **PageHeader:** action bar location
-  ([#1428](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1428))
-  ([928cec6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/928cec664f62d8276d043e7f6bb7d6fa5e329d45))
+  ([#1428](https://github.com/carbon-design-system/ibm-products/issues/1428))
+  ([928cec6](https://github.com/carbon-design-system/ibm-products/commit/928cec664f62d8276d043e7f6bb7d6fa5e329d45))
 - **pageHeader:** breadcrumb scroll without actionbar
-  ([#1363](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1363))
-  ([d9e781e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d9e781ef1b6768e0bf4c0591507b8605aba897b4))
+  ([#1363](https://github.com/carbon-design-system/ibm-products/issues/1363))
+  ([d9e781e](https://github.com/carbon-design-system/ibm-products/commit/d9e781ef1b6768e0bf4c0591507b8605aba897b4))
 - **PageHeader:** pageActions scroll without actionBar but with breadcrumbs
-  ([#1370](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1370))
-  ([9ecade4](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9ecade421b42b2bd05f03e13476f18c9d2210a45))
+  ([#1370](https://github.com/carbon-design-system/ibm-products/issues/1370))
+  ([9ecade4](https://github.com/carbon-design-system/ibm-products/commit/9ecade421b42b2bd05f03e13476f18c9d2210a45))
 - **pageHeader:** user defined page actions not visible
-  ([#1450](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1450))
-  ([b16af81](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b16af818cd652ffc9788de12b514435819df1af7))
+  ([#1450](https://github.com/carbon-design-system/ibm-products/issues/1450))
+  ([b16af81](https://github.com/carbon-design-system/ibm-products/commit/b16af818cd652ffc9788de12b514435819df1af7))
 - prevent collapse button over action bar items
-  ([#728](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/728))
-  ([b9785eb](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b9785ebeba8c8eb0ef72ffd73675314629bf4fe3))
+  ([#728](https://github.com/carbon-design-system/ibm-products/issues/728))
+  ([b9785eb](https://github.com/carbon-design-system/ibm-products/commit/b9785ebeba8c8eb0ef72ffd73675314629bf4fe3))
 - release review updates
-  ([#1237](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1237))
-  ([1880856](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1880856c4f5f8063f94a26d7e16e89c8454b6ccc))
+  ([#1237](https://github.com/carbon-design-system/ibm-products/issues/1237))
+  ([1880856](https://github.com/carbon-design-system/ibm-products/commit/1880856c4f5f8063f94a26d7e16e89c8454b6ccc))
 - release review updates for export
-  ([#828](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/828))
-  ([7a7ae3e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7a7ae3e9d02a6fcbab9d8f99a9f242f0b1c57c23))
+  ([#828](https://github.com/carbon-design-system/ibm-products/issues/828))
+  ([7a7ae3e](https://github.com/carbon-design-system/ibm-products/commit/7a7ae3e9d02a6fcbab9d8f99a9f242f0b1c57c23))
 - remove and export modal fixes
-  ([#830](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/830))
-  ([0d8a4f5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0d8a4f5d1c047b2a794a2d349693dadd891816d2))
+  ([#830](https://github.com/carbon-design-system/ibm-products/issues/830))
+  ([0d8a4f5](https://github.com/carbon-design-system/ibm-products/commit/0d8a4f5d1c047b2a794a2d349693dadd891816d2))
 - remove deprecated props from stories
-  ([#1033](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1033))
-  ([89bc2a3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/89bc2a3a4e4e7befe69bbe0eced3a31c005a61eb))
+  ([#1033](https://github.com/carbon-design-system/ibm-products/issues/1033))
+  ([89bc2a3](https://github.com/carbon-design-system/ibm-products/commit/89bc2a3a4e4e7befe69bbe0eced3a31c005a61eb))
 - remove modal release feedback updates
-  ([#757](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/757))
-  ([f6b97ba](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f6b97babd6f98da8f08ffbc3ddc24bac8f9b059e))
+  ([#757](https://github.com/carbon-design-system/ibm-products/issues/757))
+  ([f6b97ba](https://github.com/carbon-design-system/ibm-products/commit/f6b97babd6f98da8f08ffbc3ddc24bac8f9b059e))
 - remove wibble from example story
-  ([#780](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/780))
-  ([ca4910f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ca4910f918fea1d65b8e9f06767a08ba72064d93))
+  ([#780](https://github.com/carbon-design-system/ibm-products/issues/780))
+  ([ca4910f](https://github.com/carbon-design-system/ibm-products/commit/ca4910f918fea1d65b8e9f06767a08ba72064d93))
 - **RemoveModal:**
-  [#1426](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1426)
+  [#1426](https://github.com/carbon-design-system/ibm-products/issues/1426)
   reset remove modal text input value
-  ([#1433](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1433))
-  ([e2df543](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e2df543280cb9aa23942eebe40244f4c27197080))
+  ([#1433](https://github.com/carbon-design-system/ibm-products/issues/1433))
+  ([e2df543](https://github.com/carbon-design-system/ibm-products/commit/e2df543280cb9aa23942eebe40244f4c27197080))
 - renderIcon type in page header
-  ([#1010](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1010))
-  ([0235762](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0235762486382d7c8c481b58619170b98f79aec5))
+  ([#1010](https://github.com/carbon-design-system/ibm-products/issues/1010))
+  ([0235762](https://github.com/carbon-design-system/ibm-products/commit/0235762486382d7c8c481b58619170b98f79aec5))
 - replace "cloud & cognitive" with "Carbon for IBM Products" in docs
-  ([#1437](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1437))
-  ([0a58354](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0a58354ccbdd723173b2e6758907713938a7f163))
+  ([#1437](https://github.com/carbon-design-system/ibm-products/issues/1437))
+  ([0a58354](https://github.com/carbon-design-system/ibm-products/commit/0a58354ccbdd723173b2e6758907713938a7f163))
 - revert to buttoon kind
-  ([#995](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/995))
-  ([8740afd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8740afdb578cb7ec57eba4abfae44b2ca7c81068))
+  ([#995](https://github.com/carbon-design-system/ibm-products/issues/995))
+  ([8740afd](https://github.com/carbon-design-system/ibm-products/commit/8740afdb578cb7ec57eba4abfae44b2ca7c81068))
 - review feedback for cards
-  ([#1131](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1131))
-  ([aecea1c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/aecea1c5b4453e0c3a7af28ab55d6f354c77dbd5))
+  ([#1131](https://github.com/carbon-design-system/ibm-products/issues/1131))
+  ([aecea1c](https://github.com/carbon-design-system/ibm-products/commit/aecea1c5b4453e0c3a7af28ab55d6f354c77dbd5))
 - saving design feedback
-  ([#582](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/582))
-  ([121dbaf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/121dbafc1ed11579c104b4329d73cadbe56a7df9))
+  ([#582](https://github.com/carbon-design-system/ibm-products/issues/582))
+  ([121dbaf](https://github.com/carbon-design-system/ibm-products/commit/121dbafc1ed11579c104b4329d73cadbe56a7df9))
 - **SidePanel:**
-  [#1191](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1191)
+  [#1191](https://github.com/carbon-design-system/ibm-products/issues/1191)
   allow side panel title to be optional
-  ([#1202](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1202))
-  ([a9aa0e6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a9aa0e6113afd40ad17d568e60629c4e03de5555))
+  ([#1202](https://github.com/carbon-design-system/ibm-products/issues/1202))
+  ([a9aa0e6](https://github.com/carbon-design-system/ibm-products/commit/a9aa0e6113afd40ad17d568e60629c4e03de5555))
 - **SidePanel:**
-  [#1204](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1204)
+  [#1204](https://github.com/carbon-design-system/ibm-products/issues/1204)
   side panel closing animation fix
-  ([#1222](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1222))
-  ([53953a5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/53953a52b5842e27253208cad16d52f8b106530b))
+  ([#1222](https://github.com/carbon-design-system/ibm-products/issues/1222))
+  ([53953a5](https://github.com/carbon-design-system/ibm-products/commit/53953a52b5842e27253208cad16d52f8b106530b))
 - **SidePanel:** add default subtitle height value
-  ([#889](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/889))
-  ([d7c61ae](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d7c61ae118e7c4eb9217f50d0d90bebef81fc4c8))
+  ([#889](https://github.com/carbon-design-system/ibm-products/issues/889))
+  ([d7c61ae](https://github.com/carbon-design-system/ibm-products/commit/d7c61ae118e7c4eb9217f50d0d90bebef81fc4c8))
 - **SidePanel:** add extra padding bottom to collapsed title underline
-  ([#678](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/678))
-  ([c1d5eb6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c1d5eb6f8b49df96fd9f742a873ef272998900ad))
+  ([#678](https://github.com/carbon-design-system/ibm-products/issues/678))
+  ([c1d5eb6](https://github.com/carbon-design-system/ibm-products/commit/c1d5eb6f8b49df96fd9f742a873ef272998900ad))
 - **SidePanel:** add overflow hidden to body if includeOverlay exists
-  ([#1238](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1238))
-  ([6ffb602](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6ffb60287755909bae595f2d1cf8f5bc7e5ec8c5))
+  ([#1238](https://github.com/carbon-design-system/ibm-products/issues/1238))
+  ([6ffb602](https://github.com/carbon-design-system/ibm-products/commit/6ffb60287755909bae595f2d1cf8f5bc7e5ec8c5))
 - **SidePanel:** add panel height to useEffect dependencies
-  ([#1100](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1100))
-  ([fe29cc0](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fe29cc0ebdbbdf3d66acf0a7d6bc8263b2139030))
+  ([#1100](https://github.com/carbon-design-system/ibm-products/issues/1100))
+  ([fe29cc0](https://github.com/carbon-design-system/ibm-products/commit/fe29cc0ebdbbdf3d66acf0a7d6bc8263b2139030))
 - **SidePanel:** add resize detector to adapt to new actions height
-  ([#596](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/596))
-  ([e812ff9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e812ff953cc40d83265d02540357578c95150ec5))
+  ([#596](https://github.com/carbon-design-system/ibm-products/issues/596))
+  ([e812ff9](https://github.com/carbon-design-system/ibm-products/commit/e812ff953cc40d83265d02540357578c95150ec5))
 - **SidePanel:** add shadow only for slideOver panels without overlays
-  ([#722](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/722))
-  ([9cb74d4](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9cb74d4ff006e30c79512b80d480742219d2c639))
+  ([#722](https://github.com/carbon-design-system/ibm-products/issues/722))
+  ([9cb74d4](https://github.com/carbon-design-system/ibm-products/commit/9cb74d4ff006e30c79512b80d480742219d2c639))
 - **SidePanel:** add transition to divider appearing during animation
-  ([#599](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/599))
-  ([4a7fac1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4a7fac1843052b5495996aca21b61660ac0ef304))
+  ([#599](https://github.com/carbon-design-system/ibm-products/issues/599))
+  ([4a7fac1](https://github.com/carbon-design-system/ibm-products/commit/4a7fac1843052b5495996aca21b61660ac0ef304))
 - **SidePanel:** add validator to side panel and allPropType helper
-  ([#797](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/797))
-  ([c2262c9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c2262c9a8ac0ac57b21232dc0e943aca7f22d4ed))
+  ([#797](https://github.com/carbon-design-system/ibm-products/issues/797))
+  ([c2262c9](https://github.com/carbon-design-system/ibm-products/commit/c2262c9a8ac0ac57b21232dc0e943aca7f22d4ed))
 - **SidePanel:** allow animation to complete when scroll length is short
-  ([#970](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/970))
-  ([ac894a5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ac894a50bdc4a0b636adb8e6e2f5ea0a52d3e0ed))
+  ([#970](https://github.com/carbon-design-system/ibm-products/issues/970))
+  ([ac894a5](https://github.com/carbon-design-system/ibm-products/commit/ac894a50bdc4a0b636adb8e6e2f5ea0a52d3e0ed))
 - **SidePanel:** center close svg in close button
-  ([#1190](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1190))
-  ([fa4a688](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fa4a68898eb74d2e5487732d27f36664de9648a1))
+  ([#1190](https://github.com/carbon-design-system/ibm-products/issues/1190))
+  ([fa4a688](https://github.com/carbon-design-system/ibm-products/commit/fa4a68898eb74d2e5487732d27f36664de9648a1))
 - **SidePanel:** changing size prop within panel already open works now
-  ([#1371](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1371))
-  ([d8de35b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d8de35b2bb62ca64e8210370bb5a820af99f6af9))
+  ([#1371](https://github.com/carbon-design-system/ibm-products/issues/1371))
+  ([d8de35b](https://github.com/carbon-design-system/ibm-products/commit/d8de35b2bb62ca64e8210370bb5a820af99f6af9))
 - **SidePanel:** correct how bottom padding of content is calculated
-  ([#593](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/593))
-  ([12168c9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/12168c9c023e77940a2c6a5b97d1aedeed596a7f))
+  ([#593](https://github.com/carbon-design-system/ibm-products/issues/593))
+  ([12168c9](https://github.com/carbon-design-system/ibm-products/commit/12168c9c023e77940a2c6a5b97d1aedeed596a7f))
 - **SidePanel:** fix animating state of panel
-  ([#1193](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1193))
-  ([5a98abc](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5a98abc93e06b021ea4851c19afc4bbb50a7660f))
+  ([#1193](https://github.com/carbon-design-system/ibm-products/issues/1193))
+  ([5a98abc](https://github.com/carbon-design-system/ibm-products/commit/5a98abc93e06b021ea4851c19afc4bbb50a7660f))
 - **SidePanel:** fix back button positioning
-  ([#969](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/969))
-  ([34e7442](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/34e744254ce95c63779ca614bcaa8c2e4fe70309))
+  ([#969](https://github.com/carbon-design-system/ibm-products/issues/969))
+  ([34e7442](https://github.com/carbon-design-system/ibm-products/commit/34e744254ce95c63779ca614bcaa8c2e4fe70309))
 - **SidePanel:** fix label text layout issues on scroll animation
-  ([#1203](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1203))
-  ([d1c5570](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d1c5570a56eea58157b8ad2e8faca225787f8479))
+  ([#1203](https://github.com/carbon-design-system/ibm-products/issues/1203))
+  ([d1c5570](https://github.com/carbon-design-system/ibm-products/commit/d1c5570a56eea58157b8ad2e8faca225787f8479))
 - **SidePanel:** fix ref handling in clickOutside useEffect
-  ([#1322](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1322))
-  ([4fd8837](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4fd8837474042529592f644390f6d5367f78e2c0))
+  ([#1322](https://github.com/carbon-design-system/ibm-products/issues/1322))
+  ([4fd8837](https://github.com/carbon-design-system/ibm-products/commit/4fd8837474042529592f644390f6d5367f78e2c0))
 - **SidePanel:** give default scroll height if no subtitle
-  ([#1315](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1315))
-  ([b70e56b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b70e56bb78c9384d92b20596ddb8503ab2c1fb17))
+  ([#1315](https://github.com/carbon-design-system/ibm-products/issues/1315))
+  ([b70e56b](https://github.com/carbon-design-system/ibm-products/commit/b70e56bb78c9384d92b20596ddb8503ab2c1fb17))
 - **SidePanel:** make review fixes for release
-  ([#851](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/851))
-  ([076616a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/076616a3807279548cb1acc161f67f0a3454181a))
+  ([#851](https://github.com/carbon-design-system/ibm-products/issues/851))
+  ([076616a](https://github.com/carbon-design-system/ibm-products/commit/076616a3807279548cb1acc161f67f0a3454181a))
 - **SidePanel:** make title/subtitle fixed when no title animation
-  ([#933](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/933))
-  ([18c097d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/18c097d8d590d52eb0527eed7de1c4b3786751ca))
+  ([#933](https://github.com/carbon-design-system/ibm-products/issues/933))
+  ([18c097d](https://github.com/carbon-design-system/ibm-products/commit/18c097d8d590d52eb0527eed7de1c4b3786751ca))
 - **SidePanel:** revert condensed title font weight style
-  ([#1213](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1213))
-  ([9bf141d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9bf141df78325ac8b8682a647a2d27b28826dac5))
+  ([#1213](https://github.com/carbon-design-system/ibm-products/issues/1213))
+  ([9bf141d](https://github.com/carbon-design-system/ibm-products/commit/9bf141df78325ac8b8682a647a2d27b28826dac5))
 - **SidePanel:** should fix focus trap which is breaking the side panel
-  ([#511](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/511))
-  ([47d9828](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/47d98287f25284a20da3a2e8d480b138ee876cfc))
+  ([#511](https://github.com/carbon-design-system/ibm-products/issues/511))
+  ([47d9828](https://github.com/carbon-design-system/ibm-products/commit/47d98287f25284a20da3a2e8d480b138ee876cfc))
 - **SidePanel:** styles refactor/fix
-  ([#1285](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1285))
-  ([bf78f15](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/bf78f157192cefdf0e0977895cf144f22d9012ab))
+  ([#1285](https://github.com/carbon-design-system/ibm-products/issues/1285))
+  ([bf78f15](https://github.com/carbon-design-system/ibm-products/commit/bf78f157192cefdf0e0977895cf144f22d9012ab))
 - **SidePanel:** title animation bug addressed, missing default value
-  ([#1064](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1064))
-  ([40cc4a6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/40cc4a6b285c41125f4e8f85c6f38e0b25dcbd7f))
+  ([#1064](https://github.com/carbon-design-system/ibm-products/issues/1064))
+  ([40cc4a6](https://github.com/carbon-design-system/ibm-products/commit/40cc4a6b285c41125f4e8f85c6f38e0b25dcbd7f))
 - **SidePanel:** update storyname in mdx doc file
-  ([#1232](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1232))
-  ([a336e37](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a336e37d8812f4929c65fb4e74524008ff6a1278))
+  ([#1232](https://github.com/carbon-design-system/ibm-products/issues/1232))
+  ([a336e37](https://github.com/carbon-design-system/ibm-products/commit/a336e37d8812f4929c65fb4e74524008ff6a1278))
 - **SidePanel:** use carbon z index mixin for side panel container
-  ([#1317](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1317))
-  ([e3b6b8f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e3b6b8fab7ddbfa56f2334c14537056b456fa4e0))
+  ([#1317](https://github.com/carbon-design-system/ibm-products/issues/1317))
+  ([e3b6b8f](https://github.com/carbon-design-system/ibm-products/commit/e3b6b8fab7ddbfa56f2334c14537056b456fa4e0))
 - small fixes to saving for release review
-  ([#683](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/683))
-  ([384db15](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/384db15a4057b7e91543be9cba05df303f239447))
+  ([#683](https://github.com/carbon-design-system/ibm-products/issues/683))
+  ([384db15](https://github.com/carbon-design-system/ibm-products/commit/384db15a4057b7e91543be9cba05df303f239447))
 - storybook setting masking missing component color setting
-  ([#1241](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1241))
-  ([38c01ec](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/38c01ec0fa1992b358aced18b714d77eda52bf09))
+  ([#1241](https://github.com/carbon-design-system/ibm-products/issues/1241))
+  ([38c01ec](https://github.com/carbon-design-system/ibm-products/commit/38c01ec0fa1992b358aced18b714d77eda52bf09))
 - tags overflow for left side tags
-  ([#1348](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1348))
-  ([fd1f436](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fd1f436ff628c587b53518f11e5912de5c0b8799))
+  ([#1348](https://github.com/carbon-design-system/ibm-products/issues/1348))
+  ([fd1f436](https://github.com/carbon-design-system/ibm-products/commit/fd1f436ff628c587b53518f11e5912de5c0b8799))
 - **Tearsheet:** change the min() workaround to support older sass
   implementations
-  ([#1339](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1339))
-  ([8a2700c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8a2700c6e445af9d87bc0a6d38bf3cba877d71bf))
+  ([#1339](https://github.com/carbon-design-system/ibm-products/issues/1339))
+  ([8a2700c](https://github.com/carbon-design-system/ibm-products/commit/8a2700c6e445af9d87bc0a6d38bf3cba877d71bf))
 - **Tearsheet:** ensure tearsheet styles override carbon styles
-  ([#1146](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1146))
-  ([d936f42](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d936f42b05acf3827154e8656ec90a243e9932ce))
+  ([#1146](https://github.com/carbon-design-system/ibm-products/issues/1146))
+  ([d936f42](https://github.com/carbon-design-system/ibm-products/commit/d936f42b05acf3827154e8656ec90a243e9932ce))
 - **Tearsheet:** fix background of pagination
-  ([#747](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/747))
-  ([f3fd9f7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f3fd9f72e751e8b955af854b3a3c72e5a593f01d))
+  ([#747](https://github.com/carbon-design-system/ibm-products/issues/747))
+  ([f3fd9f7](https://github.com/carbon-design-system/ibm-products/commit/f3fd9f72e751e8b955af854b3a3c72e5a593f01d))
 - **Tearsheet:** prevent heading styles being added to modal heading
-  ([#1319](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1319))
-  ([0de0f13](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0de0f1304cc29388555e2e5d401166ab6d6d4c13))
+  ([#1319](https://github.com/carbon-design-system/ibm-products/issues/1319))
+  ([0de0f13](https://github.com/carbon-design-system/ibm-products/commit/0de0f1304cc29388555e2e5d401166ab6d6d4c13))
 - **Tearsheet:** set text color so theming works as expected
-  ([#1270](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1270))
-  ([a88e5f0](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a88e5f03d2e7d3e98809ed55cd593dfa56aee4c4))
+  ([#1270](https://github.com/carbon-design-system/ibm-products/issues/1270))
+  ([a88e5f0](https://github.com/carbon-design-system/ibm-products/commit/a88e5f03d2e7d3e98809ed55cd593dfa56aee4c4))
 - testing and blockclass for import modal
-  ([#686](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/686))
-  ([42a4f39](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/42a4f396b84a19cc1db98bebb3bd9ce6d860dfc4))
+  ([#686](https://github.com/carbon-design-system/ibm-products/issues/686))
+  ([42a4f39](https://github.com/carbon-design-system/ibm-products/commit/42a4f396b84a19cc1db98bebb3bd9ce6d860dfc4))
 - title and subtitle row responsivity
-  ([#730](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/730))
-  ([03e6bf2](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/03e6bf28ac2999fc5ce1d94aace6aa8926931d10))
+  ([#730](https://github.com/carbon-design-system/ibm-products/issues/730))
+  ([03e6bf2](https://github.com/carbon-design-system/ibm-products/commit/03e6bf28ac2999fc5ce1d94aace6aa8926931d10))
 - typo in property name
-  ([#929](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/929))
-  ([83e7137](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/83e713705800a072d931b4046fa0509950eabb2b))
+  ([#929](https://github.com/carbon-design-system/ibm-products/issues/929))
+  ([83e7137](https://github.com/carbon-design-system/ibm-products/commit/83e713705800a072d931b4046fa0509950eabb2b))
 - update apikeymodal prop testing
-  ([#1079](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1079))
-  ([92a1aa3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/92a1aa3b0f03c6663e83e52f586e28e1a9010232))
+  ([#1079](https://github.com/carbon-design-system/ibm-products/issues/1079))
+  ([92a1aa3](https://github.com/carbon-design-system/ibm-products/commit/92a1aa3b0f03c6663e83e52f586e28e1a9010232))
 - update package readme with usage
-  ([#951](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/951))
-  ([f5b9a84](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f5b9a8433dfa866ec29f4a28267f1f86407db1eb))
+  ([#951](https://github.com/carbon-design-system/ibm-products/issues/951))
+  ([f5b9a84](https://github.com/carbon-design-system/ibm-products/commit/f5b9a8433dfa866ec29f4a28267f1f86407db1eb))
 - update page header subtitle font
-  ([#1451](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1451))
-  ([6248c85](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6248c850fe53a9b3ad9a7d35b39534372bd548fb))
+  ([#1451](https://github.com/carbon-design-system/ibm-products/issues/1451))
+  ([6248c85](https://github.com/carbon-design-system/ibm-products/commit/6248c850fe53a9b3ad9a7d35b39534372bd548fb))
 - update testing and package-settings
-  ([#612](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/612))
-  ([d2bb0f2](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d2bb0f2ae5a4b6a7c3d1e3d61e1aa0ea94c074d8))
+  ([#612](https://github.com/carbon-design-system/ibm-products/issues/612))
+  ([d2bb0f2](https://github.com/carbon-design-system/ibm-products/commit/d2bb0f2ae5a4b6a7c3d1e3d61e1aa0ea94c074d8))
 - updates to card tests
-  ([#972](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/972))
-  ([c39e763](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c39e763ac961d64ea27f2c5375ddaccfc5ac962c))
+  ([#972](https://github.com/carbon-design-system/ibm-products/issues/972))
+  ([c39e763](https://github.com/carbon-design-system/ibm-products/commit/c39e763ac961d64ea27f2c5375ddaccfc5ac962c))
 - updates to import modal for release review
-  ([#855](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/855))
-  ([48a8c35](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/48a8c350e3e21f9b5095b1199c478911fc391225))
+  ([#855](https://github.com/carbon-design-system/ibm-products/issues/855))
+  ([48a8c35](https://github.com/carbon-design-system/ibm-products/commit/48a8c350e3e21f9b5095b1199c478911fc391225))
 - use node instead of string for remove modal input label
-  ([#1267](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1267))
-  ([7e7cdf8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7e7cdf879407d077d9d539dc7aaf9e76ffb6aaff))
+  ([#1267](https://github.com/carbon-design-system/ibm-products/issues/1267))
+  ([7e7cdf8](https://github.com/carbon-design-system/ibm-products/commit/7e7cdf879407d077d9d539dc7aaf9e76ffb6aaff))
 - **UserProfileImage:** updates based on release review notes
-  ([#665](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/665))
-  ([7294117](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7294117be66c99e6d1dfa4fa98810e7daf2f2ca4))
+  ([#665](https://github.com/carbon-design-system/ibm-products/issues/665))
+  ([7294117](https://github.com/carbon-design-system/ibm-products/commit/7294117be66c99e6d1dfa4fa98810e7daf2f2ca4))
 - **Web terminal:** a11y fix
-  ([#1394](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1394))
-  ([d34fbce](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d34fbced396e56f50671016f98b22f0414777b01))
+  ([#1394](https://github.com/carbon-design-system/ibm-products/issues/1394))
+  ([d34fbce](https://github.com/carbon-design-system/ibm-products/commit/d34fbced396e56f50671016f98b22f0414777b01))
 - **WebTerminal:** color and add additional test coverage
-  ([#1408](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1408))
-  ([163220b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/163220b5924068def341ada10a2f9c4af191da08))
+  ([#1408](https://github.com/carbon-design-system/ibm-products/issues/1408))
+  ([163220b](https://github.com/carbon-design-system/ibm-products/commit/163220b5924068def341ada10a2f9c4af191da08))
 
 ### Features
 
 - add action bar tests
-  ([#338](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/338))
-  ([d1df237](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d1df237652e9f22c5018d3fa1859827a037f477d))
+  ([#338](https://github.com/carbon-design-system/ibm-products/issues/338))
+  ([d1df237](https://github.com/carbon-design-system/ibm-products/commit/d1df237652e9f22c5018d3fa1859827a037f477d))
 - add breadcrumb test and overflow aria label
-  ([#537](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/537))
-  ([f383b36](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f383b36d4f2987ae3032fa53319b883df95602ba))
+  ([#537](https://github.com/carbon-design-system/ibm-products/issues/537))
+  ([f383b36](https://github.com/carbon-design-system/ibm-products/commit/f383b36d4f2987ae3032fa53319b883df95602ba))
 - add carbon telemetry
-  ([#477](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/477))
-  ([950c9f3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/950c9f3394af98f93f39851f70e126f944c7477a))
+  ([#477](https://github.com/carbon-design-system/ibm-products/issues/477))
+  ([950c9f3](https://github.com/carbon-design-system/ibm-products/commit/950c9f3394af98f93f39851f70e126f944c7477a))
 - add cdai apikey component
-  ([#223](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/223))
-  ([4c09f15](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4c09f15c3c62c3965d98c91b9695fa7a1cba8f0b))
+  ([#223](https://github.com/carbon-design-system/ibm-products/issues/223))
+  ([4c09f15](https://github.com/carbon-design-system/ibm-products/commit/4c09f15c3c62c3965d98c91b9695fa7a1cba8f0b))
 - add closeIconDescription required prop to AboutModal
-  ([#968](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/968))
-  ([2619256](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/261925676ab4775fe947dc39f40701a8fbfe6779))
+  ([#968](https://github.com/carbon-design-system/ibm-products/issues/968))
+  ([2619256](https://github.com/carbon-design-system/ibm-products/commit/261925676ab4775fe947dc39f40701a8fbfe6779))
 - add header pre and toggle collapse features
-  ([#541](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/541))
-  ([7ff30b8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7ff30b8d6422c955841bce4e8a75b1f805492fe3))
+  ([#541](https://github.com/carbon-design-system/ibm-products/issues/541))
+  ([7ff30b8](https://github.com/carbon-design-system/ibm-products/commit/7ff30b8d6422c955841bce4e8a75b1f805492fe3))
 - add options-tile component
-  ([#1411](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1411))
-  ([b7dbeb7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b7dbeb71c6343d0839d5c3ab74a5c83e1fd6d9b6))
+  ([#1411](https://github.com/carbon-design-system/ibm-products/issues/1411))
+  ([b7dbeb7](https://github.com/carbon-design-system/ibm-products/commit/b7dbeb71c6343d0839d5c3ab74a5c83e1fd6d9b6))
 - address review issues
-  ([#989](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/989))
-  ([e3abcda](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e3abcda9f9031e553e2e9b2374bff3848b15fef4))
+  ([#989](https://github.com/carbon-design-system/ibm-products/issues/989))
+  ([e3abcda](https://github.com/carbon-design-system/ibm-products/commit/e3abcda9f9031e553e2e9b2374bff3848b15fef4))
 - adds actions prop to web terminal
-  ([#1279](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1279))
-  ([416cb9a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/416cb9ad1e4ead91508d4b288bb98c0202d3e019))
+  ([#1279](https://github.com/carbon-design-system/ibm-products/issues/1279))
+  ([416cb9a](https://github.com/carbon-design-system/ibm-products/commit/416cb9ad1e4ead91508d4b288bb98c0202d3e019))
 - animation for in-progress icon
-  ([#512](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/512))
-  ([cf6d06f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/cf6d06f8b279fe84c18dd23baf9c267c85e88369))
+  ([#512](https://github.com/carbon-design-system/ibm-products/issues/512))
+  ([cf6d06f](https://github.com/carbon-design-system/ibm-products/commit/cf6d06f8b279fe84c18dd23baf9c267c85e88369))
 - breadcrumb overflow title and href updates
-  ([#898](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/898))
-  ([290198b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/290198bdd078060f4a91bb6c27904aa17ce21b7b))
+  ([#898](https://github.com/carbon-design-system/ibm-products/issues/898))
+  ([290198b](https://github.com/carbon-design-system/ibm-products/commit/290198bdd078060f4a91bb6c27904aa17ce21b7b))
 - card refactor
-  ([#526](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/526))
-  ([fe0943f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fe0943ff6dbf8a7e08a6b029e9b09c258c0360a5))
+  ([#526](https://github.com/carbon-design-system/ibm-products/issues/526))
+  ([fe0943f](https://github.com/carbon-design-system/ibm-products/commit/fe0943ff6dbf8a7e08a6b029e9b09c258c0360a5))
 - cascade component
-  ([#1171](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1171))
-  ([76b8b6f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/76b8b6f1b375e093e721ba415b53e97ec3ca2262))
+  ([#1171](https://github.com/carbon-design-system/ibm-products/issues/1171))
+  ([76b8b6f](https://github.com/carbon-design-system/ibm-products/commit/76b8b6f1b375e093e721ba415b53e97ec3ca2262))
 - change to breadcrumbs shape
-  ([#1047](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1047))
-  ([1205fc8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1205fc88771761ef37cc8328ef7ef71e08cdeb78))
+  ([#1047](https://github.com/carbon-design-system/ibm-products/issues/1047))
+  ([1205fc8](https://github.com/carbon-design-system/ibm-products/commit/1205fc88771761ef37cc8328ef7ef71e08cdeb78))
 - **cloud-cognitive:** use `right` `tooltipPosition` for `vertical` variant by
   default
-  ([#1403](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1403))
-  ([6a18fa6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6a18fa67dbd60087df6670d0d295a4093e9514ca))
+  ([#1403](https://github.com/carbon-design-system/ibm-products/issues/1403))
+  ([6a18fa6](https://github.com/carbon-design-system/ibm-products/commit/6a18fa67dbd60087df6670d0d295a4093e9514ca))
 - create an xl width for the page header
-  ([#1236](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1236))
-  ([d278f85](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d278f854629f12459fd2e8e7b0ca3003083574b8))
+  ([#1236](https://github.com/carbon-design-system/ibm-products/issues/1236))
+  ([d278f85](https://github.com/carbon-design-system/ibm-products/commit/d278f854629f12459fd2e8e7b0ca3003083574b8))
 - create tearsheet step, with custom components
-  ([#1342](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1342))
-  ([ef1e972](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ef1e9723340bfcbf8ce1bc50062ae4735b50ed2d))
+  ([#1342](https://github.com/carbon-design-system/ibm-products/issues/1342))
+  ([ef1e972](https://github.com/carbon-design-system/ibm-products/commit/ef1e9723340bfcbf8ce1bc50062ae4735b50ed2d))
 - **CreateInfluencer:**
-  [#1107](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1107)
+  [#1107](https://github.com/carbon-design-system/ibm-products/issues/1107)
   create influencer shared component
-  ([#1122](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1122))
-  ([369f466](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/369f4665c3c3b61c62c3aaa326c86738baa08e70))
+  ([#1122](https://github.com/carbon-design-system/ibm-products/issues/1122))
+  ([369f466](https://github.com/carbon-design-system/ibm-products/commit/369f4665c3c3b61c62c3aaa326c86738baa08e70))
 - **CreateSidePanel:** release create side panel component
-  ([#1153](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1153))
-  ([5b39d10](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5b39d1095f1a52d020985a9c8cf1cebe89c5071a))
+  ([#1153](https://github.com/carbon-design-system/ibm-products/issues/1153))
+  ([5b39d10](https://github.com/carbon-design-system/ibm-products/commit/5b39d1095f1a52d020985a9c8cf1cebe89c5071a))
 - **CreateTearsheet:**
-  [#1028](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1028)
+  [#1028](https://github.com/carbon-design-system/ibm-products/issues/1028)
   create tearsheet step add onmount prop
-  ([#1050](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1050))
-  ([1e6238a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1e6238ad19e6b6fc9759faf00152852c267285b1))
+  ([#1050](https://github.com/carbon-design-system/ibm-products/issues/1050))
+  ([1e6238a](https://github.com/carbon-design-system/ibm-products/commit/1e6238ad19e6b6fc9759faf00152852c267285b1))
 - **CreateTearsheet:**
-  [#1076](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1076)
+  [#1076](https://github.com/carbon-design-system/ibm-products/issues/1076)
   create tearsheet custom step
-  ([#1174](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1174))
-  ([8d0ab04](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8d0ab046245a9b8862e351361b08068204a97f2a))
+  ([#1174](https://github.com/carbon-design-system/ibm-products/issues/1174))
+  ([8d0ab04](https://github.com/carbon-design-system/ibm-products/commit/8d0ab046245a9b8862e351361b08068204a97f2a))
 - **CreateTearsheet:** add animation on step changes
-  ([#885](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/885))
-  ([d72c825](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d72c8250cc96a16ed76076ab4dd3a7c19cd0f5a2))
+  ([#885](https://github.com/carbon-design-system/ibm-products/issues/885))
+  ([d72c825](https://github.com/carbon-design-system/ibm-products/commit/d72c8250cc96a16ed76076ab4dd3a7c19cd0f5a2))
 - **CreateTearsheet:** add introStep functionality
-  ([#1333](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1333))
-  ([9a067ca](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9a067cabf019315ac48d6f2b27e762bef8d08fa4))
+  ([#1333](https://github.com/carbon-design-system/ibm-products/issues/1333))
+  ([9a067ca](https://github.com/carbon-design-system/ibm-products/commit/9a067cabf019315ac48d6f2b27e762bef8d08fa4))
 - **CreateTearsheet:** add microinteraction to influencer menus
-  ([#1104](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1104))
-  ([4dc051c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4dc051ce64434b9307d23defd84741048ca10c8e))
+  ([#1104](https://github.com/carbon-design-system/ibm-products/issues/1104))
+  ([4dc051c](https://github.com/carbon-design-system/ibm-products/commit/4dc051ce64434b9307d23defd84741048ca10c8e))
 - **CreateTearsheetNarrow:** initial component structure
-  ([#1014](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1014))
-  ([85a17b3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/85a17b329dd7e44ddb167ffa2ce34a4e30c5d227))
+  ([#1014](https://github.com/carbon-design-system/ibm-products/issues/1014))
+  ([85a17b3](https://github.com/carbon-design-system/ibm-products/commit/85a17b329dd7e44ddb167ffa2ce34a4e30c5d227))
 - **CreateTearsheet:** release create tearsheet narrow
-  ([#1149](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1149))
-  ([df907a5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/df907a5fa4614212ae584c1e696f46eb811130de))
+  ([#1149](https://github.com/carbon-design-system/ibm-products/issues/1149))
+  ([df907a5](https://github.com/carbon-design-system/ibm-products/commit/df907a5fa4614212ae584c1e696f46eb811130de))
 - **deps:** add Carbon packages as peer dependencies
-  ([#1089](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1089))
-  ([6b807ef](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6b807efa40798dd0977c76eb07bff8fb7daa170e))
+  ([#1089](https://github.com/carbon-design-system/ibm-products/issues/1089))
+  ([6b807ef](https://github.com/carbon-design-system/ibm-products/commit/6b807efa40798dd0977c76eb07bff8fb7daa170e))
 - **devtools:** add attribute to numerous released components
-  ([#1226](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1226))
-  ([783ebe9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/783ebe923a96a268d16e9e3b832f27d950987de4))
+  ([#1226](https://github.com/carbon-design-system/ibm-products/issues/1226))
+  ([783ebe9](https://github.com/carbon-design-system/ibm-products/commit/783ebe923a96a268d16e9e3b832f27d950987de4))
 - **devtools:** add attribute to numerous released components
-  ([#1229](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1229))
-  ([9993bbf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9993bbf233c5ec944c17388b73ac410870d2b956))
+  ([#1229](https://github.com/carbon-design-system/ibm-products/issues/1229))
+  ([9993bbf](https://github.com/carbon-design-system/ibm-products/commit/9993bbf233c5ec944c17388b73ac410870d2b956))
 - **devtools:** add mechanism to enable component DOM identification
-  ([#1187](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1187))
-  ([c433158](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c4331581e0ec806d6a0ed65b2873d4963d3c8ac3))
+  ([#1187](https://github.com/carbon-design-system/ibm-products/issues/1187))
+  ([c433158](https://github.com/carbon-design-system/ibm-products/commit/c4331581e0ec806d6a0ed65b2873d4963d3c8ac3))
 - **devtools:** add support to released components (1 / 3)
-  ([#1220](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1220))
-  ([25209f9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/25209f9dfe4115843315e74bb6dfcf784a8b950c))
+  ([#1220](https://github.com/carbon-design-system/ibm-products/issues/1220))
+  ([25209f9](https://github.com/carbon-design-system/ibm-products/commit/25209f9dfe4115843315e74bb6dfcf784a8b950c))
 - **EditSidePanel:**
-  [#1266](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1266)
+  [#1266](https://github.com/carbon-design-system/ibm-products/issues/1266)
   edit side panel
-  ([#1280](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1280))
-  ([25f2b6e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/25f2b6ebcbdb78304caa16ce4b2ece56ecc83ea5))
+  ([#1280](https://github.com/carbon-design-system/ibm-products/issues/1280))
+  ([25f2b6e](https://github.com/carbon-design-system/ibm-products/commit/25f2b6ebcbdb78304caa16ce4b2ece56ecc83ea5))
 - ensure all component SCSS imports all dependencies
-  ([#1118](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1118))
-  ([9d9617d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9d9617dadf43120ebd95aa6a255ee71b7cbf61ca))
+  ([#1118](https://github.com/carbon-design-system/ibm-products/issues/1118))
+  ([9d9617d](https://github.com/carbon-design-system/ibm-products/commit/9d9617dadf43120ebd95aa6a255ee71b7cbf61ca))
 - ensure prettier linting causes ci-check to fail
-  ([#1273](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1273))
-  ([ad6f347](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ad6f3479636d2b80b26338d9059429b4ae08ac6e))
+  ([#1273](https://github.com/carbon-design-system/ibm-products/issues/1273))
+  ([ad6f347](https://github.com/carbon-design-system/ibm-products/commit/ad6f3479636d2b80b26338d9059429b4ae08ac6e))
 - fix offset and add element based scroll
-  ([#1185](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1185))
-  ([e3149ae](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e3149aec52eec078eb3b77abd029131ad9365385))
+  ([#1185](https://github.com/carbon-design-system/ibm-products/issues/1185))
+  ([e3149ae](https://github.com/carbon-design-system/ibm-products/commit/e3149aec52eec078eb3b77abd029131ad9365385))
 - further page header review updates
-  ([#1030](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1030))
-  ([a350229](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a3502291e54108e63be2919e7914525712ed65a2))
+  ([#1030](https://github.com/carbon-design-system/ibm-products/issues/1030))
+  ([a350229](https://github.com/carbon-design-system/ibm-products/commit/a3502291e54108e63be2919e7914525712ed65a2))
 - match Carbon peer deps for react
-  ([#869](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/869))
-  ([8f42118](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8f42118754a904554acee9ec3af2e1fae8143817))
+  ([#869](https://github.com/carbon-design-system/ibm-products/issues/869))
+  ([8f42118](https://github.com/carbon-design-system/ibm-products/commit/8f42118754a904554acee9ec3af2e1fae8143817))
 - new release for experimental wrapper
-  ([#532](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/532))
-  ([b42c47d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b42c47ddc171a31457b7d4b9a1bcf804d4fa9d4f))
+  ([#532](https://github.com/carbon-design-system/ibm-products/issues/532))
+  ([b42c47d](https://github.com/carbon-design-system/ibm-products/commit/b42c47ddc171a31457b7d4b9a1bcf804d4fa9d4f))
 - page header props to influence grid width
-  ([#1225](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1225))
-  ([c73255d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c73255d87d6a1fba94b1ce27bc826250562b915b))
+  ([#1225](https://github.com/carbon-design-system/ibm-products/issues/1225))
+  ([c73255d](https://github.com/carbon-design-system/ibm-products/commit/c73255d87d6a1fba94b1ce27bc826250562b915b))
 - **PageHeader:** back button to replace breadcrumbs on small viewport
-  ([#676](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/676))
-  ([ae3224e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ae3224e12263e78487ed667914be8ba08935e3d9))
+  ([#676](https://github.com/carbon-design-system/ibm-products/issues/676))
+  ([ae3224e](https://github.com/carbon-design-system/ibm-products/commit/ae3224e12263e78487ed667914be8ba08935e3d9))
 - **PageHeader:** update for change to BreadcrumbWithOverflow props
-  ([#1053](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1053))
-  ([f6669e8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f6669e8d80d4358b19a629a92d11161ec51536c2))
+  ([#1053](https://github.com/carbon-design-system/ibm-products/issues/1053))
+  ([f6669e8](https://github.com/carbon-design-system/ibm-products/commit/f6669e8d80d4358b19a629a92d11161ec51536c2))
 - release page header
-  ([#1072](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1072))
-  ([0d397d7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0d397d77f0b353ba1d4ba368507f4f6f74733cf4))
+  ([#1072](https://github.com/carbon-design-system/ibm-products/issues/1072))
+  ([0d397d7](https://github.com/carbon-design-system/ibm-products/commit/0d397d77f0b353ba1d4ba368507f4f6f74733cf4))
 - release TagSet
-  ([#937](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/937))
-  ([e920bf5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e920bf5b8cb78a86cc51805c0d26c9bd01aeb71e))
+  ([#937](https://github.com/carbon-design-system/ibm-products/issues/937))
+  ([e920bf5](https://github.com/carbon-design-system/ibm-products/commit/e920bf5b8cb78a86cc51805c0d26c9bd01aeb71e))
 - remove child support
-  ([#992](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/992))
-  ([b5e4f3b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b5e4f3b3a05b09225a0da5ac8982f1391986a9af))
+  ([#992](https://github.com/carbon-design-system/ibm-products/issues/992))
+  ([b5e4f3b](https://github.com/carbon-design-system/ibm-products/commit/b5e4f3b3a05b09225a0da5ac8982f1391986a9af))
 - remove context header from ccs storybook
-  ([#892](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/892))
-  ([14a1c52](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/14a1c524bc9fe379072e9a55f215aaf06a4a5341))
+  ([#892](https://github.com/carbon-design-system/ibm-products/issues/892))
+  ([14a1c52](https://github.com/carbon-design-system/ibm-products/commit/14a1c524bc9fe379072e9a55f215aaf06a4a5341))
 - remove experimental package
-  ([#964](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/964))
-  ([063e1d1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/063e1d1b67eb15cf0a5397866a63a3b67fee8f4c))
+  ([#964](https://github.com/carbon-design-system/ibm-products/issues/964))
+  ([063e1d1](https://github.com/carbon-design-system/ibm-products/commit/063e1d1b67eb15cf0a5397866a63a3b67fee8f4c))
 - show collapse button if requested
-  ([#732](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/732))
-  ([05d7423](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/05d74236caf2f9d5e6d834a621ab9e708a9b1abb))
+  ([#732](https://github.com/carbon-design-system/ibm-products/issues/732))
+  ([05d7423](https://github.com/carbon-design-system/ibm-products/commit/05d74236caf2f9d5e6d834a621ab9e708a9b1abb))
 - **SidePanel:** add optional onUnmount prop for cleanup
-  ([#767](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/767))
-  ([d135ea0](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d135ea0b2c9ae9f8e415828a1199bbc80e545551))
+  ([#767](https://github.com/carbon-design-system/ibm-products/issues/767))
+  ([d135ea0](https://github.com/carbon-design-system/ibm-products/commit/d135ea0b2c9ae9f8e415828a1199bbc80e545551))
 - **SidePanel:** add prop to prevent closing panel on click outside
-  ([#1288](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1288))
-  ([8dfa143](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8dfa143ac88442e1a770d217298c9c95a07fe590))
+  ([#1288](https://github.com/carbon-design-system/ibm-products/issues/1288))
+  ([8dfa143](https://github.com/carbon-design-system/ibm-products/commit/8dfa143ac88442e1a770d217298c9c95a07fe590))
 - **SidePanel:** add rest props to actionToolbarButtons prop
-  ([#1362](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1362))
-  ([93eac3b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/93eac3b95b8ac67f74b4d707f935deb97090bec9))
+  ([#1362](https://github.com/carbon-design-system/ibm-products/issues/1362))
+  ([93eac3b](https://github.com/carbon-design-system/ibm-products/commit/93eac3b95b8ac67f74b4d707f935deb97090bec9))
 - **SidePanel:** allow actionToolbarButtons to be a bit more flexible
-  ([#1189](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1189))
-  ([bc84e20](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/bc84e20f9652ba0379b884e5a9e1c7542ef34601))
+  ([#1189](https://github.com/carbon-design-system/ibm-products/issues/1189))
+  ([bc84e20](https://github.com/carbon-design-system/ibm-products/commit/bc84e20f9652ba0379b884e5a9e1c7542ef34601))
 - **SidePanel:** allow node type for subtitle prop
-  ([#1357](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1357))
-  ([0475107](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/04751075a0936da89dd38a3cf070078404bf1a06))
+  ([#1357](https://github.com/carbon-design-system/ibm-products/issues/1357))
+  ([0475107](https://github.com/carbon-design-system/ibm-products/commit/04751075a0936da89dd38a3cf070078404bf1a06))
 - simplified carbon token value in js
-  ([#894](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/894))
-  ([a225eee](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a225eee68364554f62f1f41889164c3f0e48e645))
+  ([#894](https://github.com/carbon-design-system/ibm-products/issues/894))
+  ([a225eee](https://github.com/carbon-design-system/ibm-products/commit/a225eee68364554f62f1f41889164c3f0e48e645))
 - stop tagset overflow scrolling off screen
-  ([#740](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/740))
-  ([016a3ec](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/016a3ec8ee20691de3ee0d4eb4ea44912276e67f))
+  ([#740](https://github.com/carbon-design-system/ibm-products/issues/740))
+  ([016a3ec](https://github.com/carbon-design-system/ibm-products/commit/016a3ec8ee20691de3ee0d4eb4ea44912276e67f))
 - **styles:** export used Carbon style modules
-  ([#850](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/850))
-  ([b876002](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b876002d7de7131d7db3880d1b3d34330d43be48))
+  ([#850](https://github.com/carbon-design-system/ibm-products/issues/850))
+  ([b876002](https://github.com/carbon-design-system/ibm-products/commit/b876002d7de7131d7db3880d1b3d34330d43be48))
 - tagset modal design review updates
-  ([#774](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/774))
-  ([c9fdb06](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c9fdb06d6fdceabccd39ea97e7188141292cef9e))
+  ([#774](https://github.com/carbon-design-system/ibm-products/issues/774))
+  ([c9fdb06](https://github.com/carbon-design-system/ibm-products/commit/c9fdb06d6fdceabccd39ea97e7188141292cef9e))
 - tagset review updates part 2
-  ([#907](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/907))
-  ([fbe3143](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fbe3143b12abb3d87b6e79eb668014a2015cc9cc))
+  ([#907](https://github.com/carbon-design-system/ibm-products/issues/907))
+  ([fbe3143](https://github.com/carbon-design-system/ibm-products/commit/fbe3143b12abb3d87b6e79eb668014a2015cc9cc))
 - **toolbar:** add `caret` variant
-  ([#1297](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1297))
-  ([7496c07](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7496c07c272f51a22bdbe03aec4ab7820e968da3))
+  ([#1297](https://github.com/carbon-design-system/ibm-products/issues/1297))
+  ([7496c07](https://github.com/carbon-design-system/ibm-products/commit/7496c07c272f51a22bdbe03aec4ab7820e968da3))
 - **toolbar:** add `Toolbar`, `ToolbarButton`, and `ToolbarGroup` components
-  ([#1103](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1103))
-  ([2d5f4cf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2d5f4cfb1e5c650696831a5c2c660c57e6a54f85))
+  ([#1103](https://github.com/carbon-design-system/ibm-products/issues/1103))
+  ([2d5f4cf](https://github.com/carbon-design-system/ibm-products/commit/2d5f4cfb1e5c650696831a5c2c660c57e6a54f85))
 - **toolbar:** add vertical variant
-  ([#1173](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1173))
-  ([574a2c5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/574a2c55fd965be4de163ea8d9d9fae0baf1e7ba))
+  ([#1173](https://github.com/carbon-design-system/ibm-products/issues/1173))
+  ([574a2c5](https://github.com/carbon-design-system/ibm-products/commit/574a2c55fd965be4de163ea8d9d9fae0baf1e7ba))
 - upd breadcrumb with overflow to internal
-  ([#610](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/610))
-  ([2e34eb9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2e34eb9fe8b24c5b17d23eb134cdba6aec6736ac))
+  ([#610](https://github.com/carbon-design-system/ibm-products/issues/610))
+  ([2e34eb9](https://github.com/carbon-design-system/ibm-products/commit/2e34eb9fe8b24c5b17d23eb134cdba6aec6736ac))
 - update Carbon versions and dependencies
-  ([#1037](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1037))
-  ([8c5937a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8c5937a865d3a0cfbaf33b9eca13c4d3b4c1365d))
+  ([#1037](https://github.com/carbon-design-system/ibm-products/issues/1037))
+  ([8c5937a](https://github.com/carbon-design-system/ibm-products/commit/8c5937a865d3a0cfbaf33b9eca13c4d3b4c1365d))
 - update Carbon versions and dependencies
-  ([#1084](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1084))
-  ([3735ead](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3735ead9a96450015ec7aeafdb25deaa93d49aaa))
+  ([#1084](https://github.com/carbon-design-system/ibm-products/issues/1084))
+  ([3735ead](https://github.com/carbon-design-system/ibm-products/commit/3735ead9a96450015ec7aeafdb25deaa93d49aaa))
 - update Carbon versions and dependencies
-  ([#1110](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1110))
-  ([b41f433](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b41f4331e31cbd9e41d2364b24e6ef50c7fd2d8d))
+  ([#1110](https://github.com/carbon-design-system/ibm-products/issues/1110))
+  ([b41f433](https://github.com/carbon-design-system/ibm-products/commit/b41f4331e31cbd9e41d2364b24e6ef50c7fd2d8d))
 - update Carbon versions and dependencies
-  ([#1168](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1168))
-  ([674017f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/674017fabc13a7737c0d16deb04ffa9872d76fe6))
+  ([#1168](https://github.com/carbon-design-system/ibm-products/issues/1168))
+  ([674017f](https://github.com/carbon-design-system/ibm-products/commit/674017fabc13a7737c0d16deb04ffa9872d76fe6))
 - update Carbon versions and dependencies
-  ([#927](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/927))
-  ([5a8f7d6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5a8f7d6b81b6da26fd0cb933c1c3de4bd27b481b))
+  ([#927](https://github.com/carbon-design-system/ibm-products/issues/927))
+  ([5a8f7d6](https://github.com/carbon-design-system/ibm-products/commit/5a8f7d6b81b6da26fd0cb933c1c3de4bd27b481b))
 - update Carbon versions and dependencies
-  ([#974](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/974))
-  ([555509b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/555509b5ccb147ed0d794b5816f685aa8f7ae451))
+  ([#974](https://github.com/carbon-design-system/ibm-products/issues/974))
+  ([555509b](https://github.com/carbon-design-system/ibm-products/commit/555509b5ccb147ed0d794b5816f685aa8f7ae451))
 - update Carbon versions and dependencies to latest
-  ([#1282](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1282))
-  ([b1451cf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b1451cf5c91b75c1bd4e55ae2bdb47f025f33163))
+  ([#1282](https://github.com/carbon-design-system/ibm-products/issues/1282))
+  ([b1451cf](https://github.com/carbon-design-system/ibm-products/commit/b1451cf5c91b75c1bd4e55ae2bdb47f025f33163))
 - update Carbon versions and package dependencies
-  ([#994](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/994))
-  ([2ab4845](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2ab4845511573b999d41fcf77e6d412e0d446b9d))
+  ([#994](https://github.com/carbon-design-system/ibm-products/issues/994))
+  ([2ab4845](https://github.com/carbon-design-system/ibm-products/commit/2ab4845511573b999d41fcf77e6d412e0d446b9d))
 - update Carbon versions and package dependencies to latest
-  ([#1133](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1133))
-  ([4dfae1a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4dfae1a9b27f5676d0bde570e2c9ee9ce8550b52))
+  ([#1133](https://github.com/carbon-design-system/ibm-products/issues/1133))
+  ([4dfae1a](https://github.com/carbon-design-system/ibm-products/commit/4dfae1a9b27f5676d0bde570e2c9ee9ce8550b52))
 - update Carbon versions and package dependencies to latest
-  ([#1228](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1228))
-  ([4f5e24c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4f5e24cd3a36e7fa9a5cd62d1cafe75a090cf32e))
+  ([#1228](https://github.com/carbon-design-system/ibm-products/issues/1228))
+  ([4f5e24c](https://github.com/carbon-design-system/ibm-products/commit/4f5e24cd3a36e7fa9a5cd62d1cafe75a090cf32e))
 - update Carbon versions and package dependencies to latest
-  ([#1262](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1262))
-  ([ed4dcbe](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ed4dcbe5b6d92baa6ec39240bda6996ec55f7bc4))
+  ([#1262](https://github.com/carbon-design-system/ibm-products/issues/1262))
+  ([ed4dcbe](https://github.com/carbon-design-system/ibm-products/commit/ed4dcbe5b6d92baa6ec39240bda6996ec55f7bc4))
 - update Carbon versions and package dependencies to latest
-  ([#1296](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1296))
-  ([f1da0bd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f1da0bd9192c4d999032df0dbe20d67b6ece89b0))
+  ([#1296](https://github.com/carbon-design-system/ibm-products/issues/1296))
+  ([f1da0bd](https://github.com/carbon-design-system/ibm-products/commit/f1da0bd9192c4d999032df0dbe20d67b6ece89b0))
 - update Carbon versions and package dependencies to latest
-  ([#1309](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1309))
-  ([945bd3b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/945bd3ba5608078e961af9a04448f2abd7e7fc5e))
+  ([#1309](https://github.com/carbon-design-system/ibm-products/issues/1309))
+  ([945bd3b](https://github.com/carbon-design-system/ibm-products/commit/945bd3ba5608078e961af9a04448f2abd7e7fc5e))
 - update Carbon versions and package dependencies to latest
-  ([#1329](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1329))
-  ([fd3525e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fd3525ec3620b70ff19f85c300e7e0bb05577cd1))
+  ([#1329](https://github.com/carbon-design-system/ibm-products/issues/1329))
+  ([fd3525e](https://github.com/carbon-design-system/ibm-products/commit/fd3525ec3620b70ff19f85c300e7e0bb05577cd1))
 - update Carbon versions and package dependencies to latest
-  ([#1345](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1345))
-  ([3c7e6fe](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3c7e6fedfc46bffc38b889568133ee6c300ddb47))
+  ([#1345](https://github.com/carbon-design-system/ibm-products/issues/1345))
+  ([3c7e6fe](https://github.com/carbon-design-system/ibm-products/commit/3c7e6fedfc46bffc38b889568133ee6c300ddb47))
 - update Carbon versions and package dependencies to latest
-  ([#1356](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1356))
-  ([946afd6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/946afd6bd5a165f35940cc1d70fc0e42fb6a4303))
+  ([#1356](https://github.com/carbon-design-system/ibm-products/issues/1356))
+  ([946afd6](https://github.com/carbon-design-system/ibm-products/commit/946afd6bd5a165f35940cc1d70fc0e42fb6a4303))
 - update Carbon versions and package dependencies to latest
-  ([#1365](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1365))
-  ([ea11cf7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ea11cf7ae44b61b48142c511c16460cf7978b88c))
+  ([#1365](https://github.com/carbon-design-system/ibm-products/issues/1365))
+  ([ea11cf7](https://github.com/carbon-design-system/ibm-products/commit/ea11cf7ae44b61b48142c511c16460cf7978b88c))
 - update Carbon versions and package dependencies to latest
-  ([#1425](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1425))
-  ([4fd5883](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4fd5883961e0f3fc6be1c87bbe084b2cf6dc5db0)),
+  ([#1425](https://github.com/carbon-design-system/ibm-products/issues/1425))
+  ([4fd5883](https://github.com/carbon-design-system/ibm-products/commit/4fd5883961e0f3fc6be1c87bbe084b2cf6dc5db0)),
   closes
-  [#10000](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/10000)
+  [#10000](https://github.com/carbon-design-system/ibm-products/issues/10000)
 - update page header sticky again
-  ([#891](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/891))
-  ([b69ec15](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b69ec1597640bef2e15f166c170f002b7fb727a0))
+  ([#891](https://github.com/carbon-design-system/ibm-products/issues/891))
+  ([b69ec15](https://github.com/carbon-design-system/ibm-products/commit/b69ec1597640bef2e15f166c170f002b7fb727a0))
 
-# [0.99.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.98.0...@carbon/ibm-cloud-cognitive@0.99.0) (2021-11-16)
+# [0.99.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.98.0...@carbon/ibm-cloud-cognitive@0.99.0) (2021-11-16)
 
 ### Bug Fixes
 
 - add side effect for props-helper to package.json
-  ([#1434](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1434))
-  ([f9f6a65](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f9f6a656f4e1e563460a8b4159b9c13c26101a06))
+  ([#1434](https://github.com/carbon-design-system/ibm-products/issues/1434))
+  ([f9f6a65](https://github.com/carbon-design-system/ibm-products/commit/f9f6a656f4e1e563460a8b4159b9c13c26101a06))
 - page header background over lays
-  ([#1418](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1418))
-  ([40a3531](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/40a3531536fbe1dcda4e551bdad32f77fad440ff))
+  ([#1418](https://github.com/carbon-design-system/ibm-products/issues/1418))
+  ([40a3531](https://github.com/carbon-design-system/ibm-products/commit/40a3531536fbe1dcda4e551bdad32f77fad440ff))
 - **PageHeader:** action bar location
-  ([#1428](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1428))
-  ([928cec6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/928cec664f62d8276d043e7f6bb7d6fa5e329d45))
+  ([#1428](https://github.com/carbon-design-system/ibm-products/issues/1428))
+  ([928cec6](https://github.com/carbon-design-system/ibm-products/commit/928cec664f62d8276d043e7f6bb7d6fa5e329d45))
 - **RemoveModal:**
-  [#1426](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1426)
+  [#1426](https://github.com/carbon-design-system/ibm-products/issues/1426)
   reset remove modal text input value
-  ([#1433](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1433))
-  ([e2df543](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e2df543280cb9aa23942eebe40244f4c27197080))
+  ([#1433](https://github.com/carbon-design-system/ibm-products/issues/1433))
+  ([e2df543](https://github.com/carbon-design-system/ibm-products/commit/e2df543280cb9aa23942eebe40244f4c27197080))
 - replace "cloud & cognitive" with "Carbon for IBM Products" in docs
-  ([#1437](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1437))
-  ([0a58354](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0a58354ccbdd723173b2e6758907713938a7f163))
+  ([#1437](https://github.com/carbon-design-system/ibm-products/issues/1437))
+  ([0a58354](https://github.com/carbon-design-system/ibm-products/commit/0a58354ccbdd723173b2e6758907713938a7f163))
 - **WebTerminal:** color and add additional test coverage
-  ([#1408](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1408))
-  ([163220b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/163220b5924068def341ada10a2f9c4af191da08))
+  ([#1408](https://github.com/carbon-design-system/ibm-products/issues/1408))
+  ([163220b](https://github.com/carbon-design-system/ibm-products/commit/163220b5924068def341ada10a2f9c4af191da08))
 
 ### Features
 
 - add options-tile component
-  ([#1411](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1411))
-  ([b7dbeb7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b7dbeb71c6343d0839d5c3ab74a5c83e1fd6d9b6))
+  ([#1411](https://github.com/carbon-design-system/ibm-products/issues/1411))
+  ([b7dbeb7](https://github.com/carbon-design-system/ibm-products/commit/b7dbeb71c6343d0839d5c3ab74a5c83e1fd6d9b6))
 - **cloud-cognitive:** use `right` `tooltipPosition` for `vertical` variant by
   default
-  ([#1403](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1403))
-  ([6a18fa6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6a18fa67dbd60087df6670d0d295a4093e9514ca))
+  ([#1403](https://github.com/carbon-design-system/ibm-products/issues/1403))
+  ([6a18fa6](https://github.com/carbon-design-system/ibm-products/commit/6a18fa67dbd60087df6670d0d295a4093e9514ca))
 - update Carbon versions and package dependencies to latest
-  ([#1425](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1425))
-  ([4fd5883](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4fd5883961e0f3fc6be1c87bbe084b2cf6dc5db0)),
+  ([#1425](https://github.com/carbon-design-system/ibm-products/issues/1425))
+  ([4fd5883](https://github.com/carbon-design-system/ibm-products/commit/4fd5883961e0f3fc6be1c87bbe084b2cf6dc5db0)),
   closes
-  [#10000](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/10000)
+  [#10000](https://github.com/carbon-design-system/ibm-products/issues/10000)
 
-# [0.98.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.97.2...@carbon/ibm-cloud-cognitive@0.98.0) (2021-11-09)
+# [0.98.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.97.2...@carbon/ibm-cloud-cognitive@0.98.0) (2021-11-09)
 
 ### Bug Fixes
 
 - improve tree-shaking optimisation by importing icons directly from
   @carbons/icons-react
-  ([#1379](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1379))
-  ([9110484](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9110484d7860a95a858a5e1931015b853769c3a9))
+  ([#1379](https://github.com/carbon-design-system/ibm-products/issues/1379))
+  ([9110484](https://github.com/carbon-design-system/ibm-products/commit/9110484d7860a95a858a5e1931015b853769c3a9))
 - **Web terminal:** a11y fix
-  ([#1394](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1394))
-  ([d34fbce](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d34fbced396e56f50671016f98b22f0414777b01))
+  ([#1394](https://github.com/carbon-design-system/ibm-products/issues/1394))
+  ([d34fbce](https://github.com/carbon-design-system/ibm-products/commit/d34fbced396e56f50671016f98b22f0414777b01))
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1365](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1365))
-  ([ea11cf7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ea11cf7ae44b61b48142c511c16460cf7978b88c))
+  ([#1365](https://github.com/carbon-design-system/ibm-products/issues/1365))
+  ([ea11cf7](https://github.com/carbon-design-system/ibm-products/commit/ea11cf7ae44b61b48142c511c16460cf7978b88c))
 
-## [0.97.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.97.1...@carbon/ibm-cloud-cognitive@0.97.2) (2021-11-05)
+## [0.97.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.97.1...@carbon/ibm-cloud-cognitive@0.97.2) (2021-11-05)
 
 ### Bug Fixes
 
 - **PageHeader:** pageActions scroll without actionBar but with breadcrumbs
-  ([#1370](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1370))
-  ([9ecade4](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9ecade421b42b2bd05f03e13476f18c9d2210a45))
+  ([#1370](https://github.com/carbon-design-system/ibm-products/issues/1370))
+  ([9ecade4](https://github.com/carbon-design-system/ibm-products/commit/9ecade421b42b2bd05f03e13476f18c9d2210a45))
 - **SidePanel:** changing size prop within panel already open works now
-  ([#1371](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1371))
-  ([d8de35b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d8de35b2bb62ca64e8210370bb5a820af99f6af9))
+  ([#1371](https://github.com/carbon-design-system/ibm-products/issues/1371))
+  ([d8de35b](https://github.com/carbon-design-system/ibm-products/commit/d8de35b2bb62ca64e8210370bb5a820af99f6af9))
 
-## [0.97.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.97.0...@carbon/ibm-cloud-cognitive@0.97.1) (2021-11-03)
+## [0.97.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.97.0...@carbon/ibm-cloud-cognitive@0.97.1) (2021-11-03)
 
 ### Bug Fixes
 
 - overflwo z-indexes in page header
-  ([#1361](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1361))
-  ([21cc33d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/21cc33d4bde5f252d95f1e6fd3c5941031b67097))
+  ([#1361](https://github.com/carbon-design-system/ibm-products/issues/1361))
+  ([21cc33d](https://github.com/carbon-design-system/ibm-products/commit/21cc33d4bde5f252d95f1e6fd3c5941031b67097))
 - **pageHeader:** breadcrumb scroll without actionbar
-  ([#1363](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1363))
-  ([d9e781e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d9e781ef1b6768e0bf4c0591507b8605aba897b4))
+  ([#1363](https://github.com/carbon-design-system/ibm-products/issues/1363))
+  ([d9e781e](https://github.com/carbon-design-system/ibm-products/commit/d9e781ef1b6768e0bf4c0591507b8605aba897b4))
 
-# [0.97.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.96.0...@carbon/ibm-cloud-cognitive@0.97.0) (2021-11-01)
+# [0.97.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.96.0...@carbon/ibm-cloud-cognitive@0.97.0) (2021-11-01)
 
 ### Features
 
 - create tearsheet step, with custom components
-  ([#1342](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1342))
-  ([ef1e972](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ef1e9723340bfcbf8ce1bc50062ae4735b50ed2d))
+  ([#1342](https://github.com/carbon-design-system/ibm-products/issues/1342))
+  ([ef1e972](https://github.com/carbon-design-system/ibm-products/commit/ef1e9723340bfcbf8ce1bc50062ae4735b50ed2d))
 - **SidePanel:** add rest props to actionToolbarButtons prop
-  ([#1362](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1362))
-  ([93eac3b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/93eac3b95b8ac67f74b4d707f935deb97090bec9))
+  ([#1362](https://github.com/carbon-design-system/ibm-products/issues/1362))
+  ([93eac3b](https://github.com/carbon-design-system/ibm-products/commit/93eac3b95b8ac67f74b4d707f935deb97090bec9))
 
-# [0.96.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.95.2...@carbon/ibm-cloud-cognitive@0.96.0) (2021-10-28)
+# [0.96.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.95.2...@carbon/ibm-cloud-cognitive@0.96.0) (2021-10-28)
 
 ### Features
 
 - **SidePanel:** allow node type for subtitle prop
-  ([#1357](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1357))
-  ([0475107](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/04751075a0936da89dd38a3cf070078404bf1a06))
+  ([#1357](https://github.com/carbon-design-system/ibm-products/issues/1357))
+  ([0475107](https://github.com/carbon-design-system/ibm-products/commit/04751075a0936da89dd38a3cf070078404bf1a06))
 
-## [0.95.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.95.1...@carbon/ibm-cloud-cognitive@0.95.2) (2021-10-28)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.95.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.95.0...@carbon/ibm-cloud-cognitive@0.95.1) (2021-10-27)
+## [0.95.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.95.1...@carbon/ibm-cloud-cognitive@0.95.2) (2021-10-28)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.95.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.94.3...@carbon/ibm-cloud-cognitive@0.95.0) (2021-10-27)
+## [0.95.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.95.0...@carbon/ibm-cloud-cognitive@0.95.1) (2021-10-27)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+# [0.95.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.94.3...@carbon/ibm-cloud-cognitive@0.95.0) (2021-10-27)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1356](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1356))
-  ([946afd6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/946afd6bd5a165f35940cc1d70fc0e42fb6a4303))
+  ([#1356](https://github.com/carbon-design-system/ibm-products/issues/1356))
+  ([946afd6](https://github.com/carbon-design-system/ibm-products/commit/946afd6bd5a165f35940cc1d70fc0e42fb6a4303))
 
-## [0.94.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.94.2...@carbon/ibm-cloud-cognitive@0.94.3) (2021-10-25)
+## [0.94.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.94.2...@carbon/ibm-cloud-cognitive@0.94.3) (2021-10-25)
 
 ### Bug Fixes
 
 - fixes card href support
-  ([#1353](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1353))
-  ([30a89cb](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/30a89cb682189f2844a3d36c88bf9f40b3e33532))
+  ([#1353](https://github.com/carbon-design-system/ibm-products/issues/1353))
+  ([30a89cb](https://github.com/carbon-design-system/ibm-products/commit/30a89cb682189f2844a3d36c88bf9f40b3e33532))
 
-## [0.94.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.94.1...@carbon/ibm-cloud-cognitive@0.94.2) (2021-10-22)
+## [0.94.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.94.1...@carbon/ibm-cloud-cognitive@0.94.2) (2021-10-22)
 
 ### Bug Fixes
 
 - tags overflow for left side tags
-  ([#1348](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1348))
-  ([fd1f436](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fd1f436ff628c587b53518f11e5912de5c0b8799))
+  ([#1348](https://github.com/carbon-design-system/ibm-products/issues/1348))
+  ([fd1f436](https://github.com/carbon-design-system/ibm-products/commit/fd1f436ff628c587b53518f11e5912de5c0b8799))
 
-## [0.94.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.94.0...@carbon/ibm-cloud-cognitive@0.94.1) (2021-10-22)
+## [0.94.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.94.0...@carbon/ibm-cloud-cognitive@0.94.1) (2021-10-22)
 
 ### Bug Fixes
 
 - Ensure PageActions can be clicked, on scroll
-  ([#1347](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1347))
-  ([96183e2](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/96183e2d1e54ef9f8b6b110fdfb731cac737c181))
+  ([#1347](https://github.com/carbon-design-system/ibm-products/issues/1347))
+  ([96183e2](https://github.com/carbon-design-system/ibm-products/commit/96183e2d1e54ef9f8b6b110fdfb731cac737c181))
 - lower page header z-index for sidenav
-  ([#1343](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1343))
-  ([03d2743](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/03d2743e895c832bfb1486f1672af272510a85c8))
+  ([#1343](https://github.com/carbon-design-system/ibm-products/issues/1343))
+  ([03d2743](https://github.com/carbon-design-system/ibm-products/commit/03d2743e895c832bfb1486f1672af272510a85c8))
 
-# [0.94.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.93.2...@carbon/ibm-cloud-cognitive@0.94.0) (2021-10-20)
+# [0.94.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.93.2...@carbon/ibm-cloud-cognitive@0.94.0) (2021-10-20)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1345](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1345))
-  ([3c7e6fe](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3c7e6fedfc46bffc38b889568133ee6c300ddb47))
+  ([#1345](https://github.com/carbon-design-system/ibm-products/issues/1345))
+  ([3c7e6fe](https://github.com/carbon-design-system/ibm-products/commit/3c7e6fedfc46bffc38b889568133ee6c300ddb47))
 
-## [0.93.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.93.1...@carbon/ibm-cloud-cognitive@0.93.2) (2021-10-15)
+## [0.93.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.93.1...@carbon/ibm-cloud-cognitive@0.93.2) (2021-10-15)
 
 ### Bug Fixes
 
 - added button icon props for cards
-  ([#1336](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1336))
-  ([4974632](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4974632c7e5e691e16749a4935da2753148bfbb8))
+  ([#1336](https://github.com/carbon-design-system/ibm-products/issues/1336))
+  ([4974632](https://github.com/carbon-design-system/ibm-products/commit/4974632c7e5e691e16749a4935da2753148bfbb8))
 
-## [0.93.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.93.0...@carbon/ibm-cloud-cognitive@0.93.1) (2021-10-14)
+## [0.93.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.93.0...@carbon/ibm-cloud-cognitive@0.93.1) (2021-10-14)
 
 ### Bug Fixes
 
 - **Tearsheet:** change the min() workaround to support older sass
   implementations
-  ([#1339](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1339))
-  ([8a2700c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8a2700c6e445af9d87bc0a6d38bf3cba877d71bf))
+  ([#1339](https://github.com/carbon-design-system/ibm-products/issues/1339))
+  ([8a2700c](https://github.com/carbon-design-system/ibm-products/commit/8a2700c6e445af9d87bc0a6d38bf3cba877d71bf))
 
-# [0.93.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.92.0...@carbon/ibm-cloud-cognitive@0.93.0) (2021-10-14)
+# [0.93.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.92.0...@carbon/ibm-cloud-cognitive@0.93.0) (2021-10-14)
 
 ### Features
 
 - **CreateTearsheet:** add introStep functionality
-  ([#1333](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1333))
-  ([9a067ca](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9a067cabf019315ac48d6f2b27e762bef8d08fa4))
+  ([#1333](https://github.com/carbon-design-system/ibm-products/issues/1333))
+  ([9a067ca](https://github.com/carbon-design-system/ibm-products/commit/9a067cabf019315ac48d6f2b27e762bef8d08fa4))
 
-# [0.92.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.91.4...@carbon/ibm-cloud-cognitive@0.92.0) (2021-10-14)
+# [0.92.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.91.4...@carbon/ibm-cloud-cognitive@0.92.0) (2021-10-14)
 
 ### Bug Fixes
 
 - long tag rendering in TagSet overflow
-  ([#1301](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1301))
-  ([722aa8b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/722aa8bd3504b3050784daeffedff07d057f57ee))
+  ([#1301](https://github.com/carbon-design-system/ibm-products/issues/1301))
+  ([722aa8b](https://github.com/carbon-design-system/ibm-products/commit/722aa8bd3504b3050784daeffedff07d057f57ee))
 
 ### Features
 
 - **toolbar:** add `caret` variant
-  ([#1297](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1297))
-  ([7496c07](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7496c07c272f51a22bdbe03aec4ab7820e968da3))
+  ([#1297](https://github.com/carbon-design-system/ibm-products/issues/1297))
+  ([7496c07](https://github.com/carbon-design-system/ibm-products/commit/7496c07c272f51a22bdbe03aec4ab7820e968da3))
 - update Carbon versions and package dependencies to latest
-  ([#1329](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1329))
-  ([fd3525e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fd3525ec3620b70ff19f85c300e7e0bb05577cd1))
+  ([#1329](https://github.com/carbon-design-system/ibm-products/issues/1329))
+  ([fd3525e](https://github.com/carbon-design-system/ibm-products/commit/fd3525ec3620b70ff19f85c300e7e0bb05577cd1))
 
-## [0.91.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.91.3...@carbon/ibm-cloud-cognitive@0.91.4) (2021-10-11)
+## [0.91.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.91.3...@carbon/ibm-cloud-cognitive@0.91.4) (2021-10-11)
 
 ### Bug Fixes
 
 - **SidePanel:** fix ref handling in clickOutside useEffect
-  ([#1322](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1322))
-  ([4fd8837](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4fd8837474042529592f644390f6d5367f78e2c0))
+  ([#1322](https://github.com/carbon-design-system/ibm-products/issues/1322))
+  ([4fd8837](https://github.com/carbon-design-system/ibm-products/commit/4fd8837474042529592f644390f6d5367f78e2c0))
 
-## [0.91.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.91.2...@carbon/ibm-cloud-cognitive@0.91.3) (2021-10-07)
+## [0.91.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.91.2...@carbon/ibm-cloud-cognitive@0.91.3) (2021-10-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.91.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.91.1...@carbon/ibm-cloud-cognitive@0.91.2) (2021-10-07)
+## [0.91.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.91.1...@carbon/ibm-cloud-cognitive@0.91.2) (2021-10-07)
 
 ### Bug Fixes
 
 - **Tearsheet:** prevent heading styles being added to modal heading
-  ([#1319](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1319))
-  ([0de0f13](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0de0f1304cc29388555e2e5d401166ab6d6d4c13))
+  ([#1319](https://github.com/carbon-design-system/ibm-products/issues/1319))
+  ([0de0f13](https://github.com/carbon-design-system/ibm-products/commit/0de0f1304cc29388555e2e5d401166ab6d6d4c13))
 
-## [0.91.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.91.0...@carbon/ibm-cloud-cognitive@0.91.1) (2021-10-07)
+## [0.91.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.91.0...@carbon/ibm-cloud-cognitive@0.91.1) (2021-10-07)
 
 ### Bug Fixes
 
 - **SidePanel:** use carbon z index mixin for side panel container
-  ([#1317](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1317))
-  ([e3b6b8f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e3b6b8fab7ddbfa56f2334c14537056b456fa4e0))
+  ([#1317](https://github.com/carbon-design-system/ibm-products/issues/1317))
+  ([e3b6b8f](https://github.com/carbon-design-system/ibm-products/commit/e3b6b8fab7ddbfa56f2334c14537056b456fa4e0))
 
-# [0.91.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.90.3...@carbon/ibm-cloud-cognitive@0.91.0) (2021-10-07)
+# [0.91.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.90.3...@carbon/ibm-cloud-cognitive@0.91.0) (2021-10-07)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1309](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1309))
-  ([945bd3b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/945bd3ba5608078e961af9a04448f2abd7e7fc5e))
+  ([#1309](https://github.com/carbon-design-system/ibm-products/issues/1309))
+  ([945bd3b](https://github.com/carbon-design-system/ibm-products/commit/945bd3ba5608078e961af9a04448f2abd7e7fc5e))
 
-## [0.90.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.90.2...@carbon/ibm-cloud-cognitive@0.90.3) (2021-10-07)
+## [0.90.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.90.2...@carbon/ibm-cloud-cognitive@0.90.3) (2021-10-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.90.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.90.1...@carbon/ibm-cloud-cognitive@0.90.2) (2021-10-06)
+## [0.90.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.90.1...@carbon/ibm-cloud-cognitive@0.90.2) (2021-10-06)
 
 ### Bug Fixes
 
 - **CreateSidePanel:** scoping issue for create side panel
-  ([#1303](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1303))
-  ([3a198ea](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3a198eaf807af9401885c6b7841de65ce39b88e6))
+  ([#1303](https://github.com/carbon-design-system/ibm-products/issues/1303))
+  ([3a198ea](https://github.com/carbon-design-system/ibm-products/commit/3a198eaf807af9401885c6b7841de65ce39b88e6))
 
-## [0.90.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.90.0...@carbon/ibm-cloud-cognitive@0.90.1) (2021-10-06)
+## [0.90.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.90.0...@carbon/ibm-cloud-cognitive@0.90.1) (2021-10-06)
 
 ### Bug Fixes
 
 - **SidePanel:** give default scroll height if no subtitle
-  ([#1315](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1315))
-  ([b70e56b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b70e56bb78c9384d92b20596ddb8503ab2c1fb17))
+  ([#1315](https://github.com/carbon-design-system/ibm-products/issues/1315))
+  ([b70e56b](https://github.com/carbon-design-system/ibm-products/commit/b70e56bb78c9384d92b20596ddb8503ab2c1fb17))
 
-# [0.90.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.89.0...@carbon/ibm-cloud-cognitive@0.90.0) (2021-10-06)
+# [0.90.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.89.0...@carbon/ibm-cloud-cognitive@0.90.0) (2021-10-06)
 
 ### Features
 
 - adds actions prop to web terminal
-  ([#1279](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1279))
-  ([416cb9a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/416cb9ad1e4ead91508d4b288bb98c0202d3e019))
+  ([#1279](https://github.com/carbon-design-system/ibm-products/issues/1279))
+  ([416cb9a](https://github.com/carbon-design-system/ibm-products/commit/416cb9ad1e4ead91508d4b288bb98c0202d3e019))
 
-# [0.89.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.88.1...@carbon/ibm-cloud-cognitive@0.89.0) (2021-10-02)
+# [0.89.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.88.1...@carbon/ibm-cloud-cognitive@0.89.0) (2021-10-02)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1296](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1296))
-  ([f1da0bd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f1da0bd9192c4d999032df0dbe20d67b6ece89b0))
+  ([#1296](https://github.com/carbon-design-system/ibm-products/issues/1296))
+  ([f1da0bd](https://github.com/carbon-design-system/ibm-products/commit/f1da0bd9192c4d999032df0dbe20d67b6ece89b0))
 
-## [0.88.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.88.0...@carbon/ibm-cloud-cognitive@0.88.1) (2021-09-29)
+## [0.88.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.88.0...@carbon/ibm-cloud-cognitive@0.88.1) (2021-09-29)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.88.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.87.3...@carbon/ibm-cloud-cognitive@0.88.0) (2021-09-27)
+# [0.88.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.87.3...@carbon/ibm-cloud-cognitive@0.88.0) (2021-09-27)
 
 ### Features
 
 - **EditSidePanel:**
-  [#1266](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1266)
+  [#1266](https://github.com/carbon-design-system/ibm-products/issues/1266)
   edit side panel
-  ([#1280](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1280))
-  ([25f2b6e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/25f2b6ebcbdb78304caa16ce4b2ece56ecc83ea5))
+  ([#1280](https://github.com/carbon-design-system/ibm-products/issues/1280))
+  ([25f2b6e](https://github.com/carbon-design-system/ibm-products/commit/25f2b6ebcbdb78304caa16ce4b2ece56ecc83ea5))
 
-## [0.87.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.87.2...@carbon/ibm-cloud-cognitive@0.87.3) (2021-09-24)
+## [0.87.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.87.2...@carbon/ibm-cloud-cognitive@0.87.3) (2021-09-24)
 
 ### Bug Fixes
 
 - **EmptyStates:** give svg elements unique ids to avoid display issues
-  ([#1290](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1290))
-  ([72deea8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/72deea83d493930ba03ee938c4aa1f588662407f))
+  ([#1290](https://github.com/carbon-design-system/ibm-products/issues/1290))
+  ([72deea8](https://github.com/carbon-design-system/ibm-products/commit/72deea83d493930ba03ee938c4aa1f588662407f))
 
-## [0.87.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.87.1...@carbon/ibm-cloud-cognitive@0.87.2) (2021-09-23)
+## [0.87.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.87.1...@carbon/ibm-cloud-cognitive@0.87.2) (2021-09-23)
 
 ### Bug Fixes
 
 - **SidePanel:** styles refactor/fix
-  ([#1285](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1285))
-  ([bf78f15](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/bf78f157192cefdf0e0977895cf144f22d9012ab))
+  ([#1285](https://github.com/carbon-design-system/ibm-products/issues/1285))
+  ([bf78f15](https://github.com/carbon-design-system/ibm-products/commit/bf78f157192cefdf0e0977895cf144f22d9012ab))
 
-## [0.87.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.87.0...@carbon/ibm-cloud-cognitive@0.87.1) (2021-09-23)
+## [0.87.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.87.0...@carbon/ibm-cloud-cognitive@0.87.1) (2021-09-23)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.87.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.86.1...@carbon/ibm-cloud-cognitive@0.87.0) (2021-09-23)
+# [0.87.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.86.1...@carbon/ibm-cloud-cognitive@0.87.0) (2021-09-23)
 
 ### Features
 
 - **SidePanel:** add prop to prevent closing panel on click outside
-  ([#1288](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1288))
-  ([8dfa143](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8dfa143ac88442e1a770d217298c9c95a07fe590))
+  ([#1288](https://github.com/carbon-design-system/ibm-products/issues/1288))
+  ([8dfa143](https://github.com/carbon-design-system/ibm-products/commit/8dfa143ac88442e1a770d217298c9c95a07fe590))
 
-## [0.86.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.86.0...@carbon/ibm-cloud-cognitive@0.86.1) (2021-09-23)
+## [0.86.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.86.0...@carbon/ibm-cloud-cognitive@0.86.1) (2021-09-23)
 
 ### Bug Fixes
 
 - storybook setting masking missing component color setting
-  ([#1241](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1241))
-  ([38c01ec](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/38c01ec0fa1992b358aced18b714d77eda52bf09))
+  ([#1241](https://github.com/carbon-design-system/ibm-products/issues/1241))
+  ([38c01ec](https://github.com/carbon-design-system/ibm-products/commit/38c01ec0fa1992b358aced18b714d77eda52bf09))
 
-# [0.86.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.85.2...@carbon/ibm-cloud-cognitive@0.86.0) (2021-09-23)
+# [0.86.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.85.2...@carbon/ibm-cloud-cognitive@0.86.0) (2021-09-23)
 
 ### Features
 
 - update Carbon versions and dependencies to latest
-  ([#1282](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1282))
-  ([b1451cf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b1451cf5c91b75c1bd4e55ae2bdb47f025f33163))
+  ([#1282](https://github.com/carbon-design-system/ibm-products/issues/1282))
+  ([b1451cf](https://github.com/carbon-design-system/ibm-products/commit/b1451cf5c91b75c1bd4e55ae2bdb47f025f33163))
 
-## [0.85.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.85.1...@carbon/ibm-cloud-cognitive@0.85.2) (2021-09-22)
+## [0.85.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.85.1...@carbon/ibm-cloud-cognitive@0.85.2) (2021-09-22)
 
 ### Bug Fixes
 
 - keep page header above content on scroll
-  ([#1281](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1281))
-  ([f2d95e4](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f2d95e434f37945d6d249631f44f8ce4789b7a58))
+  ([#1281](https://github.com/carbon-design-system/ibm-products/issues/1281))
+  ([f2d95e4](https://github.com/carbon-design-system/ibm-products/commit/f2d95e434f37945d6d249631f44f8ce4789b7a58))
 
-## [0.85.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.85.0...@carbon/ibm-cloud-cognitive@0.85.1) (2021-09-22)
+## [0.85.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.85.0...@carbon/ibm-cloud-cognitive@0.85.1) (2021-09-22)
 
 ### Bug Fixes
 
 - added sideEffects field to package.json
-  ([#1251](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1251))
-  ([a54554b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a54554b8b8b940e9049ad8dcca481dec6f54c354))
+  ([#1251](https://github.com/carbon-design-system/ibm-products/issues/1251))
+  ([a54554b](https://github.com/carbon-design-system/ibm-products/commit/a54554b8b8b940e9049ad8dcca481dec6f54c354))
 
-# [0.85.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.84.1...@carbon/ibm-cloud-cognitive@0.85.0) (2021-09-21)
+# [0.85.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.84.1...@carbon/ibm-cloud-cognitive@0.85.0) (2021-09-21)
 
 ### Bug Fixes
 
 - **Tearsheet:** set text color so theming works as expected
-  ([#1270](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1270))
-  ([a88e5f0](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a88e5f03d2e7d3e98809ed55cd593dfa56aee4c4))
+  ([#1270](https://github.com/carbon-design-system/ibm-products/issues/1270))
+  ([a88e5f0](https://github.com/carbon-design-system/ibm-products/commit/a88e5f03d2e7d3e98809ed55cd593dfa56aee4c4))
 - use node instead of string for remove modal input label
-  ([#1267](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1267))
-  ([7e7cdf8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7e7cdf879407d077d9d539dc7aaf9e76ffb6aaff))
+  ([#1267](https://github.com/carbon-design-system/ibm-products/issues/1267))
+  ([7e7cdf8](https://github.com/carbon-design-system/ibm-products/commit/7e7cdf879407d077d9d539dc7aaf9e76ffb6aaff))
 
 ### Features
 
 - ensure prettier linting causes ci-check to fail
-  ([#1273](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1273))
-  ([ad6f347](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ad6f3479636d2b80b26338d9059429b4ae08ac6e))
+  ([#1273](https://github.com/carbon-design-system/ibm-products/issues/1273))
+  ([ad6f347](https://github.com/carbon-design-system/ibm-products/commit/ad6f3479636d2b80b26338d9059429b4ae08ac6e))
 - update Carbon versions and package dependencies to latest
-  ([#1262](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1262))
-  ([ed4dcbe](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ed4dcbe5b6d92baa6ec39240bda6996ec55f7bc4))
+  ([#1262](https://github.com/carbon-design-system/ibm-products/issues/1262))
+  ([ed4dcbe](https://github.com/carbon-design-system/ibm-products/commit/ed4dcbe5b6d92baa6ec39240bda6996ec55f7bc4))
 
-## [0.84.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.84.0...@carbon/ibm-cloud-cognitive@0.84.1) (2021-09-15)
+## [0.84.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.84.0...@carbon/ibm-cloud-cognitive@0.84.1) (2021-09-15)
 
 ### Bug Fixes
 
 - adds additional check for copy
-  ([#1258](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1258))
-  ([b69cca1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b69cca1314e2cca7d99351fa7f91069687d64b72))
+  ([#1258](https://github.com/carbon-design-system/ibm-products/issues/1258))
+  ([b69cca1](https://github.com/carbon-design-system/ibm-products/commit/b69cca1314e2cca7d99351fa7f91069687d64b72))
 
-# [0.84.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.83.1...@carbon/ibm-cloud-cognitive@0.84.0) (2021-09-15)
+# [0.84.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.83.1...@carbon/ibm-cloud-cognitive@0.84.0) (2021-09-15)
 
 ### Features
 
 - create an xl width for the page header
-  ([#1236](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1236))
-  ([d278f85](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d278f854629f12459fd2e8e7b0ca3003083574b8))
+  ([#1236](https://github.com/carbon-design-system/ibm-products/issues/1236))
+  ([d278f85](https://github.com/carbon-design-system/ibm-products/commit/d278f854629f12459fd2e8e7b0ca3003083574b8))
 
-## [0.83.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.83.0...@carbon/ibm-cloud-cognitive@0.83.1) (2021-09-14)
+## [0.83.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.83.0...@carbon/ibm-cloud-cognitive@0.83.1) (2021-09-14)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.83.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.82.3...@carbon/ibm-cloud-cognitive@0.83.0) (2021-09-13)
+# [0.83.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.82.3...@carbon/ibm-cloud-cognitive@0.83.0) (2021-09-13)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1228](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1228))
-  ([4f5e24c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4f5e24cd3a36e7fa9a5cd62d1cafe75a090cf32e))
+  ([#1228](https://github.com/carbon-design-system/ibm-products/issues/1228))
+  ([4f5e24c](https://github.com/carbon-design-system/ibm-products/commit/4f5e24cd3a36e7fa9a5cd62d1cafe75a090cf32e))
 
-## [0.82.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.82.2...@carbon/ibm-cloud-cognitive@0.82.3) (2021-09-09)
+## [0.82.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.82.2...@carbon/ibm-cloud-cognitive@0.82.3) (2021-09-09)
 
 ### Bug Fixes
 
 - **CreateFullPage:** explicitly set bg color for page content
-  ([#1249](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1249))
-  ([776d2d3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/776d2d35a4549815312f5b3a89be2da045271eee))
+  ([#1249](https://github.com/carbon-design-system/ibm-products/issues/1249))
+  ([776d2d3](https://github.com/carbon-design-system/ibm-products/commit/776d2d35a4549815312f5b3a89be2da045271eee))
 
-## [0.82.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.82.1...@carbon/ibm-cloud-cognitive@0.82.2) (2021-09-07)
+## [0.82.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.82.1...@carbon/ibm-cloud-cognitive@0.82.2) (2021-09-07)
 
 ### Bug Fixes
 
 - cascade release
-  ([#1242](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1242))
-  ([144af3f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/144af3f2c9a32b9621418e505ae3e5df9428fdc8))
+  ([#1242](https://github.com/carbon-design-system/ibm-products/issues/1242))
+  ([144af3f](https://github.com/carbon-design-system/ibm-products/commit/144af3f2c9a32b9621418e505ae3e5df9428fdc8))
 
-## [0.82.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.82.0...@carbon/ibm-cloud-cognitive@0.82.1) (2021-09-07)
+## [0.82.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.82.0...@carbon/ibm-cloud-cognitive@0.82.1) (2021-09-07)
 
 ### Bug Fixes
 
 - **SidePanel:** add overflow hidden to body if includeOverlay exists
-  ([#1238](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1238))
-  ([6ffb602](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6ffb60287755909bae595f2d1cf8f5bc7e5ec8c5))
+  ([#1238](https://github.com/carbon-design-system/ibm-products/issues/1238))
+  ([6ffb602](https://github.com/carbon-design-system/ibm-products/commit/6ffb60287755909bae595f2d1cf8f5bc7e5ec8c5))
 
-# [0.82.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.81.2...@carbon/ibm-cloud-cognitive@0.82.0) (2021-09-07)
+# [0.82.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.81.2...@carbon/ibm-cloud-cognitive@0.82.0) (2021-09-07)
 
 ### Features
 
 - **devtools:** add attribute to numerous released components
-  ([#1229](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1229))
-  ([9993bbf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9993bbf233c5ec944c17388b73ac410870d2b956))
+  ([#1229](https://github.com/carbon-design-system/ibm-products/issues/1229))
+  ([9993bbf](https://github.com/carbon-design-system/ibm-products/commit/9993bbf233c5ec944c17388b73ac410870d2b956))
 
-## [0.81.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.81.1...@carbon/ibm-cloud-cognitive@0.81.2) (2021-09-03)
+## [0.81.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.81.1...@carbon/ibm-cloud-cognitive@0.81.2) (2021-09-03)
 
 ### Bug Fixes
 
 - **CreateTearsheet:** updates based on release review
-  ([#1233](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1233))
-  ([f50e78a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f50e78ab7f7a6b12d14b779954cad5ef4f91f6eb))
+  ([#1233](https://github.com/carbon-design-system/ibm-products/issues/1233))
+  ([f50e78a](https://github.com/carbon-design-system/ibm-products/commit/f50e78ab7f7a6b12d14b779954cad5ef4f91f6eb))
 - release review updates
-  ([#1237](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1237))
-  ([1880856](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1880856c4f5f8063f94a26d7e16e89c8454b6ccc))
+  ([#1237](https://github.com/carbon-design-system/ibm-products/issues/1237))
+  ([1880856](https://github.com/carbon-design-system/ibm-products/commit/1880856c4f5f8063f94a26d7e16e89c8454b6ccc))
 
-## [0.81.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.81.0...@carbon/ibm-cloud-cognitive@0.81.1) (2021-09-02)
+## [0.81.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.81.0...@carbon/ibm-cloud-cognitive@0.81.1) (2021-09-02)
 
 ### Bug Fixes
 
 - **SidePanel:** update storyname in mdx doc file
-  ([#1232](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1232))
-  ([a336e37](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a336e37d8812f4929c65fb4e74524008ff6a1278))
+  ([#1232](https://github.com/carbon-design-system/ibm-products/issues/1232))
+  ([a336e37](https://github.com/carbon-design-system/ibm-products/commit/a336e37d8812f4929c65fb4e74524008ff6a1278))
 
-# [0.81.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.80.1...@carbon/ibm-cloud-cognitive@0.81.0) (2021-09-02)
+# [0.81.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.80.1...@carbon/ibm-cloud-cognitive@0.81.0) (2021-09-02)
 
 ### Features
 
 - **devtools:** add attribute to numerous released components
-  ([#1226](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1226))
-  ([783ebe9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/783ebe923a96a268d16e9e3b832f27d950987de4))
+  ([#1226](https://github.com/carbon-design-system/ibm-products/issues/1226))
+  ([783ebe9](https://github.com/carbon-design-system/ibm-products/commit/783ebe923a96a268d16e9e3b832f27d950987de4))
 
-## [0.80.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.80.0...@carbon/ibm-cloud-cognitive@0.80.1) (2021-09-01)
+## [0.80.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.80.0...@carbon/ibm-cloud-cognitive@0.80.1) (2021-09-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.80.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.79.1...@carbon/ibm-cloud-cognitive@0.80.0) (2021-08-31)
+# [0.80.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.79.1...@carbon/ibm-cloud-cognitive@0.80.0) (2021-08-31)
 
 ### Features
 
 - **devtools:** add support to released components (1 / 3)
-  ([#1220](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1220))
-  ([25209f9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/25209f9dfe4115843315e74bb6dfcf784a8b950c))
+  ([#1220](https://github.com/carbon-design-system/ibm-products/issues/1220))
+  ([25209f9](https://github.com/carbon-design-system/ibm-products/commit/25209f9dfe4115843315e74bb6dfcf784a8b950c))
 
-## [0.79.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.79.0...@carbon/ibm-cloud-cognitive@0.79.1) (2021-08-31)
+## [0.79.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.79.0...@carbon/ibm-cloud-cognitive@0.79.1) (2021-08-31)
 
 ### Bug Fixes
 
 - **SidePanel:**
-  [#1204](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1204)
+  [#1204](https://github.com/carbon-design-system/ibm-products/issues/1204)
   side panel closing animation fix
-  ([#1222](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1222))
-  ([53953a5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/53953a52b5842e27253208cad16d52f8b106530b))
+  ([#1222](https://github.com/carbon-design-system/ibm-products/issues/1222))
+  ([53953a5](https://github.com/carbon-design-system/ibm-products/commit/53953a52b5842e27253208cad16d52f8b106530b))
 
-# [0.79.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.78.4...@carbon/ibm-cloud-cognitive@0.79.0) (2021-08-31)
+# [0.79.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.78.4...@carbon/ibm-cloud-cognitive@0.79.0) (2021-08-31)
 
 ### Features
 
 - page header props to influence grid width
-  ([#1225](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1225))
-  ([c73255d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c73255d87d6a1fba94b1ce27bc826250562b915b))
+  ([#1225](https://github.com/carbon-design-system/ibm-products/issues/1225))
+  ([c73255d](https://github.com/carbon-design-system/ibm-products/commit/c73255d87d6a1fba94b1ce27bc826250562b915b))
 
-## [0.78.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.78.3...@carbon/ibm-cloud-cognitive@0.78.4) (2021-08-30)
+## [0.78.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.78.3...@carbon/ibm-cloud-cognitive@0.78.4) (2021-08-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.78.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.78.2...@carbon/ibm-cloud-cognitive@0.78.3) (2021-08-30)
+## [0.78.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.78.2...@carbon/ibm-cloud-cognitive@0.78.3) (2021-08-30)
 
 ### Bug Fixes
 
 - **CreateTearsheet:** add grid usage to step component and storybook
-  ([#1214](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1214))
-  ([8f49008](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8f490080cda913bc099a03b1e4bd97ecd93b394c))
+  ([#1214](https://github.com/carbon-design-system/ibm-products/issues/1214))
+  ([8f49008](https://github.com/carbon-design-system/ibm-products/commit/8f490080cda913bc099a03b1e4bd97ecd93b394c))
 
-## [0.78.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.78.1...@carbon/ibm-cloud-cognitive@0.78.2) (2021-08-27)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.78.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.78.0...@carbon/ibm-cloud-cognitive@0.78.1) (2021-08-27)
+## [0.78.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.78.1...@carbon/ibm-cloud-cognitive@0.78.2) (2021-08-27)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.78.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.77.6...@carbon/ibm-cloud-cognitive@0.78.0) (2021-08-27)
+## [0.78.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.78.0...@carbon/ibm-cloud-cognitive@0.78.1) (2021-08-27)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+# [0.78.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.77.6...@carbon/ibm-cloud-cognitive@0.78.0) (2021-08-27)
 
 ### Features
 
 - **devtools:** add mechanism to enable component DOM identification
-  ([#1187](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1187))
-  ([c433158](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c4331581e0ec806d6a0ed65b2873d4963d3c8ac3))
+  ([#1187](https://github.com/carbon-design-system/ibm-products/issues/1187))
+  ([c433158](https://github.com/carbon-design-system/ibm-products/commit/c4331581e0ec806d6a0ed65b2873d4963d3c8ac3))
 
-## [0.77.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.77.5...@carbon/ibm-cloud-cognitive@0.77.6) (2021-08-26)
+## [0.77.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.77.5...@carbon/ibm-cloud-cognitive@0.77.6) (2021-08-26)
 
 ### Bug Fixes
 
 - **SidePanel:** revert condensed title font weight style
-  ([#1213](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1213))
-  ([9bf141d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9bf141df78325ac8b8682a647a2d27b28826dac5))
+  ([#1213](https://github.com/carbon-design-system/ibm-products/issues/1213))
+  ([9bf141d](https://github.com/carbon-design-system/ibm-products/commit/9bf141df78325ac8b8682a647a2d27b28826dac5))
 
-## [0.77.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.77.4...@carbon/ibm-cloud-cognitive@0.77.5) (2021-08-26)
+## [0.77.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.77.4...@carbon/ibm-cloud-cognitive@0.77.5) (2021-08-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.77.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.77.3...@carbon/ibm-cloud-cognitive@0.77.4) (2021-08-26)
+## [0.77.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.77.3...@carbon/ibm-cloud-cognitive@0.77.4) (2021-08-26)
 
 ### Bug Fixes
 
 - **SidePanel:**
-  [#1191](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1191)
+  [#1191](https://github.com/carbon-design-system/ibm-products/issues/1191)
   allow side panel title to be optional
-  ([#1202](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1202))
-  ([a9aa0e6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a9aa0e6113afd40ad17d568e60629c4e03de5555))
+  ([#1202](https://github.com/carbon-design-system/ibm-products/issues/1202))
+  ([a9aa0e6](https://github.com/carbon-design-system/ibm-products/commit/a9aa0e6113afd40ad17d568e60629c4e03de5555))
 
-## [0.77.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.77.2...@carbon/ibm-cloud-cognitive@0.77.3) (2021-08-26)
+## [0.77.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.77.2...@carbon/ibm-cloud-cognitive@0.77.3) (2021-08-26)
 
 ### Bug Fixes
 
 - **SidePanel:** fix label text layout issues on scroll animation
-  ([#1203](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1203))
-  ([d1c5570](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d1c5570a56eea58157b8ad2e8faca225787f8479))
+  ([#1203](https://github.com/carbon-design-system/ibm-products/issues/1203))
+  ([d1c5570](https://github.com/carbon-design-system/ibm-products/commit/d1c5570a56eea58157b8ad2e8faca225787f8479))
 
-## [0.77.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.77.1...@carbon/ibm-cloud-cognitive@0.77.2) (2021-08-26)
+## [0.77.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.77.1...@carbon/ibm-cloud-cognitive@0.77.2) (2021-08-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.77.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.77.0...@carbon/ibm-cloud-cognitive@0.77.1) (2021-08-26)
+## [0.77.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.77.0...@carbon/ibm-cloud-cognitive@0.77.1) (2021-08-26)
 
 ### Bug Fixes
 
 - **SidePanel:** fix animating state of panel
-  ([#1193](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1193))
-  ([5a98abc](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5a98abc93e06b021ea4851c19afc4bbb50a7660f))
+  ([#1193](https://github.com/carbon-design-system/ibm-products/issues/1193))
+  ([5a98abc](https://github.com/carbon-design-system/ibm-products/commit/5a98abc93e06b021ea4851c19afc4bbb50a7660f))
 
-# [0.77.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.76.1...@carbon/ibm-cloud-cognitive@0.77.0) (2021-08-25)
+# [0.77.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.76.1...@carbon/ibm-cloud-cognitive@0.77.0) (2021-08-25)
 
 ### Features
 
 - cascade component
-  ([#1171](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1171))
-  ([76b8b6f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/76b8b6f1b375e093e721ba415b53e97ec3ca2262))
+  ([#1171](https://github.com/carbon-design-system/ibm-products/issues/1171))
+  ([76b8b6f](https://github.com/carbon-design-system/ibm-products/commit/76b8b6f1b375e093e721ba415b53e97ec3ca2262))
 
-## [0.76.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.76.0...@carbon/ibm-cloud-cognitive@0.76.1) (2021-08-25)
+## [0.76.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.76.0...@carbon/ibm-cloud-cognitive@0.76.1) (2021-08-25)
 
 ### Bug Fixes
 
 - better warnings when deprecated-usage props have invalid values
-  ([#1198](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1198))
-  ([6ec8777](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6ec8777b66b4f45d47ed1060051b8bf9ec8692d8))
+  ([#1198](https://github.com/carbon-design-system/ibm-products/issues/1198))
+  ([6ec8777](https://github.com/carbon-design-system/ibm-products/commit/6ec8777b66b4f45d47ed1060051b8bf9ec8692d8))
 
-# [0.76.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.75.1...@carbon/ibm-cloud-cognitive@0.76.0) (2021-08-25)
+# [0.76.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.75.1...@carbon/ibm-cloud-cognitive@0.76.0) (2021-08-25)
 
 ### Features
 
 - **toolbar:** add vertical variant
-  ([#1173](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1173))
-  ([574a2c5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/574a2c55fd965be4de163ea8d9d9fae0baf1e7ba))
+  ([#1173](https://github.com/carbon-design-system/ibm-products/issues/1173))
+  ([574a2c5](https://github.com/carbon-design-system/ibm-products/commit/574a2c55fd965be4de163ea8d9d9fae0baf1e7ba))
 
-## [0.75.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.75.0...@carbon/ibm-cloud-cognitive@0.75.1) (2021-08-25)
+## [0.75.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.75.0...@carbon/ibm-cloud-cognitive@0.75.1) (2021-08-25)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.75.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.74.1...@carbon/ibm-cloud-cognitive@0.75.0) (2021-08-23)
+# [0.75.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.74.1...@carbon/ibm-cloud-cognitive@0.75.0) (2021-08-23)
 
 ### Features
 
 - **SidePanel:** allow actionToolbarButtons to be a bit more flexible
-  ([#1189](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1189))
-  ([bc84e20](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/bc84e20f9652ba0379b884e5a9e1c7542ef34601))
+  ([#1189](https://github.com/carbon-design-system/ibm-products/issues/1189))
+  ([bc84e20](https://github.com/carbon-design-system/ibm-products/commit/bc84e20f9652ba0379b884e5a9e1c7542ef34601))
 
-## [0.74.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.74.0...@carbon/ibm-cloud-cognitive@0.74.1) (2021-08-23)
+## [0.74.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.74.0...@carbon/ibm-cloud-cognitive@0.74.1) (2021-08-23)
 
 ### Bug Fixes
 
 - **SidePanel:** center close svg in close button
-  ([#1190](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1190))
-  ([fa4a688](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fa4a68898eb74d2e5487732d27f36664de9648a1))
+  ([#1190](https://github.com/carbon-design-system/ibm-products/issues/1190))
+  ([fa4a688](https://github.com/carbon-design-system/ibm-products/commit/fa4a68898eb74d2e5487732d27f36664de9648a1))
 
-# [0.74.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.73.2...@carbon/ibm-cloud-cognitive@0.74.0) (2021-08-20)
+# [0.74.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.73.2...@carbon/ibm-cloud-cognitive@0.74.0) (2021-08-20)
 
 ### Features
 
 - fix offset and add element based scroll
-  ([#1185](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1185))
-  ([e3149ae](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e3149aec52eec078eb3b77abd029131ad9365385))
+  ([#1185](https://github.com/carbon-design-system/ibm-products/issues/1185))
+  ([e3149ae](https://github.com/carbon-design-system/ibm-products/commit/e3149aec52eec078eb3b77abd029131ad9365385))
 
-## [0.73.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.73.1...@carbon/ibm-cloud-cognitive@0.73.2) (2021-08-20)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.73.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.73.0...@carbon/ibm-cloud-cognitive@0.73.1) (2021-08-19)
+## [0.73.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.73.1...@carbon/ibm-cloud-cognitive@0.73.2) (2021-08-20)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.73.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.72.1...@carbon/ibm-cloud-cognitive@0.73.0) (2021-08-19)
+## [0.73.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.73.0...@carbon/ibm-cloud-cognitive@0.73.1) (2021-08-19)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+# [0.73.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.72.1...@carbon/ibm-cloud-cognitive@0.73.0) (2021-08-19)
 
 ### Features
 
 - **CreateTearsheet:**
-  [#1076](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1076)
+  [#1076](https://github.com/carbon-design-system/ibm-products/issues/1076)
   create tearsheet custom step
-  ([#1174](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1174))
-  ([8d0ab04](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8d0ab046245a9b8862e351361b08068204a97f2a))
+  ([#1174](https://github.com/carbon-design-system/ibm-products/issues/1174))
+  ([8d0ab04](https://github.com/carbon-design-system/ibm-products/commit/8d0ab046245a9b8862e351361b08068204a97f2a))
 
-## [0.72.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.72.0...@carbon/ibm-cloud-cognitive@0.72.1) (2021-08-19)
+## [0.72.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.72.0...@carbon/ibm-cloud-cognitive@0.72.1) (2021-08-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.72.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.71.8...@carbon/ibm-cloud-cognitive@0.72.0) (2021-08-19)
+# [0.72.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.71.8...@carbon/ibm-cloud-cognitive@0.72.0) (2021-08-19)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#1168](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1168))
-  ([674017f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/674017fabc13a7737c0d16deb04ffa9872d76fe6))
+  ([#1168](https://github.com/carbon-design-system/ibm-products/issues/1168))
+  ([674017f](https://github.com/carbon-design-system/ibm-products/commit/674017fabc13a7737c0d16deb04ffa9872d76fe6))
 
-## [0.71.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.71.7...@carbon/ibm-cloud-cognitive@0.71.8) (2021-08-18)
+## [0.71.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.71.7...@carbon/ibm-cloud-cognitive@0.71.8) (2021-08-18)
 
 ### Bug Fixes
 
 - **CreateTearsheet:** remove grid margin
-  ([#1170](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1170))
-  ([75bfb54](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/75bfb5462ec364d86970fc142a99b91d0c5a185b))
+  ([#1170](https://github.com/carbon-design-system/ibm-products/issues/1170))
+  ([75bfb54](https://github.com/carbon-design-system/ibm-products/commit/75bfb5462ec364d86970fc142a99b91d0c5a185b))
 
-## [0.71.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.71.6...@carbon/ibm-cloud-cognitive@0.71.7) (2021-08-18)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.71.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.71.5...@carbon/ibm-cloud-cognitive@0.71.6) (2021-08-18)
+## [0.71.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.71.6...@carbon/ibm-cloud-cognitive@0.71.7) (2021-08-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.71.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.71.4...@carbon/ibm-cloud-cognitive@0.71.5) (2021-08-18)
+## [0.71.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.71.5...@carbon/ibm-cloud-cognitive@0.71.6) (2021-08-18)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.71.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.71.4...@carbon/ibm-cloud-cognitive@0.71.5) (2021-08-18)
 
 ### Bug Fixes
 
 - Ensure SCSS for all components and stories sets required carbon and project
   settings
-  ([#1166](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1166))
-  ([5c77105](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5c77105891df498f26d3f8f6214f8d7f7fa68267))
+  ([#1166](https://github.com/carbon-design-system/ibm-products/issues/1166))
+  ([5c77105](https://github.com/carbon-design-system/ibm-products/commit/5c77105891df498f26d3f8f6214f8d7f7fa68267))
 
-## [0.71.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.71.3...@carbon/ibm-cloud-cognitive@0.71.4) (2021-08-18)
+## [0.71.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.71.3...@carbon/ibm-cloud-cognitive@0.71.4) (2021-08-18)
 
 ### Bug Fixes
 
 - ensure internal components don't render as canary placeholders
-  ([#1167](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1167))
-  ([0b557b6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0b557b6163692e796058e7d2bc3b991d019b62d9))
+  ([#1167](https://github.com/carbon-design-system/ibm-products/issues/1167))
+  ([0b557b6](https://github.com/carbon-design-system/ibm-products/commit/0b557b6163692e796058e7d2bc3b991d019b62d9))
 
-## [0.71.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.71.2...@carbon/ibm-cloud-cognitive@0.71.3) (2021-08-18)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.71.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.71.1...@carbon/ibm-cloud-cognitive@0.71.2) (2021-08-17)
+## [0.71.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.71.2...@carbon/ibm-cloud-cognitive@0.71.3) (2021-08-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.71.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.71.0...@carbon/ibm-cloud-cognitive@0.71.1) (2021-08-17)
+## [0.71.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.71.1...@carbon/ibm-cloud-cognitive@0.71.2) (2021-08-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.71.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.70.1...@carbon/ibm-cloud-cognitive@0.71.0) (2021-08-17)
+## [0.71.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.71.0...@carbon/ibm-cloud-cognitive@0.71.1) (2021-08-17)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+# [0.71.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.70.1...@carbon/ibm-cloud-cognitive@0.71.0) (2021-08-17)
 
 ### Features
 
 - **toolbar:** add `Toolbar`, `ToolbarButton`, and `ToolbarGroup` components
-  ([#1103](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1103))
-  ([2d5f4cf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2d5f4cfb1e5c650696831a5c2c660c57e6a54f85))
+  ([#1103](https://github.com/carbon-design-system/ibm-products/issues/1103))
+  ([2d5f4cf](https://github.com/carbon-design-system/ibm-products/commit/2d5f4cfb1e5c650696831a5c2c660c57e6a54f85))
 
-## [0.70.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.70.0...@carbon/ibm-cloud-cognitive@0.70.1) (2021-08-17)
+## [0.70.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.70.0...@carbon/ibm-cloud-cognitive@0.70.1) (2021-08-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.70.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.69.7...@carbon/ibm-cloud-cognitive@0.70.0) (2021-08-16)
+# [0.70.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.69.7...@carbon/ibm-cloud-cognitive@0.70.0) (2021-08-16)
 
 ### Features
 
 - **CreateSidePanel:** release create side panel component
-  ([#1153](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1153))
-  ([5b39d10](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5b39d1095f1a52d020985a9c8cf1cebe89c5071a))
+  ([#1153](https://github.com/carbon-design-system/ibm-products/issues/1153))
+  ([5b39d10](https://github.com/carbon-design-system/ibm-products/commit/5b39d1095f1a52d020985a9c8cf1cebe89c5071a))
 
-## [0.69.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.69.6...@carbon/ibm-cloud-cognitive@0.69.7) (2021-08-13)
+## [0.69.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.69.6...@carbon/ibm-cloud-cognitive@0.69.7) (2021-08-13)
 
 ### Bug Fixes
 
 - **HTTPErrors:** explicitly set text color and update snapshot
-  ([#1155](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1155))
-  ([bd37ca6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/bd37ca69a1489c55ebb94e7c9f5f4858d3ad3923))
+  ([#1155](https://github.com/carbon-design-system/ibm-products/issues/1155))
+  ([bd37ca6](https://github.com/carbon-design-system/ibm-products/commit/bd37ca69a1489c55ebb94e7c9f5f4858d3ad3923))
 
-## [0.69.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.69.5...@carbon/ibm-cloud-cognitive@0.69.6) (2021-08-13)
+## [0.69.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.69.5...@carbon/ibm-cloud-cognitive@0.69.6) (2021-08-13)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.69.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.69.4...@carbon/ibm-cloud-cognitive@0.69.5) (2021-08-13)
+## [0.69.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.69.4...@carbon/ibm-cloud-cognitive@0.69.5) (2021-08-13)
 
 ### Bug Fixes
 
 - **Tearsheet:** ensure tearsheet styles override carbon styles
-  ([#1146](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1146))
-  ([d936f42](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d936f42b05acf3827154e8656ec90a243e9932ce))
+  ([#1146](https://github.com/carbon-design-system/ibm-products/issues/1146))
+  ([d936f42](https://github.com/carbon-design-system/ibm-products/commit/d936f42b05acf3827154e8656ec90a243e9932ce))
 
-## [0.69.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.69.3...@carbon/ibm-cloud-cognitive@0.69.4) (2021-08-12)
+## [0.69.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.69.3...@carbon/ibm-cloud-cognitive@0.69.4) (2021-08-12)
 
 ### Bug Fixes
 
 - **CreateSidePanel:** design fixes and side panel header/scrolling work
-  ([#1141](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1141))
-  ([be67abc](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/be67abc89964816d447d3f0c24cbc0fcbaf61c6f))
+  ([#1141](https://github.com/carbon-design-system/ibm-products/issues/1141))
+  ([be67abc](https://github.com/carbon-design-system/ibm-products/commit/be67abc89964816d447d3f0c24cbc0fcbaf61c6f))
 
-## [0.69.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.69.2...@carbon/ibm-cloud-cognitive@0.69.3) (2021-08-12)
+## [0.69.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.69.2...@carbon/ibm-cloud-cognitive@0.69.3) (2021-08-12)
 
 ### Bug Fixes
 
 - review feedback for cards
-  ([#1131](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1131))
-  ([aecea1c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/aecea1c5b4453e0c3a7af28ab55d6f354c77dbd5))
+  ([#1131](https://github.com/carbon-design-system/ibm-products/issues/1131))
+  ([aecea1c](https://github.com/carbon-design-system/ibm-products/commit/aecea1c5b4453e0c3a7af28ab55d6f354c77dbd5))
 
-## [0.69.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.69.1...@carbon/ibm-cloud-cognitive@0.69.2) (2021-08-12)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.69.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.69.0...@carbon/ibm-cloud-cognitive@0.69.1) (2021-08-12)
+## [0.69.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.69.1...@carbon/ibm-cloud-cognitive@0.69.2) (2021-08-12)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.69.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.68.2...@carbon/ibm-cloud-cognitive@0.69.0) (2021-08-12)
+## [0.69.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.69.0...@carbon/ibm-cloud-cognitive@0.69.1) (2021-08-12)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+# [0.69.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.68.2...@carbon/ibm-cloud-cognitive@0.69.0) (2021-08-12)
 
 ### Features
 
 - **CreateTearsheet:** release create tearsheet narrow
-  ([#1149](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1149))
-  ([df907a5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/df907a5fa4614212ae584c1e696f46eb811130de))
+  ([#1149](https://github.com/carbon-design-system/ibm-products/issues/1149))
+  ([df907a5](https://github.com/carbon-design-system/ibm-products/commit/df907a5fa4614212ae584c1e696f46eb811130de))
 
-## [0.68.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.68.1...@carbon/ibm-cloud-cognitive@0.68.2) (2021-08-12)
+## [0.68.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.68.1...@carbon/ibm-cloud-cognitive@0.68.2) (2021-08-12)
 
 ### Bug Fixes
 
 - **CreateModal:** ensure closing the modal calls onRequestClose handler
-  ([#1147](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1147))
-  ([73cd1a4](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/73cd1a4e99d6ad5da326b0509f115268b5696a55))
+  ([#1147](https://github.com/carbon-design-system/ibm-products/issues/1147))
+  ([73cd1a4](https://github.com/carbon-design-system/ibm-products/commit/73cd1a4e99d6ad5da326b0509f115268b5696a55))
 
-## [0.68.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.68.0...@carbon/ibm-cloud-cognitive@0.68.1) (2021-08-11)
+## [0.68.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.68.0...@carbon/ibm-cloud-cognitive@0.68.1) (2021-08-11)
 
 ### Bug Fixes
 
 - **CreateTearsheetNarrow:** add tests and address onRequestClose issue
-  ([#1143](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1143))
-  ([87ed826](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/87ed826da64825cf7f1a3f860baed4cbae1b8a54))
+  ([#1143](https://github.com/carbon-design-system/ibm-products/issues/1143))
+  ([87ed826](https://github.com/carbon-design-system/ibm-products/commit/87ed826da64825cf7f1a3f860baed4cbae1b8a54))
 
-# [0.68.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.67.1...@carbon/ibm-cloud-cognitive@0.68.0) (2021-08-11)
+# [0.68.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.67.1...@carbon/ibm-cloud-cognitive@0.68.0) (2021-08-11)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1133](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1133))
-  ([4dfae1a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4dfae1a9b27f5676d0bde570e2c9ee9ce8550b52))
+  ([#1133](https://github.com/carbon-design-system/ibm-products/issues/1133))
+  ([4dfae1a](https://github.com/carbon-design-system/ibm-products/commit/4dfae1a9b27f5676d0bde570e2c9ee9ce8550b52))
 
-## [0.67.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.67.0...@carbon/ibm-cloud-cognitive@0.67.1) (2021-08-10)
+## [0.67.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.67.0...@carbon/ibm-cloud-cognitive@0.67.1) (2021-08-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.67.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.66.1...@carbon/ibm-cloud-cognitive@0.67.0) (2021-08-10)
+# [0.67.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.66.1...@carbon/ibm-cloud-cognitive@0.67.0) (2021-08-10)
 
 ### Features
 
 - **CreateInfluencer:**
-  [#1107](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1107)
+  [#1107](https://github.com/carbon-design-system/ibm-products/issues/1107)
   create influencer shared component
-  ([#1122](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1122))
-  ([369f466](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/369f4665c3c3b61c62c3aaa326c86738baa08e70))
+  ([#1122](https://github.com/carbon-design-system/ibm-products/issues/1122))
+  ([369f466](https://github.com/carbon-design-system/ibm-products/commit/369f4665c3c3b61c62c3aaa326c86738baa08e70))
 
-## [0.66.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.66.0...@carbon/ibm-cloud-cognitive@0.66.1) (2021-08-10)
+## [0.66.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.66.0...@carbon/ibm-cloud-cognitive@0.66.1) (2021-08-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.66.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.65.0...@carbon/ibm-cloud-cognitive@0.66.0) (2021-08-10)
+# [0.66.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.65.0...@carbon/ibm-cloud-cognitive@0.66.0) (2021-08-10)
 
 ### Bug Fixes
 
 - export cards
-  ([#1120](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1120))
-  ([7227aeb](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7227aebcc0c31c2f9a3076692c5a3b3913a6a2e0))
+  ([#1120](https://github.com/carbon-design-system/ibm-products/issues/1120))
+  ([7227aeb](https://github.com/carbon-design-system/ibm-products/commit/7227aebcc0c31c2f9a3076692c5a3b3913a6a2e0))
 
 ### Features
 
 - ensure all component SCSS imports all dependencies
-  ([#1118](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1118))
-  ([9d9617d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9d9617dadf43120ebd95aa6a255ee71b7cbf61ca))
+  ([#1118](https://github.com/carbon-design-system/ibm-products/issues/1118))
+  ([9d9617d](https://github.com/carbon-design-system/ibm-products/commit/9d9617dadf43120ebd95aa6a255ee71b7cbf61ca))
 - update Carbon versions and dependencies
-  ([#1110](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1110))
-  ([b41f433](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b41f4331e31cbd9e41d2364b24e6ef50c7fd2d8d))
+  ([#1110](https://github.com/carbon-design-system/ibm-products/issues/1110))
+  ([b41f433](https://github.com/carbon-design-system/ibm-products/commit/b41f4331e31cbd9e41d2364b24e6ef50c7fd2d8d))
 
-# [0.65.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.64.6...@carbon/ibm-cloud-cognitive@0.65.0) (2021-08-04)
+# [0.65.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.64.6...@carbon/ibm-cloud-cognitive@0.65.0) (2021-08-04)
 
 ### Features
 
 - **CreateTearsheet:** add microinteraction to influencer menus
-  ([#1104](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1104))
-  ([4dc051c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4dc051ce64434b9307d23defd84741048ca10c8e))
+  ([#1104](https://github.com/carbon-design-system/ibm-products/issues/1104))
+  ([4dc051c](https://github.com/carbon-design-system/ibm-products/commit/4dc051ce64434b9307d23defd84741048ca10c8e))
 
-## [0.64.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.64.5...@carbon/ibm-cloud-cognitive@0.64.6) (2021-08-03)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.64.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.64.4...@carbon/ibm-cloud-cognitive@0.64.5) (2021-08-03)
+## [0.64.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.64.5...@carbon/ibm-cloud-cognitive@0.64.6) (2021-08-03)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.64.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.64.3...@carbon/ibm-cloud-cognitive@0.64.4) (2021-08-03)
+## [0.64.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.64.4...@carbon/ibm-cloud-cognitive@0.64.5) (2021-08-03)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.64.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.64.3...@carbon/ibm-cloud-cognitive@0.64.4) (2021-08-03)
 
 ### Bug Fixes
 
 - **CreateTearsheet:** stories should receive args as expected now
-  ([#1099](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1099))
-  ([ec43a08](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ec43a0891c472a554228bd2bc11bb83a0fa090ce))
+  ([#1099](https://github.com/carbon-design-system/ibm-products/issues/1099))
+  ([ec43a08](https://github.com/carbon-design-system/ibm-products/commit/ec43a0891c472a554228bd2bc11bb83a0fa090ce))
 
-## [0.64.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.64.2...@carbon/ibm-cloud-cognitive@0.64.3) (2021-08-03)
+## [0.64.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.64.2...@carbon/ibm-cloud-cognitive@0.64.3) (2021-08-03)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.64.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.64.1...@carbon/ibm-cloud-cognitive@0.64.2) (2021-08-03)
+## [0.64.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.64.1...@carbon/ibm-cloud-cognitive@0.64.2) (2021-08-03)
 
 ### Bug Fixes
 
 - added additional apikeymodal tests
-  ([#1098](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1098))
-  ([e680415](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e680415bbf998584910eb9ed92eff62a71913ebe))
+  ([#1098](https://github.com/carbon-design-system/ibm-products/issues/1098))
+  ([e680415](https://github.com/carbon-design-system/ibm-products/commit/e680415bbf998584910eb9ed92eff62a71913ebe))
 
-## [0.64.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.64.0...@carbon/ibm-cloud-cognitive@0.64.1) (2021-08-03)
+## [0.64.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.64.0...@carbon/ibm-cloud-cognitive@0.64.1) (2021-08-03)
 
 ### Bug Fixes
 
 - **SidePanel:** add panel height to useEffect dependencies
-  ([#1100](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1100))
-  ([fe29cc0](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fe29cc0ebdbbdf3d66acf0a7d6bc8263b2139030))
+  ([#1100](https://github.com/carbon-design-system/ibm-products/issues/1100))
+  ([fe29cc0](https://github.com/carbon-design-system/ibm-products/commit/fe29cc0ebdbbdf3d66acf0a7d6bc8263b2139030))
 
-# [0.64.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.63.2...@carbon/ibm-cloud-cognitive@0.64.0) (2021-07-30)
+# [0.64.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.63.2...@carbon/ibm-cloud-cognitive@0.64.0) (2021-07-30)
 
 ### Features
 
 - **deps:** add Carbon packages as peer dependencies
-  ([#1089](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1089))
-  ([6b807ef](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6b807efa40798dd0977c76eb07bff8fb7daa170e))
+  ([#1089](https://github.com/carbon-design-system/ibm-products/issues/1089))
+  ([6b807ef](https://github.com/carbon-design-system/ibm-products/commit/6b807efa40798dd0977c76eb07bff8fb7daa170e))
 
-## [0.63.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.63.1...@carbon/ibm-cloud-cognitive@0.63.2) (2021-07-30)
+## [0.63.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.63.1...@carbon/ibm-cloud-cognitive@0.63.2) (2021-07-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.63.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.63.0...@carbon/ibm-cloud-cognitive@0.63.1) (2021-07-29)
+## [0.63.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.63.0...@carbon/ibm-cloud-cognitive@0.63.1) (2021-07-29)
 
 ### Bug Fixes
 
 - **CreateTearsheet:** story component updates
-  ([#1091](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1091))
-  ([62f7fbc](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/62f7fbc0b0c4d62d68cbaf288bbd5ae0170a4605))
+  ([#1091](https://github.com/carbon-design-system/ibm-products/issues/1091))
+  ([62f7fbc](https://github.com/carbon-design-system/ibm-products/commit/62f7fbc0b0c4d62d68cbaf288bbd5ae0170a4605))
 
-# [0.63.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.62.6...@carbon/ibm-cloud-cognitive@0.63.0) (2021-07-28)
+# [0.63.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.62.6...@carbon/ibm-cloud-cognitive@0.63.0) (2021-07-28)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#1084](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1084))
-  ([3735ead](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3735ead9a96450015ec7aeafdb25deaa93d49aaa))
+  ([#1084](https://github.com/carbon-design-system/ibm-products/issues/1084))
+  ([3735ead](https://github.com/carbon-design-system/ibm-products/commit/3735ead9a96450015ec7aeafdb25deaa93d49aaa))
 
-## [0.62.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.62.5...@carbon/ibm-cloud-cognitive@0.62.6) (2021-07-27)
+## [0.62.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.62.5...@carbon/ibm-cloud-cognitive@0.62.6) (2021-07-27)
 
 ### Bug Fixes
 
 - apikey story fix
-  ([#1081](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1081))
-  ([a225b3a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a225b3a291734d1d29d564708ae267aa4a202134))
+  ([#1081](https://github.com/carbon-design-system/ibm-products/issues/1081))
+  ([a225b3a](https://github.com/carbon-design-system/ibm-products/commit/a225b3a291734d1d29d564708ae267aa4a202134))
 
-## [0.62.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.62.4...@carbon/ibm-cloud-cognitive@0.62.5) (2021-07-27)
+## [0.62.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.62.4...@carbon/ibm-cloud-cognitive@0.62.5) (2021-07-27)
 
 ### Bug Fixes
 
 - update apikeymodal prop testing
-  ([#1079](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1079))
-  ([92a1aa3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/92a1aa3b0f03c6663e83e52f586e28e1a9010232))
+  ([#1079](https://github.com/carbon-design-system/ibm-products/issues/1079))
+  ([92a1aa3](https://github.com/carbon-design-system/ibm-products/commit/92a1aa3b0f03c6663e83e52f586e28e1a9010232))
 
-## [0.62.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.62.3...@carbon/ibm-cloud-cognitive@0.62.4) (2021-07-27)
+## [0.62.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.62.3...@carbon/ibm-cloud-cognitive@0.62.4) (2021-07-27)
 
 ### Bug Fixes
 
 - **CreateSidePanel:** title and subtitle padding is correct now
-  ([#1080](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1080))
-  ([9fcbe91](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9fcbe9185c403f2b8bc76f79ed3b687ada9da254))
+  ([#1080](https://github.com/carbon-design-system/ibm-products/issues/1080))
+  ([9fcbe91](https://github.com/carbon-design-system/ibm-products/commit/9fcbe9185c403f2b8bc76f79ed3b687ada9da254))
 
-## [0.62.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.62.2...@carbon/ibm-cloud-cognitive@0.62.3) (2021-07-26)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.62.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.62.1...@carbon/ibm-cloud-cognitive@0.62.2) (2021-07-26)
+## [0.62.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.62.2...@carbon/ibm-cloud-cognitive@0.62.3) (2021-07-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.62.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.62.0...@carbon/ibm-cloud-cognitive@0.62.1) (2021-07-26)
+## [0.62.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.62.1...@carbon/ibm-cloud-cognitive@0.62.2) (2021-07-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.62.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.61.3...@carbon/ibm-cloud-cognitive@0.62.0) (2021-07-23)
+## [0.62.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.62.0...@carbon/ibm-cloud-cognitive@0.62.1) (2021-07-26)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+# [0.62.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.61.3...@carbon/ibm-cloud-cognitive@0.62.0) (2021-07-23)
 
 ### Features
 
 - release page header
-  ([#1072](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1072))
-  ([0d397d7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0d397d77f0b353ba1d4ba368507f4f6f74733cf4))
+  ([#1072](https://github.com/carbon-design-system/ibm-products/issues/1072))
+  ([0d397d7](https://github.com/carbon-design-system/ibm-products/commit/0d397d77f0b353ba1d4ba368507f4f6f74733cf4))
 
-## [0.61.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.61.2...@carbon/ibm-cloud-cognitive@0.61.3) (2021-07-23)
+## [0.61.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.61.2...@carbon/ibm-cloud-cognitive@0.61.3) (2021-07-23)
 
 ### Bug Fixes
 
 - page header tests 100 percent
-  ([#1069](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1069))
-  ([3d025eb](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3d025ebf81dc4efd87b573490f87ed8969710466))
+  ([#1069](https://github.com/carbon-design-system/ibm-products/issues/1069))
+  ([3d025eb](https://github.com/carbon-design-system/ibm-products/commit/3d025ebf81dc4efd87b573490f87ed8969710466))
 
-## [0.61.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.61.1...@carbon/ibm-cloud-cognitive@0.61.2) (2021-07-23)
+## [0.61.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.61.1...@carbon/ibm-cloud-cognitive@0.61.2) (2021-07-23)
 
 ### Bug Fixes
 
 - **SidePanel:** title animation bug addressed, missing default value
-  ([#1064](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1064))
-  ([40cc4a6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/40cc4a6b285c41125f4e8f85c6f38e0b25dcbd7f))
+  ([#1064](https://github.com/carbon-design-system/ibm-products/issues/1064))
+  ([40cc4a6](https://github.com/carbon-design-system/ibm-products/commit/40cc4a6b285c41125f4e8f85c6f38e0b25dcbd7f))
 
-## [0.61.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.61.0...@carbon/ibm-cloud-cognitive@0.61.1) (2021-07-23)
+## [0.61.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.61.0...@carbon/ibm-cloud-cognitive@0.61.1) (2021-07-23)
 
 ### Bug Fixes
 
 - page header title breadcrumb
-  ([#1063](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1063))
-  ([fe5291f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fe5291f52e42d6d0532264f866e8d53602f0b8d3))
+  ([#1063](https://github.com/carbon-design-system/ibm-products/issues/1063))
+  ([fe5291f](https://github.com/carbon-design-system/ibm-products/commit/fe5291f52e42d6d0532264f866e8d53602f0b8d3))
 
-# [0.61.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.60.0...@carbon/ibm-cloud-cognitive@0.61.0) (2021-07-23)
+# [0.61.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.60.0...@carbon/ibm-cloud-cognitive@0.61.0) (2021-07-23)
 
 ### Features
 
 - **PageHeader:** update for change to BreadcrumbWithOverflow props
-  ([#1053](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1053))
-  ([f6669e8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f6669e8d80d4358b19a629a92d11161ec51536c2))
+  ([#1053](https://github.com/carbon-design-system/ibm-products/issues/1053))
+  ([f6669e8](https://github.com/carbon-design-system/ibm-products/commit/f6669e8d80d4358b19a629a92d11161ec51536c2))
 
-# [0.60.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.59.0...@carbon/ibm-cloud-cognitive@0.60.0) (2021-07-22)
+# [0.60.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.59.0...@carbon/ibm-cloud-cognitive@0.60.0) (2021-07-22)
 
 ### Features
 
 - **CreateTearsheet:**
-  [#1028](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1028)
+  [#1028](https://github.com/carbon-design-system/ibm-products/issues/1028)
   create tearsheet step add onmount prop
-  ([#1050](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1050))
-  ([1e6238a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1e6238ad19e6b6fc9759faf00152852c267285b1))
+  ([#1050](https://github.com/carbon-design-system/ibm-products/issues/1050))
+  ([1e6238a](https://github.com/carbon-design-system/ibm-products/commit/1e6238ad19e6b6fc9759faf00152852c267285b1))
 
-# [0.59.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.58.1...@carbon/ibm-cloud-cognitive@0.59.0) (2021-07-22)
+# [0.59.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.58.1...@carbon/ibm-cloud-cognitive@0.59.0) (2021-07-22)
 
 ### Features
 
 - change to breadcrumbs shape
-  ([#1047](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1047))
-  ([1205fc8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1205fc88771761ef37cc8328ef7ef71e08cdeb78))
+  ([#1047](https://github.com/carbon-design-system/ibm-products/issues/1047))
+  ([1205fc8](https://github.com/carbon-design-system/ibm-products/commit/1205fc88771761ef37cc8328ef7ef71e08cdeb78))
 
-## [0.58.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.58.0...@carbon/ibm-cloud-cognitive@0.58.1) (2021-07-22)
+## [0.58.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.58.0...@carbon/ibm-cloud-cognitive@0.58.1) (2021-07-22)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.58.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.57.6...@carbon/ibm-cloud-cognitive@0.58.0) (2021-07-21)
+# [0.58.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.57.6...@carbon/ibm-cloud-cognitive@0.58.0) (2021-07-21)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#1037](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1037))
-  ([8c5937a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8c5937a865d3a0cfbaf33b9eca13c4d3b4c1365d))
+  ([#1037](https://github.com/carbon-design-system/ibm-products/issues/1037))
+  ([8c5937a](https://github.com/carbon-design-system/ibm-products/commit/8c5937a865d3a0cfbaf33b9eca13c4d3b4c1365d))
 
-## [0.57.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.57.5...@carbon/ibm-cloud-cognitive@0.57.6) (2021-07-21)
+## [0.57.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.57.5...@carbon/ibm-cloud-cognitive@0.57.6) (2021-07-21)
 
 ### Bug Fixes
 
 - available space dep and copyright
-  ([#1039](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1039))
-  ([e6e9a42](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e6e9a4222ec6f9920689b5cd74fbf03b27430781))
+  ([#1039](https://github.com/carbon-design-system/ibm-products/issues/1039))
+  ([e6e9a42](https://github.com/carbon-design-system/ibm-products/commit/e6e9a4222ec6f9920689b5cd74fbf03b27430781))
 
-## [0.57.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.57.4...@carbon/ibm-cloud-cognitive@0.57.5) (2021-07-21)
+## [0.57.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.57.4...@carbon/ibm-cloud-cognitive@0.57.5) (2021-07-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.57.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.57.3...@carbon/ibm-cloud-cognitive@0.57.4) (2021-07-21)
+## [0.57.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.57.3...@carbon/ibm-cloud-cognitive@0.57.4) (2021-07-21)
 
 ### Bug Fixes
 
 - remove deprecated props from stories
-  ([#1033](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1033))
-  ([89bc2a3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/89bc2a3a4e4e7befe69bbe0eced3a31c005a61eb))
+  ([#1033](https://github.com/carbon-design-system/ibm-products/issues/1033))
+  ([89bc2a3](https://github.com/carbon-design-system/ibm-products/commit/89bc2a3a4e4e7befe69bbe0eced3a31c005a61eb))
 
-## [0.57.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.57.2...@carbon/ibm-cloud-cognitive@0.57.3) (2021-07-21)
+## [0.57.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.57.2...@carbon/ibm-cloud-cognitive@0.57.3) (2021-07-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.57.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.57.1...@carbon/ibm-cloud-cognitive@0.57.2) (2021-07-21)
+## [0.57.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.57.1...@carbon/ibm-cloud-cognitive@0.57.2) (2021-07-21)
 
 ### Bug Fixes
 
 - **about-modal:** align copyright and legal text color with design
-  ([#1038](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1038))
-  ([6dbd605](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6dbd605aca7f6bc0218f5a5489d2c657399f2dc0))
+  ([#1038](https://github.com/carbon-design-system/ibm-products/issues/1038))
+  ([6dbd605](https://github.com/carbon-design-system/ibm-products/commit/6dbd605aca7f6bc0218f5a5489d2c657399f2dc0))
 
-## [0.57.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.57.0...@carbon/ibm-cloud-cognitive@0.57.1) (2021-07-20)
+## [0.57.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.57.0...@carbon/ibm-cloud-cognitive@0.57.1) (2021-07-20)
 
 ### Bug Fixes
 
 - **about-modal:** prevent `p` browser defaults with no CSS reset
-  ([#1034](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1034))
-  ([cf0ae3a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/cf0ae3a5a20295c6889b20d1023d6334b8482f6d))
+  ([#1034](https://github.com/carbon-design-system/ibm-products/issues/1034))
+  ([cf0ae3a](https://github.com/carbon-design-system/ibm-products/commit/cf0ae3a5a20295c6889b20d1023d6334b8482f6d))
 
-# [0.57.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.56.3...@carbon/ibm-cloud-cognitive@0.57.0) (2021-07-20)
+# [0.57.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.56.3...@carbon/ibm-cloud-cognitive@0.57.0) (2021-07-20)
 
 ### Features
 
 - further page header review updates
-  ([#1030](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1030))
-  ([a350229](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a3502291e54108e63be2919e7914525712ed65a2))
+  ([#1030](https://github.com/carbon-design-system/ibm-products/issues/1030))
+  ([a350229](https://github.com/carbon-design-system/ibm-products/commit/a3502291e54108e63be2919e7914525712ed65a2))
 
-## [0.56.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.56.2...@carbon/ibm-cloud-cognitive@0.56.3) (2021-07-20)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.56.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.56.1...@carbon/ibm-cloud-cognitive@0.56.2) (2021-07-19)
+## [0.56.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.56.2...@carbon/ibm-cloud-cognitive@0.56.3) (2021-07-20)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.56.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.56.0...@carbon/ibm-cloud-cognitive@0.56.1) (2021-07-19)
+## [0.56.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.56.1...@carbon/ibm-cloud-cognitive@0.56.2) (2021-07-19)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.56.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.56.0...@carbon/ibm-cloud-cognitive@0.56.1) (2021-07-19)
 
 ### Bug Fixes
 
 - card updates
-  ([#1013](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1013))
-  ([2e14d8e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2e14d8e101f73e8dfb9518c783e282c2365ef850))
+  ([#1013](https://github.com/carbon-design-system/ibm-products/issues/1013))
+  ([2e14d8e](https://github.com/carbon-design-system/ibm-products/commit/2e14d8e101f73e8dfb9518c783e282c2365ef850))
 
-# [0.56.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.55.14...@carbon/ibm-cloud-cognitive@0.56.0) (2021-07-19)
+# [0.56.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.55.14...@carbon/ibm-cloud-cognitive@0.56.0) (2021-07-19)
 
 ### Features
 
 - **CreateTearsheetNarrow:** initial component structure
-  ([#1014](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1014))
-  ([85a17b3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/85a17b329dd7e44ddb167ffa2ce34a4e30c5d227))
+  ([#1014](https://github.com/carbon-design-system/ibm-products/issues/1014))
+  ([85a17b3](https://github.com/carbon-design-system/ibm-products/commit/85a17b329dd7e44ddb167ffa2ce34a4e30c5d227))
 
-## [0.55.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.55.13...@carbon/ibm-cloud-cognitive@0.55.14) (2021-07-19)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.55.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.55.12...@carbon/ibm-cloud-cognitive@0.55.13) (2021-07-19)
+## [0.55.14](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.55.13...@carbon/ibm-cloud-cognitive@0.55.14) (2021-07-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.55.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.55.11...@carbon/ibm-cloud-cognitive@0.55.12) (2021-07-19)
+## [0.55.13](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.55.12...@carbon/ibm-cloud-cognitive@0.55.13) (2021-07-19)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.55.12](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.55.11...@carbon/ibm-cloud-cognitive@0.55.12) (2021-07-19)
 
 ### Bug Fixes
 
 - **CreateTearsheet:** toggle spacing is correct now
-  ([#1025](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1025))
-  ([a662106](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a6621069d2a08c620f96c20aad4aaf431c8061bf))
+  ([#1025](https://github.com/carbon-design-system/ibm-products/issues/1025))
+  ([a662106](https://github.com/carbon-design-system/ibm-products/commit/a6621069d2a08c620f96c20aad4aaf431c8061bf))
 
-## [0.55.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.55.10...@carbon/ibm-cloud-cognitive@0.55.11) (2021-07-19)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.55.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.55.9...@carbon/ibm-cloud-cognitive@0.55.10) (2021-07-16)
+## [0.55.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.55.10...@carbon/ibm-cloud-cognitive@0.55.11) (2021-07-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.55.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.55.8...@carbon/ibm-cloud-cognitive@0.55.9) (2021-07-16)
+## [0.55.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.55.9...@carbon/ibm-cloud-cognitive@0.55.10) (2021-07-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.55.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.55.7...@carbon/ibm-cloud-cognitive@0.55.8) (2021-07-16)
+## [0.55.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.55.8...@carbon/ibm-cloud-cognitive@0.55.9) (2021-07-16)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.55.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.55.7...@carbon/ibm-cloud-cognitive@0.55.8) (2021-07-16)
 
 ### Bug Fixes
 
 - add interactive tag styling to overflow tag in TagSet
-  ([#1022](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1022))
-  ([ae5c656](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ae5c656c88703a5ec50cb6bcad8541c00a78f737))
+  ([#1022](https://github.com/carbon-design-system/ibm-products/issues/1022))
+  ([ae5c656](https://github.com/carbon-design-system/ibm-products/commit/ae5c656c88703a5ec50cb6bcad8541c00a78f737))
 
-## [0.55.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.55.6...@carbon/ibm-cloud-cognitive@0.55.7) (2021-07-16)
+## [0.55.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.55.6...@carbon/ibm-cloud-cognitive@0.55.7) (2021-07-16)
 
 ### Bug Fixes
 
 - renderIcon type in page header
-  ([#1010](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1010))
-  ([0235762](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0235762486382d7c8c481b58619170b98f79aec5))
+  ([#1010](https://github.com/carbon-design-system/ibm-products/issues/1010))
+  ([0235762](https://github.com/carbon-design-system/ibm-products/commit/0235762486382d7c8c481b58619170b98f79aec5))
 
-## [0.55.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.55.5...@carbon/ibm-cloud-cognitive@0.55.6) (2021-07-16)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.55.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.55.4...@carbon/ibm-cloud-cognitive@0.55.5) (2021-07-16)
+## [0.55.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.55.5...@carbon/ibm-cloud-cognitive@0.55.6) (2021-07-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.55.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.55.3...@carbon/ibm-cloud-cognitive@0.55.4) (2021-07-16)
+## [0.55.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.55.4...@carbon/ibm-cloud-cognitive@0.55.5) (2021-07-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.55.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.55.2...@carbon/ibm-cloud-cognitive@0.55.3) (2021-07-15)
+## [0.55.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.55.3...@carbon/ibm-cloud-cognitive@0.55.4) (2021-07-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.55.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.55.1...@carbon/ibm-cloud-cognitive@0.55.2) (2021-07-15)
+## [0.55.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.55.2...@carbon/ibm-cloud-cognitive@0.55.3) (2021-07-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.55.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.55.0...@carbon/ibm-cloud-cognitive@0.55.1) (2021-07-15)
+## [0.55.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.55.1...@carbon/ibm-cloud-cognitive@0.55.2) (2021-07-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.55.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.54.2...@carbon/ibm-cloud-cognitive@0.55.0) (2021-07-14)
+## [0.55.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.55.0...@carbon/ibm-cloud-cognitive@0.55.1) (2021-07-15)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+# [0.55.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.54.2...@carbon/ibm-cloud-cognitive@0.55.0) (2021-07-14)
 
 ### Features
 
 - update Carbon versions and package dependencies
-  ([#994](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/994))
-  ([2ab4845](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2ab4845511573b999d41fcf77e6d412e0d446b9d))
+  ([#994](https://github.com/carbon-design-system/ibm-products/issues/994))
+  ([2ab4845](https://github.com/carbon-design-system/ibm-products/commit/2ab4845511573b999d41fcf77e6d412e0d446b9d))
 
-## [0.54.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.54.1...@carbon/ibm-cloud-cognitive@0.54.2) (2021-07-14)
+## [0.54.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.54.1...@carbon/ibm-cloud-cognitive@0.54.2) (2021-07-14)
 
 ### Bug Fixes
 
 - revert to button kind
-  ([#995](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/995))
-  ([8740afd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8740afdb578cb7ec57eba4abfae44b2ca7c81068))
+  ([#995](https://github.com/carbon-design-system/ibm-products/issues/995))
+  ([8740afd](https://github.com/carbon-design-system/ibm-products/commit/8740afdb578cb7ec57eba4abfae44b2ca7c81068))
 
-## [0.54.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.54.0...@carbon/ibm-cloud-cognitive@0.54.1) (2021-07-14)
+## [0.54.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.54.0...@carbon/ibm-cloud-cognitive@0.54.1) (2021-07-14)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.54.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.53.2...@carbon/ibm-cloud-cognitive@0.54.0) (2021-07-14)
+# [0.54.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.53.2...@carbon/ibm-cloud-cognitive@0.54.0) (2021-07-14)
 
 ### Features
 
 - address review issues
-  ([#989](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/989))
-  ([e3abcda](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e3abcda9f9031e553e2e9b2374bff3848b15fef4))
+  ([#989](https://github.com/carbon-design-system/ibm-products/issues/989))
+  ([e3abcda](https://github.com/carbon-design-system/ibm-products/commit/e3abcda9f9031e553e2e9b2374bff3848b15fef4))
 - remove child support
-  ([#992](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/992))
-  ([b5e4f3b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b5e4f3b3a05b09225a0da5ac8982f1391986a9af))
+  ([#992](https://github.com/carbon-design-system/ibm-products/issues/992))
+  ([b5e4f3b](https://github.com/carbon-design-system/ibm-products/commit/b5e4f3b3a05b09225a0da5ac8982f1391986a9af))
 
-## [0.53.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.53.1...@carbon/ibm-cloud-cognitive@0.53.2) (2021-07-13)
+## [0.53.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.53.1...@carbon/ibm-cloud-cognitive@0.53.2) (2021-07-13)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.53.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.53.0...@carbon/ibm-cloud-cognitive@0.53.1) (2021-07-13)
+## [0.53.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.53.0...@carbon/ibm-cloud-cognitive@0.53.1) (2021-07-13)
 
 ### Bug Fixes
 
 - **CreateTearsheet:**
-  [#987](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/987)
+  [#987](https://github.com/carbon-design-system/ibm-products/issues/987)
   create tearsheet resizing
-  ([#988](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/988))
-  ([5f3550e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5f3550ef12665cef85b13409d438b312cb72e50b))
+  ([#988](https://github.com/carbon-design-system/ibm-products/issues/988))
+  ([5f3550e](https://github.com/carbon-design-system/ibm-products/commit/5f3550ef12665cef85b13409d438b312cb72e50b))
 
-# [0.53.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.52.5...@carbon/ibm-cloud-cognitive@0.53.0) (2021-07-13)
+# [0.53.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.52.5...@carbon/ibm-cloud-cognitive@0.53.0) (2021-07-13)
 
 ### Features
 
 - remove experimental package
-  ([#964](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/964))
-  ([063e1d1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/063e1d1b67eb15cf0a5397866a63a3b67fee8f4c))
+  ([#964](https://github.com/carbon-design-system/ibm-products/issues/964))
+  ([063e1d1](https://github.com/carbon-design-system/ibm-products/commit/063e1d1b67eb15cf0a5397866a63a3b67fee8f4c))
 
-## [0.52.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.52.4...@carbon/ibm-cloud-cognitive@0.52.5) (2021-07-13)
+## [0.52.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.52.4...@carbon/ibm-cloud-cognitive@0.52.5) (2021-07-13)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.52.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.52.3...@carbon/ibm-cloud-cognitive@0.52.4) (2021-07-12)
+## [0.52.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.52.3...@carbon/ibm-cloud-cognitive@0.52.4) (2021-07-12)
 
 ### Bug Fixes
 
 - updates to card tests
-  ([#972](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/972))
-  ([c39e763](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c39e763ac961d64ea27f2c5375ddaccfc5ac962c))
+  ([#972](https://github.com/carbon-design-system/ibm-products/issues/972))
+  ([c39e763](https://github.com/carbon-design-system/ibm-products/commit/c39e763ac961d64ea27f2c5375ddaccfc5ac962c))
 
-## [0.52.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.52.2...@carbon/ibm-cloud-cognitive@0.52.3) (2021-07-12)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.52.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.52.1...@carbon/ibm-cloud-cognitive@0.52.2) (2021-07-08)
+## [0.52.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.52.2...@carbon/ibm-cloud-cognitive@0.52.3) (2021-07-12)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.52.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.52.0...@carbon/ibm-cloud-cognitive@0.52.1) (2021-07-08)
+## [0.52.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.52.1...@carbon/ibm-cloud-cognitive@0.52.2) (2021-07-08)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.52.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.51.6...@carbon/ibm-cloud-cognitive@0.52.0) (2021-07-07)
+## [0.52.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.52.0...@carbon/ibm-cloud-cognitive@0.52.1) (2021-07-08)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+# [0.52.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.51.6...@carbon/ibm-cloud-cognitive@0.52.0) (2021-07-07)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#974](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/974))
-  ([555509b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/555509b5ccb147ed0d794b5816f685aa8f7ae451))
+  ([#974](https://github.com/carbon-design-system/ibm-products/issues/974))
+  ([555509b](https://github.com/carbon-design-system/ibm-products/commit/555509b5ccb147ed0d794b5816f685aa8f7ae451))
 
-## [0.51.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.51.5...@carbon/ibm-cloud-cognitive@0.51.6) (2021-07-07)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.51.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.51.4...@carbon/ibm-cloud-cognitive@0.51.5) (2021-07-07)
+## [0.51.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.51.5...@carbon/ibm-cloud-cognitive@0.51.6) (2021-07-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.51.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.51.3...@carbon/ibm-cloud-cognitive@0.51.4) (2021-07-07)
+## [0.51.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.51.4...@carbon/ibm-cloud-cognitive@0.51.5) (2021-07-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.51.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.51.2...@carbon/ibm-cloud-cognitive@0.51.3) (2021-07-07)
+## [0.51.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.51.3...@carbon/ibm-cloud-cognitive@0.51.4) (2021-07-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.51.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.51.1...@carbon/ibm-cloud-cognitive@0.51.2) (2021-07-07)
+## [0.51.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.51.2...@carbon/ibm-cloud-cognitive@0.51.3) (2021-07-07)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.51.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.51.1...@carbon/ibm-cloud-cognitive@0.51.2) (2021-07-07)
 
 ### Bug Fixes
 
 - **SidePanel:** allow animation to complete when scroll length is short
-  ([#970](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/970))
-  ([ac894a5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ac894a50bdc4a0b636adb8e6e2f5ea0a52d3e0ed))
+  ([#970](https://github.com/carbon-design-system/ibm-products/issues/970))
+  ([ac894a5](https://github.com/carbon-design-system/ibm-products/commit/ac894a50bdc4a0b636adb8e6e2f5ea0a52d3e0ed))
 
-## [0.51.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.51.0...@carbon/ibm-cloud-cognitive@0.51.1) (2021-07-06)
+## [0.51.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.51.0...@carbon/ibm-cloud-cognitive@0.51.1) (2021-07-06)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.51.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.50.11...@carbon/ibm-cloud-cognitive@0.51.0) (2021-07-06)
+# [0.51.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.50.11...@carbon/ibm-cloud-cognitive@0.51.0) (2021-07-06)
 
 ### Features
 
 - add closeIconDescription required prop to AboutModal
-  ([#968](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/968))
-  ([2619256](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/261925676ab4775fe947dc39f40701a8fbfe6779))
+  ([#968](https://github.com/carbon-design-system/ibm-products/issues/968))
+  ([2619256](https://github.com/carbon-design-system/ibm-products/commit/261925676ab4775fe947dc39f40701a8fbfe6779))
 
-## [0.50.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.50.10...@carbon/ibm-cloud-cognitive@0.50.11) (2021-07-06)
+## [0.50.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.50.10...@carbon/ibm-cloud-cognitive@0.50.11) (2021-07-06)
 
 ### Bug Fixes
 
 - **SidePanel:** fix back button positioning
-  ([#969](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/969))
-  ([34e7442](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/34e744254ce95c63779ca614bcaa8c2e4fe70309))
+  ([#969](https://github.com/carbon-design-system/ibm-products/issues/969))
+  ([34e7442](https://github.com/carbon-design-system/ibm-products/commit/34e744254ce95c63779ca614bcaa8c2e4fe70309))
 
-## [0.50.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.50.9...@carbon/ibm-cloud-cognitive@0.50.10) (2021-07-02)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.50.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.50.8...@carbon/ibm-cloud-cognitive@0.50.9) (2021-07-01)
+## [0.50.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.50.9...@carbon/ibm-cloud-cognitive@0.50.10) (2021-07-02)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.50.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.50.7...@carbon/ibm-cloud-cognitive@0.50.8) (2021-07-01)
+## [0.50.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.50.8...@carbon/ibm-cloud-cognitive@0.50.9) (2021-07-01)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.50.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.50.7...@carbon/ibm-cloud-cognitive@0.50.8) (2021-07-01)
 
 ### Bug Fixes
 
 - card refactor to multiple exports
-  ([#949](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/949))
-  ([e60fa76](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e60fa76963b3027aafa4a8a87e188c9dd5ab54b0))
+  ([#949](https://github.com/carbon-design-system/ibm-products/issues/949))
+  ([e60fa76](https://github.com/carbon-design-system/ibm-products/commit/e60fa76963b3027aafa4a8a87e188c9dd5ab54b0))
 - contributors
-  ([#960](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/960))
-  ([02966c3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/02966c30bf253a4bf4eb601fd928d1970c55a76f))
+  ([#960](https://github.com/carbon-design-system/ibm-products/issues/960))
+  ([02966c3](https://github.com/carbon-design-system/ibm-products/commit/02966c30bf253a4bf4eb601fd928d1970c55a76f))
 - update package readme with usage
-  ([#951](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/951))
-  ([f5b9a84](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f5b9a8433dfa866ec29f4a28267f1f86407db1eb))
+  ([#951](https://github.com/carbon-design-system/ibm-products/issues/951))
+  ([f5b9a84](https://github.com/carbon-design-system/ibm-products/commit/f5b9a8433dfa866ec29f4a28267f1f86407db1eb))
 
-## [0.50.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.50.6...@carbon/ibm-cloud-cognitive@0.50.7) (2021-07-01)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.50.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.50.5...@carbon/ibm-cloud-cognitive@0.50.6) (2021-07-01)
+## [0.50.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.50.6...@carbon/ibm-cloud-cognitive@0.50.7) (2021-07-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.50.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.50.4...@carbon/ibm-cloud-cognitive@0.50.5) (2021-06-30)
+## [0.50.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.50.5...@carbon/ibm-cloud-cognitive@0.50.6) (2021-07-01)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.50.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.50.4...@carbon/ibm-cloud-cognitive@0.50.5) (2021-06-30)
 
 ### Bug Fixes
 
 - **NotificationsPanel:** add prop to set defaultToggled value
-  ([#956](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/956))
-  ([4f92e2a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4f92e2a537bc210b86c2682bd8899a95e2693e5d))
+  ([#956](https://github.com/carbon-design-system/ibm-products/issues/956))
+  ([4f92e2a](https://github.com/carbon-design-system/ibm-products/commit/4f92e2a537bc210b86c2682bd8899a95e2693e5d))
 
-## [0.50.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.50.3...@carbon/ibm-cloud-cognitive@0.50.4) (2021-06-30)
+## [0.50.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.50.3...@carbon/ibm-cloud-cognitive@0.50.4) (2021-06-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.50.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.50.2...@carbon/ibm-cloud-cognitive@0.50.3) (2021-06-30)
+## [0.50.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.50.2...@carbon/ibm-cloud-cognitive@0.50.3) (2021-06-30)
 
 ### Bug Fixes
 
 - **CreateTearsheet:** allow progress steps to receive a secondary label
-  ([#945](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/945))
-  ([ff0ba7f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ff0ba7fb442e879541dbb268bc6c5ba3eff46786))
+  ([#945](https://github.com/carbon-design-system/ibm-products/issues/945))
+  ([ff0ba7f](https://github.com/carbon-design-system/ibm-products/commit/ff0ba7fb442e879541dbb268bc6c5ba3eff46786))
 
-## [0.50.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.50.1...@carbon/ibm-cloud-cognitive@0.50.2) (2021-06-29)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.50.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.50.0...@carbon/ibm-cloud-cognitive@0.50.1) (2021-06-25)
+## [0.50.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.50.1...@carbon/ibm-cloud-cognitive@0.50.2) (2021-06-29)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.50.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.49.4...@carbon/ibm-cloud-cognitive@0.50.0) (2021-06-25)
+## [0.50.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.50.0...@carbon/ibm-cloud-cognitive@0.50.1) (2021-06-25)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+# [0.50.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.49.4...@carbon/ibm-cloud-cognitive@0.50.0) (2021-06-25)
 
 ### Features
 
 - release TagSet
-  ([#937](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/937))
-  ([e920bf5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e920bf5b8cb78a86cc51805c0d26c9bd01aeb71e))
+  ([#937](https://github.com/carbon-design-system/ibm-products/issues/937))
+  ([e920bf5](https://github.com/carbon-design-system/ibm-products/commit/e920bf5b8cb78a86cc51805c0d26c9bd01aeb71e))
 
-## [0.49.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.49.3...@carbon/ibm-cloud-cognitive@0.49.4) (2021-06-24)
+## [0.49.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.49.3...@carbon/ibm-cloud-cognitive@0.49.4) (2021-06-24)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.49.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.49.2...@carbon/ibm-cloud-cognitive@0.49.3) (2021-06-24)
+## [0.49.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.49.2...@carbon/ibm-cloud-cognitive@0.49.3) (2021-06-24)
 
 ### Bug Fixes
 
 - **SidePanel:** make title/subtitle fixed when no title animation
-  ([#933](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/933))
-  ([18c097d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/18c097d8d590d52eb0527eed7de1c4b3786751ca))
+  ([#933](https://github.com/carbon-design-system/ibm-products/issues/933))
+  ([18c097d](https://github.com/carbon-design-system/ibm-products/commit/18c097d8d590d52eb0527eed7de1c4b3786751ca))
 
-## [0.49.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.49.1...@carbon/ibm-cloud-cognitive@0.49.2) (2021-06-24)
+## [0.49.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.49.1...@carbon/ibm-cloud-cognitive@0.49.2) (2021-06-24)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.49.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.49.0...@carbon/ibm-cloud-cognitive@0.49.1) (2021-06-24)
+## [0.49.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.49.0...@carbon/ibm-cloud-cognitive@0.49.1) (2021-06-24)
 
 ### Bug Fixes
 
 - typo in property name
-  ([#929](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/929))
-  ([83e7137](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/83e713705800a072d931b4046fa0509950eabb2b))
+  ([#929](https://github.com/carbon-design-system/ibm-products/issues/929))
+  ([83e7137](https://github.com/carbon-design-system/ibm-products/commit/83e713705800a072d931b4046fa0509950eabb2b))
 
-# [0.49.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.48.0...@carbon/ibm-cloud-cognitive@0.49.0) (2021-06-23)
+# [0.49.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.48.0...@carbon/ibm-cloud-cognitive@0.49.0) (2021-06-23)
 
 ### Features
 
 - remove context header from ccs storybook
-  ([#892](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/892))
-  ([14a1c52](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/14a1c524bc9fe379072e9a55f215aaf06a4a5341))
+  ([#892](https://github.com/carbon-design-system/ibm-products/issues/892))
+  ([14a1c52](https://github.com/carbon-design-system/ibm-products/commit/14a1c524bc9fe379072e9a55f215aaf06a4a5341))
 
-# [0.48.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.47.8...@carbon/ibm-cloud-cognitive@0.48.0) (2021-06-23)
+# [0.48.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.47.8...@carbon/ibm-cloud-cognitive@0.48.0) (2021-06-23)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#927](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/927))
-  ([5a8f7d6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5a8f7d6b81b6da26fd0cb933c1c3de4bd27b481b))
+  ([#927](https://github.com/carbon-design-system/ibm-products/issues/927))
+  ([5a8f7d6](https://github.com/carbon-design-system/ibm-products/commit/5a8f7d6b81b6da26fd0cb933c1c3de4bd27b481b))
 
-## [0.47.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.47.7...@carbon/ibm-cloud-cognitive@0.47.8) (2021-06-23)
+## [0.47.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.47.7...@carbon/ibm-cloud-cognitive@0.47.8) (2021-06-23)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.47.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.47.6...@carbon/ibm-cloud-cognitive@0.47.7) (2021-06-22)
+## [0.47.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.47.6...@carbon/ibm-cloud-cognitive@0.47.7) (2021-06-22)
 
 ### Bug Fixes
 
 - **CreateTearsheet:** remove overflow styles
-  ([#924](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/924))
-  ([369329a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/369329a34cd3ea45ae8e4c21938d358a78fd92cb))
+  ([#924](https://github.com/carbon-design-system/ibm-products/issues/924))
+  ([369329a](https://github.com/carbon-design-system/ibm-products/commit/369329a34cd3ea45ae8e4c21938d358a78fd92cb))
 
-## [0.47.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.47.5...@carbon/ibm-cloud-cognitive@0.47.6) (2021-06-22)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.47.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.47.4...@carbon/ibm-cloud-cognitive@0.47.5) (2021-06-22)
+## [0.47.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.47.5...@carbon/ibm-cloud-cognitive@0.47.6) (2021-06-22)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.47.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.47.3...@carbon/ibm-cloud-cognitive@0.47.4) (2021-06-21)
+## [0.47.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.47.4...@carbon/ibm-cloud-cognitive@0.47.5) (2021-06-22)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.47.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.47.2...@carbon/ibm-cloud-cognitive@0.47.3) (2021-06-21)
+## [0.47.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.47.3...@carbon/ibm-cloud-cognitive@0.47.4) (2021-06-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.47.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.47.1...@carbon/ibm-cloud-cognitive@0.47.2) (2021-06-21)
+## [0.47.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.47.2...@carbon/ibm-cloud-cognitive@0.47.3) (2021-06-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.47.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.47.0...@carbon/ibm-cloud-cognitive@0.47.1) (2021-06-20)
+## [0.47.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.47.1...@carbon/ibm-cloud-cognitive@0.47.2) (2021-06-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.47.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.46.1...@carbon/ibm-cloud-cognitive@0.47.0) (2021-06-18)
+## [0.47.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.47.0...@carbon/ibm-cloud-cognitive@0.47.1) (2021-06-20)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+# [0.47.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.46.1...@carbon/ibm-cloud-cognitive@0.47.0) (2021-06-18)
 
 ### Features
 
 - **CreateTearsheet:** add animation on step changes
-  ([#885](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/885))
-  ([d72c825](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d72c8250cc96a16ed76076ab4dd3a7c19cd0f5a2))
+  ([#885](https://github.com/carbon-design-system/ibm-products/issues/885))
+  ([d72c825](https://github.com/carbon-design-system/ibm-products/commit/d72c8250cc96a16ed76076ab4dd3a7c19cd0f5a2))
 
-## [0.46.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.46.0...@carbon/ibm-cloud-cognitive@0.46.1) (2021-06-18)
+## [0.46.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.46.0...@carbon/ibm-cloud-cognitive@0.46.1) (2021-06-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.46.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.45.4...@carbon/ibm-cloud-cognitive@0.46.0) (2021-06-17)
+# [0.46.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.45.4...@carbon/ibm-cloud-cognitive@0.46.0) (2021-06-17)
 
 ### Features
 
 - tagset review updates part 2
-  ([#907](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/907))
-  ([fbe3143](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fbe3143b12abb3d87b6e79eb668014a2015cc9cc))
+  ([#907](https://github.com/carbon-design-system/ibm-products/issues/907))
+  ([fbe3143](https://github.com/carbon-design-system/ibm-products/commit/fbe3143b12abb3d87b6e79eb668014a2015cc9cc))
 
-## [0.45.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.45.3...@carbon/ibm-cloud-cognitive@0.45.4) (2021-06-17)
+## [0.45.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.45.3...@carbon/ibm-cloud-cognitive@0.45.4) (2021-06-17)
 
 ### Bug Fixes
 
 - apikey modal pre release updates
-  ([#906](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/906))
-  ([6ae80e4](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6ae80e4ba115acb0ed534ccdf5efe6faa15f80e5))
+  ([#906](https://github.com/carbon-design-system/ibm-products/issues/906))
+  ([6ae80e4](https://github.com/carbon-design-system/ibm-products/commit/6ae80e4ba115acb0ed534ccdf5efe6faa15f80e5))
 
-## [0.45.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.45.2...@carbon/ibm-cloud-cognitive@0.45.3) (2021-06-17)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.45.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.45.1...@carbon/ibm-cloud-cognitive@0.45.2) (2021-06-16)
+## [0.45.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.45.2...@carbon/ibm-cloud-cognitive@0.45.3) (2021-06-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.45.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.45.0...@carbon/ibm-cloud-cognitive@0.45.1) (2021-06-15)
+## [0.45.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.45.1...@carbon/ibm-cloud-cognitive@0.45.2) (2021-06-16)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.45.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.45.0...@carbon/ibm-cloud-cognitive@0.45.1) (2021-06-15)
 
 ### Bug Fixes
 
 - **HTTPErrors:** remove canary check on http error content component
-  ([#900](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/900))
-  ([e6e394a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e6e394a4e90d3bfda58489a9a5687e0499215fb9))
+  ([#900](https://github.com/carbon-design-system/ibm-products/issues/900))
+  ([e6e394a](https://github.com/carbon-design-system/ibm-products/commit/e6e394a4e90d3bfda58489a9a5687e0499215fb9))
 
-# [0.45.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.44.0...@carbon/ibm-cloud-cognitive@0.45.0) (2021-06-15)
+# [0.45.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.44.0...@carbon/ibm-cloud-cognitive@0.45.0) (2021-06-15)
 
 ### Features
 
 - breadcrumb overflow title and href updates
-  ([#898](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/898))
-  ([290198b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/290198bdd078060f4a91bb6c27904aa17ce21b7b))
+  ([#898](https://github.com/carbon-design-system/ibm-products/issues/898))
+  ([290198b](https://github.com/carbon-design-system/ibm-products/commit/290198bdd078060f4a91bb6c27904aa17ce21b7b))
 
-# [0.44.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.43.1...@carbon/ibm-cloud-cognitive@0.44.0) (2021-06-15)
+# [0.44.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.43.1...@carbon/ibm-cloud-cognitive@0.44.0) (2021-06-15)
 
 ### Features
 
 - simplified carbon token value in js
-  ([#894](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/894))
-  ([a225eee](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a225eee68364554f62f1f41889164c3f0e48e645))
+  ([#894](https://github.com/carbon-design-system/ibm-products/issues/894))
+  ([a225eee](https://github.com/carbon-design-system/ibm-products/commit/a225eee68364554f62f1f41889164c3f0e48e645))
 
-## [0.43.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.43.0...@carbon/ibm-cloud-cognitive@0.43.1) (2021-06-15)
+## [0.43.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.43.0...@carbon/ibm-cloud-cognitive@0.43.1) (2021-06-15)
 
 ### Bug Fixes
 
 - page header performance glitches
-  ([#896](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/896))
-  ([57eae46](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/57eae4653f3b9efbe1218ad947ff6141760f0c14))
+  ([#896](https://github.com/carbon-design-system/ibm-products/issues/896))
+  ([57eae46](https://github.com/carbon-design-system/ibm-products/commit/57eae4653f3b9efbe1218ad947ff6141760f0c14))
 
-# [0.43.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.42.9...@carbon/ibm-cloud-cognitive@0.43.0) (2021-06-11)
+# [0.43.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.42.9...@carbon/ibm-cloud-cognitive@0.43.0) (2021-06-11)
 
 ### Features
 
 - update page header sticky again
-  ([#891](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/891))
-  ([b69ec15](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b69ec1597640bef2e15f166c170f002b7fb727a0))
+  ([#891](https://github.com/carbon-design-system/ibm-products/issues/891))
+  ([b69ec15](https://github.com/carbon-design-system/ibm-products/commit/b69ec1597640bef2e15f166c170f002b7fb727a0))
 
-## [0.42.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.42.8...@carbon/ibm-cloud-cognitive@0.42.9) (2021-06-11)
+## [0.42.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.42.8...@carbon/ibm-cloud-cognitive@0.42.9) (2021-06-11)
 
 ### Bug Fixes
 
 - **SidePanel:** add default subtitle height value
-  ([#889](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/889))
-  ([d7c61ae](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d7c61ae118e7c4eb9217f50d0d90bebef81fc4c8))
+  ([#889](https://github.com/carbon-design-system/ibm-products/issues/889))
+  ([d7c61ae](https://github.com/carbon-design-system/ibm-products/commit/d7c61ae118e7c4eb9217f50d0d90bebef81fc4c8))
 
-## [0.42.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.42.7...@carbon/ibm-cloud-cognitive@0.42.8) (2021-06-10)
+## [0.42.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.42.7...@carbon/ibm-cloud-cognitive@0.42.8) (2021-06-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.42.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.42.6...@carbon/ibm-cloud-cognitive@0.42.7) (2021-06-10)
+## [0.42.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.42.6...@carbon/ibm-cloud-cognitive@0.42.7) (2021-06-10)
 
 ### Bug Fixes
 
 - import review updates
-  ([#872](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/872))
-  ([fbe0ce6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fbe0ce61a5435061255e4a30bee3b3a785b7659f))
+  ([#872](https://github.com/carbon-design-system/ibm-products/issues/872))
+  ([fbe0ce6](https://github.com/carbon-design-system/ibm-products/commit/fbe0ce61a5435061255e4a30bee3b3a785b7659f))
 
-## [0.42.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.42.5...@carbon/ibm-cloud-cognitive@0.42.6) (2021-06-10)
+## [0.42.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.42.5...@carbon/ibm-cloud-cognitive@0.42.6) (2021-06-10)
 
 ### Bug Fixes
 
 - page header styling on scroll
-  ([#881](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/881))
-  ([da5a472](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/da5a472e0ecef94be5d6157dcb55b640c76bbf23))
+  ([#881](https://github.com/carbon-design-system/ibm-products/issues/881))
+  ([da5a472](https://github.com/carbon-design-system/ibm-products/commit/da5a472e0ecef94be5d6157dcb55b640c76bbf23))
 
-## [0.42.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.42.4...@carbon/ibm-cloud-cognitive@0.42.5) (2021-06-10)
+## [0.42.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.42.4...@carbon/ibm-cloud-cognitive@0.42.5) (2021-06-10)
 
 ### Bug Fixes
 
 - breadcrumb overflow in page header
-  ([#880](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/880))
-  ([fa71aa3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fa71aa39c4666efadb47c02fd85c6bfe97515284))
+  ([#880](https://github.com/carbon-design-system/ibm-products/issues/880))
+  ([fa71aa3](https://github.com/carbon-design-system/ibm-products/commit/fa71aa39c4666efadb47c02fd85c6bfe97515284))
 
-## [0.42.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.42.3...@carbon/ibm-cloud-cognitive@0.42.4) (2021-06-10)
+## [0.42.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.42.3...@carbon/ibm-cloud-cognitive@0.42.4) (2021-06-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.42.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.42.2...@carbon/ibm-cloud-cognitive@0.42.3) (2021-06-10)
+## [0.42.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.42.2...@carbon/ibm-cloud-cognitive@0.42.3) (2021-06-10)
 
 ### Bug Fixes
 
 - button and tag set block class errors
-  ([#879](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/879))
-  ([d26966d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d26966dee8ef21d002c3d524914a1d2f8ff31818))
+  ([#879](https://github.com/carbon-design-system/ibm-products/issues/879))
+  ([d26966d](https://github.com/carbon-design-system/ibm-products/commit/d26966dee8ef21d002c3d524914a1d2f8ff31818))
 
-## [0.42.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.42.1...@carbon/ibm-cloud-cognitive@0.42.2) (2021-06-10)
+## [0.42.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.42.1...@carbon/ibm-cloud-cognitive@0.42.2) (2021-06-10)
 
 ### Bug Fixes
 
 - improve AboutModal stories
-  ([#875](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/875))
-  ([5faf934](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5faf93494a33d523330e536b150013f4e339c5ec))
+  ([#875](https://github.com/carbon-design-system/ibm-products/issues/875))
+  ([5faf934](https://github.com/carbon-design-system/ibm-products/commit/5faf93494a33d523330e536b150013f4e339c5ec))
 
-## [0.42.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.42.0...@carbon/ibm-cloud-cognitive@0.42.1) (2021-06-10)
+## [0.42.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.42.0...@carbon/ibm-cloud-cognitive@0.42.1) (2021-06-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.42.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.41.10...@carbon/ibm-cloud-cognitive@0.42.0) (2021-06-09)
+# [0.42.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.41.10...@carbon/ibm-cloud-cognitive@0.42.0) (2021-06-09)
 
 ### Features
 
 - match Carbon peer deps for react
-  ([#869](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/869))
-  ([8f42118](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8f42118754a904554acee9ec3af2e1fae8143817))
+  ([#869](https://github.com/carbon-design-system/ibm-products/issues/869))
+  ([8f42118](https://github.com/carbon-design-system/ibm-products/commit/8f42118754a904554acee9ec3af2e1fae8143817))
 
-## [0.41.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.41.9...@carbon/ibm-cloud-cognitive@0.41.10) (2021-06-09)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.41.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.41.8...@carbon/ibm-cloud-cognitive@0.41.9) (2021-06-07)
+## [0.41.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.41.9...@carbon/ibm-cloud-cognitive@0.41.10) (2021-06-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.41.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.41.7...@carbon/ibm-cloud-cognitive@0.41.8) (2021-06-07)
+## [0.41.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.41.8...@carbon/ibm-cloud-cognitive@0.41.9) (2021-06-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.41.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.41.6...@carbon/ibm-cloud-cognitive@0.41.7) (2021-06-07)
+## [0.41.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.41.7...@carbon/ibm-cloud-cognitive@0.41.8) (2021-06-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.41.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.41.5...@carbon/ibm-cloud-cognitive@0.41.6) (2021-06-04)
+## [0.41.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.41.6...@carbon/ibm-cloud-cognitive@0.41.7) (2021-06-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.41.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.41.4...@carbon/ibm-cloud-cognitive@0.41.5) (2021-06-04)
+## [0.41.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.41.5...@carbon/ibm-cloud-cognitive@0.41.6) (2021-06-04)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.41.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.41.4...@carbon/ibm-cloud-cognitive@0.41.5) (2021-06-04)
 
 ### Bug Fixes
 
 - **CreateTearsheet:** import components together
-  ([#856](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/856))
-  ([65e23ad](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/65e23adfe83c9f9652e60e00cdd19e2a696a7f32))
+  ([#856](https://github.com/carbon-design-system/ibm-products/issues/856))
+  ([65e23ad](https://github.com/carbon-design-system/ibm-products/commit/65e23adfe83c9f9652e60e00cdd19e2a696a7f32))
 
-## [0.41.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.41.3...@carbon/ibm-cloud-cognitive@0.41.4) (2021-06-04)
+## [0.41.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.41.3...@carbon/ibm-cloud-cognitive@0.41.4) (2021-06-04)
 
 ### Bug Fixes
 
 - updates to import modal for release review
-  ([#855](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/855))
-  ([48a8c35](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/48a8c350e3e21f9b5095b1199c478911fc391225))
+  ([#855](https://github.com/carbon-design-system/ibm-products/issues/855))
+  ([48a8c35](https://github.com/carbon-design-system/ibm-products/commit/48a8c350e3e21f9b5095b1199c478911fc391225))
 
-## [0.41.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.41.2...@carbon/ibm-cloud-cognitive@0.41.3) (2021-06-04)
+## [0.41.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.41.2...@carbon/ibm-cloud-cognitive@0.41.3) (2021-06-04)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.41.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.41.1...@carbon/ibm-cloud-cognitive@0.41.2) (2021-06-04)
+## [0.41.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.41.1...@carbon/ibm-cloud-cognitive@0.41.2) (2021-06-04)
 
 ### Bug Fixes
 
 - **ActionSet:** ensure action set buttons have max width none
-  ([#859](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/859))
-  ([5aba160](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5aba1609193c241d86d2a2cda99ae6dfc6f43717))
+  ([#859](https://github.com/carbon-design-system/ibm-products/issues/859))
+  ([5aba160](https://github.com/carbon-design-system/ibm-products/commit/5aba1609193c241d86d2a2cda99ae6dfc6f43717))
 
-## [0.41.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.41.0...@carbon/ibm-cloud-cognitive@0.41.1) (2021-06-03)
+## [0.41.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.41.0...@carbon/ibm-cloud-cognitive@0.41.1) (2021-06-03)
 
 ### Bug Fixes
 
 - **SidePanel:** make review fixes for release
-  ([#851](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/851))
-  ([076616a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/076616a3807279548cb1acc161f67f0a3454181a))
+  ([#851](https://github.com/carbon-design-system/ibm-products/issues/851))
+  ([076616a](https://github.com/carbon-design-system/ibm-products/commit/076616a3807279548cb1acc161f67f0a3454181a))
 
-# [0.41.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.20...@carbon/ibm-cloud-cognitive@0.41.0) (2021-06-02)
+# [0.41.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.20...@carbon/ibm-cloud-cognitive@0.41.0) (2021-06-02)
 
 ### Features
 
 - **styles:** export used Carbon style modules
-  ([#850](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/850))
-  ([b876002](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b876002d7de7131d7db3880d1b3d34330d43be48))
+  ([#850](https://github.com/carbon-design-system/ibm-products/issues/850))
+  ([b876002](https://github.com/carbon-design-system/ibm-products/commit/b876002d7de7131d7db3880d1b3d34330d43be48))
 
-## [0.40.20](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.19...@carbon/ibm-cloud-cognitive@0.40.20) (2021-06-02)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.40.19](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.18...@carbon/ibm-cloud-cognitive@0.40.19) (2021-06-02)
+## [0.40.20](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.19...@carbon/ibm-cloud-cognitive@0.40.20) (2021-06-02)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.40.18](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.17...@carbon/ibm-cloud-cognitive@0.40.18) (2021-06-01)
+## [0.40.19](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.18...@carbon/ibm-cloud-cognitive@0.40.19) (2021-06-02)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.40.17](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.16...@carbon/ibm-cloud-cognitive@0.40.17) (2021-06-01)
+## [0.40.18](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.17...@carbon/ibm-cloud-cognitive@0.40.18) (2021-06-01)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.40.17](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.16...@carbon/ibm-cloud-cognitive@0.40.17) (2021-06-01)
 
 ### Bug Fixes
 
 - **CreateTearsheet:** use default button separator color variable
-  ([#802](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/802))
-  ([8594e69](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8594e69852c746b6108b778cdc88b7b56fbd6838))
+  ([#802](https://github.com/carbon-design-system/ibm-products/issues/802))
+  ([8594e69](https://github.com/carbon-design-system/ibm-products/commit/8594e69852c746b6108b778cdc88b7b56fbd6838))
 - **SidePanel:** add validator to side panel and allPropType helper
-  ([#797](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/797))
-  ([c2262c9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c2262c9a8ac0ac57b21232dc0e943aca7f22d4ed))
+  ([#797](https://github.com/carbon-design-system/ibm-products/issues/797))
+  ([c2262c9](https://github.com/carbon-design-system/ibm-products/commit/c2262c9a8ac0ac57b21232dc0e943aca7f22d4ed))
 
-## [0.40.16](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.15...@carbon/ibm-cloud-cognitive@0.40.16) (2021-06-01)
+## [0.40.16](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.15...@carbon/ibm-cloud-cognitive@0.40.16) (2021-06-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.40.15](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.14...@carbon/ibm-cloud-cognitive@0.40.15) (2021-05-29)
+## [0.40.15](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.14...@carbon/ibm-cloud-cognitive@0.40.15) (2021-05-29)
 
 ### Bug Fixes
 
 - html element method mock
-  ([#833](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/833))
-  ([fccb061](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fccb061fafaf42b9c91c309c9363b2e745ed1b11))
+  ([#833](https://github.com/carbon-design-system/ibm-products/issues/833))
+  ([fccb061](https://github.com/carbon-design-system/ibm-products/commit/fccb061fafaf42b9c91c309c9363b2e745ed1b11))
 
-## [0.40.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.13...@carbon/ibm-cloud-cognitive@0.40.14) (2021-05-28)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.40.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.12...@carbon/ibm-cloud-cognitive@0.40.13) (2021-05-28)
+## [0.40.14](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.13...@carbon/ibm-cloud-cognitive@0.40.14) (2021-05-28)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.40.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.11...@carbon/ibm-cloud-cognitive@0.40.12) (2021-05-28)
+## [0.40.13](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.12...@carbon/ibm-cloud-cognitive@0.40.13) (2021-05-28)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.40.12](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.11...@carbon/ibm-cloud-cognitive@0.40.12) (2021-05-28)
 
 ### Bug Fixes
 
 - remove and export modal fixes
-  ([#830](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/830))
-  ([0d8a4f5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0d8a4f5d1c047b2a794a2d349693dadd891816d2))
+  ([#830](https://github.com/carbon-design-system/ibm-products/issues/830))
+  ([0d8a4f5](https://github.com/carbon-design-system/ibm-products/commit/0d8a4f5d1c047b2a794a2d349693dadd891816d2))
 
-## [0.40.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.10...@carbon/ibm-cloud-cognitive@0.40.11) (2021-05-27)
+## [0.40.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.10...@carbon/ibm-cloud-cognitive@0.40.11) (2021-05-27)
 
 ### Bug Fixes
 
 - release review updates for export
-  ([#828](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/828))
-  ([7a7ae3e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7a7ae3e9d02a6fcbab9d8f99a9f242f0b1c57c23))
+  ([#828](https://github.com/carbon-design-system/ibm-products/issues/828))
+  ([7a7ae3e](https://github.com/carbon-design-system/ibm-products/commit/7a7ae3e9d02a6fcbab9d8f99a9f242f0b1c57c23))
 
-## [0.40.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.9...@carbon/ibm-cloud-cognitive@0.40.10) (2021-05-27)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.40.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.8...@carbon/ibm-cloud-cognitive@0.40.9) (2021-05-27)
+## [0.40.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.9...@carbon/ibm-cloud-cognitive@0.40.10) (2021-05-27)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.40.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.7...@carbon/ibm-cloud-cognitive@0.40.8) (2021-05-26)
+## [0.40.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.8...@carbon/ibm-cloud-cognitive@0.40.9) (2021-05-27)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.40.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.6...@carbon/ibm-cloud-cognitive@0.40.7) (2021-05-26)
+## [0.40.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.7...@carbon/ibm-cloud-cognitive@0.40.8) (2021-05-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.40.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.5...@carbon/ibm-cloud-cognitive@0.40.6) (2021-05-26)
+## [0.40.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.6...@carbon/ibm-cloud-cognitive@0.40.7) (2021-05-26)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.40.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.5...@carbon/ibm-cloud-cognitive@0.40.6) (2021-05-26)
 
 ### Bug Fixes
 
 - **HTTPErrors:** addresses review findings
-  ([#789](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/789))
-  ([1f8c9d9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1f8c9d9c26ec1635b96f7c8d13925ff3ed8213af))
+  ([#789](https://github.com/carbon-design-system/ibm-products/issues/789))
+  ([1f8c9d9](https://github.com/carbon-design-system/ibm-products/commit/1f8c9d9c26ec1635b96f7c8d13925ff3ed8213af))
 
-## [0.40.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.4...@carbon/ibm-cloud-cognitive@0.40.5) (2021-05-26)
+## [0.40.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.4...@carbon/ibm-cloud-cognitive@0.40.5) (2021-05-26)
 
 ### Bug Fixes
 
 - **CreateTearsheet:** fix console error in tests from timeout issue
-  ([#793](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/793))
-  ([18cab39](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/18cab399c921972d5b8b3eb90222f1a744a53a54))
+  ([#793](https://github.com/carbon-design-system/ibm-products/issues/793))
+  ([18cab39](https://github.com/carbon-design-system/ibm-products/commit/18cab399c921972d5b8b3eb90222f1a744a53a54))
 
-## [0.40.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.3...@carbon/ibm-cloud-cognitive@0.40.4) (2021-05-26)
+## [0.40.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.3...@carbon/ibm-cloud-cognitive@0.40.4) (2021-05-26)
 
 ### Bug Fixes
 
 - page header test coverage 100%
-  ([#788](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/788))
-  ([5a1d2d7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5a1d2d7bdfff4d1cfc0a187f8a82992dfa946c75))
+  ([#788](https://github.com/carbon-design-system/ibm-products/issues/788))
+  ([5a1d2d7](https://github.com/carbon-design-system/ibm-products/commit/5a1d2d7bdfff4d1cfc0a187f8a82992dfa946c75))
 
-## [0.40.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.2...@carbon/ibm-cloud-cognitive@0.40.3) (2021-05-26)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.40.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.1...@carbon/ibm-cloud-cognitive@0.40.2) (2021-05-26)
+## [0.40.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.2...@carbon/ibm-cloud-cognitive@0.40.3) (2021-05-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.40.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.40.0...@carbon/ibm-cloud-cognitive@0.40.1) (2021-05-25)
+## [0.40.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.1...@carbon/ibm-cloud-cognitive@0.40.2) (2021-05-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.40.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.39.11...@carbon/ibm-cloud-cognitive@0.40.0) (2021-05-25)
+## [0.40.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.40.0...@carbon/ibm-cloud-cognitive@0.40.1) (2021-05-25)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+# [0.40.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.39.11...@carbon/ibm-cloud-cognitive@0.40.0) (2021-05-25)
 
 ### Features
 
 - tagset modal design review updates
-  ([#774](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/774))
-  ([c9fdb06](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c9fdb06d6fdceabccd39ea97e7188141292cef9e))
+  ([#774](https://github.com/carbon-design-system/ibm-products/issues/774))
+  ([c9fdb06](https://github.com/carbon-design-system/ibm-products/commit/c9fdb06d6fdceabccd39ea97e7188141292cef9e))
 
-## [0.39.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.39.10...@carbon/ibm-cloud-cognitive@0.39.11) (2021-05-25)
+## [0.39.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.39.10...@carbon/ibm-cloud-cognitive@0.39.11) (2021-05-25)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.39.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.39.9...@carbon/ibm-cloud-cognitive@0.39.10) (2021-05-24)
+## [0.39.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.39.9...@carbon/ibm-cloud-cognitive@0.39.10) (2021-05-24)
 
 ### Bug Fixes
 
 - back arrow tooltip
-  ([#778](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/778))
-  ([b7c6dde](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b7c6dde284bb681ebcfc1474738b9280ecab82ed))
+  ([#778](https://github.com/carbon-design-system/ibm-products/issues/778))
+  ([b7c6dde](https://github.com/carbon-design-system/ibm-products/commit/b7c6dde284bb681ebcfc1474738b9280ecab82ed))
 
-## [0.39.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.39.8...@carbon/ibm-cloud-cognitive@0.39.9) (2021-05-24)
+## [0.39.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.39.8...@carbon/ibm-cloud-cognitive@0.39.9) (2021-05-24)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.39.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.39.7...@carbon/ibm-cloud-cognitive@0.39.8) (2021-05-24)
+## [0.39.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.39.7...@carbon/ibm-cloud-cognitive@0.39.8) (2021-05-24)
 
 ### Bug Fixes
 
 - remove wibble from example story
-  ([#780](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/780))
-  ([ca4910f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ca4910f918fea1d65b8e9f06767a08ba72064d93))
+  ([#780](https://github.com/carbon-design-system/ibm-products/issues/780))
+  ([ca4910f](https://github.com/carbon-design-system/ibm-products/commit/ca4910f918fea1d65b8e9f06767a08ba72064d93))
 
-## [0.39.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.39.6...@carbon/ibm-cloud-cognitive@0.39.7) (2021-05-24)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.39.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.39.5...@carbon/ibm-cloud-cognitive@0.39.6) (2021-05-24)
+## [0.39.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.39.6...@carbon/ibm-cloud-cognitive@0.39.7) (2021-05-24)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.39.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.39.4...@carbon/ibm-cloud-cognitive@0.39.5) (2021-05-21)
+## [0.39.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.39.5...@carbon/ibm-cloud-cognitive@0.39.6) (2021-05-24)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.39.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.39.4...@carbon/ibm-cloud-cognitive@0.39.5) (2021-05-21)
 
 ### Bug Fixes
 
 - design review niggles
-  ([#765](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/765))
-  ([46a353b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/46a353b8ba9f30657f1b7cd3808a978e5cc3869c))
+  ([#765](https://github.com/carbon-design-system/ibm-products/issues/765))
+  ([46a353b](https://github.com/carbon-design-system/ibm-products/commit/46a353b8ba9f30657f1b7cd3808a978e5cc3869c))
 
-## [0.39.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.39.3...@carbon/ibm-cloud-cognitive@0.39.4) (2021-05-21)
+## [0.39.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.39.3...@carbon/ibm-cloud-cognitive@0.39.4) (2021-05-21)
 
 ### Bug Fixes
 
 - forgot to add onClose to export modal
-  ([#776](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/776))
-  ([c381d93](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c381d93e123c33a600e7bf8dee0f3fd8c75767e6))
+  ([#776](https://github.com/carbon-design-system/ibm-products/issues/776))
+  ([c381d93](https://github.com/carbon-design-system/ibm-products/commit/c381d93e123c33a600e7bf8dee0f3fd8c75767e6))
 
-## [0.39.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.39.2...@carbon/ibm-cloud-cognitive@0.39.3) (2021-05-21)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.39.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.39.1...@carbon/ibm-cloud-cognitive@0.39.2) (2021-05-21)
+## [0.39.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.39.2...@carbon/ibm-cloud-cognitive@0.39.3) (2021-05-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.39.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.39.0...@carbon/ibm-cloud-cognitive@0.39.1) (2021-05-21)
+## [0.39.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.39.1...@carbon/ibm-cloud-cognitive@0.39.2) (2021-05-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.39.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.38.7...@carbon/ibm-cloud-cognitive@0.39.0) (2021-05-20)
+## [0.39.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.39.0...@carbon/ibm-cloud-cognitive@0.39.1) (2021-05-21)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+# [0.39.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.38.7...@carbon/ibm-cloud-cognitive@0.39.0) (2021-05-20)
 
 ### Features
 
 - **SidePanel:** add optional onUnmount prop for cleanup
-  ([#767](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/767))
-  ([d135ea0](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d135ea0b2c9ae9f8e415828a1199bbc80e545551))
+  ([#767](https://github.com/carbon-design-system/ibm-products/issues/767))
+  ([d135ea0](https://github.com/carbon-design-system/ibm-products/commit/d135ea0b2c9ae9f8e415828a1199bbc80e545551))
 
-## [0.38.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.38.6...@carbon/ibm-cloud-cognitive@0.38.7) (2021-05-19)
+## [0.38.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.38.6...@carbon/ibm-cloud-cognitive@0.38.7) (2021-05-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.38.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.38.5...@carbon/ibm-cloud-cognitive@0.38.6) (2021-05-19)
+## [0.38.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.38.5...@carbon/ibm-cloud-cognitive@0.38.6) (2021-05-19)
 
 ### Bug Fixes
 
 - remove modal release feedback updates
-  ([#757](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/757))
-  ([f6b97ba](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f6b97babd6f98da8f08ffbc3ddc24bac8f9b059e))
+  ([#757](https://github.com/carbon-design-system/ibm-products/issues/757))
+  ([f6b97ba](https://github.com/carbon-design-system/ibm-products/commit/f6b97babd6f98da8f08ffbc3ddc24bac8f9b059e))
 
-## [0.38.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.38.4...@carbon/ibm-cloud-cognitive@0.38.5) (2021-05-19)
+## [0.38.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.38.4...@carbon/ibm-cloud-cognitive@0.38.5) (2021-05-19)
 
 ### Bug Fixes
 
 - issues raised in page header design review
-  ([#754](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/754))
-  ([13c5085](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/13c5085b6de50c01a942f71b66e80a9516167c42))
+  ([#754](https://github.com/carbon-design-system/ibm-products/issues/754))
+  ([13c5085](https://github.com/carbon-design-system/ibm-products/commit/13c5085b6de50c01a942f71b66e80a9516167c42))
 
-## [0.38.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.38.3...@carbon/ibm-cloud-cognitive@0.38.4) (2021-05-19)
+## [0.38.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.38.3...@carbon/ibm-cloud-cognitive@0.38.4) (2021-05-19)
 
 ### Bug Fixes
 
 - **Tearsheet:** fix background of pagination
-  ([#747](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/747))
-  ([f3fd9f7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f3fd9f72e751e8b955af854b3a3c72e5a593f01d))
+  ([#747](https://github.com/carbon-design-system/ibm-products/issues/747))
+  ([f3fd9f7](https://github.com/carbon-design-system/ibm-products/commit/f3fd9f72e751e8b955af854b3a3c72e5a593f01d))
 
-## [0.38.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.38.2...@carbon/ibm-cloud-cognitive@0.38.3) (2021-05-19)
+## [0.38.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.38.2...@carbon/ibm-cloud-cognitive@0.38.3) (2021-05-19)
 
 ### Bug Fixes
 
 - **EmptyStates:** update stories and rename size prop
-  ([#753](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/753))
-  ([c5e6bfb](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c5e6bfb912b5d8bc2ab143df87f2b615f35939ac))
+  ([#753](https://github.com/carbon-design-system/ibm-products/issues/753))
+  ([c5e6bfb](https://github.com/carbon-design-system/ibm-products/commit/c5e6bfb912b5d8bc2ab143df87f2b615f35939ac))
 
-## [0.38.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.38.1...@carbon/ibm-cloud-cognitive@0.38.2) (2021-05-18)
+## [0.38.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.38.1...@carbon/ibm-cloud-cognitive@0.38.2) (2021-05-18)
 
 ### Bug Fixes
 
 - **UserProfileImage:** updates based on release review notes
-  ([#665](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/665))
-  ([7294117](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7294117be66c99e6d1dfa4fa98810e7daf2f2ca4))
+  ([#665](https://github.com/carbon-design-system/ibm-products/issues/665))
+  ([7294117](https://github.com/carbon-design-system/ibm-products/commit/7294117be66c99e6d1dfa4fa98810e7daf2f2ca4))
 
-## [0.38.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.38.0...@carbon/ibm-cloud-cognitive@0.38.1) (2021-05-18)
+## [0.38.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.38.0...@carbon/ibm-cloud-cognitive@0.38.1) (2021-05-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.38.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.37.3...@carbon/ibm-cloud-cognitive@0.38.0) (2021-05-18)
+# [0.38.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.37.3...@carbon/ibm-cloud-cognitive@0.38.0) (2021-05-18)
 
 ### Features
 
 - stop tagset overflow scrolling off screen
-  ([#740](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/740))
-  ([016a3ec](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/016a3ec8ee20691de3ee0d4eb4ea44912276e67f))
+  ([#740](https://github.com/carbon-design-system/ibm-products/issues/740))
+  ([016a3ec](https://github.com/carbon-design-system/ibm-products/commit/016a3ec8ee20691de3ee0d4eb4ea44912276e67f))
 
-## [0.37.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.37.2...@carbon/ibm-cloud-cognitive@0.37.3) (2021-05-18)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.37.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.37.1...@carbon/ibm-cloud-cognitive@0.37.2) (2021-05-17)
+## [0.37.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.37.2...@carbon/ibm-cloud-cognitive@0.37.3) (2021-05-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.37.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.37.0...@carbon/ibm-cloud-cognitive@0.37.1) (2021-05-14)
+## [0.37.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.37.1...@carbon/ibm-cloud-cognitive@0.37.2) (2021-05-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.37.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.24...@carbon/ibm-cloud-cognitive@0.37.0) (2021-05-14)
+## [0.37.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.37.0...@carbon/ibm-cloud-cognitive@0.37.1) (2021-05-14)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+# [0.37.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.24...@carbon/ibm-cloud-cognitive@0.37.0) (2021-05-14)
 
 ### Bug Fixes
 
 - title and subtitle row responsivity
-  ([#730](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/730))
-  ([03e6bf2](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/03e6bf28ac2999fc5ce1d94aace6aa8926931d10))
+  ([#730](https://github.com/carbon-design-system/ibm-products/issues/730))
+  ([03e6bf2](https://github.com/carbon-design-system/ibm-products/commit/03e6bf28ac2999fc5ce1d94aace6aa8926931d10))
 
 ### Features
 
 - show collapse button if requested
-  ([#732](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/732))
-  ([05d7423](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/05d74236caf2f9d5e6d834a621ab9e708a9b1abb))
+  ([#732](https://github.com/carbon-design-system/ibm-products/issues/732))
+  ([05d7423](https://github.com/carbon-design-system/ibm-products/commit/05d74236caf2f9d5e6d834a621ab9e708a9b1abb))
 
-## [0.36.24](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.23...@carbon/ibm-cloud-cognitive@0.36.24) (2021-05-13)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.36.23](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.22...@carbon/ibm-cloud-cognitive@0.36.23) (2021-05-12)
+## [0.36.24](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.23...@carbon/ibm-cloud-cognitive@0.36.24) (2021-05-13)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.36.22](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.21...@carbon/ibm-cloud-cognitive@0.36.22) (2021-05-12)
+## [0.36.23](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.22...@carbon/ibm-cloud-cognitive@0.36.23) (2021-05-12)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.36.21](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.20...@carbon/ibm-cloud-cognitive@0.36.21) (2021-05-11)
+## [0.36.22](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.21...@carbon/ibm-cloud-cognitive@0.36.22) (2021-05-12)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.36.21](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.20...@carbon/ibm-cloud-cognitive@0.36.21) (2021-05-11)
 
 ### Bug Fixes
 
 - prevent collapse button over action bar items
-  ([#728](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/728))
-  ([b9785eb](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b9785ebeba8c8eb0ef72ffd73675314629bf4fe3))
+  ([#728](https://github.com/carbon-design-system/ibm-products/issues/728))
+  ([b9785eb](https://github.com/carbon-design-system/ibm-products/commit/b9785ebeba8c8eb0ef72ffd73675314629bf4fe3))
 
-## [0.36.20](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.19...@carbon/ibm-cloud-cognitive@0.36.20) (2021-05-10)
+## [0.36.20](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.19...@carbon/ibm-cloud-cognitive@0.36.20) (2021-05-10)
 
 ### Bug Fixes
 
 - breadcrumb styling
-  ([#723](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/723))
-  ([65ac371](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/65ac371a0f48406acb1d6193dd9a45cefa8f9a57))
+  ([#723](https://github.com/carbon-design-system/ibm-products/issues/723))
+  ([65ac371](https://github.com/carbon-design-system/ibm-products/commit/65ac371a0f48406acb1d6193dd9a45cefa8f9a57))
 
-## [0.36.19](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.18...@carbon/ibm-cloud-cognitive@0.36.19) (2021-05-10)
+## [0.36.19](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.18...@carbon/ibm-cloud-cognitive@0.36.19) (2021-05-10)
 
 ### Bug Fixes
 
 - **SidePanel:** add shadow only for slideOver panels without overlays
-  ([#722](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/722))
-  ([9cb74d4](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9cb74d4ff006e30c79512b80d480742219d2c639))
+  ([#722](https://github.com/carbon-design-system/ibm-products/issues/722))
+  ([9cb74d4](https://github.com/carbon-design-system/ibm-products/commit/9cb74d4ff006e30c79512b80d480742219d2c639))
 
-## [0.36.18](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.17...@carbon/ibm-cloud-cognitive@0.36.18) (2021-05-10)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.36.17](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.16...@carbon/ibm-cloud-cognitive@0.36.17) (2021-05-10)
+## [0.36.18](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.17...@carbon/ibm-cloud-cognitive@0.36.18) (2021-05-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.36.16](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.15...@carbon/ibm-cloud-cognitive@0.36.16) (2021-05-07)
+## [0.36.17](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.16...@carbon/ibm-cloud-cognitive@0.36.17) (2021-05-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.36.15](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.14...@carbon/ibm-cloud-cognitive@0.36.15) (2021-05-05)
+## [0.36.16](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.15...@carbon/ibm-cloud-cognitive@0.36.16) (2021-05-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.36.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.13...@carbon/ibm-cloud-cognitive@0.36.14) (2021-05-05)
+## [0.36.15](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.14...@carbon/ibm-cloud-cognitive@0.36.15) (2021-05-05)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.36.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.12...@carbon/ibm-cloud-cognitive@0.36.13) (2021-05-05)
+## [0.36.14](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.13...@carbon/ibm-cloud-cognitive@0.36.14) (2021-05-05)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.36.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.11...@carbon/ibm-cloud-cognitive@0.36.12) (2021-05-05)
+## [0.36.13](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.12...@carbon/ibm-cloud-cognitive@0.36.13) (2021-05-05)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.36.12](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.11...@carbon/ibm-cloud-cognitive@0.36.12) (2021-05-05)
 
 ### Bug Fixes
 
 - page header deprecations
-  ([#697](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/697))
-  ([ee559f9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ee559f93896a416c01d0e790864835542726d44a))
+  ([#697](https://github.com/carbon-design-system/ibm-products/issues/697))
+  ([ee559f9](https://github.com/carbon-design-system/ibm-products/commit/ee559f93896a416c01d0e790864835542726d44a))
 
-## [0.36.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.10...@carbon/ibm-cloud-cognitive@0.36.11) (2021-05-04)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.36.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.9...@carbon/ibm-cloud-cognitive@0.36.10) (2021-04-30)
+## [0.36.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.10...@carbon/ibm-cloud-cognitive@0.36.11) (2021-05-04)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.36.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.8...@carbon/ibm-cloud-cognitive@0.36.9) (2021-04-30)
+## [0.36.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.9...@carbon/ibm-cloud-cognitive@0.36.10) (2021-04-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.36.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.7...@carbon/ibm-cloud-cognitive@0.36.8) (2021-04-30)
+## [0.36.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.8...@carbon/ibm-cloud-cognitive@0.36.9) (2021-04-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.36.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.6...@carbon/ibm-cloud-cognitive@0.36.7) (2021-04-30)
+## [0.36.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.7...@carbon/ibm-cloud-cognitive@0.36.8) (2021-04-30)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.36.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.6...@carbon/ibm-cloud-cognitive@0.36.7) (2021-04-30)
 
 ### Bug Fixes
 
 - testing and blockClass for import modal
-  ([#686](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/686))
-  ([42a4f39](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/42a4f396b84a19cc1db98bebb3bd9ce6d860dfc4))
+  ([#686](https://github.com/carbon-design-system/ibm-products/issues/686))
+  ([42a4f39](https://github.com/carbon-design-system/ibm-products/commit/42a4f396b84a19cc1db98bebb3bd9ce6d860dfc4))
 
-## [0.36.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.5...@carbon/ibm-cloud-cognitive@0.36.6) (2021-04-30)
+## [0.36.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.5...@carbon/ibm-cloud-cognitive@0.36.6) (2021-04-30)
 
 ### Bug Fixes
 
 - small fixes to saving for release review
-  ([#683](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/683))
-  ([384db15](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/384db15a4057b7e91543be9cba05df303f239447))
+  ([#683](https://github.com/carbon-design-system/ibm-products/issues/683))
+  ([384db15](https://github.com/carbon-design-system/ibm-products/commit/384db15a4057b7e91543be9cba05df303f239447))
 
-## [0.36.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.4...@carbon/ibm-cloud-cognitive@0.36.5) (2021-04-30)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.36.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.3...@carbon/ibm-cloud-cognitive@0.36.4) (2021-04-30)
+## [0.36.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.4...@carbon/ibm-cloud-cognitive@0.36.5) (2021-04-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.36.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.2...@carbon/ibm-cloud-cognitive@0.36.3) (2021-04-29)
+## [0.36.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.3...@carbon/ibm-cloud-cognitive@0.36.4) (2021-04-30)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.36.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.2...@carbon/ibm-cloud-cognitive@0.36.3) (2021-04-29)
 
 ### Bug Fixes
 
 - **SidePanel:** add extra padding bottom to collapsed title underline
-  ([#678](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/678))
-  ([c1d5eb6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c1d5eb6f8b49df96fd9f742a873ef272998900ad))
+  ([#678](https://github.com/carbon-design-system/ibm-products/issues/678))
+  ([c1d5eb6](https://github.com/carbon-design-system/ibm-products/commit/c1d5eb6f8b49df96fd9f742a873ef272998900ad))
 
-## [0.36.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.1...@carbon/ibm-cloud-cognitive@0.36.2) (2021-04-29)
+## [0.36.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.1...@carbon/ibm-cloud-cognitive@0.36.2) (2021-04-29)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.36.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.36.0...@carbon/ibm-cloud-cognitive@0.36.1) (2021-04-29)
+## [0.36.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.36.0...@carbon/ibm-cloud-cognitive@0.36.1) (2021-04-29)
 
 ### Bug Fixes
 
 - added additional import modal tests
-  ([#673](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/673))
-  ([f6a9a2f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f6a9a2fba7519415eb5df0b3e8485c5e6bd8c6b4))
+  ([#673](https://github.com/carbon-design-system/ibm-products/issues/673))
+  ([f6a9a2f](https://github.com/carbon-design-system/ibm-products/commit/f6a9a2fba7519415eb5df0b3e8485c5e6bd8c6b4))
 
-# [0.36.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.31...@carbon/ibm-cloud-cognitive@0.36.0) (2021-04-29)
+# [0.36.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.31...@carbon/ibm-cloud-cognitive@0.36.0) (2021-04-29)
 
 ### Features
 
 - **PageHeader:** back button to replace breadcrumbs on small viewport
-  ([#676](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/676))
-  ([ae3224e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ae3224e12263e78487ed667914be8ba08935e3d9))
+  ([#676](https://github.com/carbon-design-system/ibm-products/issues/676))
+  ([ae3224e](https://github.com/carbon-design-system/ibm-products/commit/ae3224e12263e78487ed667914be8ba08935e3d9))
 
-## [0.35.31](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.30...@carbon/ibm-cloud-cognitive@0.35.31) (2021-04-29)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.35.30](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.29...@carbon/ibm-cloud-cognitive@0.35.30) (2021-04-29)
+## [0.35.31](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.30...@carbon/ibm-cloud-cognitive@0.35.31) (2021-04-29)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.35.29](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.28...@carbon/ibm-cloud-cognitive@0.35.29) (2021-04-29)
+## [0.35.30](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.29...@carbon/ibm-cloud-cognitive@0.35.30) (2021-04-29)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.35.28](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.27...@carbon/ibm-cloud-cognitive@0.35.28) (2021-04-28)
+## [0.35.29](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.28...@carbon/ibm-cloud-cognitive@0.35.29) (2021-04-29)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.35.27](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.26...@carbon/ibm-cloud-cognitive@0.35.27) (2021-04-28)
+## [0.35.28](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.27...@carbon/ibm-cloud-cognitive@0.35.28) (2021-04-28)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.35.26](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.25...@carbon/ibm-cloud-cognitive@0.35.26) (2021-04-28)
+## [0.35.27](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.26...@carbon/ibm-cloud-cognitive@0.35.27) (2021-04-28)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.35.25](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.24...@carbon/ibm-cloud-cognitive@0.35.25) (2021-04-28)
+## [0.35.26](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.25...@carbon/ibm-cloud-cognitive@0.35.26) (2021-04-28)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.35.24](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.23...@carbon/ibm-cloud-cognitive@0.35.24) (2021-04-27)
+## [0.35.25](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.24...@carbon/ibm-cloud-cognitive@0.35.25) (2021-04-28)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.35.23](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.22...@carbon/ibm-cloud-cognitive@0.35.23) (2021-04-27)
+## [0.35.24](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.23...@carbon/ibm-cloud-cognitive@0.35.24) (2021-04-27)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.35.22](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.21...@carbon/ibm-cloud-cognitive@0.35.22) (2021-04-27)
+## [0.35.23](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.22...@carbon/ibm-cloud-cognitive@0.35.23) (2021-04-27)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.35.21](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.20...@carbon/ibm-cloud-cognitive@0.35.21) (2021-04-26)
+## [0.35.22](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.21...@carbon/ibm-cloud-cognitive@0.35.22) (2021-04-27)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.35.21](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.20...@carbon/ibm-cloud-cognitive@0.35.21) (2021-04-26)
 
 ### Bug Fixes
 
 - adds and improves testing to several components
-  ([#649](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/649))
-  ([b336afa](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b336afac9a9c8f730393a38e53f1d383911c36f3))
+  ([#649](https://github.com/carbon-design-system/ibm-products/issues/649))
+  ([b336afa](https://github.com/carbon-design-system/ibm-products/commit/b336afac9a9c8f730393a38e53f1d383911c36f3))
 
-## [0.35.20](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.19...@carbon/ibm-cloud-cognitive@0.35.20) (2021-04-26)
+## [0.35.20](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.19...@carbon/ibm-cloud-cognitive@0.35.20) (2021-04-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.35.19](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.18...@carbon/ibm-cloud-cognitive@0.35.19) (2021-04-26)
+## [0.35.19](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.18...@carbon/ibm-cloud-cognitive@0.35.19) (2021-04-26)
 
 ### Bug Fixes
 
 - add tag set tests n tidy
-  ([#642](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/642))
-  ([cfeeaf9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/cfeeaf943fe0bb70d543e962cb51e3303c6debb4))
+  ([#642](https://github.com/carbon-design-system/ibm-products/issues/642))
+  ([cfeeaf9](https://github.com/carbon-design-system/ibm-products/commit/cfeeaf943fe0bb70d543e962cb51e3303c6debb4))
 
-## [0.35.18](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.17...@carbon/ibm-cloud-cognitive@0.35.18) (2021-04-26)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.35.17](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.16...@carbon/ibm-cloud-cognitive@0.35.17) (2021-04-26)
+## [0.35.18](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.17...@carbon/ibm-cloud-cognitive@0.35.18) (2021-04-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.35.16](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.15...@carbon/ibm-cloud-cognitive@0.35.16) (2021-04-23)
+## [0.35.17](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.16...@carbon/ibm-cloud-cognitive@0.35.17) (2021-04-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.35.15](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.14...@carbon/ibm-cloud-cognitive@0.35.15) (2021-04-22)
+## [0.35.16](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.15...@carbon/ibm-cloud-cognitive@0.35.16) (2021-04-23)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.35.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.13...@carbon/ibm-cloud-cognitive@0.35.14) (2021-04-22)
+## [0.35.15](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.14...@carbon/ibm-cloud-cognitive@0.35.15) (2021-04-22)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.35.14](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.13...@carbon/ibm-cloud-cognitive@0.35.14) (2021-04-22)
 
 ### Bug Fixes
 
 - page header action bar usage
-  ([#622](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/622))
-  ([bfa4370](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/bfa437079b68ea8583e0ea5a9df5ce344936d85c))
+  ([#622](https://github.com/carbon-design-system/ibm-products/issues/622))
+  ([bfa4370](https://github.com/carbon-design-system/ibm-products/commit/bfa437079b68ea8583e0ea5a9df5ce344936d85c))
 
-## [0.35.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.12...@carbon/ibm-cloud-cognitive@0.35.13) (2021-04-21)
+## [0.35.13](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.12...@carbon/ibm-cloud-cognitive@0.35.13) (2021-04-21)
 
 ### Bug Fixes
 
 - added testing for export release review
-  ([#635](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/635))
-  ([eff717e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/eff717e88c024fc671ece9d8963924e5495772a0))
+  ([#635](https://github.com/carbon-design-system/ibm-products/issues/635))
+  ([eff717e](https://github.com/carbon-design-system/ibm-products/commit/eff717e88c024fc671ece9d8963924e5495772a0))
 
-## [0.35.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.11...@carbon/ibm-cloud-cognitive@0.35.12) (2021-04-21)
+## [0.35.12](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.11...@carbon/ibm-cloud-cognitive@0.35.12) (2021-04-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.35.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.10...@carbon/ibm-cloud-cognitive@0.35.11) (2021-04-21)
+## [0.35.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.10...@carbon/ibm-cloud-cognitive@0.35.11) (2021-04-21)
 
 ### Bug Fixes
 
 - **NotificationsPanel:** fix z index issue in bottom actions
-  ([#629](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/629))
-  ([8700e7d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8700e7d7f09c33f39395ca76540db66cd9052d2d))
+  ([#629](https://github.com/carbon-design-system/ibm-products/issues/629))
+  ([8700e7d](https://github.com/carbon-design-system/ibm-products/commit/8700e7d7f09c33f39395ca76540db66cd9052d2d))
 
-## [0.35.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.9...@carbon/ibm-cloud-cognitive@0.35.10) (2021-04-21)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.35.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.8...@carbon/ibm-cloud-cognitive@0.35.9) (2021-04-20)
+## [0.35.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.9...@carbon/ibm-cloud-cognitive@0.35.10) (2021-04-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.35.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.7...@carbon/ibm-cloud-cognitive@0.35.8) (2021-04-20)
+## [0.35.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.8...@carbon/ibm-cloud-cognitive@0.35.9) (2021-04-20)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.35.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.6...@carbon/ibm-cloud-cognitive@0.35.7) (2021-04-20)
+## [0.35.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.7...@carbon/ibm-cloud-cognitive@0.35.8) (2021-04-20)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.35.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.6...@carbon/ibm-cloud-cognitive@0.35.7) (2021-04-20)
 
 ### Bug Fixes
 
 - import modal style updates
-  ([#624](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/624))
-  ([bf94094](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/bf94094c7d0dfa4c6b60ecc248f7da514f24a47b))
+  ([#624](https://github.com/carbon-design-system/ibm-products/issues/624))
+  ([bf94094](https://github.com/carbon-design-system/ibm-products/commit/bf94094c7d0dfa4c6b60ecc248f7da514f24a47b))
 
-## [0.35.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.5...@carbon/ibm-cloud-cognitive@0.35.6) (2021-04-20)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.35.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.4...@carbon/ibm-cloud-cognitive@0.35.5) (2021-04-20)
+## [0.35.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.5...@carbon/ibm-cloud-cognitive@0.35.6) (2021-04-20)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.35.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.3...@carbon/ibm-cloud-cognitive@0.35.4) (2021-04-19)
+## [0.35.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.4...@carbon/ibm-cloud-cognitive@0.35.5) (2021-04-20)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.35.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.2...@carbon/ibm-cloud-cognitive@0.35.3) (2021-04-16)
+## [0.35.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.3...@carbon/ibm-cloud-cognitive@0.35.4) (2021-04-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.35.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.1...@carbon/ibm-cloud-cognitive@0.35.2) (2021-04-16)
+## [0.35.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.2...@carbon/ibm-cloud-cognitive@0.35.3) (2021-04-16)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.35.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.1...@carbon/ibm-cloud-cognitive@0.35.2) (2021-04-16)
 
 ### Bug Fixes
 
 - **NotificationsPanel:** address review findings and add more tests
-  ([#613](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/613))
-  ([a8e6bb4](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a8e6bb47f7b298ab00c077442c3ea3c85f7f3525))
+  ([#613](https://github.com/carbon-design-system/ibm-products/issues/613))
+  ([a8e6bb4](https://github.com/carbon-design-system/ibm-products/commit/a8e6bb47f7b298ab00c077442c3ea3c85f7f3525))
 
-## [0.35.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.35.0...@carbon/ibm-cloud-cognitive@0.35.1) (2021-04-16)
+## [0.35.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.35.0...@carbon/ibm-cloud-cognitive@0.35.1) (2021-04-16)
 
 ### Bug Fixes
 
 - minor fix to make AboutModal stories switch more smoothly
-  ([#609](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/609))
-  ([b3fe083](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b3fe083c411a3d627031094fe608c57bd378990d))
+  ([#609](https://github.com/carbon-design-system/ibm-products/issues/609))
+  ([b3fe083](https://github.com/carbon-design-system/ibm-products/commit/b3fe083c411a3d627031094fe608c57bd378990d))
 
-# [0.35.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.33...@carbon/ibm-cloud-cognitive@0.35.0) (2021-04-16)
+# [0.35.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.33...@carbon/ibm-cloud-cognitive@0.35.0) (2021-04-16)
 
 ### Features
 
 - upd breadcrumb with overflow to internal
-  ([#610](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/610))
-  ([2e34eb9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2e34eb9fe8b24c5b17d23eb134cdba6aec6736ac))
+  ([#610](https://github.com/carbon-design-system/ibm-products/issues/610))
+  ([2e34eb9](https://github.com/carbon-design-system/ibm-products/commit/2e34eb9fe8b24c5b17d23eb134cdba6aec6736ac))
 
-## [0.34.33](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.32...@carbon/ibm-cloud-cognitive@0.34.33) (2021-04-15)
+## [0.34.33](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.32...@carbon/ibm-cloud-cognitive@0.34.33) (2021-04-15)
 
 ### Bug Fixes
 
 - update testing and package-settings
-  ([#612](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/612))
-  ([d2bb0f2](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d2bb0f2ae5a4b6a7c3d1e3d61e1aa0ea94c074d8))
+  ([#612](https://github.com/carbon-design-system/ibm-products/issues/612))
+  ([d2bb0f2](https://github.com/carbon-design-system/ibm-products/commit/d2bb0f2ae5a4b6a7c3d1e3d61e1aa0ea94c074d8))
 
-## [0.34.32](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.31...@carbon/ibm-cloud-cognitive@0.34.32) (2021-04-15)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.34.31](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.30...@carbon/ibm-cloud-cognitive@0.34.31) (2021-04-15)
+## [0.34.32](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.31...@carbon/ibm-cloud-cognitive@0.34.32) (2021-04-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.34.30](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.29...@carbon/ibm-cloud-cognitive@0.34.30) (2021-04-15)
+## [0.34.31](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.30...@carbon/ibm-cloud-cognitive@0.34.31) (2021-04-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.34.29](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.28...@carbon/ibm-cloud-cognitive@0.34.29) (2021-04-14)
+## [0.34.30](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.29...@carbon/ibm-cloud-cognitive@0.34.30) (2021-04-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.34.28](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.27...@carbon/ibm-cloud-cognitive@0.34.28) (2021-04-14)
+## [0.34.29](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.28...@carbon/ibm-cloud-cognitive@0.34.29) (2021-04-14)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.34.27](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.26...@carbon/ibm-cloud-cognitive@0.34.27) (2021-04-14)
+## [0.34.28](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.27...@carbon/ibm-cloud-cognitive@0.34.28) (2021-04-14)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.34.26](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.25...@carbon/ibm-cloud-cognitive@0.34.26) (2021-04-14)
+## [0.34.27](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.26...@carbon/ibm-cloud-cognitive@0.34.27) (2021-04-14)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.34.25](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.24...@carbon/ibm-cloud-cognitive@0.34.25) (2021-04-14)
+## [0.34.26](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.25...@carbon/ibm-cloud-cognitive@0.34.26) (2021-04-14)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.34.25](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.24...@carbon/ibm-cloud-cognitive@0.34.25) (2021-04-14)
 
 ### Bug Fixes
 
 - **SidePanel:** add transition to divider appearing during animation
-  ([#599](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/599))
-  ([4a7fac1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4a7fac1843052b5495996aca21b61660ac0ef304))
+  ([#599](https://github.com/carbon-design-system/ibm-products/issues/599))
+  ([4a7fac1](https://github.com/carbon-design-system/ibm-products/commit/4a7fac1843052b5495996aca21b61660ac0ef304))
 
-## [0.34.24](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.23...@carbon/ibm-cloud-cognitive@0.34.24) (2021-04-13)
+## [0.34.24](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.23...@carbon/ibm-cloud-cognitive@0.34.24) (2021-04-13)
 
 ### Bug Fixes
 
 - **SidePanel:** add resize detector to adapt to new actions height
-  ([#596](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/596))
-  ([e812ff9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e812ff953cc40d83265d02540357578c95150ec5))
+  ([#596](https://github.com/carbon-design-system/ibm-products/issues/596))
+  ([e812ff9](https://github.com/carbon-design-system/ibm-products/commit/e812ff953cc40d83265d02540357578c95150ec5))
 
-## [0.34.23](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.22...@carbon/ibm-cloud-cognitive@0.34.23) (2021-04-13)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.34.22](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.21...@carbon/ibm-cloud-cognitive@0.34.22) (2021-04-13)
+## [0.34.23](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.22...@carbon/ibm-cloud-cognitive@0.34.23) (2021-04-13)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.34.21](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.20...@carbon/ibm-cloud-cognitive@0.34.21) (2021-04-12)
+## [0.34.22](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.21...@carbon/ibm-cloud-cognitive@0.34.22) (2021-04-13)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.34.21](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.20...@carbon/ibm-cloud-cognitive@0.34.21) (2021-04-12)
 
 ### Bug Fixes
 
 - **SidePanel:** correct how bottom padding of content is calculated
-  ([#593](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/593))
-  ([12168c9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/12168c9c023e77940a2c6a5b97d1aedeed596a7f))
+  ([#593](https://github.com/carbon-design-system/ibm-products/issues/593))
+  ([12168c9](https://github.com/carbon-design-system/ibm-products/commit/12168c9c023e77940a2c6a5b97d1aedeed596a7f))
 
-## [0.34.20](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.19...@carbon/ibm-cloud-cognitive@0.34.20) (2021-04-12)
+## [0.34.20](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.19...@carbon/ibm-cloud-cognitive@0.34.20) (2021-04-12)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.34.19](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.18...@carbon/ibm-cloud-cognitive@0.34.19) (2021-04-12)
+## [0.34.19](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.18...@carbon/ibm-cloud-cognitive@0.34.19) (2021-04-12)
 
 ### Bug Fixes
 
 - adds tests and updates docs for saving
-  ([#591](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/591))
-  ([d873051](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d8730510c08edd79f3b70a15a7fc4c323f684175))
+  ([#591](https://github.com/carbon-design-system/ibm-products/issues/591))
+  ([d873051](https://github.com/carbon-design-system/ibm-products/commit/d8730510c08edd79f3b70a15a7fc4c323f684175))
 
-## [0.34.18](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.17...@carbon/ibm-cloud-cognitive@0.34.18) (2021-04-12)
+## [0.34.18](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.17...@carbon/ibm-cloud-cognitive@0.34.18) (2021-04-12)
 
 ### Bug Fixes
 
 - **NotificationsPanel:** release review fixes
-  ([#584](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/584))
-  ([7c9af63](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7c9af63a6c1b258f1b8743bcfccc47e0bd6eb1ca))
+  ([#584](https://github.com/carbon-design-system/ibm-products/issues/584))
+  ([7c9af63](https://github.com/carbon-design-system/ibm-products/commit/7c9af63a6c1b258f1b8743bcfccc47e0bd6eb1ca))
 
-## [0.34.17](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.16...@carbon/ibm-cloud-cognitive@0.34.17) (2021-04-12)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.34.16](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.15...@carbon/ibm-cloud-cognitive@0.34.16) (2021-04-12)
+## [0.34.17](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.16...@carbon/ibm-cloud-cognitive@0.34.17) (2021-04-12)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.34.15](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.14...@carbon/ibm-cloud-cognitive@0.34.15) (2021-04-09)
+## [0.34.16](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.15...@carbon/ibm-cloud-cognitive@0.34.16) (2021-04-12)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.34.15](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.14...@carbon/ibm-cloud-cognitive@0.34.15) (2021-04-09)
 
 ### Bug Fixes
 
 - saving design feedback
-  ([#582](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/582))
-  ([121dbaf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/121dbafc1ed11579c104b4329d73cadbe56a7df9))
+  ([#582](https://github.com/carbon-design-system/ibm-products/issues/582))
+  ([121dbaf](https://github.com/carbon-design-system/ibm-products/commit/121dbafc1ed11579c104b4329d73cadbe56a7df9))
 
-## [0.34.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.13...@carbon/ibm-cloud-cognitive@0.34.14) (2021-04-09)
+## [0.34.14](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.13...@carbon/ibm-cloud-cognitive@0.34.14) (2021-04-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.34.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.12...@carbon/ibm-cloud-cognitive@0.34.13) (2021-04-09)
+## [0.34.13](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.12...@carbon/ibm-cloud-cognitive@0.34.13) (2021-04-09)
 
 ### Bug Fixes
 
 - more card design feedback
-  ([#576](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/576))
-  ([cd73a79](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/cd73a794a17b5b2e4784effd45744a07bc5b3351))
+  ([#576](https://github.com/carbon-design-system/ibm-products/issues/576))
+  ([cd73a79](https://github.com/carbon-design-system/ibm-products/commit/cd73a794a17b5b2e4784effd45744a07bc5b3351))
 
-## [0.34.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.11...@carbon/ibm-cloud-cognitive@0.34.12) (2021-04-09)
+## [0.34.12](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.11...@carbon/ibm-cloud-cognitive@0.34.12) (2021-04-09)
 
 ### Bug Fixes
 
 - out dated canary instruction
-  ([#578](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/578))
-  ([#579](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/579))
-  ([97bb6a6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/97bb6a6721cdac8c6b6c7cb98452a0025d64faeb))
+  ([#578](https://github.com/carbon-design-system/ibm-products/issues/578))
+  ([#579](https://github.com/carbon-design-system/ibm-products/issues/579))
+  ([97bb6a6](https://github.com/carbon-design-system/ibm-products/commit/97bb6a6721cdac8c6b6c7cb98452a0025d64faeb))
 
-## [0.34.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.10...@carbon/ibm-cloud-cognitive@0.34.11) (2021-04-08)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.34.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.9...@carbon/ibm-cloud-cognitive@0.34.10) (2021-04-08)
+## [0.34.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.10...@carbon/ibm-cloud-cognitive@0.34.11) (2021-04-08)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.34.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.8...@carbon/ibm-cloud-cognitive@0.34.9) (2021-04-07)
+## [0.34.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.9...@carbon/ibm-cloud-cognitive@0.34.10) (2021-04-08)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.34.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.7...@carbon/ibm-cloud-cognitive@0.34.8) (2021-04-07)
+## [0.34.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.8...@carbon/ibm-cloud-cognitive@0.34.9) (2021-04-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.34.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.6...@carbon/ibm-cloud-cognitive@0.34.7) (2021-04-06)
+## [0.34.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.7...@carbon/ibm-cloud-cognitive@0.34.8) (2021-04-07)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.34.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.6...@carbon/ibm-cloud-cognitive@0.34.7) (2021-04-06)
 
 ### Bug Fixes
 
 - card design feedback
-  ([#561](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/561))
-  ([7668278](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/76682786f4422cf9267a84b7e6f1409043758537))
+  ([#561](https://github.com/carbon-design-system/ibm-products/issues/561))
+  ([7668278](https://github.com/carbon-design-system/ibm-products/commit/76682786f4422cf9267a84b7e6f1409043758537))
 
-## [0.34.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.5...@carbon/ibm-cloud-cognitive@0.34.6) (2021-04-06)
+## [0.34.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.5...@carbon/ibm-cloud-cognitive@0.34.6) (2021-04-06)
 
 ### Bug Fixes
 
 - action bar crash when no space for overflow
-  ([#556](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/556))
-  ([74d1718](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/74d1718771dffb434512905a4c5ab2ed518a9a35))
+  ([#556](https://github.com/carbon-design-system/ibm-products/issues/556))
+  ([74d1718](https://github.com/carbon-design-system/ibm-products/commit/74d1718771dffb434512905a4c5ab2ed518a9a35))
 
-## [0.34.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.4...@carbon/ibm-cloud-cognitive@0.34.5) (2021-04-05)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.34.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.3...@carbon/ibm-cloud-cognitive@0.34.4) (2021-04-05)
+## [0.34.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.4...@carbon/ibm-cloud-cognitive@0.34.5) (2021-04-05)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.34.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.2...@carbon/ibm-cloud-cognitive@0.34.3) (2021-04-02)
+## [0.34.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.3...@carbon/ibm-cloud-cognitive@0.34.4) (2021-04-05)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.34.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.1...@carbon/ibm-cloud-cognitive@0.34.2) (2021-04-01)
+## [0.34.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.2...@carbon/ibm-cloud-cognitive@0.34.3) (2021-04-02)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.34.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.34.0...@carbon/ibm-cloud-cognitive@0.34.1) (2021-04-01)
+## [0.34.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.1...@carbon/ibm-cloud-cognitive@0.34.2) (2021-04-01)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.34.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.34.0...@carbon/ibm-cloud-cognitive@0.34.1) (2021-04-01)
 
 ### Bug Fixes
 
 - page header styles either side of md breakpoint
-  ([#554](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/554))
-  ([6abab44](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6abab440845b9919dbdd7e4a3b2c6d021f6477b8))
+  ([#554](https://github.com/carbon-design-system/ibm-products/issues/554))
+  ([6abab44](https://github.com/carbon-design-system/ibm-products/commit/6abab440845b9919dbdd7e4a3b2c6d021f6477b8))
 
-# [0.34.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.33.0...@carbon/ibm-cloud-cognitive@0.34.0) (2021-04-01)
+# [0.34.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.33.0...@carbon/ibm-cloud-cognitive@0.34.0) (2021-04-01)
 
 ### Features
 
 - add breadcrumb test and overflow aria label
-  ([#537](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/537))
-  ([f383b36](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f383b36d4f2987ae3032fa53319b883df95602ba))
+  ([#537](https://github.com/carbon-design-system/ibm-products/issues/537))
+  ([f383b36](https://github.com/carbon-design-system/ibm-products/commit/f383b36d4f2987ae3032fa53319b883df95602ba))
 
-# [0.33.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.32.4...@carbon/ibm-cloud-cognitive@0.33.0) (2021-04-01)
+# [0.33.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.32.4...@carbon/ibm-cloud-cognitive@0.33.0) (2021-04-01)
 
 ### Features
 
 - card refactor
-  ([#526](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/526))
-  ([fe0943f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fe0943ff6dbf8a7e08a6b029e9b09c258c0360a5))
+  ([#526](https://github.com/carbon-design-system/ibm-products/issues/526))
+  ([fe0943f](https://github.com/carbon-design-system/ibm-products/commit/fe0943ff6dbf8a7e08a6b029e9b09c258c0360a5))
 
-## [0.32.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.32.3...@carbon/ibm-cloud-cognitive@0.32.4) (2021-03-31)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.32.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.32.2...@carbon/ibm-cloud-cognitive@0.32.3) (2021-03-31)
+## [0.32.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.32.3...@carbon/ibm-cloud-cognitive@0.32.4) (2021-03-31)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.32.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.32.1...@carbon/ibm-cloud-cognitive@0.32.2) (2021-03-30)
+## [0.32.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.32.2...@carbon/ibm-cloud-cognitive@0.32.3) (2021-03-31)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.32.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.32.0...@carbon/ibm-cloud-cognitive@0.32.1) (2021-03-30)
+## [0.32.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.32.1...@carbon/ibm-cloud-cognitive@0.32.2) (2021-03-30)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.32.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.32.0...@carbon/ibm-cloud-cognitive@0.32.1) (2021-03-30)
 
 ### Bug Fixes
 
 - **HTTPErrors:** fix centering issue with css
-  ([#543](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/543))
-  ([3783d62](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3783d627b5626fe6077a317c15f1b6542e23e8ff))
+  ([#543](https://github.com/carbon-design-system/ibm-products/issues/543))
+  ([3783d62](https://github.com/carbon-design-system/ibm-products/commit/3783d627b5626fe6077a317c15f1b6542e23e8ff))
 
-# [0.32.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.31.5...@carbon/ibm-cloud-cognitive@0.32.0) (2021-03-30)
+# [0.32.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.31.5...@carbon/ibm-cloud-cognitive@0.32.0) (2021-03-30)
 
 ### Features
 
 - add header pre and toggle collapse features
-  ([#541](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/541))
-  ([7ff30b8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7ff30b8d6422c955841bce4e8a75b1f805492fe3))
+  ([#541](https://github.com/carbon-design-system/ibm-products/issues/541))
+  ([7ff30b8](https://github.com/carbon-design-system/ibm-products/commit/7ff30b8d6422c955841bce4e8a75b1f805492fe3))
 
-## [0.31.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.31.4...@carbon/ibm-cloud-cognitive@0.31.5) (2021-03-30)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.31.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.31.3...@carbon/ibm-cloud-cognitive@0.31.4) (2021-03-30)
+## [0.31.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.31.4...@carbon/ibm-cloud-cognitive@0.31.5) (2021-03-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.31.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.31.2...@carbon/ibm-cloud-cognitive@0.31.3) (2021-03-30)
+## [0.31.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.31.3...@carbon/ibm-cloud-cognitive@0.31.4) (2021-03-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.31.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.31.1...@carbon/ibm-cloud-cognitive@0.31.2) (2021-03-30)
+## [0.31.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.31.2...@carbon/ibm-cloud-cognitive@0.31.3) (2021-03-30)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.31.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.31.1...@carbon/ibm-cloud-cognitive@0.31.2) (2021-03-30)
 
 ### Bug Fixes
 
 - **EmptyState:** fix error logs by not having defaults for shared props
-  ([#535](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/535))
-  ([3de7429](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3de7429a8bb841c97df37d2711bc4a97f0241064))
+  ([#535](https://github.com/carbon-design-system/ibm-products/issues/535))
+  ([3de7429](https://github.com/carbon-design-system/ibm-products/commit/3de7429a8bb841c97df37d2711bc4a97f0241064))
 
-## [0.31.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.31.0...@carbon/ibm-cloud-cognitive@0.31.1) (2021-03-30)
+## [0.31.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.31.0...@carbon/ibm-cloud-cognitive@0.31.1) (2021-03-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-# [0.31.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.30.8...@carbon/ibm-cloud-cognitive@0.31.0) (2021-03-26)
+# [0.31.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.30.8...@carbon/ibm-cloud-cognitive@0.31.0) (2021-03-26)
 
 ### Features
 
 - new release for experimental wrapper
-  ([#532](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/532))
-  ([b42c47d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b42c47ddc171a31457b7d4b9a1bcf804d4fa9d4f))
+  ([#532](https://github.com/carbon-design-system/ibm-products/issues/532))
+  ([b42c47d](https://github.com/carbon-design-system/ibm-products/commit/b42c47ddc171a31457b7d4b9a1bcf804d4fa9d4f))
 
-## [0.30.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.30.7...@carbon/ibm-cloud-cognitive@0.30.8) (2021-03-26)
+## [0.30.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.30.7...@carbon/ibm-cloud-cognitive@0.30.8) (2021-03-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.30.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.30.6...@carbon/ibm-cloud-cognitive@0.30.7) (2021-03-26)
+## [0.30.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.30.6...@carbon/ibm-cloud-cognitive@0.30.7) (2021-03-26)
 
 ### Bug Fixes
 
 - **Notifications:** new notifications get sorted as expected now
-  ([#527](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/527))
-  ([2f762e8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2f762e812c9728525721b2480e3bdd86f533bbc0))
+  ([#527](https://github.com/carbon-design-system/ibm-products/issues/527))
+  ([2f762e8](https://github.com/carbon-design-system/ibm-products/commit/2f762e812c9728525721b2480e3bdd86f533bbc0))
 
-## [0.30.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.30.5...@carbon/ibm-cloud-cognitive@0.30.6) (2021-03-26)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.30.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.30.4...@carbon/ibm-cloud-cognitive@0.30.5) (2021-03-25)
+## [0.30.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.30.5...@carbon/ibm-cloud-cognitive@0.30.6) (2021-03-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.30.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.30.3...@carbon/ibm-cloud-cognitive@0.30.4) (2021-03-25)
+## [0.30.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.30.4...@carbon/ibm-cloud-cognitive@0.30.5) (2021-03-25)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.30.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.30.3...@carbon/ibm-cloud-cognitive@0.30.4) (2021-03-25)
 
 ### Bug Fixes
 
 - add tests to PageActionItem
-  ([#516](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/516))
-  ([f1e5de2](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f1e5de288720be43f411b173486b5ed5ebe33759))
+  ([#516](https://github.com/carbon-design-system/ibm-products/issues/516))
+  ([f1e5de2](https://github.com/carbon-design-system/ibm-products/commit/f1e5de288720be43f411b173486b5ed5ebe33759))
 
-## [0.30.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.30.2...@carbon/ibm-cloud-cognitive@0.30.3) (2021-03-25)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.30.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.30.1...@carbon/ibm-cloud-cognitive@0.30.2) (2021-03-25)
+## [0.30.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.30.2...@carbon/ibm-cloud-cognitive@0.30.3) (2021-03-25)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.30.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.30.0...@carbon/ibm-cloud-cognitive@0.30.1) (2021-03-25)
+## [0.30.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.30.1...@carbon/ibm-cloud-cognitive@0.30.2) (2021-03-25)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.30.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.30.0...@carbon/ibm-cloud-cognitive@0.30.1) (2021-03-25)
 
 ### Bug Fixes
 
 - **SidePanel:** should fix focus trap which is breaking the side panel
-  ([#511](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/511))
-  ([47d9828](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/47d98287f25284a20da3a2e8d480b138ee876cfc))
+  ([#511](https://github.com/carbon-design-system/ibm-products/issues/511))
+  ([47d9828](https://github.com/carbon-design-system/ibm-products/commit/47d98287f25284a20da3a2e8d480b138ee876cfc))
 
-# [0.30.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.29.0...@carbon/ibm-cloud-cognitive@0.30.0) (2021-03-24)
+# [0.30.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.29.0...@carbon/ibm-cloud-cognitive@0.30.0) (2021-03-24)
 
 ### Features
 
 - animation for in-progress icon
-  ([#512](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/512))
-  ([cf6d06f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/cf6d06f8b279fe84c18dd23baf9c267c85e88369))
+  ([#512](https://github.com/carbon-design-system/ibm-products/issues/512))
+  ([cf6d06f](https://github.com/carbon-design-system/ibm-products/commit/cf6d06f8b279fe84c18dd23baf9c267c85e88369))
 
-# [0.29.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.28.10...@carbon/ibm-cloud-cognitive@0.29.0) (2021-03-24)
+# [0.29.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.28.10...@carbon/ibm-cloud-cognitive@0.29.0) (2021-03-24)
 
 ### Features
 
 - add action bar tests
-  ([#338](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/338))
-  ([d1df237](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d1df237652e9f22c5018d3fa1859827a037f477d))
+  ([#338](https://github.com/carbon-design-system/ibm-products/issues/338))
+  ([d1df237](https://github.com/carbon-design-system/ibm-products/commit/d1df237652e9f22c5018d3fa1859827a037f477d))
 
-## [0.28.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.28.9...@carbon/ibm-cloud-cognitive@0.28.10) (2021-03-24)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
-
-## [0.28.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.28.8...@carbon/ibm-cloud-cognitive@0.28.9) (2021-03-23)
+## [0.28.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.28.9...@carbon/ibm-cloud-cognitive@0.28.10) (2021-03-24)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.28.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.28.7...@carbon/ibm-cloud-cognitive@0.28.8) (2021-03-23)
+## [0.28.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.28.8...@carbon/ibm-cloud-cognitive@0.28.9) (2021-03-23)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.28.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.28.6...@carbon/ibm-cloud-cognitive@0.28.7) (2021-03-22)
+## [0.28.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.28.7...@carbon/ibm-cloud-cognitive@0.28.8) (2021-03-23)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
-## [0.28.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.2.7...@carbon/ibm-cloud-cognitive@0.28.6) (2021-03-22)
+## [0.28.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.28.6...@carbon/ibm-cloud-cognitive@0.28.7) (2021-03-22)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive
+
+## [0.28.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive@0.2.7...@carbon/ibm-cloud-cognitive@0.28.6) (2021-03-22)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive
 
 ## -------- Renamed ibm-cloud-cognitive-experimental package to ibm-cloud-cognitive ----------
 
-## [0.28.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.28.3...@carbon/ibm-cloud-cognitive-experimental@0.28.4) (2021-03-22)
+## [0.28.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.28.3...@carbon/ibm-cloud-cognitive-experimental@0.28.4) (2021-03-22)
 
-## [0.28.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.28.2...@carbon/ibm-cloud-cognitive-experimental@0.28.3) (2021-03-19)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
-
-## [0.28.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.28.1...@carbon/ibm-cloud-cognitive-experimental@0.28.2) (2021-03-19)
+## [0.28.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.28.2...@carbon/ibm-cloud-cognitive-experimental@0.28.3) (2021-03-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.28.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.28.0...@carbon/ibm-cloud-cognitive-experimental@0.28.1) (2021-03-19)
+## [0.28.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.28.1...@carbon/ibm-cloud-cognitive-experimental@0.28.2) (2021-03-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-# [0.28.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.27.1...@carbon/ibm-cloud-cognitive-experimental@0.28.0) (2021-03-19)
+## [0.28.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.28.0...@carbon/ibm-cloud-cognitive-experimental@0.28.1) (2021-03-19)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
+
+# [0.28.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.27.1...@carbon/ibm-cloud-cognitive-experimental@0.28.0) (2021-03-19)
 
 ### Features
 
 - saving
-  ([#476](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/476))
-  ([8ccf7bd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8ccf7bd412e8b94ac86abc9c635a47a097700133))
+  ([#476](https://github.com/carbon-design-system/ibm-products/issues/476))
+  ([8ccf7bd](https://github.com/carbon-design-system/ibm-products/commit/8ccf7bd412e8b94ac86abc9c635a47a097700133))
 
-## [0.27.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.27.0...@carbon/ibm-cloud-cognitive-experimental@0.27.1) (2021-03-19)
+## [0.27.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.27.0...@carbon/ibm-cloud-cognitive-experimental@0.27.1) (2021-03-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-# [0.27.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.11...@carbon/ibm-cloud-cognitive-experimental@0.27.0) (2021-03-19)
+# [0.27.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.11...@carbon/ibm-cloud-cognitive-experimental@0.27.0) (2021-03-19)
 
 ### Features
 
 - add carbon telemetry
-  ([#477](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/477))
-  ([950c9f3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/950c9f3394af98f93f39851f70e126f944c7477a))
+  ([#477](https://github.com/carbon-design-system/ibm-products/issues/477))
+  ([950c9f3](https://github.com/carbon-design-system/ibm-products/commit/950c9f3394af98f93f39851f70e126f944c7477a))
 
-## [0.26.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.10...@carbon/ibm-cloud-cognitive-experimental@0.26.11) (2021-03-18)
+## [0.26.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.10...@carbon/ibm-cloud-cognitive-experimental@0.26.11) (2021-03-18)
 
 ### Bug Fixes
 
 - update WebTerminal
-  ([#479](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/479))
-  ([211f3dd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/211f3dd2fce7e455fc98dc407ac01b9aefb3f15f))
+  ([#479](https://github.com/carbon-design-system/ibm-products/issues/479))
+  ([211f3dd](https://github.com/carbon-design-system/ibm-products/commit/211f3dd2fce7e455fc98dc407ac01b9aefb3f15f))
 
-## [0.26.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.9...@carbon/ibm-cloud-cognitive-experimental@0.26.10) (2021-03-18)
+## [0.26.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.9...@carbon/ibm-cloud-cognitive-experimental@0.26.10) (2021-03-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.26.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.8...@carbon/ibm-cloud-cognitive-experimental@0.26.9) (2021-03-18)
+## [0.26.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.8...@carbon/ibm-cloud-cognitive-experimental@0.26.9) (2021-03-18)
 
 ### Bug Fixes
 
 - set standard pattern for SCSS per Carbon
-  ([#478](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/478))
-  ([fd19d32](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fd19d32199ea377d46d4bf42375b4ba6d80c31d3))
+  ([#478](https://github.com/carbon-design-system/ibm-products/issues/478))
+  ([fd19d32](https://github.com/carbon-design-system/ibm-products/commit/fd19d32199ea377d46d4bf42375b4ba6d80c31d3))
 
-## [0.26.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.7...@carbon/ibm-cloud-cognitive-experimental@0.26.8) (2021-03-18)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
-
-## [0.26.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.6...@carbon/ibm-cloud-cognitive-experimental@0.26.7) (2021-03-18)
+## [0.26.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.7...@carbon/ibm-cloud-cognitive-experimental@0.26.8) (2021-03-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.26.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.5...@carbon/ibm-cloud-cognitive-experimental@0.26.6) (2021-03-18)
+## [0.26.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.6...@carbon/ibm-cloud-cognitive-experimental@0.26.7) (2021-03-18)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
+
+## [0.26.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.5...@carbon/ibm-cloud-cognitive-experimental@0.26.6) (2021-03-18)
 
 ### Bug Fixes
 
 - **Notifications:** use new empty state, add empty state label prop
-  ([#468](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/468))
-  ([7ee3dcd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7ee3dcd52f07d9bbf4b21c5b60af07168efa90c0))
+  ([#468](https://github.com/carbon-design-system/ibm-products/issues/468))
+  ([7ee3dcd](https://github.com/carbon-design-system/ibm-products/commit/7ee3dcd52f07d9bbf4b21c5b60af07168efa90c0))
 
-## [0.26.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.4...@carbon/ibm-cloud-cognitive-experimental@0.26.5) (2021-03-18)
+## [0.26.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.4...@carbon/ibm-cloud-cognitive-experimental@0.26.5) (2021-03-18)
 
 ### Bug Fixes
 
 - **EmptyStates:** remove utility classnames function
-  ([#465](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/465))
-  ([04d688e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/04d688e90e0b51971ad3016eb622a760408f697a))
+  ([#465](https://github.com/carbon-design-system/ibm-products/issues/465))
+  ([04d688e](https://github.com/carbon-design-system/ibm-products/commit/04d688e90e0b51971ad3016eb622a760408f697a))
 
-## [0.26.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.3...@carbon/ibm-cloud-cognitive-experimental@0.26.4) (2021-03-18)
+## [0.26.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.3...@carbon/ibm-cloud-cognitive-experimental@0.26.4) (2021-03-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.26.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.2...@carbon/ibm-cloud-cognitive-experimental@0.26.3) (2021-03-18)
+## [0.26.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.2...@carbon/ibm-cloud-cognitive-experimental@0.26.3) (2021-03-18)
 
 ### Bug Fixes
 
 - canary component warnings
-  ([#472](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/472))
-  ([91930f0](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/91930f0ce6cba909baf01e61d8b4917fe1dadef1))
+  ([#472](https://github.com/carbon-design-system/ibm-products/issues/472))
+  ([91930f0](https://github.com/carbon-design-system/ibm-products/commit/91930f0ce6cba909baf01e61d8b4917fe1dadef1))
 
-## [0.26.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.1...@carbon/ibm-cloud-cognitive-experimental@0.26.2) (2021-03-17)
+## [0.26.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.1...@carbon/ibm-cloud-cognitive-experimental@0.26.2) (2021-03-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.26.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.0...@carbon/ibm-cloud-cognitive-experimental@0.26.1) (2021-03-17)
+## [0.26.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.26.0...@carbon/ibm-cloud-cognitive-experimental@0.26.1) (2021-03-17)
 
 ### Bug Fixes
 
 - quieten experimental tests
-  ([#454](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/454))
-  ([85d5a52](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/85d5a52c98370743c6218f41ba192da9d10e7508))
+  ([#454](https://github.com/carbon-design-system/ibm-products/issues/454))
+  ([85d5a52](https://github.com/carbon-design-system/ibm-products/commit/85d5a52c98370743c6218f41ba192da9d10e7508))
 
-# [0.26.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.25.1...@carbon/ibm-cloud-cognitive-experimental@0.26.0) (2021-03-16)
+# [0.26.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.25.1...@carbon/ibm-cloud-cognitive-experimental@0.26.0) (2021-03-16)
 
 ### Features
 
 - **HTTPErrors:** add new 404 and other http error components
-  ([#456](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/456))
-  ([ea42547](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ea425472c2a31144989acc8f9ba53d6a175651ab))
+  ([#456](https://github.com/carbon-design-system/ibm-products/issues/456))
+  ([ea42547](https://github.com/carbon-design-system/ibm-products/commit/ea425472c2a31144989acc8f9ba53d6a175651ab))
 
-## [0.25.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.25.0...@carbon/ibm-cloud-cognitive-experimental@0.25.1) (2021-03-16)
+## [0.25.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.25.0...@carbon/ibm-cloud-cognitive-experimental@0.25.1) (2021-03-16)
 
 ### Bug Fixes
 
 - update card docs
-  ([#459](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/459))
-  ([faac6c6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/faac6c68268c9a9538807cd9dafaee69e13f9617))
+  ([#459](https://github.com/carbon-design-system/ibm-products/issues/459))
+  ([faac6c6](https://github.com/carbon-design-system/ibm-products/commit/faac6c68268c9a9538807cd9dafaee69e13f9617))
 
-# [0.25.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.24.6...@carbon/ibm-cloud-cognitive-experimental@0.25.0) (2021-03-16)
+# [0.25.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.24.6...@carbon/ibm-cloud-cognitive-experimental@0.25.0) (2021-03-16)
 
 ### Features
 
 - warn on feature flag use
-  ([#436](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/436))
-  ([b3fc781](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b3fc7811e84f3e721da7882256925d9eb4bbfbda))
+  ([#436](https://github.com/carbon-design-system/ibm-products/issues/436))
+  ([b3fc781](https://github.com/carbon-design-system/ibm-products/commit/b3fc7811e84f3e721da7882256925d9eb4bbfbda))
 
-## [0.24.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.24.5...@carbon/ibm-cloud-cognitive-experimental@0.24.6) (2021-03-16)
+## [0.24.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.24.5...@carbon/ibm-cloud-cognitive-experimental@0.24.6) (2021-03-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.24.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.24.4...@carbon/ibm-cloud-cognitive-experimental@0.24.5) (2021-03-16)
+## [0.24.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.24.4...@carbon/ibm-cloud-cognitive-experimental@0.24.5) (2021-03-16)
 
 ### Bug Fixes
 
 - useless fragment issue in unwrap
-  ([#448](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/448))
-  ([ef94bf2](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ef94bf217ced96f34aa1c5bfd48a7dff376339ed))
+  ([#448](https://github.com/carbon-design-system/ibm-products/issues/448))
+  ([ef94bf2](https://github.com/carbon-design-system/ibm-products/commit/ef94bf217ced96f34aa1c5bfd48a7dff376339ed))
 
-## [0.24.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.24.3...@carbon/ibm-cloud-cognitive-experimental@0.24.4) (2021-03-16)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
-
-## [0.24.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.24.2...@carbon/ibm-cloud-cognitive-experimental@0.24.3) (2021-03-16)
+## [0.24.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.24.3...@carbon/ibm-cloud-cognitive-experimental@0.24.4) (2021-03-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.24.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.24.1...@carbon/ibm-cloud-cognitive-experimental@0.24.2) (2021-03-16)
+## [0.24.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.24.2...@carbon/ibm-cloud-cognitive-experimental@0.24.3) (2021-03-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.24.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.24.0...@carbon/ibm-cloud-cognitive-experimental@0.24.1) (2021-03-16)
+## [0.24.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.24.1...@carbon/ibm-cloud-cognitive-experimental@0.24.2) (2021-03-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-# [0.24.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.23.3...@carbon/ibm-cloud-cognitive-experimental@0.24.0) (2021-03-15)
+## [0.24.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.24.0...@carbon/ibm-cloud-cognitive-experimental@0.24.1) (2021-03-16)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
+
+# [0.24.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.23.3...@carbon/ibm-cloud-cognitive-experimental@0.24.0) (2021-03-15)
 
 ### Features
 
 - **HTTPErrors:** initial component structure
-  ([#437](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/437))
-  ([23e4454](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/23e44549b6ac331e115f7a38665ca10639c05679))
+  ([#437](https://github.com/carbon-design-system/ibm-products/issues/437))
+  ([23e4454](https://github.com/carbon-design-system/ibm-products/commit/23e44549b6ac331e115f7a38665ca10639c05679))
 
-## [0.23.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.23.2...@carbon/ibm-cloud-cognitive-experimental@0.23.3) (2021-03-15)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
-
-## [0.23.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.23.1...@carbon/ibm-cloud-cognitive-experimental@0.23.2) (2021-03-12)
+## [0.23.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.23.2...@carbon/ibm-cloud-cognitive-experimental@0.23.3) (2021-03-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.23.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.23.0...@carbon/ibm-cloud-cognitive-experimental@0.23.1) (2021-03-11)
+## [0.23.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.23.1...@carbon/ibm-cloud-cognitive-experimental@0.23.2) (2021-03-12)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
+
+## [0.23.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.23.0...@carbon/ibm-cloud-cognitive-experimental@0.23.1) (2021-03-11)
 
 ### Bug Fixes
 
 - **SidePanel:** add classname prop to side panel
-  ([#433](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/433))
-  ([b2c7f18](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b2c7f188e50e9aaad8a1dcab3b22083ac911933a))
+  ([#433](https://github.com/carbon-design-system/ibm-products/issues/433))
+  ([b2c7f18](https://github.com/carbon-design-system/ibm-products/commit/b2c7f188e50e9aaad8a1dcab3b22083ac911933a))
 
-# [0.23.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.22.0...@carbon/ibm-cloud-cognitive-experimental@0.23.0) (2021-03-11)
+# [0.23.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.22.0...@carbon/ibm-cloud-cognitive-experimental@0.23.0) (2021-03-11)
 
 ### Features
 
 - update remaining components to be in line with feature flags proposal
-  ([#429](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/429))
-  ([a6c870a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a6c870a62e72a8ca1b992f17188cc8a991f00ec8))
+  ([#429](https://github.com/carbon-design-system/ibm-products/issues/429))
+  ([a6c870a](https://github.com/carbon-design-system/ibm-products/commit/a6c870a62e72a8ca1b992f17188cc8a991f00ec8))
 
-# [0.22.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.21.6...@carbon/ibm-cloud-cognitive-experimental@0.22.0) (2021-03-11)
+# [0.22.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.21.6...@carbon/ibm-cloud-cognitive-experimental@0.22.0) (2021-03-11)
 
 ### Features
 
 - bump carbon versions to latest
-  ([#426](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/426))
-  ([761ea98](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/761ea98c33a6be318293526833c316f3d44db533))
+  ([#426](https://github.com/carbon-design-system/ibm-products/issues/426))
+  ([761ea98](https://github.com/carbon-design-system/ibm-products/commit/761ea98c33a6be318293526833c316f3d44db533))
 
-## [0.21.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.21.5...@carbon/ibm-cloud-cognitive-experimental@0.21.6) (2021-03-11)
+## [0.21.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.21.5...@carbon/ibm-cloud-cognitive-experimental@0.21.6) (2021-03-11)
 
 ### Bug Fixes
 
 - **EmptyState:** illustrations should render correctly now
-  ([#332](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/332))
-  ([d81fee2](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d81fee2322e6c66a9773de71f57390956756bfd3)),
+  ([#332](https://github.com/carbon-design-system/ibm-products/issues/332))
+  ([d81fee2](https://github.com/carbon-design-system/ibm-products/commit/d81fee2322e6c66a9773de71f57390956756bfd3)),
   closes
-  [#392](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/392)
-  [#396](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/396)
-  [#400](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/400)
-  [#389](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/389)
-  [#406](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/406)
-  [#402](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/402)
-  [#401](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/401)
-  [#398](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/398)
-  [#410](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/410)
-  [#403](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/403)
-  [#414](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/414)
-  [#387](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/387)
-  [#417](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/417)
-  [#385](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/385)
-  [#419](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/419)
-  [#418](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/418)
-  [#412](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/412)
-  [#421](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/421)
-  [#423](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/423)
-  [#425](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/425)
-  [#422](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/422)
-  [#351](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/351)
-  [#428](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/428)
+  [#392](https://github.com/carbon-design-system/ibm-products/issues/392)
+  [#396](https://github.com/carbon-design-system/ibm-products/issues/396)
+  [#400](https://github.com/carbon-design-system/ibm-products/issues/400)
+  [#389](https://github.com/carbon-design-system/ibm-products/issues/389)
+  [#406](https://github.com/carbon-design-system/ibm-products/issues/406)
+  [#402](https://github.com/carbon-design-system/ibm-products/issues/402)
+  [#401](https://github.com/carbon-design-system/ibm-products/issues/401)
+  [#398](https://github.com/carbon-design-system/ibm-products/issues/398)
+  [#410](https://github.com/carbon-design-system/ibm-products/issues/410)
+  [#403](https://github.com/carbon-design-system/ibm-products/issues/403)
+  [#414](https://github.com/carbon-design-system/ibm-products/issues/414)
+  [#387](https://github.com/carbon-design-system/ibm-products/issues/387)
+  [#417](https://github.com/carbon-design-system/ibm-products/issues/417)
+  [#385](https://github.com/carbon-design-system/ibm-products/issues/385)
+  [#419](https://github.com/carbon-design-system/ibm-products/issues/419)
+  [#418](https://github.com/carbon-design-system/ibm-products/issues/418)
+  [#412](https://github.com/carbon-design-system/ibm-products/issues/412)
+  [#421](https://github.com/carbon-design-system/ibm-products/issues/421)
+  [#423](https://github.com/carbon-design-system/ibm-products/issues/423)
+  [#425](https://github.com/carbon-design-system/ibm-products/issues/425)
+  [#422](https://github.com/carbon-design-system/ibm-products/issues/422)
+  [#351](https://github.com/carbon-design-system/ibm-products/issues/351)
+  [#428](https://github.com/carbon-design-system/ibm-products/issues/428)
 
-## [0.21.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.21.4...@carbon/ibm-cloud-cognitive-experimental@0.21.5) (2021-03-10)
+## [0.21.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.21.4...@carbon/ibm-cloud-cognitive-experimental@0.21.5) (2021-03-10)
 
 ### Bug Fixes
 
 - card feedback round 3
-  ([#428](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/428))
-  ([c167a11](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c167a11ddabb122831295e75cab98c273c20463c))
+  ([#428](https://github.com/carbon-design-system/ibm-products/issues/428))
+  ([c167a11](https://github.com/carbon-design-system/ibm-products/commit/c167a11ddabb122831295e75cab98c273c20463c))
 
-## [0.21.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.21.3...@carbon/ibm-cloud-cognitive-experimental@0.21.4) (2021-03-10)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
-
-## [0.21.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.21.2...@carbon/ibm-cloud-cognitive-experimental@0.21.3) (2021-03-10)
+## [0.21.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.21.3...@carbon/ibm-cloud-cognitive-experimental@0.21.4) (2021-03-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.21.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.21.1...@carbon/ibm-cloud-cognitive-experimental@0.21.2) (2021-03-09)
+## [0.21.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.21.2...@carbon/ibm-cloud-cognitive-experimental@0.21.3) (2021-03-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.21.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.21.0...@carbon/ibm-cloud-cognitive-experimental@0.21.1) (2021-03-09)
+## [0.21.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.21.1...@carbon/ibm-cloud-cognitive-experimental@0.21.2) (2021-03-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-# [0.21.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.14...@carbon/ibm-cloud-cognitive-experimental@0.21.0) (2021-03-09)
+## [0.21.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.21.0...@carbon/ibm-cloud-cognitive-experimental@0.21.1) (2021-03-09)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
+
+# [0.21.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.14...@carbon/ibm-cloud-cognitive-experimental@0.21.0) (2021-03-09)
 
 ### Features
 
 - **WebTerminal:** add entrance/exit animation to panel
-  ([#412](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/412))
-  ([1fe152c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1fe152cd14e82fb9e698acc4728da5bc65ed13ae))
+  ([#412](https://github.com/carbon-design-system/ibm-products/issues/412))
+  ([1fe152c](https://github.com/carbon-design-system/ibm-products/commit/1fe152cd14e82fb9e698acc4728da5bc65ed13ae))
 
-## [0.20.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.13...@carbon/ibm-cloud-cognitive-experimental@0.20.14) (2021-03-09)
+## [0.20.14](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.13...@carbon/ibm-cloud-cognitive-experimental@0.20.14) (2021-03-09)
 
 ### Bug Fixes
 
 - canary scss and settings imports
-  ([#418](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/418))
-  ([29711ec](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/29711ec18c66e70565be3361688e2bfd377d23f3))
+  ([#418](https://github.com/carbon-design-system/ibm-products/issues/418))
+  ([29711ec](https://github.com/carbon-design-system/ibm-products/commit/29711ec18c66e70565be3361688e2bfd377d23f3))
 
-## [0.20.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.12...@carbon/ibm-cloud-cognitive-experimental@0.20.13) (2021-03-09)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
-
-## [0.20.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.11...@carbon/ibm-cloud-cognitive-experimental@0.20.12) (2021-03-08)
+## [0.20.13](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.12...@carbon/ibm-cloud-cognitive-experimental@0.20.13) (2021-03-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.20.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.10...@carbon/ibm-cloud-cognitive-experimental@0.20.11) (2021-03-08)
+## [0.20.12](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.11...@carbon/ibm-cloud-cognitive-experimental@0.20.12) (2021-03-08)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
+
+## [0.20.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.10...@carbon/ibm-cloud-cognitive-experimental@0.20.11) (2021-03-08)
 
 ### Bug Fixes
 
 - **PageHeader:** story previews show correctly again in docs
-  ([#414](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/414))
-  ([1d58962](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1d58962b66f5fc15c44939ee194f4b8eacbb6312))
+  ([#414](https://github.com/carbon-design-system/ibm-products/issues/414))
+  ([1d58962](https://github.com/carbon-design-system/ibm-products/commit/1d58962b66f5fc15c44939ee194f4b8eacbb6312))
 - action bar item tip and title title
-  ([#403](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/403))
-  ([7ec2bc9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7ec2bc9c740fdb7e15c6b6ddcd8be94c8fecf0d8))
+  ([#403](https://github.com/carbon-design-system/ibm-products/issues/403))
+  ([7ec2bc9](https://github.com/carbon-design-system/ibm-products/commit/7ec2bc9c740fdb7e15c6b6ddcd8be94c8fecf0d8))
 
-## [0.20.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.9...@carbon/ibm-cloud-cognitive-experimental@0.20.10) (2021-03-08)
+## [0.20.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.9...@carbon/ibm-cloud-cognitive-experimental@0.20.10) (2021-03-08)
 
 ### Bug Fixes
 
 - remove console log from page header test
-  ([#410](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/410))
-  ([05aa11b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/05aa11bc5d0d60a1b645a3569963f6411da7549e))
+  ([#410](https://github.com/carbon-design-system/ibm-products/issues/410))
+  ([05aa11b](https://github.com/carbon-design-system/ibm-products/commit/05aa11bc5d0d60a1b645a3569963f6411da7549e))
 
-## [0.20.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.8...@carbon/ibm-cloud-cognitive-experimental@0.20.9) (2021-03-05)
+## [0.20.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.8...@carbon/ibm-cloud-cognitive-experimental@0.20.9) (2021-03-05)
 
 ### Bug Fixes
 
 - **Notifications:** add props for label strings and fix classname usage
-  ([#398](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/398))
-  ([08a836f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/08a836fe0ed3de03b80f2df2d2daf80f4e3611df))
+  ([#398](https://github.com/carbon-design-system/ibm-products/issues/398))
+  ([08a836f](https://github.com/carbon-design-system/ibm-products/commit/08a836fe0ed3de03b80f2df2d2daf80f4e3611df))
 
-## [0.20.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.7...@carbon/ibm-cloud-cognitive-experimental@0.20.8) (2021-03-05)
+## [0.20.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.7...@carbon/ibm-cloud-cognitive-experimental@0.20.8) (2021-03-05)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.20.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.6...@carbon/ibm-cloud-cognitive-experimental@0.20.7) (2021-03-04)
+## [0.20.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.6...@carbon/ibm-cloud-cognitive-experimental@0.20.7) (2021-03-04)
 
 ### Bug Fixes
 
 - **WebTerminal:** move from experimental to canary in storybook
-  ([#406](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/406))
-  ([e179f34](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e179f34709aa65e190c9fcecbe0cae86ce736df5))
+  ([#406](https://github.com/carbon-design-system/ibm-products/issues/406))
+  ([e179f34](https://github.com/carbon-design-system/ibm-products/commit/e179f34709aa65e190c9fcecbe0cae86ce736df5))
 
-## [0.20.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.5...@carbon/ibm-cloud-cognitive-experimental@0.20.6) (2021-03-04)
+## [0.20.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.5...@carbon/ibm-cloud-cognitive-experimental@0.20.6) (2021-03-04)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.20.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.4...@carbon/ibm-cloud-cognitive-experimental@0.20.5) (2021-03-04)
+## [0.20.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.4...@carbon/ibm-cloud-cognitive-experimental@0.20.5) (2021-03-04)
 
 ### Bug Fixes
 
 - **SidePanel:** remove slideIn prop from storybook, refactor classnames
-  ([#400](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/400))
-  ([e7b0d70](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e7b0d70d6dd2e5727d65d2e736a1ed537a6ed044))
+  ([#400](https://github.com/carbon-design-system/ibm-products/issues/400))
+  ([e7b0d70](https://github.com/carbon-design-system/ibm-products/commit/e7b0d70d6dd2e5727d65d2e736a1ed537a6ed044))
 
-## [0.20.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.3...@carbon/ibm-cloud-cognitive-experimental@0.20.4) (2021-03-04)
+## [0.20.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.3...@carbon/ibm-cloud-cognitive-experimental@0.20.4) (2021-03-04)
 
 ### Bug Fixes
 
 - card design revisions v1
-  ([#396](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/396))
-  ([7dd4479](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7dd44792239c42fc812e9af266e881ca0abff398))
+  ([#396](https://github.com/carbon-design-system/ibm-products/issues/396))
+  ([7dd4479](https://github.com/carbon-design-system/ibm-products/commit/7dd44792239c42fc812e9af266e881ca0abff398))
 
-## [0.20.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.2...@carbon/ibm-cloud-cognitive-experimental@0.20.3) (2021-03-03)
+## [0.20.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.2...@carbon/ibm-cloud-cognitive-experimental@0.20.3) (2021-03-03)
 
 ### Bug Fixes
 
 - remove spurious scrollbar when available height is very small
-  ([#392](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/392))
-  ([37dd87c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/37dd87cfb906d8d9256be6d71f0218d2156b3095))
+  ([#392](https://github.com/carbon-design-system/ibm-products/issues/392))
+  ([37dd87c](https://github.com/carbon-design-system/ibm-products/commit/37dd87cfb906d8d9256be6d71f0218d2156b3095))
 
-## [0.20.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.1...@carbon/ibm-cloud-cognitive-experimental@0.20.2) (2021-03-01)
+## [0.20.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.1...@carbon/ibm-cloud-cognitive-experimental@0.20.2) (2021-03-01)
 
 ### Bug Fixes
 
 - **SidePanel:** added design changes and added new labelText prop
-  ([#388](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/388))
-  ([0d0186d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0d0186d874b79797fa7ca4cd3997197cddff0242))
+  ([#388](https://github.com/carbon-design-system/ibm-products/issues/388))
+  ([0d0186d](https://github.com/carbon-design-system/ibm-products/commit/0d0186d874b79797fa7ca4cd3997197cddff0242))
 
-## [0.20.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.0...@carbon/ibm-cloud-cognitive-experimental@0.20.1) (2021-03-01)
+## [0.20.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.20.0...@carbon/ibm-cloud-cognitive-experimental@0.20.1) (2021-03-01)
 
 ### Bug Fixes
 
 - added decorator to card story
-  ([#359](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/359))
-  ([6ef696a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6ef696a53ece33e1d05e8a7e8d1326d840f5f80a))
+  ([#359](https://github.com/carbon-design-system/ibm-products/issues/359))
+  ([6ef696a](https://github.com/carbon-design-system/ibm-products/commit/6ef696a53ece33e1d05e8a7e8d1326d840f5f80a))
 
-# [0.20.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.22...@carbon/ibm-cloud-cognitive-experimental@0.20.0) (2021-02-25)
+# [0.20.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.22...@carbon/ibm-cloud-cognitive-experimental@0.20.0) (2021-02-25)
 
 ### Features
 
 - Adds the web terminal component
-  ([#341](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/341))
-  ([2460eed](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2460eed2b0ef29d97a0bd2a2f63f6064ee406a03))
+  ([#341](https://github.com/carbon-design-system/ibm-products/issues/341))
+  ([2460eed](https://github.com/carbon-design-system/ibm-products/commit/2460eed2b0ef29d97a0bd2a2f63f6064ee406a03))
 
-## [0.19.22](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.21...@carbon/ibm-cloud-cognitive-experimental@0.19.22) (2021-02-25)
+## [0.19.22](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.21...@carbon/ibm-cloud-cognitive-experimental@0.19.22) (2021-02-25)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.19.21](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.20...@carbon/ibm-cloud-cognitive-experimental@0.19.21) (2021-02-24)
+## [0.19.21](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.20...@carbon/ibm-cloud-cognitive-experimental@0.19.21) (2021-02-24)
 
 ### Bug Fixes
 
 - crypto for ssr and add test
-  ([#337](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/337))
-  ([1464d16](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1464d16646832472f44c2105c4a1c0e44b69c5bc))
+  ([#337](https://github.com/carbon-design-system/ibm-products/issues/337))
+  ([1464d16](https://github.com/carbon-design-system/ibm-products/commit/1464d16646832472f44c2105c4a1c0e44b69c5bc))
 
-## [0.19.20](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.19...@carbon/ibm-cloud-cognitive-experimental@0.19.20) (2021-02-23)
+## [0.19.20](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.19...@carbon/ibm-cloud-cognitive-experimental@0.19.20) (2021-02-23)
 
 ### Bug Fixes
 
 - prefix not using global settings
-  ([#331](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/331))
-  ([39b3c54](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/39b3c544cf0769dc621ae11843e60a4a54773ddf))
+  ([#331](https://github.com/carbon-design-system/ibm-products/issues/331))
+  ([39b3c54](https://github.com/carbon-design-system/ibm-products/commit/39b3c544cf0769dc621ae11843e60a4a54773ddf))
 
-## [0.19.19](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.18...@carbon/ibm-cloud-cognitive-experimental@0.19.19) (2021-02-23)
+## [0.19.19](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.18...@carbon/ibm-cloud-cognitive-experimental@0.19.19) (2021-02-23)
 
 ### Bug Fixes
 
 - unwrap if fragment
-  ([#357](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/357))
-  ([f03c063](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f03c063ed60b563de4513ba513fd86c1f3e31a36))
+  ([#357](https://github.com/carbon-design-system/ibm-products/issues/357))
+  ([f03c063](https://github.com/carbon-design-system/ibm-products/commit/f03c063ed60b563de4513ba513fd86c1f3e31a36))
 
-## [0.19.18](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.17...@carbon/ibm-cloud-cognitive-experimental@0.19.18) (2021-02-23)
+## [0.19.18](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.17...@carbon/ibm-cloud-cognitive-experimental@0.19.18) (2021-02-23)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.19.17](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.16...@carbon/ibm-cloud-cognitive-experimental@0.19.17) (2021-02-22)
+## [0.19.17](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.16...@carbon/ibm-cloud-cognitive-experimental@0.19.17) (2021-02-22)
 
 ### Bug Fixes
 
 - secondary button + prop comments + column config
-  ([#335](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/335))
-  ([87b704b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/87b704b4dd656dead0fa5992f5536aa303af5cfa))
+  ([#335](https://github.com/carbon-design-system/ibm-products/issues/335))
+  ([87b704b](https://github.com/carbon-design-system/ibm-products/commit/87b704b4dd656dead0fa5992f5536aa303af5cfa))
 
-## [0.19.16](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.15...@carbon/ibm-cloud-cognitive-experimental@0.19.16) (2021-02-19)
+## [0.19.16](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.15...@carbon/ibm-cloud-cognitive-experimental@0.19.16) (2021-02-19)
 
 ### Bug Fixes
 
 - add export
-  ([#354](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/354))
-  ([c8c2eb7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c8c2eb7818c0fedf5471f684040788f1fac2afe3))
+  ([#354](https://github.com/carbon-design-system/ibm-products/issues/354))
+  ([c8c2eb7](https://github.com/carbon-design-system/ibm-products/commit/c8c2eb7818c0fedf5471f684040788f1fac2afe3))
 
-## [0.19.15](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.14...@carbon/ibm-cloud-cognitive-experimental@0.19.15) (2021-02-17)
+## [0.19.15](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.14...@carbon/ibm-cloud-cognitive-experimental@0.19.15) (2021-02-17)
 
 ### Bug Fixes
 
 - script to generate component shell using correct prefix now
-  ([#350](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/350))
-  ([671897d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/671897dc27ff82c68119f4164e3a5139aeec6de0))
+  ([#350](https://github.com/carbon-design-system/ibm-products/issues/350))
+  ([671897d](https://github.com/carbon-design-system/ibm-products/commit/671897dc27ff82c68119f4164e3a5139aeec6de0))
 
-## [0.19.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.13...@carbon/ibm-cloud-cognitive-experimental@0.19.14) (2021-02-17)
+## [0.19.14](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.13...@carbon/ibm-cloud-cognitive-experimental@0.19.14) (2021-02-17)
 
 ### Bug Fixes
 
 - **Notifications:** underline issue and fix named vs default imports
-  ([#343](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/343))
-  ([2691b64](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2691b64b07882e50ecefd9c97dc3e47d5bee6327))
+  ([#343](https://github.com/carbon-design-system/ibm-products/issues/343))
+  ([2691b64](https://github.com/carbon-design-system/ibm-products/commit/2691b64b07882e50ecefd9c97dc3e47d5bee6327))
 
-## [0.19.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.12...@carbon/ibm-cloud-cognitive-experimental@0.19.13) (2021-02-16)
+## [0.19.13](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.12...@carbon/ibm-cloud-cognitive-experimental@0.19.13) (2021-02-16)
 
 ### Bug Fixes
 
 - more header review updates
-  ([#325](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/325))
-  ([2809275](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/28092758e76a0f56daa14df747f3ce0572ef8b59))
+  ([#325](https://github.com/carbon-design-system/ibm-products/issues/325))
+  ([2809275](https://github.com/carbon-design-system/ibm-products/commit/28092758e76a0f56daa14df747f3ce0572ef8b59))
 
-## [0.19.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.11...@carbon/ibm-cloud-cognitive-experimental@0.19.12) (2021-02-12)
+## [0.19.12](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.11...@carbon/ibm-cloud-cognitive-experimental@0.19.12) (2021-02-12)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.19.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.10...@carbon/ibm-cloud-cognitive-experimental@0.19.11) (2021-02-11)
+## [0.19.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.10...@carbon/ibm-cloud-cognitive-experimental@0.19.11) (2021-02-11)
 
 ### Bug Fixes
 
 - **Notifications:** use correct value to prevent horizontal scroll
-  ([#334](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/334))
-  ([fbc260e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fbc260ec9fa54842a5f72c0890dd09e40988b096))
+  ([#334](https://github.com/carbon-design-system/ibm-products/issues/334))
+  ([fbc260e](https://github.com/carbon-design-system/ibm-products/commit/fbc260ec9fa54842a5f72c0890dd09e40988b096))
 
-## [0.19.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.9...@carbon/ibm-cloud-cognitive-experimental@0.19.10) (2021-02-11)
+## [0.19.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.9...@carbon/ibm-cloud-cognitive-experimental@0.19.10) (2021-02-11)
 
 ### Bug Fixes
 
 - change action bar overflow item format
-  ([#327](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/327))
-  ([d497609](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d497609d0a34f2d45a1b38412652a57f7fae8f2f))
+  ([#327](https://github.com/carbon-design-system/ibm-products/issues/327))
+  ([d497609](https://github.com/carbon-design-system/ibm-products/commit/d497609d0a34f2d45a1b38412652a57f7fae8f2f))
 
-## [0.19.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.8...@carbon/ibm-cloud-cognitive-experimental@0.19.9) (2021-02-10)
+## [0.19.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.8...@carbon/ibm-cloud-cognitive-experimental@0.19.9) (2021-02-10)
 
 ### Bug Fixes
 
 - styling of breadcrumb with overflow
-  ([#329](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/329))
-  ([95c168b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/95c168babf1312885132a44d5f11d3c82f010d12))
+  ([#329](https://github.com/carbon-design-system/ibm-products/issues/329))
+  ([95c168b](https://github.com/carbon-design-system/ibm-products/commit/95c168babf1312885132a44d5f11d3c82f010d12))
 
-## [0.19.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.7...@carbon/ibm-cloud-cognitive-experimental@0.19.8) (2021-02-10)
+## [0.19.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.7...@carbon/ibm-cloud-cognitive-experimental@0.19.8) (2021-02-10)
 
 ### Bug Fixes
 
 - card updates
-  ([#326](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/326))
-  ([1a59e35](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1a59e35aeed86fd9c0a8c318a6fb671a25b51690))
+  ([#326](https://github.com/carbon-design-system/ibm-products/issues/326))
+  ([1a59e35](https://github.com/carbon-design-system/ibm-products/commit/1a59e35aeed86fd9c0a8c318a6fb671a25b51690))
 
-## [0.19.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.6...@carbon/ibm-cloud-cognitive-experimental@0.19.7) (2021-02-09)
+## [0.19.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.6...@carbon/ibm-cloud-cognitive-experimental@0.19.7) (2021-02-09)
 
 ### Bug Fixes
 
 - further page header review updates
-  ([#323](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/323))
-  ([137d952](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/137d952d669adfd2cf1d794f0f3346d9d310d4f9))
+  ([#323](https://github.com/carbon-design-system/ibm-products/issues/323))
+  ([137d952](https://github.com/carbon-design-system/ibm-products/commit/137d952d669adfd2cf1d794f0f3346d9d310d4f9))
 
-## [0.19.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.5...@carbon/ibm-cloud-cognitive-experimental@0.19.6) (2021-02-08)
+## [0.19.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.5...@carbon/ibm-cloud-cognitive-experimental@0.19.6) (2021-02-08)
 
 ### Bug Fixes
 
 - review updates
-  ([#321](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/321))
-  ([fd06c3a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fd06c3addc3a85bf29499ed64e73e15099be4def))
+  ([#321](https://github.com/carbon-design-system/ibm-products/issues/321))
+  ([fd06c3a](https://github.com/carbon-design-system/ibm-products/commit/fd06c3addc3a85bf29499ed64e73e15099be4def))
 
-## [0.19.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.4...@carbon/ibm-cloud-cognitive-experimental@0.19.5) (2021-02-05)
+## [0.19.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.4...@carbon/ibm-cloud-cognitive-experimental@0.19.5) (2021-02-05)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.19.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.3...@carbon/ibm-cloud-cognitive-experimental@0.19.4) (2021-02-03)
+## [0.19.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.3...@carbon/ibm-cloud-cognitive-experimental@0.19.4) (2021-02-03)
 
 ### Bug Fixes
 
 - responsivity in action bar column
-  ([#307](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/307))
-  ([fcf8dc9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fcf8dc9c4d5d7a5d200c5c4f5b71dcfe177c615c))
+  ([#307](https://github.com/carbon-design-system/ibm-products/issues/307))
+  ([fcf8dc9](https://github.com/carbon-design-system/ibm-products/commit/fcf8dc9c4d5d7a5d200c5c4f5b71dcfe177c615c))
 
-## [0.19.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.2...@carbon/ibm-cloud-cognitive-experimental@0.19.3) (2021-02-02)
+## [0.19.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.2...@carbon/ibm-cloud-cognitive-experimental@0.19.3) (2021-02-02)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.19.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.1...@carbon/ibm-cloud-cognitive-experimental@0.19.2) (2021-02-02)
+## [0.19.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.1...@carbon/ibm-cloud-cognitive-experimental@0.19.2) (2021-02-02)
 
 ### Bug Fixes
 
 - additional design feedback
-  ([#314](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/314))
-  ([ab07dc2](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ab07dc2c359b7316becb18314b9b29b24aa0af1a))
+  ([#314](https://github.com/carbon-design-system/ibm-products/issues/314))
+  ([ab07dc2](https://github.com/carbon-design-system/ibm-products/commit/ab07dc2c359b7316becb18314b9b29b24aa0af1a))
 
-## [0.19.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.0...@carbon/ibm-cloud-cognitive-experimental@0.19.1) (2021-01-29)
+## [0.19.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.19.0...@carbon/ibm-cloud-cognitive-experimental@0.19.1) (2021-01-29)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-# [0.19.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.18.0...@carbon/ibm-cloud-cognitive-experimental@0.19.0) (2021-01-28)
+# [0.19.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.18.0...@carbon/ibm-cloud-cognitive-experimental@0.19.0) (2021-01-28)
 
 ### Features
 
 - update carbon to 10-27
-  ([#311](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/311))
-  ([b7569b8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b7569b8e3a339b8886175ed224164030e036b36c))
+  ([#311](https://github.com/carbon-design-system/ibm-products/issues/311))
+  ([b7569b8](https://github.com/carbon-design-system/ibm-products/commit/b7569b8e3a339b8886175ed224164030e036b36c))
 
-# [0.18.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.17.2...@carbon/ibm-cloud-cognitive-experimental@0.18.0) (2021-01-28)
+# [0.18.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.17.2...@carbon/ibm-cloud-cognitive-experimental@0.18.0) (2021-01-28)
 
 ### Features
 
 - prefix change proposal
-  ([#310](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/310))
-  ([be09803](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/be09803976360b7158bb2268e66047fbcb70f3ab))
+  ([#310](https://github.com/carbon-design-system/ibm-products/issues/310))
+  ([be09803](https://github.com/carbon-design-system/ibm-products/commit/be09803976360b7158bb2268e66047fbcb70f3ab))
 
-## [0.17.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.17.1...@carbon/ibm-cloud-cognitive-experimental@0.17.2) (2021-01-26)
+## [0.17.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.17.1...@carbon/ibm-cloud-cognitive-experimental@0.17.2) (2021-01-26)
 
 ### Bug Fixes
 
 - keyboard support for apikey modal
-  ([#298](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/298))
-  ([67fc055](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/67fc055fc1ca9b60553da9c278533863b87eda1f))
+  ([#298](https://github.com/carbon-design-system/ibm-products/issues/298))
+  ([67fc055](https://github.com/carbon-design-system/ibm-products/commit/67fc055fc1ca9b60553da9c278533863b87eda1f))
 
-## [0.17.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.17.0...@carbon/ibm-cloud-cognitive-experimental@0.17.1) (2021-01-26)
+## [0.17.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.17.0...@carbon/ibm-cloud-cognitive-experimental@0.17.1) (2021-01-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-# [0.17.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.10...@carbon/ibm-cloud-cognitive-experimental@0.17.0) (2021-01-26)
+# [0.17.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.10...@carbon/ibm-cloud-cognitive-experimental@0.17.0) (2021-01-26)
 
 ### Features
 
 - add side panel component
-  ([#282](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/282))
-  ([4a128d8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4a128d8b9ca78aca67c3c0870dee5baa11d0d05e))
+  ([#282](https://github.com/carbon-design-system/ibm-products/issues/282))
+  ([4a128d8](https://github.com/carbon-design-system/ibm-products/commit/4a128d8b9ca78aca67c3c0870dee5baa11d0d05e))
 
-## [0.16.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.9...@carbon/ibm-cloud-cognitive-experimental@0.16.10) (2021-01-26)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
-
-## [0.16.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.8...@carbon/ibm-cloud-cognitive-experimental@0.16.9) (2021-01-25)
+## [0.16.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.9...@carbon/ibm-cloud-cognitive-experimental@0.16.10) (2021-01-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.16.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.7...@carbon/ibm-cloud-cognitive-experimental@0.16.8) (2021-01-21)
+## [0.16.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.8...@carbon/ibm-cloud-cognitive-experimental@0.16.9) (2021-01-25)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.16.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.6...@carbon/ibm-cloud-cognitive-experimental@0.16.7) (2021-01-20)
+## [0.16.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.7...@carbon/ibm-cloud-cognitive-experimental@0.16.8) (2021-01-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.16.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.5...@carbon/ibm-cloud-cognitive-experimental@0.16.6) (2021-01-19)
+## [0.16.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.6...@carbon/ibm-cloud-cognitive-experimental@0.16.7) (2021-01-20)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
+
+## [0.16.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.5...@carbon/ibm-cloud-cognitive-experimental@0.16.6) (2021-01-19)
 
 ### Bug Fixes
 
 - design feedback updates for ApiKeyModal
-  ([#297](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/297))
-  ([50f432a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/50f432a2ff68a1e036225ef810ef2078a04ac9a9))
+  ([#297](https://github.com/carbon-design-system/ibm-products/issues/297))
+  ([50f432a](https://github.com/carbon-design-system/ibm-products/commit/50f432a2ff68a1e036225ef810ef2078a04ac9a9))
 
-## [0.16.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.4...@carbon/ibm-cloud-cognitive-experimental@0.16.5) (2021-01-13)
+## [0.16.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.4...@carbon/ibm-cloud-cognitive-experimental@0.16.5) (2021-01-13)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.16.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.3...@carbon/ibm-cloud-cognitive-experimental@0.16.4) (2021-01-07)
+## [0.16.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.3...@carbon/ibm-cloud-cognitive-experimental@0.16.4) (2021-01-07)
 
 ### Bug Fixes
 
 - import container disabled after file added in import modal
-  ([#294](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/294))
-  ([98f1633](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/98f1633086d5e427f3c7b1dc2e8eb3a1d73cf635))
+  ([#294](https://github.com/carbon-design-system/ibm-products/issues/294))
+  ([98f1633](https://github.com/carbon-design-system/ibm-products/commit/98f1633086d5e427f3c7b1dc2e8eb3a1d73cf635))
 
-## [0.16.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.2...@carbon/ibm-cloud-cognitive-experimental@0.16.3) (2021-01-06)
+## [0.16.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.2...@carbon/ibm-cloud-cognitive-experimental@0.16.3) (2021-01-06)
 
 ### Bug Fixes
 
 - apikey modal design feedback
-  ([#293](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/293))
-  ([0f4b08f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0f4b08fec6c8b65da7c336fb2fef0464598b1665))
+  ([#293](https://github.com/carbon-design-system/ibm-products/issues/293))
+  ([0f4b08f](https://github.com/carbon-design-system/ibm-products/commit/0f4b08fec6c8b65da7c336fb2fef0464598b1665))
 
-## [0.16.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.1...@carbon/ibm-cloud-cognitive-experimental@0.16.2) (2021-01-05)
+## [0.16.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.1...@carbon/ibm-cloud-cognitive-experimental@0.16.2) (2021-01-05)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.16.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.0...@carbon/ibm-cloud-cognitive-experimental@0.16.1) (2020-12-17)
+## [0.16.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.16.0...@carbon/ibm-cloud-cognitive-experimental@0.16.1) (2020-12-17)
 
 ### Bug Fixes
 
 - merge issue in breadcrumb dom
-  ([#289](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/289))
-  ([017b235](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/017b23575644d7250f58c7fb6cc234d44d8c0902))
+  ([#289](https://github.com/carbon-design-system/ibm-products/issues/289))
+  ([017b235](https://github.com/carbon-design-system/ibm-products/commit/017b23575644d7250f58c7fb6cc234d44d8c0902))
 
-# [0.16.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.15.1...@carbon/ibm-cloud-cognitive-experimental@0.16.0) (2020-12-17)
+# [0.16.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.15.1...@carbon/ibm-cloud-cognitive-experimental@0.16.0) (2020-12-17)
 
 ### Features
 
 - add breadcrumb with overflow
-  ([#275](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/275))
-  ([d810cd9](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d810cd963be0bbf4228bbfe52ba8028e7872d057))
+  ([#275](https://github.com/carbon-design-system/ibm-products/issues/275))
+  ([d810cd9](https://github.com/carbon-design-system/ibm-products/commit/d810cd963be0bbf4228bbfe52ba8028e7872d057))
 
-## [0.15.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.15.0...@carbon/ibm-cloud-cognitive-experimental@0.15.1) (2020-12-17)
+## [0.15.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.15.0...@carbon/ibm-cloud-cognitive-experimental@0.15.1) (2020-12-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-# [0.15.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.14.0...@carbon/ibm-cloud-cognitive-experimental@0.15.0) (2020-12-16)
+# [0.15.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.14.0...@carbon/ibm-cloud-cognitive-experimental@0.15.0) (2020-12-16)
 
 ### Features
 
 - added multi-step functionality to apikey modal
-  ([#279](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/279))
-  ([13db6e1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/13db6e12ea47e142a04fa7ad0a4c149a16d0baa4))
+  ([#279](https://github.com/carbon-design-system/ibm-products/issues/279))
+  ([13db6e1](https://github.com/carbon-design-system/ibm-products/commit/13db6e12ea47e142a04fa7ad0a4c149a16d0baa4))
 
-# [0.14.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.13.2...@carbon/ibm-cloud-cognitive-experimental@0.14.0) (2020-12-16)
+# [0.14.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.13.2...@carbon/ibm-cloud-cognitive-experimental@0.14.0) (2020-12-16)
 
 ### Features
 
 - review updates for page header
-  ([#284](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/284))
-  ([b45bc0f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b45bc0fc40dda64f25a267f1da07bbd699689486))
+  ([#284](https://github.com/carbon-design-system/ibm-products/issues/284))
+  ([b45bc0f](https://github.com/carbon-design-system/ibm-products/commit/b45bc0fc40dda64f25a267f1da07bbd699689486))
 
-## [0.13.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.13.1...@carbon/ibm-cloud-cognitive-experimental@0.13.2) (2020-12-16)
+## [0.13.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.13.1...@carbon/ibm-cloud-cognitive-experimental@0.13.2) (2020-12-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.13.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.13.0...@carbon/ibm-cloud-cognitive-experimental@0.13.1) (2020-12-16)
+## [0.13.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.13.0...@carbon/ibm-cloud-cognitive-experimental@0.13.1) (2020-12-16)
 
 ### Bug Fixes
 
 - uuidv4 for ssr
-  ([#278](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/278))
-  ([1e06320](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/1e06320b4a1cc2ee1eca78ccf17e588da76680aa))
+  ([#278](https://github.com/carbon-design-system/ibm-products/issues/278))
+  ([1e06320](https://github.com/carbon-design-system/ibm-products/commit/1e06320b4a1cc2ee1eca78ccf17e588da76680aa))
 
-# [0.13.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.12.6...@carbon/ibm-cloud-cognitive-experimental@0.13.0) (2020-12-16)
+# [0.13.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.12.6...@carbon/ibm-cloud-cognitive-experimental@0.13.0) (2020-12-16)
 
 ### Features
 
 - Page header tag overflow update
-  ([#264](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/264))
-  ([ee22520](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ee225206e291fa3bca990cb2ccabfece8930fc88))
+  ([#264](https://github.com/carbon-design-system/ibm-products/issues/264))
+  ([ee22520](https://github.com/carbon-design-system/ibm-products/commit/ee225206e291fa3bca990cb2ccabfece8930fc88))
 
-## [0.12.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.12.5...@carbon/ibm-cloud-cognitive-experimental@0.12.6) (2020-12-10)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
-
-## [0.12.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.12.4...@carbon/ibm-cloud-cognitive-experimental@0.12.5) (2020-12-08)
+## [0.12.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.12.5...@carbon/ibm-cloud-cognitive-experimental@0.12.6) (2020-12-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.12.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.12.3...@carbon/ibm-cloud-cognitive-experimental@0.12.4) (2020-12-08)
+## [0.12.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.12.4...@carbon/ibm-cloud-cognitive-experimental@0.12.5) (2020-12-08)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
+
+## [0.12.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.12.3...@carbon/ibm-cloud-cognitive-experimental@0.12.4) (2020-12-08)
 
 ### Bug Fixes
 
 - additional stories and selection for export
-  ([#263](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/263))
-  ([a02a1a7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a02a1a71045a34bd8475cfbc5a7bd69d1add6a27))
+  ([#263](https://github.com/carbon-design-system/ibm-products/issues/263))
+  ([a02a1a7](https://github.com/carbon-design-system/ibm-products/commit/a02a1a71045a34bd8475cfbc5a7bd69d1add6a27))
 
-## [0.12.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.12.2...@carbon/ibm-cloud-cognitive-experimental@0.12.3) (2020-12-04)
+## [0.12.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.12.2...@carbon/ibm-cloud-cognitive-experimental@0.12.3) (2020-12-04)
 
 ### Bug Fixes
 
 - change RemovalModal to RemoveDeleteModal
-  ([#255](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/255))
-  ([cdb2f5b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/cdb2f5b2c0643bbe5c8d8ab27d5763c939da2302))
+  ([#255](https://github.com/carbon-design-system/ibm-products/issues/255))
+  ([cdb2f5b](https://github.com/carbon-design-system/ibm-products/commit/cdb2f5b2c0643bbe5c8d8ab27d5763c939da2302))
 
-## [0.12.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.12.1...@carbon/ibm-cloud-cognitive-experimental@0.12.2) (2020-12-04)
+## [0.12.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.12.1...@carbon/ibm-cloud-cognitive-experimental@0.12.2) (2020-12-04)
 
 ### Bug Fixes
 
 - use correct carbon token for about modal gradient
-  ([#256](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/256))
-  ([9a9626a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9a9626af8d8eb5b5ae26135a755e3047f1e8ea6b))
+  ([#256](https://github.com/carbon-design-system/ibm-products/issues/256))
+  ([9a9626a](https://github.com/carbon-design-system/ibm-products/commit/9a9626af8d8eb5b5ae26135a755e3047f1e8ea6b))
 
-## [0.12.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.12.0...@carbon/ibm-cloud-cognitive-experimental@0.12.1) (2020-12-03)
+## [0.12.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.12.0...@carbon/ibm-cloud-cognitive-experimental@0.12.1) (2020-12-03)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-# [0.12.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.11.0...@carbon/ibm-cloud-cognitive-experimental@0.12.0) (2020-12-03)
+# [0.12.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.11.0...@carbon/ibm-cloud-cognitive-experimental@0.12.0) (2020-12-03)
 
 ### Features
 
 - Breadcrumb with overflow
-  ([#252](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/252))
-  ([c9acc7a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c9acc7af3fa35fa72495e93cb30271ce5124f99f))
+  ([#252](https://github.com/carbon-design-system/ibm-products/issues/252))
+  ([c9acc7a](https://github.com/carbon-design-system/ibm-products/commit/c9acc7af3fa35fa72495e93cb30271ce5124f99f))
 
-# [0.11.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.10.2...@carbon/ibm-cloud-cognitive-experimental@0.11.0) (2020-12-03)
+# [0.11.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.10.2...@carbon/ibm-cloud-cognitive-experimental@0.11.0) (2020-12-03)
 
 ### Features
 
 - export modal
-  ([#253](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/253))
-  ([d7e35ae](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d7e35ae34567dbfdb99ece3964f558137b687940))
+  ([#253](https://github.com/carbon-design-system/ibm-products/issues/253))
+  ([d7e35ae](https://github.com/carbon-design-system/ibm-products/commit/d7e35ae34567dbfdb99ece3964f558137b687940))
 
-## [0.10.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.10.1...@carbon/ibm-cloud-cognitive-experimental@0.10.2) (2020-12-02)
+## [0.10.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.10.1...@carbon/ibm-cloud-cognitive-experimental@0.10.2) (2020-12-02)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.10.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.10.0...@carbon/ibm-cloud-cognitive-experimental@0.10.1) (2020-12-01)
+## [0.10.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.10.0...@carbon/ibm-cloud-cognitive-experimental@0.10.1) (2020-12-01)
 
 ### Bug Fixes
 
 - import modal typo fix
-  ([#247](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/247))
-  ([56b1165](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/56b11654238e35fa4da7de0da4b842916633a984))
+  ([#247](https://github.com/carbon-design-system/ibm-products/issues/247))
+  ([56b1165](https://github.com/carbon-design-system/ibm-products/commit/56b11654238e35fa4da7de0da4b842916633a984))
 
-# [0.10.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.9.7...@carbon/ibm-cloud-cognitive-experimental@0.10.0) (2020-12-01)
+# [0.10.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.9.7...@carbon/ibm-cloud-cognitive-experimental@0.10.0) (2020-12-01)
 
 ### Features
 
 - add automated tests for tearsheet component
-  ([#249](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/249))
-  ([6510288](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6510288adc51d3983d85904406184f5e0aa7db78))
+  ([#249](https://github.com/carbon-design-system/ibm-products/issues/249))
+  ([6510288](https://github.com/carbon-design-system/ibm-products/commit/6510288adc51d3983d85904406184f5e0aa7db78))
 
-## [0.9.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.9.6...@carbon/ibm-cloud-cognitive-experimental@0.9.7) (2020-12-01)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
-
-## [0.9.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-experimental@0.9.5...@carbon/ibm-cloud-cognitive-experimental@0.9.6) (2020-11-30)
+## [0.9.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.9.6...@carbon/ibm-cloud-cognitive-experimental@0.9.7) (2020-12-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.9.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.9.4...@carbon/ibm-cloud-cognitive-experimental@0.9.5) (2020-11-26)
+## [0.9.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-experimental@0.9.5...@carbon/ibm-cloud-cognitive-experimental@0.9.6) (2020-11-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.9.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.9.3...@carbon/ibm-cloud-cognitive-experimental@0.9.4) (2020-11-26)
+## [0.9.5](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.9.4...@carbon/ibm-cloud-cognitive-experimental@0.9.5) (2020-11-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.9.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.9.2...@carbon/ibm-cloud-cognitive-experimental@0.9.3) (2020-11-26)
+## [0.9.4](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.9.3...@carbon/ibm-cloud-cognitive-experimental@0.9.4) (2020-11-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.9.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.9.1...@carbon/ibm-cloud-cognitive-experimental@0.9.2) (2020-11-26)
+## [0.9.3](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.9.2...@carbon/ibm-cloud-cognitive-experimental@0.9.3) (2020-11-26)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
+
+## [0.9.2](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.9.1...@carbon/ibm-cloud-cognitive-experimental@0.9.2) (2020-11-26)
 
 ### Bug Fixes
 
 - docgen optional chaining issue TagSet and ModifiedTabs
-  ([#237](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/237))
-  ([93c6e53](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/93c6e5347670f6157e3caba62099af6109fb1f2c))
+  ([#237](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/237))
+  ([93c6e53](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/93c6e5347670f6157e3caba62099af6109fb1f2c))
 
-## [0.9.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.9.0...@carbon/ibm-cloud-cognitive-experimental@0.9.1) (2020-11-26)
+## [0.9.1](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.9.0...@carbon/ibm-cloud-cognitive-experimental@0.9.1) (2020-11-26)
 
 ### Bug Fixes
 
 - small stories update to RemovalModal
-  ([#230](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/230))
-  ([2e3e564](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/2e3e564b43efbf75bacabf1db16a700062fd2d82))
+  ([#230](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/230))
+  ([2e3e564](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/2e3e564b43efbf75bacabf1db16a700062fd2d82))
 
-# [0.9.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.8.0...@carbon/ibm-cloud-cognitive-experimental@0.9.0) (2020-11-25)
+# [0.9.0](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.8.0...@carbon/ibm-cloud-cognitive-experimental@0.9.0) (2020-11-25)
 
 ### Features
 
 - improve tearsheet documentation and stories
-  ([#235](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/235))
-  ([2daff03](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/2daff03ae5cf427b8a0bce2d465d7879b519eecf))
+  ([#235](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/235))
+  ([2daff03](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/2daff03ae5cf427b8a0bce2d465d7879b519eecf))
 
-# [0.8.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.7.1...@carbon/ibm-cloud-cognitive-experimental@0.8.0) (2020-11-24)
+# [0.8.0](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.7.1...@carbon/ibm-cloud-cognitive-experimental@0.8.0) (2020-11-24)
 
 ### Features
 
 - make tearsheets stackable
-  ([#229](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/229))
-  ([23c26b2](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/23c26b2db35cff9f20732e3e5f327743bdcbdfb7))
+  ([#229](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/229))
+  ([23c26b2](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/23c26b2db35cff9f20732e3e5f327743bdcbdfb7))
 
-## [0.7.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.7.0...@carbon/ibm-cloud-cognitive-experimental@0.7.1) (2020-11-24)
+## [0.7.1](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.7.0...@carbon/ibm-cloud-cognitive-experimental@0.7.1) (2020-11-24)
 
 ### Bug Fixes
 
 - update import and remove modal stories
-  ([#221](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/221))
-  ([c08d1cf](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/c08d1cf44a4b3c726b304061a3ac6e1b6b4035e6))
+  ([#221](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/221))
+  ([c08d1cf](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/c08d1cf44a4b3c726b304061a3ac6e1b6b4035e6))
 
-# [0.7.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.6.0...@carbon/ibm-cloud-cognitive-experimental@0.7.0) (2020-11-23)
+# [0.7.0](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.6.0...@carbon/ibm-cloud-cognitive-experimental@0.7.0) (2020-11-23)
 
 ### Features
 
 - add cdai apikey component
-  ([#223](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/223))
-  ([4c09f15](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/4c09f15c3c62c3965d98c91b9695fa7a1cba8f0b))
+  ([#223](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/223))
+  ([4c09f15](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/4c09f15c3c62c3965d98c91b9695fa7a1cba8f0b))
 - add show all to tag-set
-  ([#222](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/222))
-  ([762060a](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/762060acf708ea6d19d9f48d6520d05ef3e43836))
+  ([#222](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/222))
+  ([762060a](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/762060acf708ea6d19d9f48d6520d05ef3e43836))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.6.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.5.0...@carbon/ibm-cloud-cognitive-experimental@0.6.0) (2020-11-19)
+# [0.6.0](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.5.0...@carbon/ibm-cloud-cognitive-experimental@0.6.0) (2020-11-19)
 
 ### Features
 
 - apikey modal
-  ([#200](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/200))
-  ([e4d94e5](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/e4d94e549fa693a66850228407a748503ff47325))
+  ([#200](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/200))
+  ([e4d94e5](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/e4d94e549fa693a66850228407a748503ff47325))
 
-# [0.5.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.4.1...@carbon/ibm-cloud-cognitive-experimental@0.5.0) (2020-11-18)
+# [0.5.0](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.4.1...@carbon/ibm-cloud-cognitive-experimental@0.5.0) (2020-11-18)
 
 ### Features
 
 - improve Tearsheet stories
-  ([#220](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/220))
-  ([c1fd523](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/c1fd523001357157fee25ffbb42ae054a5c11156))
+  ([#220](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/220))
+  ([c1fd523](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/c1fd523001357157fee25ffbb42ae054a5c11156))
 
-## [0.4.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.4.0...@carbon/ibm-cloud-cognitive-experimental@0.4.1) (2020-11-18)
+## [0.4.1](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.4.0...@carbon/ibm-cloud-cognitive-experimental@0.4.1) (2020-11-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-# [0.4.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.3.0...@carbon/ibm-cloud-cognitive-experimental@0.4.0) (2020-11-17)
+# [0.4.0](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.3.0...@carbon/ibm-cloud-cognitive-experimental@0.4.0) (2020-11-17)
 
 ### Features
 
 - add TearsheetNarrow component
-  ([#218](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/218))
-  ([fe967c0](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/fe967c03ff79c241e19278dc95a803c577efc676))
+  ([#218](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/218))
+  ([fe967c0](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/fe967c03ff79c241e19278dc95a803c577efc676))
 
-# [0.3.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.2.5...@carbon/ibm-cloud-cognitive-experimental@0.3.0) (2020-11-17)
+# [0.3.0](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.2.5...@carbon/ibm-cloud-cognitive-experimental@0.3.0) (2020-11-17)
 
 ### Features
 
 - update to carbon 10.24.0
-  ([#217](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/217))
-  ([76839f3](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/76839f36eca23132559c47f61d9efa0cfcd8414d))
+  ([#217](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/217))
+  ([76839f3](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/76839f36eca23132559c47f61d9efa0cfcd8414d))
 
-## [0.2.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.2.4...@carbon/ibm-cloud-cognitive-experimental@0.2.5) (2020-11-17)
+## [0.2.5](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.2.4...@carbon/ibm-cloud-cognitive-experimental@0.2.5) (2020-11-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-## [0.2.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.2.3...@carbon/ibm-cloud-cognitive-experimental@0.2.4) (2020-11-17)
+## [0.2.4](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.2.3...@carbon/ibm-cloud-cognitive-experimental@0.2.4) (2020-11-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
@@ -5762,64 +5762,64 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.2.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.2.2...@carbon/ibm-cloud-cognitive-experimental@0.2.3) (2020-11-11)
+## [0.2.3](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.2.2...@carbon/ibm-cloud-cognitive-experimental@0.2.3) (2020-11-11)
 
 ### Bug Fixes
 
 - add Tearsheet and PageHeader to index.js
-  ([#203](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/203))
-  ([cd4731f](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/cd4731fb36b9e5517e1aa756e4432f8fd68088c6))
+  ([#203](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/203))
+  ([cd4731f](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/cd4731fb36b9e5517e1aa756e4432f8fd68088c6))
 
-## [0.2.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.2.1...@carbon/ibm-cloud-cognitive-experimental@0.2.2) (2020-11-11)
+## [0.2.2](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.2.1...@carbon/ibm-cloud-cognitive-experimental@0.2.2) (2020-11-11)
 
 ### Bug Fixes
 
 - overflow tag styling
-  ([#202](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/202))
-  ([15c9abd](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/15c9abd219e5f3cf8033a3e85a215de585b1ae3e))
+  ([#202](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/202))
+  ([15c9abd](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/15c9abd219e5f3cf8033a3e85a215de585b1ae3e))
 
-## [0.2.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.2.0...@carbon/ibm-cloud-cognitive-experimental@0.2.1) (2020-11-11)
+## [0.2.1](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.2.0...@carbon/ibm-cloud-cognitive-experimental@0.2.1) (2020-11-11)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-experimental
 
-# [0.2.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.1.0...@carbon/ibm-cloud-cognitive-experimental@0.2.0) (2020-11-10)
+# [0.2.0](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/compare/@carbon/ibm-cloud-cognitive-experimental@0.1.0...@carbon/ibm-cloud-cognitive-experimental@0.2.0) (2020-11-10)
 
 ### Features
 
 - create tag set (tags with overflow)
-  ([#188](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/188))
-  ([84c4d3e](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/84c4d3ee3c5783e506a231a18b3e2fa738c9c0d1))
+  ([#188](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/188))
+  ([84c4d3e](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/84c4d3ee3c5783e506a231a18b3e2fa738c9c0d1))
 
 # 0.1.0 (2020-11-10)
 
 ### Bug Fixes
 
 - broken carbon tabs
-  ([#160](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/160))
-  ([b5b46b3](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/b5b46b3916cba06bd5a3a3c275b8ac3dda7a952b))
+  ([#160](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/160))
+  ([b5b46b3](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/b5b46b3916cba06bd5a3a3c275b8ac3dda7a952b))
 - multiple review issues
-  ([#152](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/152))
-  ([6de02a2](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/6de02a27962b28b6ad42ae8984b712abdf525ff4)),
+  ([#152](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/152))
+  ([6de02a2](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/6de02a27962b28b6ad42ae8984b712abdf525ff4)),
   closes
-  [#151](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/151)
-  [#153](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/153)
-  [#149](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/149)
-  [#155](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/155)
+  [#151](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/151)
+  [#153](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/153)
+  [#149](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/149)
+  [#155](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/155)
 - page header responsiveness
-  ([#189](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/189))
-  ([dc93431](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/dc934310ee3448cc382dcc3b8dcdf2e206be94a9))
+  ([#189](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/189))
+  ([dc93431](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/dc934310ee3448cc382dcc3b8dcdf2e206be94a9))
 - small RemovalModal docs update
-  ([#156](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/156))
-  ([7006941](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/7006941a35d149f49fa12dbb1f87cd7f8ded8762))
+  ([#156](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/156))
+  ([7006941](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/7006941a35d149f49fa12dbb1f87cd7f8ded8762))
 
 ### Features
 
 - add new about screen modal component
-  ([#187](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/187))
-  ([7a8fadf](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/7a8fadf3b52bb50a733fbbbe5978051a00cf406e))
+  ([#187](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/187))
+  ([7a8fadf](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/7a8fadf3b52bb50a733fbbbe5978051a00cf406e))
 - Import component
-  ([#163](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/163))
-  ([980f4f3](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/980f4f3334610e97c0552921cdab269a6e01e6a7))
+  ([#163](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/163))
+  ([980f4f3](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/980f4f3334610e97c0552921cdab269a6e01e6a7))
 - various review updates
-  ([#158](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/issues/158))
-  ([9a39ba2](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental/commit/9a39ba2cb2df682897b4ba293eafac8e8762a13c))
+  ([#158](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/issues/158))
+  ([9a39ba2](https://github.com/carbon-design-system/ibm-products/tree/master/packages/experimental/commit/9a39ba2cb2df682897b4ba293eafac8e8762a13c))

--- a/packages/cloud-cognitive/README.md
+++ b/packages/cloud-cognitive/README.md
@@ -5,14 +5,14 @@
 > These PAL designs build on the foundation of IBM’s open source Carbon Design
 > System and React implementation to offer components and patterns beyond the
 > typical component library. Carbon for IBM Products was previously known as
-> Carbon for IBM Cloud and Cognitive (@carbon/ibm-cloud-cognitive), and this
-> name can still be encountered in various places and historical logs.
+> Carbon for IBM Cloud and Cognitive (@carbon/ibm-products), and this name can
+> still be encountered in various places and historical logs.
 
 [![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg)](#contributors-)
 [![Licensed under the Apache License, Version 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://github.com/carbon-design-system/ibm-products/blob/master/LICENSE)
 [![Build status](https://github.com/carbon-design-system/ibm-products/actions/workflows/ci.yml/badge.svg)](https://github.com/carbon-design-system/ibm-products/actions/workflows/ci.yml)
 [![Netlify status](https://img.shields.io/netlify/f850c678-e8be-43c0-aa95-b2b9cca8ac21)](https://app.netlify.com/sites/carbon-for-ibm-products/deploys)
-[![GitHub Lerna version](https://img.shields.io/github/lerna-json/v/carbon-design-system/ibm-cloud-cognitive)](https://lerna.js.org)
+[![GitHub Lerna version](https://img.shields.io/github/lerna-json/v/carbon-design-system/ibm-products)](https://lerna.js.org)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](https://github.com/carbon-design-system/ibm-products/blob/master/.github/CONTRIBUTING.md)
 
 > Carbon for IBM Products common UI components
@@ -74,7 +74,7 @@ dependencies which need to be installed.
 
 **Note:** `@carbon/elements` rolls up a number of Carbon packages that could be
 installed independently. As this list of dependencies could change, we leave you
-to view `package.json` in ibm-cloud-cognitive if you wish to install individual
+to view `package.json` in ibm-products if you wish to install individual
 packages.
 
 ## Examples
@@ -83,7 +83,7 @@ packages.
 
 Examples for each released component, and some that are still not quite ready,
 can be found here on
-[CodeSandbox](https://codesandbox.io/examples/package/@carbon/ibm-cloud-cognitive).
+[CodeSandbox](https://codesandbox.io/examples/package/@carbon/ibm-products).
 
 ### Packages
 

--- a/packages/cloud-cognitive/README.md
+++ b/packages/cloud-cognitive/README.md
@@ -5,8 +5,8 @@
 > These PAL designs build on the foundation of IBM’s open source Carbon Design
 > System and React implementation to offer components and patterns beyond the
 > typical component library. Carbon for IBM Products was previously known as
-> Carbon for IBM Cloud and Cognitive (@carbon/ibm-products), and this name can
-> still be encountered in various places and historical logs.
+> Carbon for IBM Cloud and Cognitive (@carbon/ibm-cloud-cognitive), and this
+> name can still be encountered in various places and historical logs.
 
 [![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg)](#contributors-)
 [![Licensed under the Apache License, Version 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://github.com/carbon-design-system/ibm-products/blob/master/LICENSE)

--- a/packages/cloud-cognitive/README.md
+++ b/packages/cloud-cognitive/README.md
@@ -9,11 +9,11 @@
 > name can still be encountered in various places and historical logs.
 
 [![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg)](#contributors-)
-[![Licensed under the Apache License, Version 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/LICENSE)
-[![Build status](https://github.com/carbon-design-system/ibm-cloud-cognitive/actions/workflows/ci.yml/badge.svg)](https://github.com/carbon-design-system/ibm-cloud-cognitive/actions/workflows/ci.yml)
+[![Licensed under the Apache License, Version 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://github.com/carbon-design-system/ibm-products/blob/master/LICENSE)
+[![Build status](https://github.com/carbon-design-system/ibm-products/actions/workflows/ci.yml/badge.svg)](https://github.com/carbon-design-system/ibm-products/actions/workflows/ci.yml)
 [![Netlify status](https://img.shields.io/netlify/f850c678-e8be-43c0-aa95-b2b9cca8ac21)](https://app.netlify.com/sites/carbon-for-ibm-products/deploys)
 [![GitHub Lerna version](https://img.shields.io/github/lerna-json/v/carbon-design-system/ibm-cloud-cognitive)](https://lerna.js.org)
-[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/.github/CONTRIBUTING.md)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](https://github.com/carbon-design-system/ibm-products/blob/master/.github/CONTRIBUTING.md)
 
 > Carbon for IBM Products common UI components
 
@@ -44,7 +44,7 @@ import '@carbon/ibm-products/css/index.min.css';
 ### Webpack 4
 
 Our package requires support for ES modules (see
-[#2378](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2378#issuecomment-1319276192)).
+[#2378](https://github.com/carbon-design-system/ibm-products/issues/2378#issuecomment-1319276192)).
 In Webpack 5, these are supported by default. In Webpack 4, you will need to add
 the [following rule](https://stackoverflow.com/a/72149467) to your config.
 
@@ -170,7 +170,7 @@ So, do not be shy. We both depend on and appreciate contributors, new and old,
 who help us fix bugs, build new features, improve our documentation, etc.
 
 If you’re interested, definitely check out our
-[Contributing Guide](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/.github/CONTRIBUTING.md)
+[Contributing Guide](https://github.com/carbon-design-system/ibm-products/blob/master/.github/CONTRIBUTING.md)
 and
 [Carbon’s Developer Handbook](https://github.com/carbon-design-system/carbon/blob/master/docs/developer-handbook.md)!
 👀
@@ -180,13 +180,13 @@ and
 <!-- markdownlint-disable -->
 <table>
   <tr>
-    <td align="center"><a href="https://github.com/lee-chase"><img src="https://avatars0.githubusercontent.com/u/15086604?v=4" width="100px;" alt=""/><br /><sub><b>Lee Chase</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=lee-chase" title="Code">💻</a></td>
-    <td align="center"><a href="http://davidmenendez.net"><img src="https://avatars1.githubusercontent.com/u/6370760?v=4" width="100px;" alt=""/><br /><sub><b>David Menendez</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=davidmenendez" title="Code">💻</a></td>
-    <td align="center"><a href="http://www.matthewdgallo.com"><img src="https://avatars0.githubusercontent.com/u/10215203?v=4" width="100px;" alt=""/><br /><sub><b>Matthew Gallo</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=matthewgallo" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/lee-chase"><img src="https://avatars0.githubusercontent.com/u/15086604?v=4" width="100px;" alt=""/><br /><sub><b>Lee Chase</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=lee-chase" title="Code">💻</a></td>
+    <td align="center"><a href="http://davidmenendez.net"><img src="https://avatars1.githubusercontent.com/u/6370760?v=4" width="100px;" alt=""/><br /><sub><b>David Menendez</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=davidmenendez" title="Code">💻</a></td>
+    <td align="center"><a href="http://www.matthewdgallo.com"><img src="https://avatars0.githubusercontent.com/u/10215203?v=4" width="100px;" alt=""/><br /><sub><b>Matthew Gallo</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=matthewgallo" title="Code">💻</a></td>
   </tr>
   <tr>
-    <td align="center"><a href="http://simonfinney.dev"><img src="https://avatars2.githubusercontent.com/u/3846874?v=4" width="100px;" alt=""/><br /><sub><b>Simon Finney</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=SimonFinney" title="Code">💻</a></td>
-    <td align="center"><a href="https://github.com/polinaouk"><img src="https://avatars2.githubusercontent.com/u/24444328?v=4" width="100px;" alt=""/><br /><sub><b>Polina Olemskaia</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-cloud-cognitive/commits?author=polinaouk" title="Code">💻</a></td>
+    <td align="center"><a href="http://simonfinney.dev"><img src="https://avatars2.githubusercontent.com/u/3846874?v=4" width="100px;" alt=""/><br /><sub><b>Simon Finney</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=SimonFinney" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/polinaouk"><img src="https://avatars2.githubusercontent.com/u/24444328?v=4" width="100px;" alt=""/><br /><sub><b>Polina Olemskaia</b></sub></a><br /><a href="https://github.com/carbon-design-system/ibm-products/commits?author=polinaouk" title="Code">💻</a></td>
   </tr>
 </table>
 
@@ -203,6 +203,6 @@ In order to gather usage information for these components we use
 ## 📝 License
 
 Licensed under the
-[Apache-2.0 License](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/LICENSE).
+[Apache-2.0 License](https://github.com/carbon-design-system/ibm-products/blob/master/LICENSE).
 
 [![This site is powered by Netlify](https://www.netlify.com/img/global/badges/netlify-color-accent.svg)](https://www.netlify.com)

--- a/packages/cloud-cognitive/package.json
+++ b/packages/cloud-cognitive/package.json
@@ -7,7 +7,7 @@
   "module": "es/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "url": "https://github.com/carbon-design-system/ibm-products.git",
     "directory": "packages/cloud-cognitive"
   },
   "bugs": "https://github.com/carbon-design-system/ibm-products/issues",

--- a/packages/cloud-cognitive/package.json
+++ b/packages/cloud-cognitive/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
     "directory": "packages/cloud-cognitive"
   },
-  "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
+  "bugs": "https://github.com/carbon-design-system/ibm-products/issues",
   "sideEffects": [
     "**/global/js/utils/props-helper.js",
     "**/*.css",

--- a/packages/cloud-cognitive/src/components/HTTPErrors/HTTPError403/HTTPError403.stories.js
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/HTTPError403/HTTPError403.stories.js
@@ -52,7 +52,7 @@ export const withAllPropsSet = prepareStory(Template, {
       },
       {
         text: 'Carbon for IBM Products component library',
-        href: 'https://github.com/carbon-design-system/ibm-cloud-cognitive',
+        href: 'https://github.com/carbon-design-system/ibm-products',
       },
     ],
   },

--- a/packages/cloud-cognitive/src/components/HTTPErrors/HTTPError404/HTTPError404.stories.js
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/HTTPError404/HTTPError404.stories.js
@@ -46,7 +46,7 @@ export const withAllPropsSet = prepareStory(Template, {
       },
       {
         text: 'Carbon for IBM Products component library',
-        href: 'https://github.com/carbon-design-system/ibm-cloud-cognitive',
+        href: 'https://github.com/carbon-design-system/ibm-products',
       },
     ],
   },

--- a/packages/cloud-cognitive/src/components/HTTPErrors/HTTPErrorOther/HTTPErrorOther.stories.js
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/HTTPErrorOther/HTTPErrorOther.stories.js
@@ -46,7 +46,7 @@ export const withAllPropsSet = prepareStory(Template, {
       },
       {
         text: 'Carbon for IBM Products component library',
-        href: 'https://github.com/carbon-design-system/ibm-cloud-cognitive',
+        href: 'https://github.com/carbon-design-system/ibm-products',
       },
     ],
   },

--- a/packages/cloud-cognitive/src/components/HTTPErrors/HTTPErrors.test.js
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/HTTPErrors.test.js
@@ -37,7 +37,7 @@ const defaultProps = {
     },
     {
       text: 'Carbon for IBM Products component library',
-      href: 'https://github.com/carbon-design-system/ibm-cloud-cognitive',
+      href: 'https://github.com/carbon-design-system/ibm-products',
     },
   ],
   ref,

--- a/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.test.js
+++ b/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.test.js
@@ -54,9 +54,9 @@ describe(name, () => {
   });
 
   /**
-    We are skipping the a11y test for now since the only a11y violation 
+    We are skipping the a11y test for now since the only a11y violation
     is a potential violation. We can remove the skip once we fix our accessibility-checker
-    issue. https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2154
+    issue. https://github.com/carbon-design-system/ibm-products/issues/2154
   */
   it.skip('has no accessibility violations', async () => {
     const { container } = render(
@@ -82,7 +82,7 @@ describe(name, () => {
   });
 
   it('custom hook should toggle web terminal', () => {
-    /**  Utilizing renderHook so jest knows about the custom hook and passing 
+    /**  Utilizing renderHook so jest knows about the custom hook and passing
          in the WebTerminalProvider so that the hook can consume the value  */
     const { result } = renderHook(() => useWebTerminal(), {
       wrapper: WebTerminalProvider,
@@ -106,7 +106,7 @@ describe(name, () => {
   });
 
   it('custom hook should open and close web terminal', () => {
-    /**  Utilizing renderHook so jest knows about the custom hook and passing 
+    /**  Utilizing renderHook so jest knows about the custom hook and passing
          in the WebTerminalProvider so that the hook can consume the value  */
     const { result } = renderHook(() => useWebTerminal(), {
       wrapper: WebTerminalProvider,
@@ -160,7 +160,7 @@ describe(name, () => {
     const ref = React.createRef(null);
     render(<MockWebTerminal ref={ref}>Body content</MockWebTerminal>);
 
-    /** 
+    /**
       This await is necessary so that the document loads completely and the ref isn't null */
     await screen.findByText('Body content');
 

--- a/packages/cloud-cognitive/src/global/js/utils/story-helper.js
+++ b/packages/cloud-cognitive/src/global/js/utils/story-helper.js
@@ -70,7 +70,7 @@ export const prepareStory = (template, options) => {
  */
 export const CodesandboxLink = ({ exampleDirectory }) => (
   <a
-    href={`https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/${exampleDirectory}`}
+    href={`https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/${exampleDirectory}`}
   >
     <img
       alt="Edit on CodeSandbox"

--- a/packages/component-usage-report/CHANGELOG.md
+++ b/packages/component-usage-report/CHANGELOG.md
@@ -3,23 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.2.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/component-usage-report@0.2.0...@carbon/component-usage-report@0.2.1) (2022-03-22)
+## [0.2.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/component-usage-report@0.2.0...@carbon/component-usage-report@0.2.1) (2022-03-22)
 
 
 ### Bug Fixes
 
-* add publishConfig to component usage package.json ([#1785](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1785)) ([7325a3b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7325a3bbfaaf2b52121f9965142e2856641818e5))
+* add publishConfig to component usage package.json ([#1785](https://github.com/carbon-design-system/ibm-products/issues/1785)) ([7325a3b](https://github.com/carbon-design-system/ibm-products/commit/7325a3bbfaaf2b52121f9965142e2856641818e5))
 
 
 
 
 
-# [0.2.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/component-usage-report@0.1.0...@carbon/component-usage-report@0.2.0) (2022-03-15)
+# [0.2.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/component-usage-report@0.1.0...@carbon/component-usage-report@0.2.0) (2022-03-15)
 
 
 ### Features
 
-* make cli out of component usage report ([#1763](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1763)) ([6e711c5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6e711c535ea53cf0de63a14595fc82af029108a2))
+* make cli out of component usage report ([#1763](https://github.com/carbon-design-system/ibm-products/issues/1763)) ([6e711c5](https://github.com/carbon-design-system/ibm-products/commit/6e711c535ea53cf0de63a14595fc82af029108a2))
 
 
 
@@ -30,4 +30,4 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* create an initial dux report package ([#1715](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1715)) ([544d1a8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/544d1a8f22d65a1e8cb8e9aea636cb9e7852dd2d))
+* create an initial dux report package ([#1715](https://github.com/carbon-design-system/ibm-products/issues/1715)) ([544d1a8](https://github.com/carbon-design-system/ibm-products/commit/544d1a8f22d65a1e8cb8e9aea636cb9e7852dd2d))

--- a/packages/component-usage-report/src/scan.js
+++ b/packages/component-usage-report/src/scan.js
@@ -17,8 +17,8 @@ import { export1 } from '@carbon/ibm-products/lib';
 import { export1 as alias1 } from "@carbon/ibm-products";
 import { export1 , export2 } from '@carbon/ibm-cloud-cognitive';
 import { export1 , export2 as alias2 } from "@carbon/ibm-cloud-cognitive";
-import { export1 , export2 as alias2 } from "@carbon/ibm-cloud-cognitive/lib";
-import { export1 , export2 as alias2 } from "@carbon/ibm-cloud-cognitive/es";
+import { export1 , export2 as alias2 } from "@carbon/ibm-products/lib";
+import { export1 , export2 as alias2 } from "@carbon/ibm-products/es";
 import defaultExport, { export1 } from '@carbon/ibm-cloud-cognitive';
 import defaultExport, * as name from "@carbon/ibm-cloud-cognitive";
 */

--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -74,7 +74,7 @@ const decorators = [
                     kind="ghost"
                     onClick={() => {
                       window.open(
-                        'https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/main/packages/cloud-cognitive#enabling-canary-components-and-flagged-features'
+                        'https://github.com/carbon-design-system/ibm-products/tree/main/packages/cloud-cognitive#enabling-canary-components-and-flagged-features'
                       );
                     }}
                   >

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,52 +3,52 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.43.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.42.0...@carbon/ibm-cloud-cognitive-core@0.43.0) (2023-05-04)
+# [0.43.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.42.0...@carbon/ibm-cloud-cognitive-core@0.43.0) (2023-05-04)
 
 
 ### Features
 
-* **Datagrid:** add feature flag to select hooks until fully released ([#2937](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2937)) ([387b593](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/387b5938ebd469708dae997d5d4701ebb1215edb))
-* feature flagging in v1 with example ([#2928](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2928)) ([8da8deb](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8da8deb337772162aa74d686e76fc178e05a2dfc))
+* **Datagrid:** add feature flag to select hooks until fully released ([#2937](https://github.com/carbon-design-system/ibm-products/issues/2937)) ([387b593](https://github.com/carbon-design-system/ibm-products/commit/387b5938ebd469708dae997d5d4701ebb1215edb))
+* feature flagging in v1 with example ([#2928](https://github.com/carbon-design-system/ibm-products/issues/2928)) ([8da8deb](https://github.com/carbon-design-system/ibm-products/commit/8da8deb337772162aa74d686e76fc178e05a2dfc))
 
 
 
 
 
-# [0.42.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.41.0...@carbon/ibm-cloud-cognitive-core@0.42.0) (2023-05-02)
-
-
-### Features
-
-* Rename inline edit (V1) ([#2881](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2881)) ([cff465d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/cff465d845d0bdf5835a4dfe2fa87aa75e658578))
-
-
-
-
-
-# [0.41.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.40.5...@carbon/ibm-cloud-cognitive-core@0.41.0) (2023-04-11)
+# [0.42.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.41.0...@carbon/ibm-cloud-cognitive-core@0.42.0) (2023-05-02)
 
 
 ### Features
 
-* add new NonLinearReading component ([#2793](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2793)) ([2516844](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/251684484022517ccf4c6d829b63a5e8b7949c86))
+* Rename inline edit (V1) ([#2881](https://github.com/carbon-design-system/ibm-products/issues/2881)) ([cff465d](https://github.com/carbon-design-system/ibm-products/commit/cff465d845d0bdf5835a4dfe2fa87aa75e658578))
 
 
 
 
 
-## [0.40.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.40.4...@carbon/ibm-cloud-cognitive-core@0.40.5) (2023-03-28)
+# [0.41.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.40.5...@carbon/ibm-cloud-cognitive-core@0.41.0) (2023-04-11)
+
+
+### Features
+
+* add new NonLinearReading component ([#2793](https://github.com/carbon-design-system/ibm-products/issues/2793)) ([2516844](https://github.com/carbon-design-system/ibm-products/commit/251684484022517ccf4c6d829b63a5e8b7949c86))
+
+
+
+
+
+## [0.40.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.40.4...@carbon/ibm-cloud-cognitive-core@0.40.5) (2023-03-28)
 
 
 ### Bug Fixes
 
-* update to Carbon v10 compatible versions to latest ([#2739](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2739)) ([7065855](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/70658550120822ab0a6dd296bc9022cc7d0856db))
+* update to Carbon v10 compatible versions to latest ([#2739](https://github.com/carbon-design-system/ibm-products/issues/2739)) ([7065855](https://github.com/carbon-design-system/ibm-products/commit/70658550120822ab0a6dd296bc9022cc7d0856db))
 
 
 
 
 
-## [0.40.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.40.3...@carbon/ibm-cloud-cognitive-core@0.40.4) (2023-03-07)
+## [0.40.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.40.3...@carbon/ibm-cloud-cognitive-core@0.40.4) (2023-03-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
@@ -56,7 +56,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.40.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.40.2...@carbon/ibm-cloud-cognitive-core@0.40.3) (2023-02-07)
+## [0.40.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.40.2...@carbon/ibm-cloud-cognitive-core@0.40.3) (2023-02-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
@@ -69,7 +69,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.40.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.40.1...@carbon/ibm-cloud-cognitive-core@0.40.2) (2023-01-10)
+## [0.40.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.40.1...@carbon/ibm-cloud-cognitive-core@0.40.2) (2023-01-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
@@ -78,2001 +78,2001 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.40.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.40.0...@carbon/ibm-cloud-cognitive-core@0.40.1) (2022-12-10)
+## [0.40.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.40.0...@carbon/ibm-cloud-cognitive-core@0.40.1) (2022-12-10)
 
 ### Bug Fixes
 
 - **ButtonMenu:** Revert back to OverflowMenu
-  ([#2521](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2521))
-  ([19b3277](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/19b3277d897f86a8c26f383b553c5cd706912e0e))
+  ([#2521](https://github.com/carbon-design-system/ibm-products/issues/2521))
+  ([19b3277](https://github.com/carbon-design-system/ibm-products/commit/19b3277d897f86a8c26f383b553c5cd706912e0e))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.40.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.39.1...@carbon/ibm-cloud-cognitive-core@0.40.0) (2022-11-22)
+# [0.40.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.39.1...@carbon/ibm-cloud-cognitive-core@0.40.0) (2022-11-22)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#2462](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2462))
-  ([4353991](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/43539912353a965549f0f2e5f8245168d2ce1c98))
+  ([#2462](https://github.com/carbon-design-system/ibm-products/issues/2462))
+  ([4353991](https://github.com/carbon-design-system/ibm-products/commit/43539912353a965549f0f2e5f8245168d2ce1c98))
 
 ### Features
 
 - adds FilterSummary
-  ([#2466](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2466))
-  ([46dd712](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/46dd7120f088d3f05ecd653d44058f3e51d76c9c))
+  ([#2466](https://github.com/carbon-design-system/ibm-products/issues/2466))
+  ([46dd712](https://github.com/carbon-design-system/ibm-products/commit/46dd7120f088d3f05ecd653d44058f3e51d76c9c))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.39.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.39.0...@carbon/ibm-cloud-cognitive-core@0.39.1) (2022-11-08)
+## [0.39.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.39.0...@carbon/ibm-cloud-cognitive-core@0.39.1) (2022-11-08)
 
 ### Bug Fixes
 
 - add inline edit wrapper component
-  ([#2404](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2404))
-  ([53dc96c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/53dc96c6a85f0e0c501799ab3715ab83057f746d))
+  ([#2404](https://github.com/carbon-design-system/ibm-products/issues/2404))
+  ([53dc96c](https://github.com/carbon-design-system/ibm-products/commit/53dc96c6a85f0e0c501799ab3715ab83057f746d))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.39.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.38.1...@carbon/ibm-cloud-cognitive-core@0.39.0) (2022-10-25)
+# [0.39.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.38.1...@carbon/ibm-cloud-cognitive-core@0.39.0) (2022-10-25)
 
 ### Features
 
 - **EditUpdateCards:** Edit and update cards
-  ([#2212](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2212))
-  ([ac140f8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ac140f8f8320f4985d95a8a270a440fd7b5cb2cf))
+  ([#2212](https://github.com/carbon-design-system/ibm-products/issues/2212))
+  ([ac140f8](https://github.com/carbon-design-system/ibm-products/commit/ac140f8f8320f4985d95a8a270a440fd7b5cb2cf))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.38.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.38.0...@carbon/ibm-cloud-cognitive-core@0.38.1) (2022-10-18)
+## [0.38.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.38.0...@carbon/ibm-cloud-cognitive-core@0.38.1) (2022-10-18)
 
 ### Bug Fixes
 
 - update Carbon v10 compatible versions to latest
-  ([#2362](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2362))
-  ([e328904](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e328904b20bdc0c652661de829c0d1bfcb8738b6))
+  ([#2362](https://github.com/carbon-design-system/ibm-products/issues/2362))
+  ([e328904](https://github.com/carbon-design-system/ibm-products/commit/e328904b20bdc0c652661de829c0d1bfcb8738b6))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.38.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.37.5...@carbon/ibm-cloud-cognitive-core@0.38.0) (2022-10-11)
+# [0.38.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.37.5...@carbon/ibm-cloud-cognitive-core@0.38.0) (2022-10-11)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#2331](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2331))
-  ([26f7bc1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/26f7bc1b05ded4d79634a06dea725746e6e381e7))
+  ([#2331](https://github.com/carbon-design-system/ibm-products/issues/2331))
+  ([26f7bc1](https://github.com/carbon-design-system/ibm-products/commit/26f7bc1b05ded4d79634a06dea725746e6e381e7))
 
 ### Features
 
 - inline edit refactor
-  ([#2330](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2330))
-  ([ecd7b6d](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ecd7b6dbc0174c0a06d3540a02c19e1881d85a59))
+  ([#2330](https://github.com/carbon-design-system/ibm-products/issues/2330))
+  ([ecd7b6d](https://github.com/carbon-design-system/ibm-products/commit/ecd7b6dbc0174c0a06d3540a02c19e1881d85a59))
 
-## [0.37.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.37.4...@carbon/ibm-cloud-cognitive-core@0.37.5) (2022-10-04)
+## [0.37.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.37.4...@carbon/ibm-cloud-cognitive-core@0.37.5) (2022-10-04)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.37.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.37.3...@carbon/ibm-cloud-cognitive-core@0.37.4) (2022-09-27)
+## [0.37.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.37.3...@carbon/ibm-cloud-cognitive-core@0.37.4) (2022-09-27)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#2276](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2276))
-  ([c35a363](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c35a3630ecb0dd60d920e57d81bd8f6e84aae008))
+  ([#2276](https://github.com/carbon-design-system/ibm-products/issues/2276))
+  ([c35a363](https://github.com/carbon-design-system/ibm-products/commit/c35a3630ecb0dd60d920e57d81bd8f6e84aae008))
 
-## [0.37.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.37.2...@carbon/ibm-cloud-cognitive-core@0.37.3) (2022-09-20)
+## [0.37.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.37.2...@carbon/ibm-cloud-cognitive-core@0.37.3) (2022-09-20)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.37.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.37.1...@carbon/ibm-cloud-cognitive-core@0.37.2) (2022-09-06)
+## [0.37.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.37.1...@carbon/ibm-cloud-cognitive-core@0.37.2) (2022-09-06)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#2249](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2249))
-  ([2a2ccfa](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2a2ccfaef41d5247724aed978fb62567932ea6dc))
+  ([#2249](https://github.com/carbon-design-system/ibm-products/issues/2249))
+  ([2a2ccfa](https://github.com/carbon-design-system/ibm-products/commit/2a2ccfaef41d5247724aed978fb62567932ea6dc))
 
-## [0.37.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.37.0...@carbon/ibm-cloud-cognitive-core@0.37.1) (2022-08-16)
+## [0.37.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.37.0...@carbon/ibm-cloud-cognitive-core@0.37.1) (2022-08-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-# [0.37.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.36.0...@carbon/ibm-cloud-cognitive-core@0.37.0) (2022-08-02)
+# [0.37.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.36.0...@carbon/ibm-cloud-cognitive-core@0.37.0) (2022-08-02)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#2144](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2144))
-  ([c67ce20](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c67ce20cf586218f28d2ad7bba4de6fd4d21efae))
+  ([#2144](https://github.com/carbon-design-system/ibm-products/issues/2144))
+  ([c67ce20](https://github.com/carbon-design-system/ibm-products/commit/c67ce20cf586218f28d2ad7bba4de6fd4d21efae))
 
 ### Features
 
 - Create Getting Started layout
-  ([#1516](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1516))
-  ([455f762](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/455f76223d6b43b3ee55c344108dbcd79133b8b8))
+  ([#1516](https://github.com/carbon-design-system/ibm-products/issues/1516))
+  ([455f762](https://github.com/carbon-design-system/ibm-products/commit/455f76223d6b43b3ee55c344108dbcd79133b8b8))
 
-# [0.36.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.35.8...@carbon/ibm-cloud-cognitive-core@0.36.0) (2022-07-27)
+# [0.36.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.35.8...@carbon/ibm-cloud-cognitive-core@0.36.0) (2022-07-27)
 
 ### Features
 
 - **edit and update:** edit and update tearsheet
-  ([#1975](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1975))
-  ([cd09bab](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/cd09babac9f862339760acd64fc24340c06423ae))
+  ([#1975](https://github.com/carbon-design-system/ibm-products/issues/1975))
+  ([cd09bab](https://github.com/carbon-design-system/ibm-products/commit/cd09babac9f862339760acd64fc24340c06423ae))
 
-## [0.35.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.35.7...@carbon/ibm-cloud-cognitive-core@0.35.8) (2022-07-19)
-
-### Bug Fixes
-
-- update to Carbon v10 compatible versions to latest
-  ([#2101](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2101))
-  ([feebce3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/feebce38ac474917e29d201d9198e3baf9452a97))
-
-## [0.35.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.35.6...@carbon/ibm-cloud-cognitive-core@0.35.7) (2022-07-12)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
-
-## [0.35.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.35.5...@carbon/ibm-cloud-cognitive-core@0.35.6) (2022-05-31)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
-
-## [0.35.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.35.4...@carbon/ibm-cloud-cognitive-core@0.35.5) (2022-05-17)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
-
-## [0.35.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.35.3...@carbon/ibm-cloud-cognitive-core@0.35.4) (2022-05-10)
+## [0.35.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.35.7...@carbon/ibm-cloud-cognitive-core@0.35.8) (2022-07-19)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#1971](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1971))
-  ([95374b8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/95374b89a15b1a76d18fb29c40e161a54720c447)),
+  ([#2101](https://github.com/carbon-design-system/ibm-products/issues/2101))
+  ([feebce3](https://github.com/carbon-design-system/ibm-products/commit/feebce38ac474917e29d201d9198e3baf9452a97))
+
+## [0.35.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.35.6...@carbon/ibm-cloud-cognitive-core@0.35.7) (2022-07-12)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
+
+## [0.35.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.35.5...@carbon/ibm-cloud-cognitive-core@0.35.6) (2022-05-31)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
+
+## [0.35.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.35.4...@carbon/ibm-cloud-cognitive-core@0.35.5) (2022-05-17)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
+
+## [0.35.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.35.3...@carbon/ibm-cloud-cognitive-core@0.35.4) (2022-05-10)
+
+### Bug Fixes
+
+- update to Carbon v10 compatible versions to latest
+  ([#1971](https://github.com/carbon-design-system/ibm-products/issues/1971))
+  ([95374b8](https://github.com/carbon-design-system/ibm-products/commit/95374b89a15b1a76d18fb29c40e161a54720c447)),
   closes
-  [#1970](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1970)
-  [#1972](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1972)
+  [#1970](https://github.com/carbon-design-system/ibm-products/issues/1970)
+  [#1972](https://github.com/carbon-design-system/ibm-products/issues/1972)
 
-## [0.35.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.35.2...@carbon/ibm-cloud-cognitive-core@0.35.3) (2022-05-03)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
-
-## [0.35.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.35.1...@carbon/ibm-cloud-cognitive-core@0.35.2) (2022-04-26)
+## [0.35.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.35.2...@carbon/ibm-cloud-cognitive-core@0.35.3) (2022-05-03)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.35.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.35.0...@carbon/ibm-cloud-cognitive-core@0.35.1) (2022-04-19)
+## [0.35.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.35.1...@carbon/ibm-cloud-cognitive-core@0.35.2) (2022-04-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-# [0.35.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.34.7...@carbon/ibm-cloud-cognitive-core@0.35.0) (2022-04-12)
+## [0.35.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.35.0...@carbon/ibm-cloud-cognitive-core@0.35.1) (2022-04-19)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
+
+# [0.35.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.34.7...@carbon/ibm-cloud-cognitive-core@0.35.0) (2022-04-12)
 
 ### Features
 
 - Datagrid component
-  ([#1877](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1877))
-  ([f9dd8ce](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f9dd8ce0ab87cea39e91603fdb542091fa757cbe))
+  ([#1877](https://github.com/carbon-design-system/ibm-products/issues/1877))
+  ([f9dd8ce](https://github.com/carbon-design-system/ibm-products/commit/f9dd8ce0ab87cea39e91603fdb542091fa757cbe))
 
-## [0.34.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.34.6...@carbon/ibm-cloud-cognitive-core@0.34.7) (2022-04-05)
+## [0.34.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.34.6...@carbon/ibm-cloud-cognitive-core@0.34.7) (2022-04-05)
 
 ### Bug Fixes
 
 - update Carbon versions to latest
-  ([#1862](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1862))
-  ([c0e8024](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c0e8024cf060cec0262c79628077810a92a56619))
+  ([#1862](https://github.com/carbon-design-system/ibm-products/issues/1862))
+  ([c0e8024](https://github.com/carbon-design-system/ibm-products/commit/c0e8024cf060cec0262c79628077810a92a56619))
 
-## [0.34.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.34.5...@carbon/ibm-cloud-cognitive-core@0.34.6) (2022-03-29)
+## [0.34.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.34.5...@carbon/ibm-cloud-cognitive-core@0.34.6) (2022-03-29)
 
 ### Bug Fixes
 
 - **ComponentPlayground:** fix carbon settings import
-  ([#1842](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1842))
-  ([9977edc](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9977edc19597dd1002d61ce814d96cf88e6e4fcc))
+  ([#1842](https://github.com/carbon-design-system/ibm-products/issues/1842))
+  ([9977edc](https://github.com/carbon-design-system/ibm-products/commit/9977edc19597dd1002d61ce814d96cf88e6e4fcc))
 - update Carbon versions to latest
-  ([#1835](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1835))
-  ([b9152d1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b9152d15813b7feab937092bbbf46439305aab50))
+  ([#1835](https://github.com/carbon-design-system/ibm-products/issues/1835))
+  ([b9152d1](https://github.com/carbon-design-system/ibm-products/commit/b9152d15813b7feab937092bbbf46439305aab50))
 
-## [0.34.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.34.4...@carbon/ibm-cloud-cognitive-core@0.34.5) (2022-03-22)
+## [0.34.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.34.4...@carbon/ibm-cloud-cognitive-core@0.34.5) (2022-03-22)
 
 ### Bug Fixes
 
 - **LoadingBar:** remove loadingbar component
-  [#1738](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1738)
-  ([#1791](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1791))
-  ([80c93a6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/80c93a6bd4787ed0e1eed518c08e0ea6466ad0d5))
+  [#1738](https://github.com/carbon-design-system/ibm-products/issues/1738)
+  ([#1791](https://github.com/carbon-design-system/ibm-products/issues/1791))
+  ([80c93a6](https://github.com/carbon-design-system/ibm-products/commit/80c93a6bd4787ed0e1eed518c08e0ea6466ad0d5))
 - update Carbon versions to latest
-  ([#1793](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1793))
-  ([9943926](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9943926b5234ce0690417d16483da4caa84790cf)),
+  ([#1793](https://github.com/carbon-design-system/ibm-products/issues/1793))
+  ([9943926](https://github.com/carbon-design-system/ibm-products/commit/9943926b5234ce0690417d16483da4caa84790cf)),
   closes
-  [#1738](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1738)
-  [#1791](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1791)
-  [#1738](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1738)
-  [#1790](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1790)
+  [#1738](https://github.com/carbon-design-system/ibm-products/issues/1738)
+  [#1791](https://github.com/carbon-design-system/ibm-products/issues/1791)
+  [#1738](https://github.com/carbon-design-system/ibm-products/issues/1738)
+  [#1790](https://github.com/carbon-design-system/ibm-products/issues/1790)
 
-## [0.34.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.34.3...@carbon/ibm-cloud-cognitive-core@0.34.4) (2022-03-15)
+## [0.34.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.34.3...@carbon/ibm-cloud-cognitive-core@0.34.4) (2022-03-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.34.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.34.2...@carbon/ibm-cloud-cognitive-core@0.34.3) (2022-03-08)
+## [0.34.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.34.2...@carbon/ibm-cloud-cognitive-core@0.34.3) (2022-03-08)
 
 ### Bug Fixes
 
 - update Carbon versions to latest
-  ([#1733](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1733))
-  ([9783faa](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9783faac23d8f03598ef0e5994743c4c5f915705))
+  ([#1733](https://github.com/carbon-design-system/ibm-products/issues/1733))
+  ([9783faa](https://github.com/carbon-design-system/ibm-products/commit/9783faac23d8f03598ef0e5994743c4c5f915705))
 
-## [0.34.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.34.1...@carbon/ibm-cloud-cognitive-core@0.34.2) (2022-03-01)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
-
-## [0.34.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.34.0...@carbon/ibm-cloud-cognitive-core@0.34.1) (2022-02-22)
+## [0.34.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.34.1...@carbon/ibm-cloud-cognitive-core@0.34.2) (2022-03-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-# [0.34.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.33.3...@carbon/ibm-cloud-cognitive-core@0.34.0) (2022-02-16)
+## [0.34.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.34.0...@carbon/ibm-cloud-cognitive-core@0.34.1) (2022-02-22)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
+
+# [0.34.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.33.3...@carbon/ibm-cloud-cognitive-core@0.34.0) (2022-02-16)
 
 ### Features
 
 - **DataSpreadsheet:** add initial component
-  ([#1606](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1606))
-  ([331a087](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/331a08757d0715aea156027e4f62772febdcf059))
+  ([#1606](https://github.com/carbon-design-system/ibm-products/issues/1606))
+  ([331a087](https://github.com/carbon-design-system/ibm-products/commit/331a08757d0715aea156027e4f62772febdcf059))
 - update Carbon versions to latest
-  ([#1646](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1646))
-  ([e323739](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e323739ac9a6155aa0fddf39b13e4440d04117fc))
+  ([#1646](https://github.com/carbon-design-system/ibm-products/issues/1646))
+  ([e323739](https://github.com/carbon-design-system/ibm-products/commit/e323739ac9a6155aa0fddf39b13e4440d04117fc))
 
-## [0.33.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.33.2...@carbon/ibm-cloud-cognitive-core@0.33.3) (2022-02-15)
+## [0.33.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.33.2...@carbon/ibm-cloud-cognitive-core@0.33.3) (2022-02-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.33.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.33.1...@carbon/ibm-cloud-cognitive-core@0.33.2) (2022-02-09)
+## [0.33.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.33.1...@carbon/ibm-cloud-cognitive-core@0.33.2) (2022-02-09)
 
 ### Bug Fixes
 
 - update Carbon versions to latest
-  ([#1587](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1587))
-  ([d4b5ccc](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d4b5cccd9ef4a9df2966063c21f49fe7810245a8))
+  ([#1587](https://github.com/carbon-design-system/ibm-products/issues/1587))
+  ([d4b5ccc](https://github.com/carbon-design-system/ibm-products/commit/d4b5cccd9ef4a9df2966063c21f49fe7810245a8))
 
-## [0.33.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.33.0...@carbon/ibm-cloud-cognitive-core@0.33.1) (2022-02-01)
+## [0.33.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.33.0...@carbon/ibm-cloud-cognitive-core@0.33.1) (2022-02-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-# [0.33.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.32.0...@carbon/ibm-cloud-cognitive-core@0.33.0) (2022-01-25)
+# [0.33.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.32.0...@carbon/ibm-cloud-cognitive-core@0.33.0) (2022-01-25)
 
 ### Bug Fixes
 
 - update Carbon versions to latest
-  ([#1548](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1548))
-  ([5617870](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/561787014feac09c1a8e70895c51abb3bf46245e))
+  ([#1548](https://github.com/carbon-design-system/ibm-products/issues/1548))
+  ([5617870](https://github.com/carbon-design-system/ibm-products/commit/561787014feac09c1a8e70895c51abb3bf46245e))
 
 ### Features
 
 - initial inline edit to page-header
-  ([#1533](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1533))
-  ([dffbba6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/dffbba6a761237a3fa1aa92d8f3b07c8de88fe0d))
+  ([#1533](https://github.com/carbon-design-system/ibm-products/issues/1533))
+  ([dffbba6](https://github.com/carbon-design-system/ibm-products/commit/dffbba6a761237a3fa1aa92d8f3b07c8de88fe0d))
 - split addselect into multiple exports
-  ([#1542](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1542))
-  ([b9de902](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b9de9024b7e5e422119fc90ef0258a1314a62124))
+  ([#1542](https://github.com/carbon-design-system/ibm-products/issues/1542))
+  ([b9de902](https://github.com/carbon-design-system/ibm-products/commit/b9de9024b7e5e422119fc90ef0258a1314a62124))
 
-# [0.32.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.31.5...@carbon/ibm-cloud-cognitive-core@0.32.0) (2022-01-18)
+# [0.32.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.31.5...@carbon/ibm-cloud-cognitive-core@0.32.0) (2022-01-18)
 
 ### Features
 
 - add select component init
-  ([#1523](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1523))
-  ([3c61353](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3c613539ce6334be13dbf2b5d09b5f7b73f87a20))
+  ([#1523](https://github.com/carbon-design-system/ibm-products/issues/1523))
+  ([3c61353](https://github.com/carbon-design-system/ibm-products/commit/3c613539ce6334be13dbf2b5d09b5f7b73f87a20))
 
-## [0.31.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.31.4...@carbon/ibm-cloud-cognitive-core@0.31.5) (2022-01-11)
-
-### Bug Fixes
-
-- update Carbon versions and package dependencies to latest
-  ([#1513](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1513))
-  ([505ba0e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/505ba0e13ec58bef19422835fd8ffee87c24e82a))
-- update Carbon versions and package dependencies to latest
-  ([#1518](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1518))
-  ([3ddcdf6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3ddcdf6617e0d7c9f182da91e3eb0935b34cbc05))
-
-## [0.31.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.31.3...@carbon/ibm-cloud-cognitive-core@0.31.4) (2022-01-04)
+## [0.31.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.31.4...@carbon/ibm-cloud-cognitive-core@0.31.5) (2022-01-11)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1509](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1509))
-  ([613db81](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/613db817bffec2c5b26b1fe50a337dd7bac5d963))
+  ([#1513](https://github.com/carbon-design-system/ibm-products/issues/1513))
+  ([505ba0e](https://github.com/carbon-design-system/ibm-products/commit/505ba0e13ec58bef19422835fd8ffee87c24e82a))
+- update Carbon versions and package dependencies to latest
+  ([#1518](https://github.com/carbon-design-system/ibm-products/issues/1518))
+  ([3ddcdf6](https://github.com/carbon-design-system/ibm-products/commit/3ddcdf6617e0d7c9f182da91e3eb0935b34cbc05))
 
-## [0.31.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.31.2...@carbon/ibm-cloud-cognitive-core@0.31.3) (2021-12-21)
+## [0.31.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.31.3...@carbon/ibm-cloud-cognitive-core@0.31.4) (2022-01-04)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1499](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1499))
-  ([8aed3d5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8aed3d53d06cc896984e6847c0450cc647e34041))
+  ([#1509](https://github.com/carbon-design-system/ibm-products/issues/1509))
+  ([613db81](https://github.com/carbon-design-system/ibm-products/commit/613db817bffec2c5b26b1fe50a337dd7bac5d963))
 
-## [0.31.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.31.1...@carbon/ibm-cloud-cognitive-core@0.31.2) (2021-12-14)
-
-### Bug Fixes
-
-- update Carbon versions and package dependencies to latest
-  ([#1493](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1493))
-  ([91b8238](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/91b82383e0aa74383ebb81f625a9e7b870f06c00))
-
-## [0.31.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.31.0...@carbon/ibm-cloud-cognitive-core@0.31.1) (2021-12-07)
+## [0.31.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.31.2...@carbon/ibm-cloud-cognitive-core@0.31.3) (2021-12-21)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1491](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1491))
-  ([45f7b77](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/45f7b77f797c5841b9dc15bc3013f31e50244d29))
+  ([#1499](https://github.com/carbon-design-system/ibm-products/issues/1499))
+  ([8aed3d5](https://github.com/carbon-design-system/ibm-products/commit/8aed3d53d06cc896984e6847c0450cc647e34041))
 
-# [0.31.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.30.0...@carbon/ibm-cloud-cognitive-core@0.31.0) (2021-11-30)
+## [0.31.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.31.1...@carbon/ibm-cloud-cognitive-core@0.31.2) (2021-12-14)
+
+### Bug Fixes
+
+- update Carbon versions and package dependencies to latest
+  ([#1493](https://github.com/carbon-design-system/ibm-products/issues/1493))
+  ([91b8238](https://github.com/carbon-design-system/ibm-products/commit/91b82383e0aa74383ebb81f625a9e7b870f06c00))
+
+## [0.31.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.31.0...@carbon/ibm-cloud-cognitive-core@0.31.1) (2021-12-07)
+
+### Bug Fixes
+
+- update Carbon versions and package dependencies to latest
+  ([#1491](https://github.com/carbon-design-system/ibm-products/issues/1491))
+  ([45f7b77](https://github.com/carbon-design-system/ibm-products/commit/45f7b77f797c5841b9dc15bc3013f31e50244d29))
+
+# [0.31.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.30.0...@carbon/ibm-cloud-cognitive-core@0.31.0) (2021-11-30)
 
 ### Features
 
 - update Carbon versions and dependencies to latest
-  ([#1473](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1473))
-  ([9cafbea](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9cafbea95226c46ff1732f9ad6b22c9c8837616e))
+  ([#1473](https://github.com/carbon-design-system/ibm-products/issues/1473))
+  ([9cafbea](https://github.com/carbon-design-system/ibm-products/commit/9cafbea95226c46ff1732f9ad6b22c9c8837616e))
 
-# [0.30.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.29.0...@carbon/ibm-cloud-cognitive-core@0.30.0) (2021-11-23)
+# [0.30.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.29.0...@carbon/ibm-cloud-cognitive-core@0.30.0) (2021-11-23)
 
 ### Features
 
 - update Carbon versions and dependencies to latest
-  ([#1465](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1465))
-  ([0c6b37f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0c6b37f5b713c54ec320d9da945fbd3f6b3f91d9))
+  ([#1465](https://github.com/carbon-design-system/ibm-products/issues/1465))
+  ([0c6b37f](https://github.com/carbon-design-system/ibm-products/commit/0c6b37f5b713c54ec320d9da945fbd3f6b3f91d9))
 
-# [0.29.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.28.0...@carbon/ibm-cloud-cognitive-core@0.29.0) (2021-11-16)
+# [0.29.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.28.0...@carbon/ibm-cloud-cognitive-core@0.29.0) (2021-11-16)
 
 ### Bug Fixes
 
 - replace "cloud & cognitive" with "Carbon for IBM Products" in docs
-  ([#1437](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1437))
-  ([0a58354](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0a58354ccbdd723173b2e6758907713938a7f163))
+  ([#1437](https://github.com/carbon-design-system/ibm-products/issues/1437))
+  ([0a58354](https://github.com/carbon-design-system/ibm-products/commit/0a58354ccbdd723173b2e6758907713938a7f163))
 
 ### Features
 
 - add options-tile component
-  ([#1411](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1411))
-  ([b7dbeb7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b7dbeb71c6343d0839d5c3ab74a5c83e1fd6d9b6))
+  ([#1411](https://github.com/carbon-design-system/ibm-products/issues/1411))
+  ([b7dbeb7](https://github.com/carbon-design-system/ibm-products/commit/b7dbeb71c6343d0839d5c3ab74a5c83e1fd6d9b6))
 - update Carbon versions and package dependencies to latest
-  ([#1425](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1425))
-  ([4fd5883](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4fd5883961e0f3fc6be1c87bbe084b2cf6dc5db0)),
+  ([#1425](https://github.com/carbon-design-system/ibm-products/issues/1425))
+  ([4fd5883](https://github.com/carbon-design-system/ibm-products/commit/4fd5883961e0f3fc6be1c87bbe084b2cf6dc5db0)),
   closes
-  [#10000](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/10000)
+  [#10000](https://github.com/carbon-design-system/ibm-products/issues/10000)
 
-# [0.28.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.27.0...@carbon/ibm-cloud-cognitive-core@0.28.0) (2021-11-09)
+# [0.28.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.27.0...@carbon/ibm-cloud-cognitive-core@0.28.0) (2021-11-09)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1365](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1365))
-  ([ea11cf7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ea11cf7ae44b61b48142c511c16460cf7978b88c))
+  ([#1365](https://github.com/carbon-design-system/ibm-products/issues/1365))
+  ([ea11cf7](https://github.com/carbon-design-system/ibm-products/commit/ea11cf7ae44b61b48142c511c16460cf7978b88c))
 
-# [0.27.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.26.0...@carbon/ibm-cloud-cognitive-core@0.27.0) (2021-11-05)
+# [0.27.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.26.0...@carbon/ibm-cloud-cognitive-core@0.27.0) (2021-11-05)
 
 ### Features
 
 - migrate Security package
-  ([#918](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/918))
-  ([08573c5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/08573c512adc60c40071699ff040d4a14bfedf36))
+  ([#918](https://github.com/carbon-design-system/ibm-products/issues/918))
+  ([08573c5](https://github.com/carbon-design-system/ibm-products/commit/08573c512adc60c40071699ff040d4a14bfedf36))
 
-# [0.26.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.25.1...@carbon/ibm-cloud-cognitive-core@0.26.0) (2021-10-27)
+# [0.26.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.25.1...@carbon/ibm-cloud-cognitive-core@0.26.0) (2021-10-27)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1356](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1356))
-  ([946afd6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/946afd6bd5a165f35940cc1d70fc0e42fb6a4303))
+  ([#1356](https://github.com/carbon-design-system/ibm-products/issues/1356))
+  ([946afd6](https://github.com/carbon-design-system/ibm-products/commit/946afd6bd5a165f35940cc1d70fc0e42fb6a4303))
 
-## [0.25.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.25.0...@carbon/ibm-cloud-cognitive-core@0.25.1) (2021-10-26)
+## [0.25.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.25.0...@carbon/ibm-cloud-cognitive-core@0.25.1) (2021-10-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-# [0.25.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.24.1...@carbon/ibm-cloud-cognitive-core@0.25.0) (2021-10-20)
+# [0.25.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.24.1...@carbon/ibm-cloud-cognitive-core@0.25.0) (2021-10-20)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1345](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1345))
-  ([3c7e6fe](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3c7e6fedfc46bffc38b889568133ee6c300ddb47))
+  ([#1345](https://github.com/carbon-design-system/ibm-products/issues/1345))
+  ([3c7e6fe](https://github.com/carbon-design-system/ibm-products/commit/3c7e6fedfc46bffc38b889568133ee6c300ddb47))
 
-## [0.24.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.24.0...@carbon/ibm-cloud-cognitive-core@0.24.1) (2021-10-20)
+## [0.24.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.24.0...@carbon/ibm-cloud-cognitive-core@0.24.1) (2021-10-20)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-# [0.24.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.23.0...@carbon/ibm-cloud-cognitive-core@0.24.0) (2021-10-14)
+# [0.24.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.23.0...@carbon/ibm-cloud-cognitive-core@0.24.0) (2021-10-14)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1329](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1329))
-  ([fd3525e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fd3525ec3620b70ff19f85c300e7e0bb05577cd1))
+  ([#1329](https://github.com/carbon-design-system/ibm-products/issues/1329))
+  ([fd3525e](https://github.com/carbon-design-system/ibm-products/commit/fd3525ec3620b70ff19f85c300e7e0bb05577cd1))
 
-# [0.23.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.22.0...@carbon/ibm-cloud-cognitive-core@0.23.0) (2021-10-07)
-
-### Features
-
-- update Carbon versions and package dependencies to latest
-  ([#1309](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1309))
-  ([945bd3b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/945bd3ba5608078e961af9a04448f2abd7e7fc5e))
-
-# [0.22.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.21.1...@carbon/ibm-cloud-cognitive-core@0.22.0) (2021-10-02)
+# [0.23.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.22.0...@carbon/ibm-cloud-cognitive-core@0.23.0) (2021-10-07)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1296](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1296))
-  ([f1da0bd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f1da0bd9192c4d999032df0dbe20d67b6ece89b0))
+  ([#1309](https://github.com/carbon-design-system/ibm-products/issues/1309))
+  ([945bd3b](https://github.com/carbon-design-system/ibm-products/commit/945bd3ba5608078e961af9a04448f2abd7e7fc5e))
 
-## [0.21.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.21.0...@carbon/ibm-cloud-cognitive-core@0.21.1) (2021-09-29)
+# [0.22.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.21.1...@carbon/ibm-cloud-cognitive-core@0.22.0) (2021-10-02)
+
+### Features
+
+- update Carbon versions and package dependencies to latest
+  ([#1296](https://github.com/carbon-design-system/ibm-products/issues/1296))
+  ([f1da0bd](https://github.com/carbon-design-system/ibm-products/commit/f1da0bd9192c4d999032df0dbe20d67b6ece89b0))
+
+## [0.21.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.21.0...@carbon/ibm-cloud-cognitive-core@0.21.1) (2021-09-29)
 
 ### Bug Fixes
 
 - ensure story order matches PAL site
-  ([#1298](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1298))
-  ([6210273](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/62102731829ce6c9d93a060e9f7202f9006cf9a0))
+  ([#1298](https://github.com/carbon-design-system/ibm-products/issues/1298))
+  ([6210273](https://github.com/carbon-design-system/ibm-products/commit/62102731829ce6c9d93a060e9f7202f9006cf9a0))
 
-# [0.21.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.20.1...@carbon/ibm-cloud-cognitive-core@0.21.0) (2021-09-27)
+# [0.21.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.20.1...@carbon/ibm-cloud-cognitive-core@0.21.0) (2021-09-27)
 
 ### Features
 
 - **EditSidePanel:**
-  [#1266](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1266)
+  [#1266](https://github.com/carbon-design-system/ibm-products/issues/1266)
   edit side panel
-  ([#1280](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1280))
-  ([25f2b6e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/25f2b6ebcbdb78304caa16ce4b2ece56ecc83ea5))
+  ([#1280](https://github.com/carbon-design-system/ibm-products/issues/1280))
+  ([25f2b6e](https://github.com/carbon-design-system/ibm-products/commit/25f2b6ebcbdb78304caa16ce4b2ece56ecc83ea5))
 
-## [0.20.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.20.0...@carbon/ibm-cloud-cognitive-core@0.20.1) (2021-09-23)
+## [0.20.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.20.0...@carbon/ibm-cloud-cognitive-core@0.20.1) (2021-09-23)
 
 ### Bug Fixes
 
 - storybook setting masking missing component color setting
-  ([#1241](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1241))
-  ([38c01ec](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/38c01ec0fa1992b358aced18b714d77eda52bf09))
+  ([#1241](https://github.com/carbon-design-system/ibm-products/issues/1241))
+  ([38c01ec](https://github.com/carbon-design-system/ibm-products/commit/38c01ec0fa1992b358aced18b714d77eda52bf09))
 
-# [0.20.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.19.0...@carbon/ibm-cloud-cognitive-core@0.20.0) (2021-09-23)
+# [0.20.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.19.0...@carbon/ibm-cloud-cognitive-core@0.20.0) (2021-09-23)
 
 ### Features
 
 - update Carbon versions and dependencies to latest
-  ([#1282](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1282))
-  ([b1451cf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b1451cf5c91b75c1bd4e55ae2bdb47f025f33163))
+  ([#1282](https://github.com/carbon-design-system/ibm-products/issues/1282))
+  ([b1451cf](https://github.com/carbon-design-system/ibm-products/commit/b1451cf5c91b75c1bd4e55ae2bdb47f025f33163))
 
-# [0.19.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.18.1...@carbon/ibm-cloud-cognitive-core@0.19.0) (2021-09-21)
+# [0.19.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.18.1...@carbon/ibm-cloud-cognitive-core@0.19.0) (2021-09-21)
 
 ### Features
 
 - ensure prettier linting causes ci-check to fail
-  ([#1273](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1273))
-  ([ad6f347](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ad6f3479636d2b80b26338d9059429b4ae08ac6e))
+  ([#1273](https://github.com/carbon-design-system/ibm-products/issues/1273))
+  ([ad6f347](https://github.com/carbon-design-system/ibm-products/commit/ad6f3479636d2b80b26338d9059429b4ae08ac6e))
 - update Carbon versions and package dependencies to latest
-  ([#1262](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1262))
-  ([ed4dcbe](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ed4dcbe5b6d92baa6ec39240bda6996ec55f7bc4))
+  ([#1262](https://github.com/carbon-design-system/ibm-products/issues/1262))
+  ([ed4dcbe](https://github.com/carbon-design-system/ibm-products/commit/ed4dcbe5b6d92baa6ec39240bda6996ec55f7bc4))
 
-## [0.18.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.18.0...@carbon/ibm-cloud-cognitive-core@0.18.1) (2021-09-14)
+## [0.18.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.18.0...@carbon/ibm-cloud-cognitive-core@0.18.1) (2021-09-14)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-# [0.18.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.17.2...@carbon/ibm-cloud-cognitive-core@0.18.0) (2021-09-13)
+# [0.18.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.17.2...@carbon/ibm-cloud-cognitive-core@0.18.0) (2021-09-13)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1228](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1228))
-  ([4f5e24c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4f5e24cd3a36e7fa9a5cd62d1cafe75a090cf32e))
+  ([#1228](https://github.com/carbon-design-system/ibm-products/issues/1228))
+  ([4f5e24c](https://github.com/carbon-design-system/ibm-products/commit/4f5e24cd3a36e7fa9a5cd62d1cafe75a090cf32e))
 
-## [0.17.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.17.1...@carbon/ibm-cloud-cognitive-core@0.17.2) (2021-09-09)
+## [0.17.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.17.1...@carbon/ibm-cloud-cognitive-core@0.17.2) (2021-09-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.17.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.17.0...@carbon/ibm-cloud-cognitive-core@0.17.1) (2021-09-07)
+## [0.17.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.17.0...@carbon/ibm-cloud-cognitive-core@0.17.1) (2021-09-07)
 
 ### Bug Fixes
 
 - cascade release
-  ([#1242](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1242))
-  ([144af3f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/144af3f2c9a32b9621418e505ae3e5df9428fdc8))
+  ([#1242](https://github.com/carbon-design-system/ibm-products/issues/1242))
+  ([144af3f](https://github.com/carbon-design-system/ibm-products/commit/144af3f2c9a32b9621418e505ae3e5df9428fdc8))
 
-# [0.17.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.16.0...@carbon/ibm-cloud-cognitive-core@0.17.0) (2021-08-25)
+# [0.17.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.16.0...@carbon/ibm-cloud-cognitive-core@0.17.0) (2021-08-25)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#1199](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1199))
-  ([13ebf0b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/13ebf0b7bea06fa4cd2231bd613011d7717e5d03))
+  ([#1199](https://github.com/carbon-design-system/ibm-products/issues/1199))
+  ([13ebf0b](https://github.com/carbon-design-system/ibm-products/commit/13ebf0b7bea06fa4cd2231bd613011d7717e5d03))
 
-# [0.16.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.15.4...@carbon/ibm-cloud-cognitive-core@0.16.0) (2021-08-25)
+# [0.16.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.15.4...@carbon/ibm-cloud-cognitive-core@0.16.0) (2021-08-25)
 
 ### Features
 
 - cascade component
-  ([#1171](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1171))
-  ([76b8b6f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/76b8b6f1b375e093e721ba415b53e97ec3ca2262))
+  ([#1171](https://github.com/carbon-design-system/ibm-products/issues/1171))
+  ([76b8b6f](https://github.com/carbon-design-system/ibm-products/commit/76b8b6f1b375e093e721ba415b53e97ec3ca2262))
 
-## [0.15.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.15.3...@carbon/ibm-cloud-cognitive-core@0.15.4) (2021-08-23)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
-
-## [0.15.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.15.2...@carbon/ibm-cloud-cognitive-core@0.15.3) (2021-08-19)
+## [0.15.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.15.3...@carbon/ibm-cloud-cognitive-core@0.15.4) (2021-08-23)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.15.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.15.1...@carbon/ibm-cloud-cognitive-core@0.15.2) (2021-08-18)
+## [0.15.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.15.2...@carbon/ibm-cloud-cognitive-core@0.15.3) (2021-08-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.15.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.15.0...@carbon/ibm-cloud-cognitive-core@0.15.1) (2021-08-13)
+## [0.15.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.15.1...@carbon/ibm-cloud-cognitive-core@0.15.2) (2021-08-18)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
+
+## [0.15.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.15.0...@carbon/ibm-cloud-cognitive-core@0.15.1) (2021-08-13)
 
 ### Bug Fixes
 
 - **Tearsheet:** ensure tearsheet styles override carbon styles
-  ([#1146](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1146))
-  ([d936f42](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d936f42b05acf3827154e8656ec90a243e9932ce))
+  ([#1146](https://github.com/carbon-design-system/ibm-products/issues/1146))
+  ([d936f42](https://github.com/carbon-design-system/ibm-products/commit/d936f42b05acf3827154e8656ec90a243e9932ce))
 
-# [0.15.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.14.0...@carbon/ibm-cloud-cognitive-core@0.15.0) (2021-08-11)
+# [0.15.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.14.0...@carbon/ibm-cloud-cognitive-core@0.15.0) (2021-08-11)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1133](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1133))
-  ([4dfae1a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4dfae1a9b27f5676d0bde570e2c9ee9ce8550b52))
+  ([#1133](https://github.com/carbon-design-system/ibm-products/issues/1133))
+  ([4dfae1a](https://github.com/carbon-design-system/ibm-products/commit/4dfae1a9b27f5676d0bde570e2c9ee9ce8550b52))
 
-# [0.14.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.13.3...@carbon/ibm-cloud-cognitive-core@0.14.0) (2021-08-10)
-
-### Features
-
-- update Carbon versions and dependencies
-  ([#1110](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1110))
-  ([b41f433](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b41f4331e31cbd9e41d2364b24e6ef50c7fd2d8d))
-
-## [0.13.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.13.2...@carbon/ibm-cloud-cognitive-core@0.13.3) (2021-08-03)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
-
-## [0.13.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.13.1...@carbon/ibm-cloud-cognitive-core@0.13.2) (2021-07-30)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
-
-## [0.13.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.13.0...@carbon/ibm-cloud-cognitive-core@0.13.1) (2021-07-29)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
-
-# [0.13.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.12.5...@carbon/ibm-cloud-cognitive-core@0.13.0) (2021-07-28)
+# [0.14.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.13.3...@carbon/ibm-cloud-cognitive-core@0.14.0) (2021-08-10)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#1084](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1084))
-  ([3735ead](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3735ead9a96450015ec7aeafdb25deaa93d49aaa))
+  ([#1110](https://github.com/carbon-design-system/ibm-products/issues/1110))
+  ([b41f433](https://github.com/carbon-design-system/ibm-products/commit/b41f4331e31cbd9e41d2364b24e6ef50c7fd2d8d))
 
-## [0.12.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.12.4...@carbon/ibm-cloud-cognitive-core@0.12.5) (2021-07-23)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
-
-## [0.12.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.12.3...@carbon/ibm-cloud-cognitive-core@0.12.4) (2021-07-23)
+## [0.13.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.13.2...@carbon/ibm-cloud-cognitive-core@0.13.3) (2021-08-03)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.12.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.12.2...@carbon/ibm-cloud-cognitive-core@0.12.3) (2021-07-22)
+## [0.13.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.13.1...@carbon/ibm-cloud-cognitive-core@0.13.2) (2021-07-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.12.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.12.1...@carbon/ibm-cloud-cognitive-core@0.12.2) (2021-07-22)
+## [0.13.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.13.0...@carbon/ibm-cloud-cognitive-core@0.13.1) (2021-07-29)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.12.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.12.0...@carbon/ibm-cloud-cognitive-core@0.12.1) (2021-07-22)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
-
-# [0.12.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.26...@carbon/ibm-cloud-cognitive-core@0.12.0) (2021-07-21)
+# [0.13.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.12.5...@carbon/ibm-cloud-cognitive-core@0.13.0) (2021-07-28)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#1037](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1037))
-  ([8c5937a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8c5937a865d3a0cfbaf33b9eca13c4d3b4c1365d))
+  ([#1084](https://github.com/carbon-design-system/ibm-products/issues/1084))
+  ([3735ead](https://github.com/carbon-design-system/ibm-products/commit/3735ead9a96450015ec7aeafdb25deaa93d49aaa))
 
-## [0.11.26](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.25...@carbon/ibm-cloud-cognitive-core@0.11.26) (2021-07-21)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
-
-## [0.11.25](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.24...@carbon/ibm-cloud-cognitive-core@0.11.25) (2021-07-21)
+## [0.12.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.12.4...@carbon/ibm-cloud-cognitive-core@0.12.5) (2021-07-23)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.24](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.23...@carbon/ibm-cloud-cognitive-core@0.11.24) (2021-07-21)
+## [0.12.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.12.3...@carbon/ibm-cloud-cognitive-core@0.12.4) (2021-07-23)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.23](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.22...@carbon/ibm-cloud-cognitive-core@0.11.23) (2021-07-21)
+## [0.12.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.12.2...@carbon/ibm-cloud-cognitive-core@0.12.3) (2021-07-22)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.22](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.21...@carbon/ibm-cloud-cognitive-core@0.11.22) (2021-07-21)
+## [0.12.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.12.1...@carbon/ibm-cloud-cognitive-core@0.12.2) (2021-07-22)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.21](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.20...@carbon/ibm-cloud-cognitive-core@0.11.21) (2021-07-20)
+## [0.12.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.12.0...@carbon/ibm-cloud-cognitive-core@0.12.1) (2021-07-22)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.20](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.19...@carbon/ibm-cloud-cognitive-core@0.11.20) (2021-07-20)
+# [0.12.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.26...@carbon/ibm-cloud-cognitive-core@0.12.0) (2021-07-21)
+
+### Features
+
+- update Carbon versions and dependencies
+  ([#1037](https://github.com/carbon-design-system/ibm-products/issues/1037))
+  ([8c5937a](https://github.com/carbon-design-system/ibm-products/commit/8c5937a865d3a0cfbaf33b9eca13c4d3b4c1365d))
+
+## [0.11.26](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.25...@carbon/ibm-cloud-cognitive-core@0.11.26) (2021-07-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.19](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.18...@carbon/ibm-cloud-cognitive-core@0.11.19) (2021-07-20)
+## [0.11.25](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.24...@carbon/ibm-cloud-cognitive-core@0.11.25) (2021-07-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.18](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.17...@carbon/ibm-cloud-cognitive-core@0.11.18) (2021-07-19)
+## [0.11.24](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.23...@carbon/ibm-cloud-cognitive-core@0.11.24) (2021-07-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.17](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.16...@carbon/ibm-cloud-cognitive-core@0.11.17) (2021-07-19)
+## [0.11.23](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.22...@carbon/ibm-cloud-cognitive-core@0.11.23) (2021-07-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.16](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.15...@carbon/ibm-cloud-cognitive-core@0.11.16) (2021-07-19)
+## [0.11.22](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.21...@carbon/ibm-cloud-cognitive-core@0.11.22) (2021-07-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.15](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.14...@carbon/ibm-cloud-cognitive-core@0.11.15) (2021-07-19)
+## [0.11.21](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.20...@carbon/ibm-cloud-cognitive-core@0.11.21) (2021-07-20)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.13...@carbon/ibm-cloud-cognitive-core@0.11.14) (2021-07-19)
+## [0.11.20](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.19...@carbon/ibm-cloud-cognitive-core@0.11.20) (2021-07-20)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.12...@carbon/ibm-cloud-cognitive-core@0.11.13) (2021-07-19)
+## [0.11.19](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.18...@carbon/ibm-cloud-cognitive-core@0.11.19) (2021-07-20)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.11...@carbon/ibm-cloud-cognitive-core@0.11.12) (2021-07-19)
+## [0.11.18](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.17...@carbon/ibm-cloud-cognitive-core@0.11.18) (2021-07-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.10...@carbon/ibm-cloud-cognitive-core@0.11.11) (2021-07-16)
+## [0.11.17](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.16...@carbon/ibm-cloud-cognitive-core@0.11.17) (2021-07-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.9...@carbon/ibm-cloud-cognitive-core@0.11.10) (2021-07-16)
+## [0.11.16](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.15...@carbon/ibm-cloud-cognitive-core@0.11.16) (2021-07-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.8...@carbon/ibm-cloud-cognitive-core@0.11.9) (2021-07-16)
+## [0.11.15](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.14...@carbon/ibm-cloud-cognitive-core@0.11.15) (2021-07-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.7...@carbon/ibm-cloud-cognitive-core@0.11.8) (2021-07-16)
+## [0.11.14](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.13...@carbon/ibm-cloud-cognitive-core@0.11.14) (2021-07-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.6...@carbon/ibm-cloud-cognitive-core@0.11.7) (2021-07-16)
+## [0.11.13](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.12...@carbon/ibm-cloud-cognitive-core@0.11.13) (2021-07-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.5...@carbon/ibm-cloud-cognitive-core@0.11.6) (2021-07-16)
+## [0.11.12](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.11...@carbon/ibm-cloud-cognitive-core@0.11.12) (2021-07-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.4...@carbon/ibm-cloud-cognitive-core@0.11.5) (2021-07-16)
+## [0.11.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.10...@carbon/ibm-cloud-cognitive-core@0.11.11) (2021-07-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.3...@carbon/ibm-cloud-cognitive-core@0.11.4) (2021-07-15)
+## [0.11.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.9...@carbon/ibm-cloud-cognitive-core@0.11.10) (2021-07-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.2...@carbon/ibm-cloud-cognitive-core@0.11.3) (2021-07-15)
+## [0.11.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.8...@carbon/ibm-cloud-cognitive-core@0.11.9) (2021-07-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.1...@carbon/ibm-cloud-cognitive-core@0.11.2) (2021-07-15)
+## [0.11.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.7...@carbon/ibm-cloud-cognitive-core@0.11.8) (2021-07-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.11.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.11.0...@carbon/ibm-cloud-cognitive-core@0.11.1) (2021-07-15)
+## [0.11.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.6...@carbon/ibm-cloud-cognitive-core@0.11.7) (2021-07-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-# [0.11.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.10.12...@carbon/ibm-cloud-cognitive-core@0.11.0) (2021-07-14)
+## [0.11.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.5...@carbon/ibm-cloud-cognitive-core@0.11.6) (2021-07-16)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
+
+## [0.11.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.4...@carbon/ibm-cloud-cognitive-core@0.11.5) (2021-07-16)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
+
+## [0.11.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.3...@carbon/ibm-cloud-cognitive-core@0.11.4) (2021-07-15)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
+
+## [0.11.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.2...@carbon/ibm-cloud-cognitive-core@0.11.3) (2021-07-15)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
+
+## [0.11.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.1...@carbon/ibm-cloud-cognitive-core@0.11.2) (2021-07-15)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
+
+## [0.11.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.11.0...@carbon/ibm-cloud-cognitive-core@0.11.1) (2021-07-15)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
+
+# [0.11.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.10.12...@carbon/ibm-cloud-cognitive-core@0.11.0) (2021-07-14)
 
 ### Features
 
 - update Carbon versions and package dependencies
-  ([#994](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/994))
-  ([2ab4845](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2ab4845511573b999d41fcf77e6d412e0d446b9d))
+  ([#994](https://github.com/carbon-design-system/ibm-products/issues/994))
+  ([2ab4845](https://github.com/carbon-design-system/ibm-products/commit/2ab4845511573b999d41fcf77e6d412e0d446b9d))
 
-## [0.10.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.10.11...@carbon/ibm-cloud-cognitive-core@0.10.12) (2021-07-14)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
-
-## [0.10.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.10.10...@carbon/ibm-cloud-cognitive-core@0.10.11) (2021-07-14)
+## [0.10.12](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.10.11...@carbon/ibm-cloud-cognitive-core@0.10.12) (2021-07-14)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.10.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.10.9...@carbon/ibm-cloud-cognitive-core@0.10.10) (2021-07-14)
+## [0.10.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.10.10...@carbon/ibm-cloud-cognitive-core@0.10.11) (2021-07-14)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.10.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.10.8...@carbon/ibm-cloud-cognitive-core@0.10.9) (2021-07-13)
+## [0.10.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.10.9...@carbon/ibm-cloud-cognitive-core@0.10.10) (2021-07-14)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.10.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.10.7...@carbon/ibm-cloud-cognitive-core@0.10.8) (2021-07-13)
+## [0.10.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.10.8...@carbon/ibm-cloud-cognitive-core@0.10.9) (2021-07-13)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.10.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.10.6...@carbon/ibm-cloud-cognitive-core@0.10.7) (2021-07-13)
+## [0.10.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.10.7...@carbon/ibm-cloud-cognitive-core@0.10.8) (2021-07-13)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.10.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.10.5...@carbon/ibm-cloud-cognitive-core@0.10.6) (2021-07-13)
+## [0.10.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.10.6...@carbon/ibm-cloud-cognitive-core@0.10.7) (2021-07-13)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.10.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.10.4...@carbon/ibm-cloud-cognitive-core@0.10.5) (2021-07-12)
+## [0.10.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.10.5...@carbon/ibm-cloud-cognitive-core@0.10.6) (2021-07-13)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.10.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.10.3...@carbon/ibm-cloud-cognitive-core@0.10.4) (2021-07-12)
+## [0.10.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.10.4...@carbon/ibm-cloud-cognitive-core@0.10.5) (2021-07-12)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.10.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.10.2...@carbon/ibm-cloud-cognitive-core@0.10.3) (2021-07-08)
+## [0.10.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.10.3...@carbon/ibm-cloud-cognitive-core@0.10.4) (2021-07-12)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.10.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.10.1...@carbon/ibm-cloud-cognitive-core@0.10.2) (2021-07-08)
+## [0.10.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.10.2...@carbon/ibm-cloud-cognitive-core@0.10.3) (2021-07-08)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.10.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.10.0...@carbon/ibm-cloud-cognitive-core@0.10.1) (2021-07-08)
+## [0.10.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.10.1...@carbon/ibm-cloud-cognitive-core@0.10.2) (2021-07-08)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-# [0.10.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.26...@carbon/ibm-cloud-cognitive-core@0.10.0) (2021-07-07)
+## [0.10.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.10.0...@carbon/ibm-cloud-cognitive-core@0.10.1) (2021-07-08)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
+
+# [0.10.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.26...@carbon/ibm-cloud-cognitive-core@0.10.0) (2021-07-07)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#974](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/974))
-  ([555509b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/555509b5ccb147ed0d794b5816f685aa8f7ae451))
+  ([#974](https://github.com/carbon-design-system/ibm-products/issues/974))
+  ([555509b](https://github.com/carbon-design-system/ibm-products/commit/555509b5ccb147ed0d794b5816f685aa8f7ae451))
 
-## [0.9.26](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.25...@carbon/ibm-cloud-cognitive-core@0.9.26) (2021-07-07)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
-
-## [0.9.25](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.24...@carbon/ibm-cloud-cognitive-core@0.9.25) (2021-07-07)
+## [0.9.26](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.25...@carbon/ibm-cloud-cognitive-core@0.9.26) (2021-07-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.24](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.23...@carbon/ibm-cloud-cognitive-core@0.9.24) (2021-07-07)
+## [0.9.25](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.24...@carbon/ibm-cloud-cognitive-core@0.9.25) (2021-07-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.23](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.22...@carbon/ibm-cloud-cognitive-core@0.9.23) (2021-07-07)
+## [0.9.24](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.23...@carbon/ibm-cloud-cognitive-core@0.9.24) (2021-07-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.22](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.21...@carbon/ibm-cloud-cognitive-core@0.9.22) (2021-07-07)
+## [0.9.23](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.22...@carbon/ibm-cloud-cognitive-core@0.9.23) (2021-07-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.21](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.20...@carbon/ibm-cloud-cognitive-core@0.9.21) (2021-07-06)
+## [0.9.22](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.21...@carbon/ibm-cloud-cognitive-core@0.9.22) (2021-07-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.20](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.19...@carbon/ibm-cloud-cognitive-core@0.9.20) (2021-07-06)
+## [0.9.21](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.20...@carbon/ibm-cloud-cognitive-core@0.9.21) (2021-07-06)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.19](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.18...@carbon/ibm-cloud-cognitive-core@0.9.19) (2021-07-06)
+## [0.9.20](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.19...@carbon/ibm-cloud-cognitive-core@0.9.20) (2021-07-06)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.18](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.17...@carbon/ibm-cloud-cognitive-core@0.9.18) (2021-07-02)
+## [0.9.19](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.18...@carbon/ibm-cloud-cognitive-core@0.9.19) (2021-07-06)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.17](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.16...@carbon/ibm-cloud-cognitive-core@0.9.17) (2021-07-01)
+## [0.9.18](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.17...@carbon/ibm-cloud-cognitive-core@0.9.18) (2021-07-02)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.16](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.15...@carbon/ibm-cloud-cognitive-core@0.9.16) (2021-07-01)
+## [0.9.17](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.16...@carbon/ibm-cloud-cognitive-core@0.9.17) (2021-07-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.15](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.14...@carbon/ibm-cloud-cognitive-core@0.9.15) (2021-07-01)
+## [0.9.16](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.15...@carbon/ibm-cloud-cognitive-core@0.9.16) (2021-07-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.13...@carbon/ibm-cloud-cognitive-core@0.9.14) (2021-07-01)
+## [0.9.15](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.14...@carbon/ibm-cloud-cognitive-core@0.9.15) (2021-07-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.12...@carbon/ibm-cloud-cognitive-core@0.9.13) (2021-07-01)
+## [0.9.14](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.13...@carbon/ibm-cloud-cognitive-core@0.9.14) (2021-07-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.11...@carbon/ibm-cloud-cognitive-core@0.9.12) (2021-06-30)
+## [0.9.13](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.12...@carbon/ibm-cloud-cognitive-core@0.9.13) (2021-07-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.10...@carbon/ibm-cloud-cognitive-core@0.9.11) (2021-06-30)
+## [0.9.12](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.11...@carbon/ibm-cloud-cognitive-core@0.9.12) (2021-06-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.9...@carbon/ibm-cloud-cognitive-core@0.9.10) (2021-06-30)
+## [0.9.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.10...@carbon/ibm-cloud-cognitive-core@0.9.11) (2021-06-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.8...@carbon/ibm-cloud-cognitive-core@0.9.9) (2021-06-29)
+## [0.9.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.9...@carbon/ibm-cloud-cognitive-core@0.9.10) (2021-06-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.7...@carbon/ibm-cloud-cognitive-core@0.9.8) (2021-06-25)
+## [0.9.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.8...@carbon/ibm-cloud-cognitive-core@0.9.9) (2021-06-29)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.6...@carbon/ibm-cloud-cognitive-core@0.9.7) (2021-06-25)
+## [0.9.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.7...@carbon/ibm-cloud-cognitive-core@0.9.8) (2021-06-25)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.5...@carbon/ibm-cloud-cognitive-core@0.9.6) (2021-06-24)
+## [0.9.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.6...@carbon/ibm-cloud-cognitive-core@0.9.7) (2021-06-25)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.4...@carbon/ibm-cloud-cognitive-core@0.9.5) (2021-06-24)
+## [0.9.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.5...@carbon/ibm-cloud-cognitive-core@0.9.6) (2021-06-24)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.3...@carbon/ibm-cloud-cognitive-core@0.9.4) (2021-06-24)
+## [0.9.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.4...@carbon/ibm-cloud-cognitive-core@0.9.5) (2021-06-24)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.2...@carbon/ibm-cloud-cognitive-core@0.9.3) (2021-06-24)
+## [0.9.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.3...@carbon/ibm-cloud-cognitive-core@0.9.4) (2021-06-24)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.1...@carbon/ibm-cloud-cognitive-core@0.9.2) (2021-06-24)
+## [0.9.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.2...@carbon/ibm-cloud-cognitive-core@0.9.3) (2021-06-24)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.9.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.9.0...@carbon/ibm-cloud-cognitive-core@0.9.1) (2021-06-23)
+## [0.9.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.1...@carbon/ibm-cloud-cognitive-core@0.9.2) (2021-06-24)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-# [0.9.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.236...@carbon/ibm-cloud-cognitive-core@0.9.0) (2021-06-23)
+## [0.9.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.9.0...@carbon/ibm-cloud-cognitive-core@0.9.1) (2021-06-23)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
+
+# [0.9.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.236...@carbon/ibm-cloud-cognitive-core@0.9.0) (2021-06-23)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#927](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/927))
-  ([5a8f7d6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5a8f7d6b81b6da26fd0cb933c1c3de4bd27b481b))
+  ([#927](https://github.com/carbon-design-system/ibm-products/issues/927))
+  ([5a8f7d6](https://github.com/carbon-design-system/ibm-products/commit/5a8f7d6b81b6da26fd0cb933c1c3de4bd27b481b))
 
-## [0.8.236](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.235...@carbon/ibm-cloud-cognitive-core@0.8.236) (2021-06-23)
+## [0.8.236](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.235...@carbon/ibm-cloud-cognitive-core@0.8.236) (2021-06-23)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.235](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.234...@carbon/ibm-cloud-cognitive-core@0.8.235) (2021-06-22)
+## [0.8.235](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.234...@carbon/ibm-cloud-cognitive-core@0.8.235) (2021-06-22)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.234](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.233...@carbon/ibm-cloud-cognitive-core@0.8.234) (2021-06-22)
+## [0.8.234](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.233...@carbon/ibm-cloud-cognitive-core@0.8.234) (2021-06-22)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.233](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.232...@carbon/ibm-cloud-cognitive-core@0.8.233) (2021-06-22)
+## [0.8.233](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.232...@carbon/ibm-cloud-cognitive-core@0.8.233) (2021-06-22)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.232](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.231...@carbon/ibm-cloud-cognitive-core@0.8.232) (2021-06-21)
+## [0.8.232](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.231...@carbon/ibm-cloud-cognitive-core@0.8.232) (2021-06-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.231](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.230...@carbon/ibm-cloud-cognitive-core@0.8.231) (2021-06-21)
+## [0.8.231](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.230...@carbon/ibm-cloud-cognitive-core@0.8.231) (2021-06-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.230](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.229...@carbon/ibm-cloud-cognitive-core@0.8.230) (2021-06-21)
+## [0.8.230](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.229...@carbon/ibm-cloud-cognitive-core@0.8.230) (2021-06-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.229](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.228...@carbon/ibm-cloud-cognitive-core@0.8.229) (2021-06-20)
+## [0.8.229](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.228...@carbon/ibm-cloud-cognitive-core@0.8.229) (2021-06-20)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.228](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.227...@carbon/ibm-cloud-cognitive-core@0.8.228) (2021-06-18)
+## [0.8.228](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.227...@carbon/ibm-cloud-cognitive-core@0.8.228) (2021-06-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.227](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.226...@carbon/ibm-cloud-cognitive-core@0.8.227) (2021-06-18)
+## [0.8.227](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.226...@carbon/ibm-cloud-cognitive-core@0.8.227) (2021-06-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.226](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.225...@carbon/ibm-cloud-cognitive-core@0.8.226) (2021-06-17)
+## [0.8.226](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.225...@carbon/ibm-cloud-cognitive-core@0.8.226) (2021-06-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.225](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.224...@carbon/ibm-cloud-cognitive-core@0.8.225) (2021-06-17)
+## [0.8.225](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.224...@carbon/ibm-cloud-cognitive-core@0.8.225) (2021-06-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.224](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.223...@carbon/ibm-cloud-cognitive-core@0.8.224) (2021-06-17)
+## [0.8.224](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.223...@carbon/ibm-cloud-cognitive-core@0.8.224) (2021-06-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.223](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.222...@carbon/ibm-cloud-cognitive-core@0.8.223) (2021-06-16)
+## [0.8.223](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.222...@carbon/ibm-cloud-cognitive-core@0.8.223) (2021-06-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.222](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.221...@carbon/ibm-cloud-cognitive-core@0.8.222) (2021-06-15)
+## [0.8.222](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.221...@carbon/ibm-cloud-cognitive-core@0.8.222) (2021-06-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.221](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.220...@carbon/ibm-cloud-cognitive-core@0.8.221) (2021-06-15)
+## [0.8.221](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.220...@carbon/ibm-cloud-cognitive-core@0.8.221) (2021-06-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.220](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.219...@carbon/ibm-cloud-cognitive-core@0.8.220) (2021-06-15)
+## [0.8.220](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.219...@carbon/ibm-cloud-cognitive-core@0.8.220) (2021-06-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.219](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.218...@carbon/ibm-cloud-cognitive-core@0.8.219) (2021-06-15)
+## [0.8.219](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.218...@carbon/ibm-cloud-cognitive-core@0.8.219) (2021-06-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.218](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.217...@carbon/ibm-cloud-cognitive-core@0.8.218) (2021-06-11)
+## [0.8.218](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.217...@carbon/ibm-cloud-cognitive-core@0.8.218) (2021-06-11)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.217](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.216...@carbon/ibm-cloud-cognitive-core@0.8.217) (2021-06-11)
+## [0.8.217](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.216...@carbon/ibm-cloud-cognitive-core@0.8.217) (2021-06-11)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.216](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.215...@carbon/ibm-cloud-cognitive-core@0.8.216) (2021-06-10)
+## [0.8.216](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.215...@carbon/ibm-cloud-cognitive-core@0.8.216) (2021-06-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.215](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.214...@carbon/ibm-cloud-cognitive-core@0.8.215) (2021-06-10)
+## [0.8.215](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.214...@carbon/ibm-cloud-cognitive-core@0.8.215) (2021-06-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.214](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.213...@carbon/ibm-cloud-cognitive-core@0.8.214) (2021-06-10)
+## [0.8.214](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.213...@carbon/ibm-cloud-cognitive-core@0.8.214) (2021-06-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.213](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.212...@carbon/ibm-cloud-cognitive-core@0.8.213) (2021-06-10)
+## [0.8.213](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.212...@carbon/ibm-cloud-cognitive-core@0.8.213) (2021-06-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.212](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.211...@carbon/ibm-cloud-cognitive-core@0.8.212) (2021-06-10)
+## [0.8.212](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.211...@carbon/ibm-cloud-cognitive-core@0.8.212) (2021-06-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.211](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.210...@carbon/ibm-cloud-cognitive-core@0.8.211) (2021-06-10)
+## [0.8.211](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.210...@carbon/ibm-cloud-cognitive-core@0.8.211) (2021-06-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.210](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.209...@carbon/ibm-cloud-cognitive-core@0.8.210) (2021-06-10)
+## [0.8.210](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.209...@carbon/ibm-cloud-cognitive-core@0.8.210) (2021-06-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.209](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.208...@carbon/ibm-cloud-cognitive-core@0.8.209) (2021-06-10)
+## [0.8.209](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.208...@carbon/ibm-cloud-cognitive-core@0.8.209) (2021-06-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.208](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.207...@carbon/ibm-cloud-cognitive-core@0.8.208) (2021-06-09)
+## [0.8.208](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.207...@carbon/ibm-cloud-cognitive-core@0.8.208) (2021-06-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.207](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.206...@carbon/ibm-cloud-cognitive-core@0.8.207) (2021-06-09)
+## [0.8.207](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.206...@carbon/ibm-cloud-cognitive-core@0.8.207) (2021-06-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.206](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.205...@carbon/ibm-cloud-cognitive-core@0.8.206) (2021-06-09)
+## [0.8.206](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.205...@carbon/ibm-cloud-cognitive-core@0.8.206) (2021-06-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.205](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.204...@carbon/ibm-cloud-cognitive-core@0.8.205) (2021-06-07)
+## [0.8.205](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.204...@carbon/ibm-cloud-cognitive-core@0.8.205) (2021-06-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.204](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.203...@carbon/ibm-cloud-cognitive-core@0.8.204) (2021-06-07)
+## [0.8.204](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.203...@carbon/ibm-cloud-cognitive-core@0.8.204) (2021-06-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.203](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.202...@carbon/ibm-cloud-cognitive-core@0.8.203) (2021-06-07)
+## [0.8.203](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.202...@carbon/ibm-cloud-cognitive-core@0.8.203) (2021-06-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.202](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.201...@carbon/ibm-cloud-cognitive-core@0.8.202) (2021-06-04)
+## [0.8.202](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.201...@carbon/ibm-cloud-cognitive-core@0.8.202) (2021-06-04)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.201](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.200...@carbon/ibm-cloud-cognitive-core@0.8.201) (2021-06-04)
+## [0.8.201](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.200...@carbon/ibm-cloud-cognitive-core@0.8.201) (2021-06-04)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.200](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.199...@carbon/ibm-cloud-cognitive-core@0.8.200) (2021-06-04)
+## [0.8.200](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.199...@carbon/ibm-cloud-cognitive-core@0.8.200) (2021-06-04)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.199](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.198...@carbon/ibm-cloud-cognitive-core@0.8.199) (2021-06-04)
+## [0.8.199](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.198...@carbon/ibm-cloud-cognitive-core@0.8.199) (2021-06-04)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.198](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.197...@carbon/ibm-cloud-cognitive-core@0.8.198) (2021-06-04)
+## [0.8.198](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.197...@carbon/ibm-cloud-cognitive-core@0.8.198) (2021-06-04)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.197](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.196...@carbon/ibm-cloud-cognitive-core@0.8.197) (2021-06-03)
+## [0.8.197](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.196...@carbon/ibm-cloud-cognitive-core@0.8.197) (2021-06-03)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.196](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.195...@carbon/ibm-cloud-cognitive-core@0.8.196) (2021-06-02)
+## [0.8.196](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.195...@carbon/ibm-cloud-cognitive-core@0.8.196) (2021-06-02)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.195](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.194...@carbon/ibm-cloud-cognitive-core@0.8.195) (2021-06-02)
+## [0.8.195](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.194...@carbon/ibm-cloud-cognitive-core@0.8.195) (2021-06-02)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.194](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.193...@carbon/ibm-cloud-cognitive-core@0.8.194) (2021-06-02)
+## [0.8.194](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.193...@carbon/ibm-cloud-cognitive-core@0.8.194) (2021-06-02)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.193](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.192...@carbon/ibm-cloud-cognitive-core@0.8.193) (2021-06-01)
+## [0.8.193](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.192...@carbon/ibm-cloud-cognitive-core@0.8.193) (2021-06-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.192](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.191...@carbon/ibm-cloud-cognitive-core@0.8.192) (2021-06-01)
+## [0.8.192](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.191...@carbon/ibm-cloud-cognitive-core@0.8.192) (2021-06-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.191](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.190...@carbon/ibm-cloud-cognitive-core@0.8.191) (2021-06-01)
+## [0.8.191](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.190...@carbon/ibm-cloud-cognitive-core@0.8.191) (2021-06-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.190](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.189...@carbon/ibm-cloud-cognitive-core@0.8.190) (2021-05-29)
+## [0.8.190](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.189...@carbon/ibm-cloud-cognitive-core@0.8.190) (2021-05-29)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.189](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.188...@carbon/ibm-cloud-cognitive-core@0.8.189) (2021-05-28)
+## [0.8.189](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.188...@carbon/ibm-cloud-cognitive-core@0.8.189) (2021-05-28)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.188](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.187...@carbon/ibm-cloud-cognitive-core@0.8.188) (2021-05-28)
+## [0.8.188](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.187...@carbon/ibm-cloud-cognitive-core@0.8.188) (2021-05-28)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.187](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.186...@carbon/ibm-cloud-cognitive-core@0.8.187) (2021-05-28)
+## [0.8.187](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.186...@carbon/ibm-cloud-cognitive-core@0.8.187) (2021-05-28)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.186](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.185...@carbon/ibm-cloud-cognitive-core@0.8.186) (2021-05-27)
+## [0.8.186](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.185...@carbon/ibm-cloud-cognitive-core@0.8.186) (2021-05-27)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.185](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.184...@carbon/ibm-cloud-cognitive-core@0.8.185) (2021-05-27)
+## [0.8.185](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.184...@carbon/ibm-cloud-cognitive-core@0.8.185) (2021-05-27)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.184](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.183...@carbon/ibm-cloud-cognitive-core@0.8.184) (2021-05-27)
+## [0.8.184](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.183...@carbon/ibm-cloud-cognitive-core@0.8.184) (2021-05-27)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.183](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.182...@carbon/ibm-cloud-cognitive-core@0.8.183) (2021-05-26)
+## [0.8.183](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.182...@carbon/ibm-cloud-cognitive-core@0.8.183) (2021-05-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.182](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.181...@carbon/ibm-cloud-cognitive-core@0.8.182) (2021-05-26)
+## [0.8.182](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.181...@carbon/ibm-cloud-cognitive-core@0.8.182) (2021-05-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.181](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.180...@carbon/ibm-cloud-cognitive-core@0.8.181) (2021-05-26)
+## [0.8.181](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.180...@carbon/ibm-cloud-cognitive-core@0.8.181) (2021-05-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.180](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.179...@carbon/ibm-cloud-cognitive-core@0.8.180) (2021-05-26)
+## [0.8.180](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.179...@carbon/ibm-cloud-cognitive-core@0.8.180) (2021-05-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.179](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.178...@carbon/ibm-cloud-cognitive-core@0.8.179) (2021-05-26)
+## [0.8.179](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.178...@carbon/ibm-cloud-cognitive-core@0.8.179) (2021-05-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.178](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.177...@carbon/ibm-cloud-cognitive-core@0.8.178) (2021-05-26)
+## [0.8.178](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.177...@carbon/ibm-cloud-cognitive-core@0.8.178) (2021-05-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.177](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.176...@carbon/ibm-cloud-cognitive-core@0.8.177) (2021-05-26)
+## [0.8.177](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.176...@carbon/ibm-cloud-cognitive-core@0.8.177) (2021-05-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.176](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.175...@carbon/ibm-cloud-cognitive-core@0.8.176) (2021-05-25)
+## [0.8.176](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.175...@carbon/ibm-cloud-cognitive-core@0.8.176) (2021-05-25)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.175](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.174...@carbon/ibm-cloud-cognitive-core@0.8.175) (2021-05-25)
+## [0.8.175](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.174...@carbon/ibm-cloud-cognitive-core@0.8.175) (2021-05-25)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.174](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.173...@carbon/ibm-cloud-cognitive-core@0.8.174) (2021-05-25)
+## [0.8.174](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.173...@carbon/ibm-cloud-cognitive-core@0.8.174) (2021-05-25)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.173](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.172...@carbon/ibm-cloud-cognitive-core@0.8.173) (2021-05-24)
+## [0.8.173](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.172...@carbon/ibm-cloud-cognitive-core@0.8.173) (2021-05-24)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.172](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.171...@carbon/ibm-cloud-cognitive-core@0.8.172) (2021-05-24)
+## [0.8.172](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.171...@carbon/ibm-cloud-cognitive-core@0.8.172) (2021-05-24)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.171](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.170...@carbon/ibm-cloud-cognitive-core@0.8.171) (2021-05-24)
+## [0.8.171](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.170...@carbon/ibm-cloud-cognitive-core@0.8.171) (2021-05-24)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.170](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.169...@carbon/ibm-cloud-cognitive-core@0.8.170) (2021-05-24)
+## [0.8.170](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.169...@carbon/ibm-cloud-cognitive-core@0.8.170) (2021-05-24)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.169](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.168...@carbon/ibm-cloud-cognitive-core@0.8.169) (2021-05-24)
+## [0.8.169](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.168...@carbon/ibm-cloud-cognitive-core@0.8.169) (2021-05-24)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.168](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.167...@carbon/ibm-cloud-cognitive-core@0.8.168) (2021-05-21)
+## [0.8.168](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.167...@carbon/ibm-cloud-cognitive-core@0.8.168) (2021-05-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.167](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.166...@carbon/ibm-cloud-cognitive-core@0.8.167) (2021-05-21)
+## [0.8.167](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.166...@carbon/ibm-cloud-cognitive-core@0.8.167) (2021-05-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.166](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.165...@carbon/ibm-cloud-cognitive-core@0.8.166) (2021-05-21)
+## [0.8.166](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.165...@carbon/ibm-cloud-cognitive-core@0.8.166) (2021-05-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.165](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.164...@carbon/ibm-cloud-cognitive-core@0.8.165) (2021-05-21)
+## [0.8.165](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.164...@carbon/ibm-cloud-cognitive-core@0.8.165) (2021-05-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.164](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.163...@carbon/ibm-cloud-cognitive-core@0.8.164) (2021-05-21)
+## [0.8.164](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.163...@carbon/ibm-cloud-cognitive-core@0.8.164) (2021-05-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.163](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.162...@carbon/ibm-cloud-cognitive-core@0.8.163) (2021-05-20)
+## [0.8.163](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.162...@carbon/ibm-cloud-cognitive-core@0.8.163) (2021-05-20)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.162](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.161...@carbon/ibm-cloud-cognitive-core@0.8.162) (2021-05-19)
+## [0.8.162](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.161...@carbon/ibm-cloud-cognitive-core@0.8.162) (2021-05-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.161](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.160...@carbon/ibm-cloud-cognitive-core@0.8.161) (2021-05-19)
+## [0.8.161](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.160...@carbon/ibm-cloud-cognitive-core@0.8.161) (2021-05-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.160](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.159...@carbon/ibm-cloud-cognitive-core@0.8.160) (2021-05-19)
+## [0.8.160](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.159...@carbon/ibm-cloud-cognitive-core@0.8.160) (2021-05-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.159](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.158...@carbon/ibm-cloud-cognitive-core@0.8.159) (2021-05-19)
+## [0.8.159](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.158...@carbon/ibm-cloud-cognitive-core@0.8.159) (2021-05-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.158](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.157...@carbon/ibm-cloud-cognitive-core@0.8.158) (2021-05-19)
+## [0.8.158](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.157...@carbon/ibm-cloud-cognitive-core@0.8.158) (2021-05-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.157](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.156...@carbon/ibm-cloud-cognitive-core@0.8.157) (2021-05-18)
+## [0.8.157](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.156...@carbon/ibm-cloud-cognitive-core@0.8.157) (2021-05-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.156](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.155...@carbon/ibm-cloud-cognitive-core@0.8.156) (2021-05-18)
+## [0.8.156](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.155...@carbon/ibm-cloud-cognitive-core@0.8.156) (2021-05-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.155](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.154...@carbon/ibm-cloud-cognitive-core@0.8.155) (2021-05-18)
+## [0.8.155](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.154...@carbon/ibm-cloud-cognitive-core@0.8.155) (2021-05-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.154](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.153...@carbon/ibm-cloud-cognitive-core@0.8.154) (2021-05-18)
+## [0.8.154](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.153...@carbon/ibm-cloud-cognitive-core@0.8.154) (2021-05-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.153](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.152...@carbon/ibm-cloud-cognitive-core@0.8.153) (2021-05-17)
+## [0.8.153](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.152...@carbon/ibm-cloud-cognitive-core@0.8.153) (2021-05-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.152](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.151...@carbon/ibm-cloud-cognitive-core@0.8.152) (2021-05-14)
+## [0.8.152](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.151...@carbon/ibm-cloud-cognitive-core@0.8.152) (2021-05-14)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.151](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.150...@carbon/ibm-cloud-cognitive-core@0.8.151) (2021-05-14)
+## [0.8.151](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.150...@carbon/ibm-cloud-cognitive-core@0.8.151) (2021-05-14)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.150](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.149...@carbon/ibm-cloud-cognitive-core@0.8.150) (2021-05-13)
+## [0.8.150](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.149...@carbon/ibm-cloud-cognitive-core@0.8.150) (2021-05-13)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.149](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.148...@carbon/ibm-cloud-cognitive-core@0.8.149) (2021-05-12)
+## [0.8.149](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.148...@carbon/ibm-cloud-cognitive-core@0.8.149) (2021-05-12)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.148](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.147...@carbon/ibm-cloud-cognitive-core@0.8.148) (2021-05-12)
+## [0.8.148](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.147...@carbon/ibm-cloud-cognitive-core@0.8.148) (2021-05-12)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.147](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.146...@carbon/ibm-cloud-cognitive-core@0.8.147) (2021-05-11)
+## [0.8.147](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.146...@carbon/ibm-cloud-cognitive-core@0.8.147) (2021-05-11)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.146](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.145...@carbon/ibm-cloud-cognitive-core@0.8.146) (2021-05-10)
+## [0.8.146](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.145...@carbon/ibm-cloud-cognitive-core@0.8.146) (2021-05-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.145](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.144...@carbon/ibm-cloud-cognitive-core@0.8.145) (2021-05-10)
+## [0.8.145](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.144...@carbon/ibm-cloud-cognitive-core@0.8.145) (2021-05-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.144](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.143...@carbon/ibm-cloud-cognitive-core@0.8.144) (2021-05-10)
+## [0.8.144](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.143...@carbon/ibm-cloud-cognitive-core@0.8.144) (2021-05-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.143](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.142...@carbon/ibm-cloud-cognitive-core@0.8.143) (2021-05-10)
+## [0.8.143](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.142...@carbon/ibm-cloud-cognitive-core@0.8.143) (2021-05-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.142](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.141...@carbon/ibm-cloud-cognitive-core@0.8.142) (2021-05-07)
+## [0.8.142](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.141...@carbon/ibm-cloud-cognitive-core@0.8.142) (2021-05-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.141](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.140...@carbon/ibm-cloud-cognitive-core@0.8.141) (2021-05-05)
+## [0.8.141](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.140...@carbon/ibm-cloud-cognitive-core@0.8.141) (2021-05-05)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.140](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.139...@carbon/ibm-cloud-cognitive-core@0.8.140) (2021-05-05)
+## [0.8.140](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.139...@carbon/ibm-cloud-cognitive-core@0.8.140) (2021-05-05)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.139](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.138...@carbon/ibm-cloud-cognitive-core@0.8.139) (2021-05-05)
+## [0.8.139](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.138...@carbon/ibm-cloud-cognitive-core@0.8.139) (2021-05-05)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.138](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.137...@carbon/ibm-cloud-cognitive-core@0.8.138) (2021-05-05)
+## [0.8.138](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.137...@carbon/ibm-cloud-cognitive-core@0.8.138) (2021-05-05)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.137](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.136...@carbon/ibm-cloud-cognitive-core@0.8.137) (2021-05-04)
+## [0.8.137](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.136...@carbon/ibm-cloud-cognitive-core@0.8.137) (2021-05-04)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.136](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.135...@carbon/ibm-cloud-cognitive-core@0.8.136) (2021-04-30)
+## [0.8.136](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.135...@carbon/ibm-cloud-cognitive-core@0.8.136) (2021-04-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.135](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.134...@carbon/ibm-cloud-cognitive-core@0.8.135) (2021-04-30)
+## [0.8.135](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.134...@carbon/ibm-cloud-cognitive-core@0.8.135) (2021-04-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.134](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.133...@carbon/ibm-cloud-cognitive-core@0.8.134) (2021-04-30)
+## [0.8.134](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.133...@carbon/ibm-cloud-cognitive-core@0.8.134) (2021-04-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.133](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.132...@carbon/ibm-cloud-cognitive-core@0.8.133) (2021-04-30)
+## [0.8.133](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.132...@carbon/ibm-cloud-cognitive-core@0.8.133) (2021-04-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.132](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.131...@carbon/ibm-cloud-cognitive-core@0.8.132) (2021-04-30)
+## [0.8.132](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.131...@carbon/ibm-cloud-cognitive-core@0.8.132) (2021-04-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.131](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.130...@carbon/ibm-cloud-cognitive-core@0.8.131) (2021-04-30)
+## [0.8.131](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.130...@carbon/ibm-cloud-cognitive-core@0.8.131) (2021-04-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.130](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.129...@carbon/ibm-cloud-cognitive-core@0.8.130) (2021-04-30)
+## [0.8.130](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.129...@carbon/ibm-cloud-cognitive-core@0.8.130) (2021-04-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.129](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.128...@carbon/ibm-cloud-cognitive-core@0.8.129) (2021-04-29)
+## [0.8.129](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.128...@carbon/ibm-cloud-cognitive-core@0.8.129) (2021-04-29)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.128](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.127...@carbon/ibm-cloud-cognitive-core@0.8.128) (2021-04-29)
+## [0.8.128](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.127...@carbon/ibm-cloud-cognitive-core@0.8.128) (2021-04-29)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.127](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.126...@carbon/ibm-cloud-cognitive-core@0.8.127) (2021-04-29)
+## [0.8.127](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.126...@carbon/ibm-cloud-cognitive-core@0.8.127) (2021-04-29)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.126](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.125...@carbon/ibm-cloud-cognitive-core@0.8.126) (2021-04-29)
+## [0.8.126](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.125...@carbon/ibm-cloud-cognitive-core@0.8.126) (2021-04-29)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.125](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.124...@carbon/ibm-cloud-cognitive-core@0.8.125) (2021-04-29)
+## [0.8.125](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.124...@carbon/ibm-cloud-cognitive-core@0.8.125) (2021-04-29)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.124](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.123...@carbon/ibm-cloud-cognitive-core@0.8.124) (2021-04-29)
+## [0.8.124](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.123...@carbon/ibm-cloud-cognitive-core@0.8.124) (2021-04-29)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.123](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.122...@carbon/ibm-cloud-cognitive-core@0.8.123) (2021-04-29)
+## [0.8.123](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.122...@carbon/ibm-cloud-cognitive-core@0.8.123) (2021-04-29)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.122](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.121...@carbon/ibm-cloud-cognitive-core@0.8.122) (2021-04-28)
+## [0.8.122](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.121...@carbon/ibm-cloud-cognitive-core@0.8.122) (2021-04-28)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.121](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.120...@carbon/ibm-cloud-cognitive-core@0.8.121) (2021-04-28)
+## [0.8.121](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.120...@carbon/ibm-cloud-cognitive-core@0.8.121) (2021-04-28)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.120](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.119...@carbon/ibm-cloud-cognitive-core@0.8.120) (2021-04-28)
+## [0.8.120](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.119...@carbon/ibm-cloud-cognitive-core@0.8.120) (2021-04-28)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.119](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.118...@carbon/ibm-cloud-cognitive-core@0.8.119) (2021-04-28)
+## [0.8.119](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.118...@carbon/ibm-cloud-cognitive-core@0.8.119) (2021-04-28)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.118](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.117...@carbon/ibm-cloud-cognitive-core@0.8.118) (2021-04-27)
+## [0.8.118](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.117...@carbon/ibm-cloud-cognitive-core@0.8.118) (2021-04-27)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.117](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.116...@carbon/ibm-cloud-cognitive-core@0.8.117) (2021-04-27)
+## [0.8.117](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.116...@carbon/ibm-cloud-cognitive-core@0.8.117) (2021-04-27)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.116](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.115...@carbon/ibm-cloud-cognitive-core@0.8.116) (2021-04-27)
+## [0.8.116](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.115...@carbon/ibm-cloud-cognitive-core@0.8.116) (2021-04-27)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.115](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.114...@carbon/ibm-cloud-cognitive-core@0.8.115) (2021-04-26)
+## [0.8.115](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.114...@carbon/ibm-cloud-cognitive-core@0.8.115) (2021-04-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.114](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.113...@carbon/ibm-cloud-cognitive-core@0.8.114) (2021-04-26)
+## [0.8.114](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.113...@carbon/ibm-cloud-cognitive-core@0.8.114) (2021-04-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.113](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.112...@carbon/ibm-cloud-cognitive-core@0.8.113) (2021-04-26)
+## [0.8.113](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.112...@carbon/ibm-cloud-cognitive-core@0.8.113) (2021-04-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.112](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.111...@carbon/ibm-cloud-cognitive-core@0.8.112) (2021-04-26)
+## [0.8.112](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.111...@carbon/ibm-cloud-cognitive-core@0.8.112) (2021-04-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.111](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.110...@carbon/ibm-cloud-cognitive-core@0.8.111) (2021-04-26)
+## [0.8.111](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.110...@carbon/ibm-cloud-cognitive-core@0.8.111) (2021-04-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.110](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.109...@carbon/ibm-cloud-cognitive-core@0.8.110) (2021-04-23)
+## [0.8.110](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.109...@carbon/ibm-cloud-cognitive-core@0.8.110) (2021-04-23)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.109](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.108...@carbon/ibm-cloud-cognitive-core@0.8.109) (2021-04-22)
+## [0.8.109](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.108...@carbon/ibm-cloud-cognitive-core@0.8.109) (2021-04-22)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.108](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.107...@carbon/ibm-cloud-cognitive-core@0.8.108) (2021-04-22)
+## [0.8.108](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.107...@carbon/ibm-cloud-cognitive-core@0.8.108) (2021-04-22)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.107](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.106...@carbon/ibm-cloud-cognitive-core@0.8.107) (2021-04-21)
+## [0.8.107](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.106...@carbon/ibm-cloud-cognitive-core@0.8.107) (2021-04-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.106](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.105...@carbon/ibm-cloud-cognitive-core@0.8.106) (2021-04-21)
+## [0.8.106](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.105...@carbon/ibm-cloud-cognitive-core@0.8.106) (2021-04-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.105](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.104...@carbon/ibm-cloud-cognitive-core@0.8.105) (2021-04-21)
+## [0.8.105](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.104...@carbon/ibm-cloud-cognitive-core@0.8.105) (2021-04-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.104](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.103...@carbon/ibm-cloud-cognitive-core@0.8.104) (2021-04-21)
+## [0.8.104](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.103...@carbon/ibm-cloud-cognitive-core@0.8.104) (2021-04-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.103](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.102...@carbon/ibm-cloud-cognitive-core@0.8.103) (2021-04-20)
+## [0.8.103](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.102...@carbon/ibm-cloud-cognitive-core@0.8.103) (2021-04-20)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.102](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.101...@carbon/ibm-cloud-cognitive-core@0.8.102) (2021-04-20)
+## [0.8.102](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.101...@carbon/ibm-cloud-cognitive-core@0.8.102) (2021-04-20)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.101](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.100...@carbon/ibm-cloud-cognitive-core@0.8.101) (2021-04-20)
+## [0.8.101](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.100...@carbon/ibm-cloud-cognitive-core@0.8.101) (2021-04-20)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.100](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.99...@carbon/ibm-cloud-cognitive-core@0.8.100) (2021-04-20)
+## [0.8.100](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.99...@carbon/ibm-cloud-cognitive-core@0.8.100) (2021-04-20)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.99](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.98...@carbon/ibm-cloud-cognitive-core@0.8.99) (2021-04-20)
+## [0.8.99](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.98...@carbon/ibm-cloud-cognitive-core@0.8.99) (2021-04-20)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.98](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.97...@carbon/ibm-cloud-cognitive-core@0.8.98) (2021-04-19)
+## [0.8.98](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.97...@carbon/ibm-cloud-cognitive-core@0.8.98) (2021-04-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.97](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.96...@carbon/ibm-cloud-cognitive-core@0.8.97) (2021-04-16)
+## [0.8.97](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.96...@carbon/ibm-cloud-cognitive-core@0.8.97) (2021-04-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.96](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.95...@carbon/ibm-cloud-cognitive-core@0.8.96) (2021-04-16)
+## [0.8.96](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.95...@carbon/ibm-cloud-cognitive-core@0.8.96) (2021-04-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.95](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.94...@carbon/ibm-cloud-cognitive-core@0.8.95) (2021-04-16)
+## [0.8.95](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.94...@carbon/ibm-cloud-cognitive-core@0.8.95) (2021-04-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.94](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.93...@carbon/ibm-cloud-cognitive-core@0.8.94) (2021-04-16)
+## [0.8.94](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.93...@carbon/ibm-cloud-cognitive-core@0.8.94) (2021-04-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.93](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.92...@carbon/ibm-cloud-cognitive-core@0.8.93) (2021-04-15)
+## [0.8.93](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.92...@carbon/ibm-cloud-cognitive-core@0.8.93) (2021-04-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.92](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.91...@carbon/ibm-cloud-cognitive-core@0.8.92) (2021-04-15)
+## [0.8.92](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.91...@carbon/ibm-cloud-cognitive-core@0.8.92) (2021-04-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.91](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.90...@carbon/ibm-cloud-cognitive-core@0.8.91) (2021-04-15)
+## [0.8.91](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.90...@carbon/ibm-cloud-cognitive-core@0.8.91) (2021-04-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.90](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.89...@carbon/ibm-cloud-cognitive-core@0.8.90) (2021-04-15)
+## [0.8.90](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.89...@carbon/ibm-cloud-cognitive-core@0.8.90) (2021-04-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.89](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.88...@carbon/ibm-cloud-cognitive-core@0.8.89) (2021-04-14)
+## [0.8.89](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.88...@carbon/ibm-cloud-cognitive-core@0.8.89) (2021-04-14)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.88](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.87...@carbon/ibm-cloud-cognitive-core@0.8.88) (2021-04-14)
+## [0.8.88](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.87...@carbon/ibm-cloud-cognitive-core@0.8.88) (2021-04-14)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.87](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.86...@carbon/ibm-cloud-cognitive-core@0.8.87) (2021-04-14)
+## [0.8.87](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.86...@carbon/ibm-cloud-cognitive-core@0.8.87) (2021-04-14)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.86](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.85...@carbon/ibm-cloud-cognitive-core@0.8.86) (2021-04-14)
+## [0.8.86](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.85...@carbon/ibm-cloud-cognitive-core@0.8.86) (2021-04-14)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.85](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.84...@carbon/ibm-cloud-cognitive-core@0.8.85) (2021-04-14)
+## [0.8.85](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.84...@carbon/ibm-cloud-cognitive-core@0.8.85) (2021-04-14)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.84](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.83...@carbon/ibm-cloud-cognitive-core@0.8.84) (2021-04-13)
+## [0.8.84](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.83...@carbon/ibm-cloud-cognitive-core@0.8.84) (2021-04-13)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.83](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.82...@carbon/ibm-cloud-cognitive-core@0.8.83) (2021-04-13)
+## [0.8.83](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.82...@carbon/ibm-cloud-cognitive-core@0.8.83) (2021-04-13)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.82](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.81...@carbon/ibm-cloud-cognitive-core@0.8.82) (2021-04-13)
+## [0.8.82](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.81...@carbon/ibm-cloud-cognitive-core@0.8.82) (2021-04-13)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.81](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.80...@carbon/ibm-cloud-cognitive-core@0.8.81) (2021-04-12)
+## [0.8.81](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.80...@carbon/ibm-cloud-cognitive-core@0.8.81) (2021-04-12)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.80](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.79...@carbon/ibm-cloud-cognitive-core@0.8.80) (2021-04-12)
+## [0.8.80](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.79...@carbon/ibm-cloud-cognitive-core@0.8.80) (2021-04-12)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.79](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.78...@carbon/ibm-cloud-cognitive-core@0.8.79) (2021-04-12)
+## [0.8.79](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.78...@carbon/ibm-cloud-cognitive-core@0.8.79) (2021-04-12)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.78](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.77...@carbon/ibm-cloud-cognitive-core@0.8.78) (2021-04-12)
+## [0.8.78](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.77...@carbon/ibm-cloud-cognitive-core@0.8.78) (2021-04-12)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.77](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.76...@carbon/ibm-cloud-cognitive-core@0.8.77) (2021-04-12)
+## [0.8.77](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.76...@carbon/ibm-cloud-cognitive-core@0.8.77) (2021-04-12)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.76](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.75...@carbon/ibm-cloud-cognitive-core@0.8.76) (2021-04-12)
+## [0.8.76](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.75...@carbon/ibm-cloud-cognitive-core@0.8.76) (2021-04-12)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.75](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.74...@carbon/ibm-cloud-cognitive-core@0.8.75) (2021-04-09)
+## [0.8.75](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.74...@carbon/ibm-cloud-cognitive-core@0.8.75) (2021-04-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.74](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.73...@carbon/ibm-cloud-cognitive-core@0.8.74) (2021-04-09)
+## [0.8.74](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.73...@carbon/ibm-cloud-cognitive-core@0.8.74) (2021-04-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.73](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.72...@carbon/ibm-cloud-cognitive-core@0.8.73) (2021-04-09)
+## [0.8.73](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.72...@carbon/ibm-cloud-cognitive-core@0.8.73) (2021-04-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.72](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.71...@carbon/ibm-cloud-cognitive-core@0.8.72) (2021-04-09)
+## [0.8.72](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.71...@carbon/ibm-cloud-cognitive-core@0.8.72) (2021-04-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.71](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.70...@carbon/ibm-cloud-cognitive-core@0.8.71) (2021-04-08)
+## [0.8.71](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.70...@carbon/ibm-cloud-cognitive-core@0.8.71) (2021-04-08)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.70](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.69...@carbon/ibm-cloud-cognitive-core@0.8.70) (2021-04-08)
+## [0.8.70](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.69...@carbon/ibm-cloud-cognitive-core@0.8.70) (2021-04-08)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.69](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.68...@carbon/ibm-cloud-cognitive-core@0.8.69) (2021-04-07)
+## [0.8.69](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.68...@carbon/ibm-cloud-cognitive-core@0.8.69) (2021-04-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.68](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.67...@carbon/ibm-cloud-cognitive-core@0.8.68) (2021-04-07)
+## [0.8.68](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.67...@carbon/ibm-cloud-cognitive-core@0.8.68) (2021-04-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.67](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.66...@carbon/ibm-cloud-cognitive-core@0.8.67) (2021-04-06)
+## [0.8.67](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.66...@carbon/ibm-cloud-cognitive-core@0.8.67) (2021-04-06)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.66](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.65...@carbon/ibm-cloud-cognitive-core@0.8.66) (2021-04-06)
+## [0.8.66](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.65...@carbon/ibm-cloud-cognitive-core@0.8.66) (2021-04-06)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.65](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.64...@carbon/ibm-cloud-cognitive-core@0.8.65) (2021-04-05)
+## [0.8.65](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.64...@carbon/ibm-cloud-cognitive-core@0.8.65) (2021-04-05)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.64](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.63...@carbon/ibm-cloud-cognitive-core@0.8.64) (2021-04-05)
+## [0.8.64](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.63...@carbon/ibm-cloud-cognitive-core@0.8.64) (2021-04-05)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.63](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.62...@carbon/ibm-cloud-cognitive-core@0.8.63) (2021-04-02)
+## [0.8.63](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.62...@carbon/ibm-cloud-cognitive-core@0.8.63) (2021-04-02)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.62](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.61...@carbon/ibm-cloud-cognitive-core@0.8.62) (2021-04-01)
+## [0.8.62](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.61...@carbon/ibm-cloud-cognitive-core@0.8.62) (2021-04-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.61](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.60...@carbon/ibm-cloud-cognitive-core@0.8.61) (2021-04-01)
+## [0.8.61](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.60...@carbon/ibm-cloud-cognitive-core@0.8.61) (2021-04-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.60](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.59...@carbon/ibm-cloud-cognitive-core@0.8.60) (2021-04-01)
+## [0.8.60](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.59...@carbon/ibm-cloud-cognitive-core@0.8.60) (2021-04-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.59](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.58...@carbon/ibm-cloud-cognitive-core@0.8.59) (2021-04-01)
+## [0.8.59](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.58...@carbon/ibm-cloud-cognitive-core@0.8.59) (2021-04-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.58](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.57...@carbon/ibm-cloud-cognitive-core@0.8.58) (2021-03-31)
+## [0.8.58](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.57...@carbon/ibm-cloud-cognitive-core@0.8.58) (2021-03-31)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.57](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.56...@carbon/ibm-cloud-cognitive-core@0.8.57) (2021-03-31)
+## [0.8.57](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.56...@carbon/ibm-cloud-cognitive-core@0.8.57) (2021-03-31)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.56](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.55...@carbon/ibm-cloud-cognitive-core@0.8.56) (2021-03-30)
+## [0.8.56](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.55...@carbon/ibm-cloud-cognitive-core@0.8.56) (2021-03-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.55](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.54...@carbon/ibm-cloud-cognitive-core@0.8.55) (2021-03-30)
+## [0.8.55](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.54...@carbon/ibm-cloud-cognitive-core@0.8.55) (2021-03-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.54](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.53...@carbon/ibm-cloud-cognitive-core@0.8.54) (2021-03-30)
+## [0.8.54](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.53...@carbon/ibm-cloud-cognitive-core@0.8.54) (2021-03-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.53](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.52...@carbon/ibm-cloud-cognitive-core@0.8.53) (2021-03-30)
+## [0.8.53](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.52...@carbon/ibm-cloud-cognitive-core@0.8.53) (2021-03-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.52](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.51...@carbon/ibm-cloud-cognitive-core@0.8.52) (2021-03-30)
+## [0.8.52](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.51...@carbon/ibm-cloud-cognitive-core@0.8.52) (2021-03-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.51](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.50...@carbon/ibm-cloud-cognitive-core@0.8.51) (2021-03-30)
+## [0.8.51](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.50...@carbon/ibm-cloud-cognitive-core@0.8.51) (2021-03-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.50](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.49...@carbon/ibm-cloud-cognitive-core@0.8.50) (2021-03-30)
+## [0.8.50](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.49...@carbon/ibm-cloud-cognitive-core@0.8.50) (2021-03-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.49](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.48...@carbon/ibm-cloud-cognitive-core@0.8.49) (2021-03-30)
+## [0.8.49](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.48...@carbon/ibm-cloud-cognitive-core@0.8.49) (2021-03-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.48](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.47...@carbon/ibm-cloud-cognitive-core@0.8.48) (2021-03-26)
+## [0.8.48](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.47...@carbon/ibm-cloud-cognitive-core@0.8.48) (2021-03-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.47](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.46...@carbon/ibm-cloud-cognitive-core@0.8.47) (2021-03-26)
+## [0.8.47](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.46...@carbon/ibm-cloud-cognitive-core@0.8.47) (2021-03-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.46](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.45...@carbon/ibm-cloud-cognitive-core@0.8.46) (2021-03-26)
+## [0.8.46](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.45...@carbon/ibm-cloud-cognitive-core@0.8.46) (2021-03-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.45](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.44...@carbon/ibm-cloud-cognitive-core@0.8.45) (2021-03-26)
+## [0.8.45](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.44...@carbon/ibm-cloud-cognitive-core@0.8.45) (2021-03-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.44](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.43...@carbon/ibm-cloud-cognitive-core@0.8.44) (2021-03-25)
+## [0.8.44](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.43...@carbon/ibm-cloud-cognitive-core@0.8.44) (2021-03-25)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.43](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.42...@carbon/ibm-cloud-cognitive-core@0.8.43) (2021-03-25)
+## [0.8.43](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.42...@carbon/ibm-cloud-cognitive-core@0.8.43) (2021-03-25)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.42](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.41...@carbon/ibm-cloud-cognitive-core@0.8.42) (2021-03-25)
+## [0.8.42](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.41...@carbon/ibm-cloud-cognitive-core@0.8.42) (2021-03-25)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.41](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.40...@carbon/ibm-cloud-cognitive-core@0.8.41) (2021-03-25)
+## [0.8.41](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.40...@carbon/ibm-cloud-cognitive-core@0.8.41) (2021-03-25)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.40](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.39...@carbon/ibm-cloud-cognitive-core@0.8.40) (2021-03-25)
+## [0.8.40](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.39...@carbon/ibm-cloud-cognitive-core@0.8.40) (2021-03-25)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.39](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.38...@carbon/ibm-cloud-cognitive-core@0.8.39) (2021-03-24)
+## [0.8.39](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.38...@carbon/ibm-cloud-cognitive-core@0.8.39) (2021-03-24)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.38](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.37...@carbon/ibm-cloud-cognitive-core@0.8.38) (2021-03-24)
+## [0.8.38](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.37...@carbon/ibm-cloud-cognitive-core@0.8.38) (2021-03-24)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.37](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.36...@carbon/ibm-cloud-cognitive-core@0.8.37) (2021-03-24)
+## [0.8.37](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.36...@carbon/ibm-cloud-cognitive-core@0.8.37) (2021-03-24)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.36](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.35...@carbon/ibm-cloud-cognitive-core@0.8.36) (2021-03-23)
+## [0.8.36](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.35...@carbon/ibm-cloud-cognitive-core@0.8.36) (2021-03-23)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.35](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.34...@carbon/ibm-cloud-cognitive-core@0.8.35) (2021-03-23)
+## [0.8.35](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.34...@carbon/ibm-cloud-cognitive-core@0.8.35) (2021-03-23)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.34](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.33...@carbon/ibm-cloud-cognitive-core@0.8.34) (2021-03-22)
+## [0.8.34](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.33...@carbon/ibm-cloud-cognitive-core@0.8.34) (2021-03-22)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.33](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.32...@carbon/ibm-cloud-cognitive-core@0.8.33) (2021-03-22)
+## [0.8.33](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.32...@carbon/ibm-cloud-cognitive-core@0.8.33) (2021-03-22)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.32](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.31...@carbon/ibm-cloud-cognitive-core@0.8.32) (2021-03-22)
+## [0.8.32](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.31...@carbon/ibm-cloud-cognitive-core@0.8.32) (2021-03-22)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.31](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.30...@carbon/ibm-cloud-cognitive-core@0.8.31) (2021-03-22)
+## [0.8.31](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.30...@carbon/ibm-cloud-cognitive-core@0.8.31) (2021-03-22)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.30](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.29...@carbon/ibm-cloud-cognitive-core@0.8.30) (2021-03-19)
+## [0.8.30](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.29...@carbon/ibm-cloud-cognitive-core@0.8.30) (2021-03-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.29](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.28...@carbon/ibm-cloud-cognitive-core@0.8.29) (2021-03-19)
+## [0.8.29](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.28...@carbon/ibm-cloud-cognitive-core@0.8.29) (2021-03-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.28](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.27...@carbon/ibm-cloud-cognitive-core@0.8.28) (2021-03-19)
+## [0.8.28](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.27...@carbon/ibm-cloud-cognitive-core@0.8.28) (2021-03-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.27](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.26...@carbon/ibm-cloud-cognitive-core@0.8.27) (2021-03-19)
+## [0.8.27](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.26...@carbon/ibm-cloud-cognitive-core@0.8.27) (2021-03-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.26](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.25...@carbon/ibm-cloud-cognitive-core@0.8.26) (2021-03-19)
+## [0.8.26](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.25...@carbon/ibm-cloud-cognitive-core@0.8.26) (2021-03-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.25](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.24...@carbon/ibm-cloud-cognitive-core@0.8.25) (2021-03-19)
+## [0.8.25](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.24...@carbon/ibm-cloud-cognitive-core@0.8.25) (2021-03-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.24](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.23...@carbon/ibm-cloud-cognitive-core@0.8.24) (2021-03-18)
+## [0.8.24](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.23...@carbon/ibm-cloud-cognitive-core@0.8.24) (2021-03-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.23](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.22...@carbon/ibm-cloud-cognitive-core@0.8.23) (2021-03-18)
+## [0.8.23](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.22...@carbon/ibm-cloud-cognitive-core@0.8.23) (2021-03-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.22](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.21...@carbon/ibm-cloud-cognitive-core@0.8.22) (2021-03-18)
+## [0.8.22](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.21...@carbon/ibm-cloud-cognitive-core@0.8.22) (2021-03-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.21](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.20...@carbon/ibm-cloud-cognitive-core@0.8.21) (2021-03-18)
+## [0.8.21](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.20...@carbon/ibm-cloud-cognitive-core@0.8.21) (2021-03-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.20](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.19...@carbon/ibm-cloud-cognitive-core@0.8.20) (2021-03-18)
+## [0.8.20](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.19...@carbon/ibm-cloud-cognitive-core@0.8.20) (2021-03-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.19](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.18...@carbon/ibm-cloud-cognitive-core@0.8.19) (2021-03-18)
+## [0.8.19](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.18...@carbon/ibm-cloud-cognitive-core@0.8.19) (2021-03-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.18](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.17...@carbon/ibm-cloud-cognitive-core@0.8.18) (2021-03-18)
+## [0.8.18](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.17...@carbon/ibm-cloud-cognitive-core@0.8.18) (2021-03-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.17](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.16...@carbon/ibm-cloud-cognitive-core@0.8.17) (2021-03-18)
+## [0.8.17](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.16...@carbon/ibm-cloud-cognitive-core@0.8.17) (2021-03-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.16](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.15...@carbon/ibm-cloud-cognitive-core@0.8.16) (2021-03-18)
+## [0.8.16](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.15...@carbon/ibm-cloud-cognitive-core@0.8.16) (2021-03-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.15](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.14...@carbon/ibm-cloud-cognitive-core@0.8.15) (2021-03-17)
+## [0.8.15](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.14...@carbon/ibm-cloud-cognitive-core@0.8.15) (2021-03-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.13...@carbon/ibm-cloud-cognitive-core@0.8.14) (2021-03-17)
+## [0.8.14](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.13...@carbon/ibm-cloud-cognitive-core@0.8.14) (2021-03-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.12...@carbon/ibm-cloud-cognitive-core@0.8.13) (2021-03-16)
+## [0.8.13](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.12...@carbon/ibm-cloud-cognitive-core@0.8.13) (2021-03-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.11...@carbon/ibm-cloud-cognitive-core@0.8.12) (2021-03-16)
+## [0.8.12](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.11...@carbon/ibm-cloud-cognitive-core@0.8.12) (2021-03-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.10...@carbon/ibm-cloud-cognitive-core@0.8.11) (2021-03-16)
+## [0.8.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.10...@carbon/ibm-cloud-cognitive-core@0.8.11) (2021-03-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.9...@carbon/ibm-cloud-cognitive-core@0.8.10) (2021-03-16)
+## [0.8.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.9...@carbon/ibm-cloud-cognitive-core@0.8.10) (2021-03-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.8...@carbon/ibm-cloud-cognitive-core@0.8.9) (2021-03-16)
+## [0.8.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.8...@carbon/ibm-cloud-cognitive-core@0.8.9) (2021-03-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.7...@carbon/ibm-cloud-cognitive-core@0.8.8) (2021-03-16)
+## [0.8.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.7...@carbon/ibm-cloud-cognitive-core@0.8.8) (2021-03-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.6...@carbon/ibm-cloud-cognitive-core@0.8.7) (2021-03-16)
+## [0.8.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.6...@carbon/ibm-cloud-cognitive-core@0.8.7) (2021-03-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.5...@carbon/ibm-cloud-cognitive-core@0.8.6) (2021-03-16)
+## [0.8.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.5...@carbon/ibm-cloud-cognitive-core@0.8.6) (2021-03-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.4...@carbon/ibm-cloud-cognitive-core@0.8.5) (2021-03-16)
+## [0.8.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.4...@carbon/ibm-cloud-cognitive-core@0.8.5) (2021-03-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.3...@carbon/ibm-cloud-cognitive-core@0.8.4) (2021-03-15)
+## [0.8.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.3...@carbon/ibm-cloud-cognitive-core@0.8.4) (2021-03-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.2...@carbon/ibm-cloud-cognitive-core@0.8.3) (2021-03-15)
+## [0.8.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.2...@carbon/ibm-cloud-cognitive-core@0.8.3) (2021-03-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.1...@carbon/ibm-cloud-cognitive-core@0.8.2) (2021-03-12)
+## [0.8.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.1...@carbon/ibm-cloud-cognitive-core@0.8.2) (2021-03-12)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.8.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.8.0...@carbon/ibm-cloud-cognitive-core@0.8.1) (2021-03-11)
+## [0.8.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.8.0...@carbon/ibm-cloud-cognitive-core@0.8.1) (2021-03-11)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-# [0.8.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.7.0...@carbon/ibm-cloud-cognitive-core@0.8.0) (2021-03-11)
+# [0.8.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.7.0...@carbon/ibm-cloud-cognitive-core@0.8.0) (2021-03-11)
 
 ### Features
 
 - update remaining components to be in line with feature flags proposal
-  ([#429](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/429))
-  ([a6c870a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a6c870a62e72a8ca1b992f17188cc8a991f00ec8))
+  ([#429](https://github.com/carbon-design-system/ibm-products/issues/429))
+  ([a6c870a](https://github.com/carbon-design-system/ibm-products/commit/a6c870a62e72a8ca1b992f17188cc8a991f00ec8))
 
-# [0.7.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.6.14...@carbon/ibm-cloud-cognitive-core@0.7.0) (2021-03-11)
+# [0.7.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.6.14...@carbon/ibm-cloud-cognitive-core@0.7.0) (2021-03-11)
 
 ### Features
 
 - bump carbon versions to latest
-  ([#426](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/426))
-  ([761ea98](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/761ea98c33a6be318293526833c316f3d44db533))
+  ([#426](https://github.com/carbon-design-system/ibm-products/issues/426))
+  ([761ea98](https://github.com/carbon-design-system/ibm-products/commit/761ea98c33a6be318293526833c316f3d44db533))
 
-## [0.6.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.6.13...@carbon/ibm-cloud-cognitive-core@0.6.14) (2021-03-11)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
-
-## [0.6.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.6.12...@carbon/ibm-cloud-cognitive-core@0.6.13) (2021-03-10)
+## [0.6.14](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.6.13...@carbon/ibm-cloud-cognitive-core@0.6.14) (2021-03-11)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.6.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.6.11...@carbon/ibm-cloud-cognitive-core@0.6.12) (2021-03-10)
+## [0.6.13](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.6.12...@carbon/ibm-cloud-cognitive-core@0.6.13) (2021-03-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.6.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.6.10...@carbon/ibm-cloud-cognitive-core@0.6.11) (2021-03-10)
+## [0.6.12](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.6.11...@carbon/ibm-cloud-cognitive-core@0.6.12) (2021-03-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.6.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.6.9...@carbon/ibm-cloud-cognitive-core@0.6.10) (2021-03-09)
+## [0.6.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.6.10...@carbon/ibm-cloud-cognitive-core@0.6.11) (2021-03-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.6.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.6.8...@carbon/ibm-cloud-cognitive-core@0.6.9) (2021-03-09)
+## [0.6.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.6.9...@carbon/ibm-cloud-cognitive-core@0.6.10) (2021-03-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.6.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.6.7...@carbon/ibm-cloud-cognitive-core@0.6.8) (2021-03-09)
+## [0.6.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.6.8...@carbon/ibm-cloud-cognitive-core@0.6.9) (2021-03-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.6.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.6.6...@carbon/ibm-cloud-cognitive-core@0.6.7) (2021-03-09)
+## [0.6.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.6.7...@carbon/ibm-cloud-cognitive-core@0.6.8) (2021-03-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.6.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.6.5...@carbon/ibm-cloud-cognitive-core@0.6.6) (2021-03-09)
+## [0.6.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.6.6...@carbon/ibm-cloud-cognitive-core@0.6.7) (2021-03-09)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
+
+## [0.6.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.6.5...@carbon/ibm-cloud-cognitive-core@0.6.6) (2021-03-09)
 
 ### Bug Fixes
 
 - canary scss and settings imports
-  ([#418](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/418))
-  ([29711ec](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/29711ec18c66e70565be3361688e2bfd377d23f3))
+  ([#418](https://github.com/carbon-design-system/ibm-products/issues/418))
+  ([29711ec](https://github.com/carbon-design-system/ibm-products/commit/29711ec18c66e70565be3361688e2bfd377d23f3))
 
-## [0.6.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.6.4...@carbon/ibm-cloud-cognitive-core@0.6.5) (2021-03-08)
+## [0.6.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.6.4...@carbon/ibm-cloud-cognitive-core@0.6.5) (2021-03-08)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.6.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.6.3...@carbon/ibm-cloud-cognitive-core@0.6.4) (2021-03-05)
+## [0.6.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.6.3...@carbon/ibm-cloud-cognitive-core@0.6.4) (2021-03-05)
 
 ### Bug Fixes
 
 - story sort order
-  ([#401](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/401))
-  ([447b375](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/447b37510143435d58de56638a90c3ede8a8bb23))
+  ([#401](https://github.com/carbon-design-system/ibm-products/issues/401))
+  ([447b375](https://github.com/carbon-design-system/ibm-products/commit/447b37510143435d58de56638a90c3ede8a8bb23))
 
-## [0.6.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.6.2...@carbon/ibm-cloud-cognitive-core@0.6.3) (2021-03-04)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
-
-## [0.6.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.6.1...@carbon/ibm-cloud-cognitive-core@0.6.2) (2021-02-25)
+## [0.6.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.6.2...@carbon/ibm-cloud-cognitive-core@0.6.3) (2021-03-04)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.6.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.6.0...@carbon/ibm-cloud-cognitive-core@0.6.1) (2021-01-29)
+## [0.6.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.6.1...@carbon/ibm-cloud-cognitive-core@0.6.2) (2021-02-25)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
+
+## [0.6.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.6.0...@carbon/ibm-cloud-cognitive-core@0.6.1) (2021-01-29)
 
 ### Bug Fixes
 
 - **combo-button:** add truncation
-  ([#308](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/308))
-  ([35b3517](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/35b351776107d23f6dafd30b9d4a24d626a9d9ec))
+  ([#308](https://github.com/carbon-design-system/ibm-products/issues/308))
+  ([35b3517](https://github.com/carbon-design-system/ibm-products/commit/35b351776107d23f6dafd30b9d4a24d626a9d9ec))
 
-# [0.6.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.5.2...@carbon/ibm-cloud-cognitive-core@0.6.0) (2021-01-28)
+# [0.6.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.5.2...@carbon/ibm-cloud-cognitive-core@0.6.0) (2021-01-28)
 
 ### Features
 
 - update carbon to 10-27
-  ([#311](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/311))
-  ([b7569b8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b7569b8e3a339b8886175ed224164030e036b36c))
+  ([#311](https://github.com/carbon-design-system/ibm-products/issues/311))
+  ([b7569b8](https://github.com/carbon-design-system/ibm-products/commit/b7569b8e3a339b8886175ed224164030e036b36c))
 
-## [0.5.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.5.1...@carbon/ibm-cloud-cognitive-core@0.5.2) (2021-01-26)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
-
-## [0.5.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.5.0...@carbon/ibm-cloud-cognitive-core@0.5.1) (2021-01-20)
+## [0.5.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.5.1...@carbon/ibm-cloud-cognitive-core@0.5.2) (2021-01-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-# [0.5.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.4.6...@carbon/ibm-cloud-cognitive-core@0.5.0) (2020-12-16)
+## [0.5.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.5.0...@carbon/ibm-cloud-cognitive-core@0.5.1) (2021-01-20)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
+
+# [0.5.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.4.6...@carbon/ibm-cloud-cognitive-core@0.5.0) (2020-12-16)
 
 ### Features
 
 - Page header tag overflow update
-  ([#264](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/264))
-  ([ee22520](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ee225206e291fa3bca990cb2ccabfece8930fc88))
+  ([#264](https://github.com/carbon-design-system/ibm-products/issues/264))
+  ([ee22520](https://github.com/carbon-design-system/ibm-products/commit/ee225206e291fa3bca990cb2ccabfece8930fc88))
 
-## [0.4.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.4.5...@carbon/ibm-cloud-cognitive-core@0.4.6) (2020-12-10)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
-
-## [0.4.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.4.4...@carbon/ibm-cloud-cognitive-core@0.4.5) (2020-12-08)
+## [0.4.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.4.5...@carbon/ibm-cloud-cognitive-core@0.4.6) (2020-12-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.4.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.4.3...@carbon/ibm-cloud-cognitive-core@0.4.4) (2020-12-02)
+## [0.4.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.4.4...@carbon/ibm-cloud-cognitive-core@0.4.5) (2020-12-08)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.4.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.4.2...@carbon/ibm-cloud-cognitive-core@0.4.3) (2020-12-01)
+## [0.4.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.4.3...@carbon/ibm-cloud-cognitive-core@0.4.4) (2020-12-02)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.4.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-core@0.4.1...@carbon/ibm-cloud-cognitive-core@0.4.2) (2020-11-30)
+## [0.4.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.4.2...@carbon/ibm-cloud-cognitive-core@0.4.3) (2020-12-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.4.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/compare/@carbon/ibm-cloud-cognitive-core@0.4.0...@carbon/ibm-cloud-cognitive-core@0.4.1) (2020-11-26)
+## [0.4.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-core@0.4.1...@carbon/ibm-cloud-cognitive-core@0.4.2) (2020-11-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-# [0.4.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/compare/@carbon/ibm-cloud-cognitive-core@0.3.0...@carbon/ibm-cloud-cognitive-core@0.4.0) (2020-11-26)
+## [0.4.1](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/compare/@carbon/ibm-cloud-cognitive-core@0.4.0...@carbon/ibm-cloud-cognitive-core@0.4.1) (2020-11-26)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
+
+# [0.4.0](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/compare/@carbon/ibm-cloud-cognitive-core@0.3.0...@carbon/ibm-cloud-cognitive-core@0.4.0) (2020-11-26)
 
 ### Features
 
 - add cdai apikey component
-  ([#223](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/issues/223))
-  ([4c09f15](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/commit/4c09f15c3c62c3965d98c91b9695fa7a1cba8f0b))
+  ([#223](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/issues/223))
+  ([4c09f15](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/commit/4c09f15c3c62c3965d98c91b9695fa7a1cba8f0b))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.3.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/compare/@carbon/ibm-cloud-cognitive-core@0.2.0...@carbon/ibm-cloud-cognitive-core@0.3.0) (2020-11-19)
+# [0.3.0](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/compare/@carbon/ibm-cloud-cognitive-core@0.2.0...@carbon/ibm-cloud-cognitive-core@0.3.0) (2020-11-19)
 
 ### Features
 
 - apikey modal
-  ([#200](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/issues/200))
-  ([e4d94e5](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/commit/e4d94e549fa693a66850228407a748503ff47325))
+  ([#200](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/issues/200))
+  ([e4d94e5](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/commit/e4d94e549fa693a66850228407a748503ff47325))
 
-# [0.2.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/compare/@carbon/ibm-cloud-cognitive-core@0.1.4...@carbon/ibm-cloud-cognitive-core@0.2.0) (2020-11-17)
+# [0.2.0](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/compare/@carbon/ibm-cloud-cognitive-core@0.1.4...@carbon/ibm-cloud-cognitive-core@0.2.0) (2020-11-17)
 
 ### Features
 
 - update to carbon 10.24.0
-  ([#217](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/issues/217))
-  ([76839f3](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/commit/76839f36eca23132559c47f61d9efa0cfcd8414d))
+  ([#217](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/issues/217))
+  ([76839f3](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/commit/76839f36eca23132559c47f61d9efa0cfcd8414d))
 
-## [0.1.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/compare/@carbon/ibm-cloud-cognitive-core@0.1.3...@carbon/ibm-cloud-cognitive-core@0.1.4) (2020-11-17)
+## [0.1.4](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/compare/@carbon/ibm-cloud-cognitive-core@0.1.3...@carbon/ibm-cloud-cognitive-core@0.1.4) (2020-11-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.1.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/compare/@carbon/ibm-cloud-cognitive-core@0.1.2...@carbon/ibm-cloud-cognitive-core@0.1.3) (2020-11-17)
+## [0.1.3](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/compare/@carbon/ibm-cloud-cognitive-core@0.1.2...@carbon/ibm-cloud-cognitive-core@0.1.3) (2020-11-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
@@ -2081,11 +2081,11 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.1.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/compare/@carbon/ibm-cloud-cognitive-core@0.1.1...@carbon/ibm-cloud-cognitive-core@0.1.2) (2020-11-16)
+## [0.1.2](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/compare/@carbon/ibm-cloud-cognitive-core@0.1.1...@carbon/ibm-cloud-cognitive-core@0.1.2) (2020-11-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
-## [0.1.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/compare/@carbon/ibm-cloud-cognitive-core@0.1.0...@carbon/ibm-cloud-cognitive-core@0.1.1) (2020-11-13)
+## [0.1.1](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/compare/@carbon/ibm-cloud-cognitive-core@0.1.0...@carbon/ibm-cloud-cognitive-core@0.1.1) (2020-11-13)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-core
 
@@ -2099,32 +2099,32 @@ All notable changes to this project will be documented in this file. See
 ### Bug Fixes
 
 - broken carbon tabs
-  ([#160](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/issues/160))
-  ([b5b46b3](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/commit/b5b46b3916cba06bd5a3a3c275b8ac3dda7a952b))
+  ([#160](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/issues/160))
+  ([b5b46b3](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/commit/b5b46b3916cba06bd5a3a3c275b8ac3dda7a952b))
 
 ### Features
 
 - add experimental package
-  ([#78](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/issues/78))
-  ([a66bd49](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/commit/a66bd49561cba368bf6c82608e0b0945df7fc821))
+  ([#78](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/issues/78))
+  ([a66bd49](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/commit/a66bd49561cba368bf6c82608e0b0945df7fc821))
 - add storysource addon
-  ([#82](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/issues/82))
-  ([d5377ae](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/commit/d5377ae6435a43a4cdaf023adf22ace49f53ec79))
+  ([#82](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/issues/82))
+  ([d5377ae](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/commit/d5377ae6435a43a4cdaf023adf22ace49f53ec79))
 - copy unpublished carbon theme switcher addon
-  ([#99](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/issues/99))
-  ([daeeb79](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/commit/daeeb79f979d77177f4874c82bddb004d91617fa))
+  ([#99](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/issues/99))
+  ([daeeb79](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/commit/daeeb79f979d77177f4874c82bddb004d91617fa))
 - First pass at docs page for PageHeader component
-  ([#110](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/issues/110))
-  ([23370f2](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/commit/23370f2899261d87bd865d33b7e446a0b9e5a43d))
+  ([#110](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/issues/110))
+  ([23370f2](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/commit/23370f2899261d87bd865d33b7e446a0b9e5a43d))
 - improve PageHeader stories
-  ([#103](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/issues/103))
-  ([8584cc9](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/commit/8584cc901c0ac855bb23d8b0e4eec76d0122c3ab))
+  ([#103](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/issues/103))
+  ([8584cc9](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/commit/8584cc901c0ac855bb23d8b0e4eec76d0122c3ab))
 - modified tabs first pass
-  ([#79](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/issues/79))
-  ([c38ebcd](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/commit/c38ebcd5d654492b4963d707078b7793b93064f1))
+  ([#79](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/issues/79))
+  ([c38ebcd](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/commit/c38ebcd5d654492b4963d707078b7793b93064f1))
 - update modified tabs and carbon version
-  ([#88](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/issues/88))
-  ([4c7ffd5](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/commit/4c7ffd54c36f7cade014e33b1c883f4e68708c17))
+  ([#88](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/issues/88))
+  ([4c7ffd5](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/commit/4c7ffd54c36f7cade014e33b1c883f4e68708c17))
 - **storybook:** upgrade Storybook
-  ([#77](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/issues/77))
-  ([b1a3ad0](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core/commit/b1a3ad02816de050fbc85d7fa4ef60c58204a9d9))
+  ([#77](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/issues/77))
+  ([b1a3ad0](https://github.com/carbon-design-system/ibm-products/tree/master/packages/core/commit/b1a3ad02816de050fbc85d7fa4ef60c58204a9d9))

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
     "directory": "packages/core"
   },
-  "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
+  "bugs": "https://github.com/carbon-design-system/ibm-products/issues",
   "keywords": [
     "carbon",
     "carbon design system",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,7 @@
   "main": "scripts/build.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "url": "https://github.com/carbon-design-system/ibm-products.git",
     "directory": "packages/core"
   },
   "bugs": "https://github.com/carbon-design-system/ibm-products/issues",

--- a/packages/security/CHANGELOG.md
+++ b/packages/security/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [2.13.17](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.13.16...@carbon/ibm-security@2.13.17) (2023-04-11)
+## [2.13.17](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.13.16...@carbon/ibm-security@2.13.17) (2023-04-11)
 
 **Note:** Version bump only for package @carbon/ibm-security
 
@@ -11,18 +11,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [2.13.16](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.13.15...@carbon/ibm-security@2.13.16) (2023-03-28)
+## [2.13.16](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.13.15...@carbon/ibm-security@2.13.16) (2023-03-28)
 
 
 ### Bug Fixes
 
-* update to Carbon v10 compatible versions to latest ([#2739](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2739)) ([7065855](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/70658550120822ab0a6dd296bc9022cc7d0856db))
+* update to Carbon v10 compatible versions to latest ([#2739](https://github.com/carbon-design-system/ibm-products/issues/2739)) ([7065855](https://github.com/carbon-design-system/ibm-products/commit/70658550120822ab0a6dd296bc9022cc7d0856db))
 
 
 
 
 
-## [2.13.15](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.13.14...@carbon/ibm-security@2.13.15) (2023-03-07)
+## [2.13.15](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.13.14...@carbon/ibm-security@2.13.15) (2023-03-07)
 
 **Note:** Version bump only for package @carbon/ibm-security
 
@@ -30,7 +30,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [2.13.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.13.13...@carbon/ibm-security@2.13.14) (2023-02-07)
+## [2.13.14](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.13.13...@carbon/ibm-security@2.13.14) (2023-02-07)
 
 **Note:** Version bump only for package @carbon/ibm-security
 
@@ -43,7 +43,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [2.13.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.13.12...@carbon/ibm-security@2.13.13) (2023-01-10)
+## [2.13.13](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.13.12...@carbon/ibm-security@2.13.13) (2023-01-10)
 
 **Note:** Version bump only for package @carbon/ibm-security
 
@@ -52,20 +52,20 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [2.13.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.13.11...@carbon/ibm-security@2.13.12) (2022-11-22)
+## [2.13.12](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.13.11...@carbon/ibm-security@2.13.12) (2022-11-22)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#2462](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2462))
-  ([4353991](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/43539912353a965549f0f2e5f8245168d2ce1c98))
+  ([#2462](https://github.com/carbon-design-system/ibm-products/issues/2462))
+  ([4353991](https://github.com/carbon-design-system/ibm-products/commit/43539912353a965549f0f2e5f8245168d2ce1c98))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [2.13.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.13.10...@carbon/ibm-security@2.13.11) (2022-11-08)
+## [2.13.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.13.10...@carbon/ibm-security@2.13.11) (2022-11-08)
 
 **Note:** Version bump only for package @carbon/ibm-security
 
@@ -74,7 +74,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [2.13.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.13.9...@carbon/ibm-security@2.13.10) (2022-11-01)
+## [2.13.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.13.9...@carbon/ibm-security@2.13.10) (2022-11-01)
 
 **Note:** Version bump only for package @carbon/ibm-security
 
@@ -83,7 +83,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [2.13.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.13.8...@carbon/ibm-security@2.13.9) (2022-10-25)
+## [2.13.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.13.8...@carbon/ibm-security@2.13.9) (2022-10-25)
 
 **Note:** Version bump only for package @carbon/ibm-security
 
@@ -92,775 +92,775 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [2.13.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.13.7...@carbon/ibm-security@2.13.8) (2022-10-18)
+## [2.13.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.13.7...@carbon/ibm-security@2.13.8) (2022-10-18)
 
 ### Bug Fixes
 
 - update Carbon v10 compatible versions to latest
-  ([#2362](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2362))
-  ([e328904](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e328904b20bdc0c652661de829c0d1bfcb8738b6))
+  ([#2362](https://github.com/carbon-design-system/ibm-products/issues/2362))
+  ([e328904](https://github.com/carbon-design-system/ibm-products/commit/e328904b20bdc0c652661de829c0d1bfcb8738b6))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [2.13.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.13.6...@carbon/ibm-security@2.13.7) (2022-10-11)
+## [2.13.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.13.6...@carbon/ibm-security@2.13.7) (2022-10-11)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#2331](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2331))
-  ([26f7bc1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/26f7bc1b05ded4d79634a06dea725746e6e381e7))
+  ([#2331](https://github.com/carbon-design-system/ibm-products/issues/2331))
+  ([26f7bc1](https://github.com/carbon-design-system/ibm-products/commit/26f7bc1b05ded4d79634a06dea725746e6e381e7))
 
-## [2.13.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.13.5...@carbon/ibm-security@2.13.6) (2022-10-04)
+## [2.13.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.13.5...@carbon/ibm-security@2.13.6) (2022-10-04)
 
 ### Bug Fixes
 
 - **NavList:** use type.displayName
-  ([#2334](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2334))
-  ([6364c8b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6364c8b2c74e2521f48f924e0e92feb4f5c50b3e))
+  ([#2334](https://github.com/carbon-design-system/ibm-products/issues/2334))
+  ([6364c8b](https://github.com/carbon-design-system/ibm-products/commit/6364c8b2c74e2521f48f924e0e92feb4f5c50b3e))
 
-## [2.13.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.13.4...@carbon/ibm-security@2.13.5) (2022-09-27)
-
-### Bug Fixes
-
-- update to Carbon v10 compatible versions to latest
-  ([#2276](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2276))
-  ([c35a363](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c35a3630ecb0dd60d920e57d81bd8f6e84aae008))
-
-## [2.13.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.13.3...@carbon/ibm-security@2.13.4) (2022-09-06)
+## [2.13.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.13.4...@carbon/ibm-security@2.13.5) (2022-09-27)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#2249](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2249))
-  ([2a2ccfa](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2a2ccfaef41d5247724aed978fb62567932ea6dc))
+  ([#2276](https://github.com/carbon-design-system/ibm-products/issues/2276))
+  ([c35a363](https://github.com/carbon-design-system/ibm-products/commit/c35a3630ecb0dd60d920e57d81bd8f6e84aae008))
 
-## [2.13.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.13.2...@carbon/ibm-security@2.13.3) (2022-08-30)
-
-**Note:** Version bump only for package @carbon/ibm-security
-
-## [2.13.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.13.1...@carbon/ibm-security@2.13.2) (2022-08-23)
-
-**Note:** Version bump only for package @carbon/ibm-security
-
-## [2.13.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.13.0...@carbon/ibm-security@2.13.1) (2022-08-16)
-
-**Note:** Version bump only for package @carbon/ibm-security
-
-# [2.13.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.12.1...@carbon/ibm-security@2.13.0) (2022-08-02)
+## [2.13.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.13.3...@carbon/ibm-security@2.13.4) (2022-09-06)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#2144](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2144))
-  ([c67ce20](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c67ce20cf586218f28d2ad7bba4de6fd4d21efae))
+  ([#2249](https://github.com/carbon-design-system/ibm-products/issues/2249))
+  ([2a2ccfa](https://github.com/carbon-design-system/ibm-products/commit/2a2ccfaef41d5247724aed978fb62567932ea6dc))
+
+## [2.13.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.13.2...@carbon/ibm-security@2.13.3) (2022-08-30)
+
+**Note:** Version bump only for package @carbon/ibm-security
+
+## [2.13.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.13.1...@carbon/ibm-security@2.13.2) (2022-08-23)
+
+**Note:** Version bump only for package @carbon/ibm-security
+
+## [2.13.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.13.0...@carbon/ibm-security@2.13.1) (2022-08-16)
+
+**Note:** Version bump only for package @carbon/ibm-security
+
+# [2.13.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.12.1...@carbon/ibm-security@2.13.0) (2022-08-02)
+
+### Bug Fixes
+
+- update to Carbon v10 compatible versions to latest
+  ([#2144](https://github.com/carbon-design-system/ibm-products/issues/2144))
+  ([c67ce20](https://github.com/carbon-design-system/ibm-products/commit/c67ce20cf586218f28d2ad7bba4de6fd4d21efae))
 
 ### Features
 
 - Create Getting Started layout
-  ([#1516](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1516))
-  ([455f762](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/455f76223d6b43b3ee55c344108dbcd79133b8b8))
+  ([#1516](https://github.com/carbon-design-system/ibm-products/issues/1516))
+  ([455f762](https://github.com/carbon-design-system/ibm-products/commit/455f76223d6b43b3ee55c344108dbcd79133b8b8))
 
-## [2.12.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.12.0...@carbon/ibm-security@2.12.1) (2022-07-27)
+## [2.12.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.12.0...@carbon/ibm-security@2.12.1) (2022-07-27)
 
 **Note:** Version bump only for package @carbon/ibm-security
 
-# [2.12.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.11.13...@carbon/ibm-security@2.12.0) (2022-07-19)
+# [2.12.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.11.13...@carbon/ibm-security@2.12.0) (2022-07-19)
 
 ### Bug Fixes
 
 - update to Carbon v10 compatible versions to latest
-  ([#2101](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2101))
-  ([feebce3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/feebce38ac474917e29d201d9198e3baf9452a97))
+  ([#2101](https://github.com/carbon-design-system/ibm-products/issues/2101))
+  ([feebce3](https://github.com/carbon-design-system/ibm-products/commit/feebce38ac474917e29d201d9198e3baf9452a97))
 
 ### Features
 
 - add dense, short, and stacked options to DescriptionList Module
-  ([#2095](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2095))
-  ([9b34ab3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9b34ab3c548da8458be0c8a03d032fc3bd8c6b64))
+  ([#2095](https://github.com/carbon-design-system/ibm-products/issues/2095))
+  ([9b34ab3](https://github.com/carbon-design-system/ibm-products/commit/9b34ab3c548da8458be0c8a03d032fc3bd8c6b64))
 - index carbon security components
-  ([#2057](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2057))
-  ([16deb8c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/16deb8c6e6d05d913c94d6343574332676b1667d))
+  ([#2057](https://github.com/carbon-design-system/ibm-products/issues/2057))
+  ([16deb8c](https://github.com/carbon-design-system/ibm-products/commit/16deb8c6e6d05d913c94d6343574332676b1667d))
 
-## [2.11.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.11.12...@carbon/ibm-security@2.11.13) (2022-07-12)
-
-**Note:** Version bump only for package @carbon/ibm-security
-
-## [2.11.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.11.11...@carbon/ibm-security@2.11.12) (2022-05-31)
+## [2.11.13](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.11.12...@carbon/ibm-security@2.11.13) (2022-07-12)
 
 **Note:** Version bump only for package @carbon/ibm-security
 
-## [2.11.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.11.10...@carbon/ibm-security@2.11.11) (2022-05-17)
+## [2.11.12](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.11.11...@carbon/ibm-security@2.11.12) (2022-05-31)
+
+**Note:** Version bump only for package @carbon/ibm-security
+
+## [2.11.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.11.10...@carbon/ibm-security@2.11.11) (2022-05-17)
 
 ### Bug Fixes
 
 - a11y issue profile-button
-  ([#1978](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1978))
-  ([#1979](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1979))
-  ([7ec5bb4](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7ec5bb4d5aa263aad7dde45f4cd9865d3388f84b))
+  ([#1978](https://github.com/carbon-design-system/ibm-products/issues/1978))
+  ([#1979](https://github.com/carbon-design-system/ibm-products/issues/1979))
+  ([7ec5bb4](https://github.com/carbon-design-system/ibm-products/commit/7ec5bb4d5aa263aad7dde45f4cd9865d3388f84b))
 
-## [2.11.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.11.9...@carbon/ibm-security@2.11.10) (2022-05-10)
+## [2.11.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.11.9...@carbon/ibm-security@2.11.10) (2022-05-10)
 
 ### Bug Fixes
 
 - Feature/roll back legacy tags
-  ([#1963](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1963))
-  ([33a53db](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/33a53dbafdbd80169eeefdc9f00dd700f8ccfd89))
+  ([#1963](https://github.com/carbon-design-system/ibm-products/issues/1963))
+  ([33a53db](https://github.com/carbon-design-system/ibm-products/commit/33a53dbafdbd80169eeefdc9f00dd700f8ccfd89))
 - update to Carbon v10 compatible versions to latest
-  ([#1971](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1971))
-  ([95374b8](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/95374b89a15b1a76d18fb29c40e161a54720c447)),
+  ([#1971](https://github.com/carbon-design-system/ibm-products/issues/1971))
+  ([95374b8](https://github.com/carbon-design-system/ibm-products/commit/95374b89a15b1a76d18fb29c40e161a54720c447)),
   closes
-  [#1970](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1970)
-  [#1972](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1972)
+  [#1970](https://github.com/carbon-design-system/ibm-products/issues/1970)
+  [#1972](https://github.com/carbon-design-system/ibm-products/issues/1972)
 
-## [2.11.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.11.8...@carbon/ibm-security@2.11.9) (2022-05-03)
-
-**Note:** Version bump only for package @carbon/ibm-security
-
-## [2.11.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.11.7...@carbon/ibm-security@2.11.8) (2022-04-26)
+## [2.11.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.11.8...@carbon/ibm-security@2.11.9) (2022-05-03)
 
 **Note:** Version bump only for package @carbon/ibm-security
 
-## [2.11.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.11.6...@carbon/ibm-security@2.11.7) (2022-04-19)
+## [2.11.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.11.7...@carbon/ibm-security@2.11.8) (2022-04-26)
 
 **Note:** Version bump only for package @carbon/ibm-security
 
-## [2.11.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.11.5...@carbon/ibm-security@2.11.6) (2022-04-05)
+## [2.11.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.11.6...@carbon/ibm-security@2.11.7) (2022-04-19)
+
+**Note:** Version bump only for package @carbon/ibm-security
+
+## [2.11.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.11.5...@carbon/ibm-security@2.11.6) (2022-04-05)
 
 ### Bug Fixes
 
 - update Carbon versions to latest
-  ([#1862](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1862))
-  ([c0e8024](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/c0e8024cf060cec0262c79628077810a92a56619))
+  ([#1862](https://github.com/carbon-design-system/ibm-products/issues/1862))
+  ([c0e8024](https://github.com/carbon-design-system/ibm-products/commit/c0e8024cf060cec0262c79628077810a92a56619))
 
-## [2.11.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.11.4...@carbon/ibm-security@2.11.5) (2022-03-29)
-
-### Bug Fixes
-
-- update Carbon versions to latest
-  ([#1835](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1835))
-  ([b9152d1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b9152d15813b7feab937092bbbf46439305aab50))
-
-## [2.11.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.11.3...@carbon/ibm-security@2.11.4) (2022-03-22)
+## [2.11.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.11.4...@carbon/ibm-security@2.11.5) (2022-03-29)
 
 ### Bug Fixes
 
 - update Carbon versions to latest
-  ([#1793](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1793))
-  ([9943926](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9943926b5234ce0690417d16483da4caa84790cf)),
+  ([#1835](https://github.com/carbon-design-system/ibm-products/issues/1835))
+  ([b9152d1](https://github.com/carbon-design-system/ibm-products/commit/b9152d15813b7feab937092bbbf46439305aab50))
+
+## [2.11.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.11.3...@carbon/ibm-security@2.11.4) (2022-03-22)
+
+### Bug Fixes
+
+- update Carbon versions to latest
+  ([#1793](https://github.com/carbon-design-system/ibm-products/issues/1793))
+  ([9943926](https://github.com/carbon-design-system/ibm-products/commit/9943926b5234ce0690417d16483da4caa84790cf)),
   closes
-  [#1738](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1738)
-  [#1791](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1791)
-  [#1738](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1738)
-  [#1790](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1790)
+  [#1738](https://github.com/carbon-design-system/ibm-products/issues/1738)
+  [#1791](https://github.com/carbon-design-system/ibm-products/issues/1791)
+  [#1738](https://github.com/carbon-design-system/ibm-products/issues/1738)
+  [#1790](https://github.com/carbon-design-system/ibm-products/issues/1790)
 
-## [2.11.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.11.2...@carbon/ibm-security@2.11.3) (2022-03-08)
+## [2.11.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.11.2...@carbon/ibm-security@2.11.3) (2022-03-08)
 
 ### Bug Fixes
 
 - update Carbon versions to latest
-  ([#1733](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1733))
-  ([9783faa](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/9783faac23d8f03598ef0e5994743c4c5f915705))
+  ([#1733](https://github.com/carbon-design-system/ibm-products/issues/1733))
+  ([9783faa](https://github.com/carbon-design-system/ibm-products/commit/9783faac23d8f03598ef0e5994743c4c5f915705))
 
-## [2.11.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.11.1...@carbon/ibm-security@2.11.2) (2022-03-01)
-
-**Note:** Version bump only for package @carbon/ibm-security
-
-## [2.11.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.11.0...@carbon/ibm-security@2.11.1) (2022-02-22)
+## [2.11.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.11.1...@carbon/ibm-security@2.11.2) (2022-03-01)
 
 **Note:** Version bump only for package @carbon/ibm-security
 
-# [2.11.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.10.10...@carbon/ibm-security@2.11.0) (2022-02-16)
+## [2.11.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.11.0...@carbon/ibm-security@2.11.1) (2022-02-22)
+
+**Note:** Version bump only for package @carbon/ibm-security
+
+# [2.11.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.10.10...@carbon/ibm-security@2.11.0) (2022-02-16)
 
 ### Features
 
 - update Carbon versions to latest
-  ([#1646](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1646))
-  ([e323739](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/e323739ac9a6155aa0fddf39b13e4440d04117fc))
+  ([#1646](https://github.com/carbon-design-system/ibm-products/issues/1646))
+  ([e323739](https://github.com/carbon-design-system/ibm-products/commit/e323739ac9a6155aa0fddf39b13e4440d04117fc))
 
-## [2.10.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.10.9...@carbon/ibm-security@2.10.10) (2022-02-15)
+## [2.10.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.10.9...@carbon/ibm-security@2.10.10) (2022-02-15)
 
 **Note:** Version bump only for package @carbon/ibm-security
 
-## [2.10.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.10.8...@carbon/ibm-security@2.10.9) (2022-02-09)
+## [2.10.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.10.8...@carbon/ibm-security@2.10.9) (2022-02-09)
 
 ### Bug Fixes
 
 - update Carbon versions to latest
-  ([#1587](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1587))
-  ([d4b5ccc](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/d4b5cccd9ef4a9df2966063c21f49fe7810245a8))
+  ([#1587](https://github.com/carbon-design-system/ibm-products/issues/1587))
+  ([d4b5ccc](https://github.com/carbon-design-system/ibm-products/commit/d4b5cccd9ef4a9df2966063c21f49fe7810245a8))
 - update stylelint to latest version
-  ([#1597](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1597))
-  ([13d8f9e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/13d8f9eb2885e687ba23f66b019a5629fffa2a85))
+  ([#1597](https://github.com/carbon-design-system/ibm-products/issues/1597))
+  ([13d8f9e](https://github.com/carbon-design-system/ibm-products/commit/13d8f9eb2885e687ba23f66b019a5629fffa2a85))
 
-## [2.10.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.10.7...@carbon/ibm-security@2.10.8) (2022-02-01)
+## [2.10.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.10.7...@carbon/ibm-security@2.10.8) (2022-02-01)
 
 **Note:** Version bump only for package @carbon/ibm-security
 
-## [2.10.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.10.6...@carbon/ibm-security@2.10.7) (2022-01-25)
+## [2.10.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.10.6...@carbon/ibm-security@2.10.7) (2022-01-25)
 
 ### Bug Fixes
 
 - update Carbon versions to latest
-  ([#1548](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1548))
-  ([5617870](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/561787014feac09c1a8e70895c51abb3bf46245e))
+  ([#1548](https://github.com/carbon-design-system/ibm-products/issues/1548))
+  ([5617870](https://github.com/carbon-design-system/ibm-products/commit/561787014feac09c1a8e70895c51abb3bf46245e))
 
-## [2.10.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.10.5...@carbon/ibm-security@2.10.6) (2022-01-11)
-
-### Bug Fixes
-
-- update Carbon versions and package dependencies to latest
-  ([#1513](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1513))
-  ([505ba0e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/505ba0e13ec58bef19422835fd8ffee87c24e82a))
-- update Carbon versions and package dependencies to latest
-  ([#1518](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1518))
-  ([3ddcdf6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3ddcdf6617e0d7c9f182da91e3eb0935b34cbc05))
-
-## [2.10.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.10.4...@carbon/ibm-security@2.10.5) (2022-01-04)
+## [2.10.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.10.5...@carbon/ibm-security@2.10.6) (2022-01-11)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1509](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1509))
-  ([613db81](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/613db817bffec2c5b26b1fe50a337dd7bac5d963))
+  ([#1513](https://github.com/carbon-design-system/ibm-products/issues/1513))
+  ([505ba0e](https://github.com/carbon-design-system/ibm-products/commit/505ba0e13ec58bef19422835fd8ffee87c24e82a))
+- update Carbon versions and package dependencies to latest
+  ([#1518](https://github.com/carbon-design-system/ibm-products/issues/1518))
+  ([3ddcdf6](https://github.com/carbon-design-system/ibm-products/commit/3ddcdf6617e0d7c9f182da91e3eb0935b34cbc05))
 
-## [2.10.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.10.3...@carbon/ibm-security@2.10.4) (2021-12-21)
+## [2.10.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.10.4...@carbon/ibm-security@2.10.5) (2022-01-04)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1499](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1499))
-  ([8aed3d5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8aed3d53d06cc896984e6847c0450cc647e34041))
+  ([#1509](https://github.com/carbon-design-system/ibm-products/issues/1509))
+  ([613db81](https://github.com/carbon-design-system/ibm-products/commit/613db817bffec2c5b26b1fe50a337dd7bac5d963))
 
-## [2.10.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.10.2...@carbon/ibm-security@2.10.3) (2021-12-14)
-
-### Bug Fixes
-
-- update Carbon versions and package dependencies to latest
-  ([#1493](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1493))
-  ([91b8238](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/91b82383e0aa74383ebb81f625a9e7b870f06c00))
-
-## [2.10.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.10.1...@carbon/ibm-security@2.10.2) (2021-12-07)
+## [2.10.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.10.3...@carbon/ibm-security@2.10.4) (2021-12-21)
 
 ### Bug Fixes
 
 - update Carbon versions and package dependencies to latest
-  ([#1491](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1491))
-  ([45f7b77](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/45f7b77f797c5841b9dc15bc3013f31e50244d29))
+  ([#1499](https://github.com/carbon-design-system/ibm-products/issues/1499))
+  ([8aed3d5](https://github.com/carbon-design-system/ibm-products/commit/8aed3d53d06cc896984e6847c0450cc647e34041))
 
-## [2.10.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.10.0...@carbon/ibm-security@2.10.1) (2021-11-30)
+## [2.10.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.10.2...@carbon/ibm-security@2.10.3) (2021-12-14)
+
+### Bug Fixes
+
+- update Carbon versions and package dependencies to latest
+  ([#1493](https://github.com/carbon-design-system/ibm-products/issues/1493))
+  ([91b8238](https://github.com/carbon-design-system/ibm-products/commit/91b82383e0aa74383ebb81f625a9e7b870f06c00))
+
+## [2.10.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.10.1...@carbon/ibm-security@2.10.2) (2021-12-07)
+
+### Bug Fixes
+
+- update Carbon versions and package dependencies to latest
+  ([#1491](https://github.com/carbon-design-system/ibm-products/issues/1491))
+  ([45f7b77](https://github.com/carbon-design-system/ibm-products/commit/45f7b77f797c5841b9dc15bc3013f31e50244d29))
+
+## [2.10.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.10.0...@carbon/ibm-security@2.10.1) (2021-11-30)
 
 **Note:** Version bump only for package @carbon/ibm-security
 
-# [2.10.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.9.0...@carbon/ibm-security@2.10.0) (2021-11-23)
+# [2.10.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.9.0...@carbon/ibm-security@2.10.0) (2021-11-23)
 
 ### Features
 
 - update Carbon versions and dependencies to latest
-  ([#1465](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1465))
-  ([0c6b37f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/0c6b37f5b713c54ec320d9da945fbd3f6b3f91d9))
+  ([#1465](https://github.com/carbon-design-system/ibm-products/issues/1465))
+  ([0c6b37f](https://github.com/carbon-design-system/ibm-products/commit/0c6b37f5b713c54ec320d9da945fbd3f6b3f91d9))
 
-# [2.9.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.8.1...@carbon/ibm-security@2.9.0) (2021-11-16)
+# [2.9.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.8.1...@carbon/ibm-security@2.9.0) (2021-11-16)
 
 ### Bug Fixes
 
 - **storybook:** remove require statements from roots config
-  ([#1431](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1431))
-  ([7493d59](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/7493d59fb8bbe03dfe41a0031745e3ac186b688b))
+  ([#1431](https://github.com/carbon-design-system/ibm-products/issues/1431))
+  ([7493d59](https://github.com/carbon-design-system/ibm-products/commit/7493d59fb8bbe03dfe41a0031745e3ac186b688b))
 
 ### Features
 
 - **security:** upgrade `carbon-components`, fix public API snapshot
-  ([#1389](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1389))
-  ([def48b1](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/def48b1768e187c19403660f1ec2b3af961e75bf))
+  ([#1389](https://github.com/carbon-design-system/ibm-products/issues/1389))
+  ([def48b1](https://github.com/carbon-design-system/ibm-products/commit/def48b1768e187c19403660f1ec2b3af961e75bf))
 - update Carbon versions and package dependencies to latest
-  ([#1425](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1425))
-  ([4fd5883](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4fd5883961e0f3fc6be1c87bbe084b2cf6dc5db0)),
+  ([#1425](https://github.com/carbon-design-system/ibm-products/issues/1425))
+  ([4fd5883](https://github.com/carbon-design-system/ibm-products/commit/4fd5883961e0f3fc6be1c87bbe084b2cf6dc5db0)),
   closes
-  [#10000](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/10000)
+  [#10000](https://github.com/carbon-design-system/ibm-products/issues/10000)
 
-## [2.8.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.8.0...@carbon/ibm-security@2.8.1) (2021-11-10)
+## [2.8.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.8.0...@carbon/ibm-security@2.8.1) (2021-11-10)
 
 ### Bug Fixes
 
 - replace es imports with lib for the cjs build
-  ([#1402](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1402))
-  ([f2a7013](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f2a701340a9bad876081ebd5986bb0154118ebe5))
+  ([#1402](https://github.com/carbon-design-system/ibm-products/issues/1402))
+  ([f2a7013](https://github.com/carbon-design-system/ibm-products/commit/f2a701340a9bad876081ebd5986bb0154118ebe5))
 
-# [2.8.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-security@2.7.0...@carbon/ibm-security@2.8.0) (2021-11-09)
+# [2.8.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-security@2.7.0...@carbon/ibm-security@2.8.0) (2021-11-09)
 
 ### Bug Fixes
 
 - **security:** reinstate minified CSS
-  ([#1390](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1390))
-  ([6cce621](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/6cce621519af8be87411db0cf482e2ed83896afb))
+  ([#1390](https://github.com/carbon-design-system/ibm-products/issues/1390))
+  ([6cce621](https://github.com/carbon-design-system/ibm-products/commit/6cce621519af8be87411db0cf482e2ed83896afb))
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1365](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1365))
-  ([ea11cf7](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ea11cf7ae44b61b48142c511c16460cf7978b88c))
+  ([#1365](https://github.com/carbon-design-system/ibm-products/issues/1365))
+  ([ea11cf7](https://github.com/carbon-design-system/ibm-products/commit/ea11cf7ae44b61b48142c511c16460cf7978b88c))
 
 # 2.7.0 (2021-11-05)
 
 ### Bug Fixes
 
 - **combo-button:** add truncation
-  ([#308](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/308))
-  ([35b3517](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/35b351776107d23f6dafd30b9d4a24d626a9d9ec))
+  ([#308](https://github.com/carbon-design-system/ibm-products/issues/308))
+  ([35b3517](https://github.com/carbon-design-system/ibm-products/commit/35b351776107d23f6dafd30b9d4a24d626a9d9ec))
 - **security:** add sideEffects for tree shaking
-  ([#1253](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1253))
-  ([12f9eef](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/12f9eefbdc238314dd13d6d06cc625a7658913c2))
+  ([#1253](https://github.com/carbon-design-system/ibm-products/issues/1253))
+  ([12f9eef](https://github.com/carbon-design-system/ibm-products/commit/12f9eefbdc238314dd13d6d06cc625a7658913c2))
 - **security:** remove circular dependency for `@carbon/ibm-security`
   consumption
-  ([#300](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/300))
-  ([a91d705](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a91d705cb499b9a7a8462853fde9d4eb6b6021d9))
+  ([#300](https://github.com/carbon-design-system/ibm-products/issues/300))
+  ([a91d705](https://github.com/carbon-design-system/ibm-products/commit/a91d705cb499b9a7a8462853fde9d4eb6b6021d9))
 
 ### Features
 
 - add cdai apikey component
-  ([#223](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/223))
-  ([4c09f15](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4c09f15c3c62c3965d98c91b9695fa7a1cba8f0b))
+  ([#223](https://github.com/carbon-design-system/ibm-products/issues/223))
+  ([4c09f15](https://github.com/carbon-design-system/ibm-products/commit/4c09f15c3c62c3965d98c91b9695fa7a1cba8f0b))
 - **combo-button:** add `ComboButton` logic, story, and styles
-  ([#233](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/233))
-  ([85e2b62](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/85e2b62de80166cda84fa8cc9af311e664d241af))
+  ([#233](https://github.com/carbon-design-system/ibm-products/issues/233))
+  ([85e2b62](https://github.com/carbon-design-system/ibm-products/commit/85e2b62de80166cda84fa8cc9af311e664d241af))
 - **combo-button:** add `renderIcon` support
-  ([#299](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/299))
-  ([794deaf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/794deafaf8d091f8c2761e835e693bcaaacf32c7))
+  ([#299](https://github.com/carbon-design-system/ibm-products/issues/299))
+  ([794deaf](https://github.com/carbon-design-system/ibm-products/commit/794deafaf8d091f8c2761e835e693bcaaacf32c7))
 - **decorator:** export component, add story
-  ([#43](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/43))
-  ([15304ca](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/15304ca5d4bbc0b5a70ab2d3b9a46e6590beaf56))
+  ([#43](https://github.com/carbon-design-system/ibm-products/issues/43))
+  ([15304ca](https://github.com/carbon-design-system/ibm-products/commit/15304ca5d4bbc0b5a70ab2d3b9a46e6590beaf56))
 - ensure prettier linting causes ci-check to fail
-  ([#1273](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1273))
-  ([ad6f347](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ad6f3479636d2b80b26338d9059429b4ae08ac6e))
+  ([#1273](https://github.com/carbon-design-system/ibm-products/issues/1273))
+  ([ad6f347](https://github.com/carbon-design-system/ibm-products/commit/ad6f3479636d2b80b26338d9059429b4ae08ac6e))
 - migrate Security package
-  ([#918](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/918))
-  ([08573c5](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/08573c512adc60c40071699ff040d4a14bfedf36))
+  ([#918](https://github.com/carbon-design-system/ibm-products/issues/918))
+  ([08573c5](https://github.com/carbon-design-system/ibm-products/commit/08573c512adc60c40071699ff040d4a14bfedf36))
 - **storybook:** upgrade Storybook
-  ([#77](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/77))
-  ([b1a3ad0](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b1a3ad02816de050fbc85d7fa4ef60c58204a9d9))
+  ([#77](https://github.com/carbon-design-system/ibm-products/issues/77))
+  ([b1a3ad0](https://github.com/carbon-design-system/ibm-products/commit/b1a3ad02816de050fbc85d7fa4ef60c58204a9d9))
 - update Carbon versions and dependencies
-  ([#1037](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1037))
-  ([8c5937a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8c5937a865d3a0cfbaf33b9eca13c4d3b4c1365d))
+  ([#1037](https://github.com/carbon-design-system/ibm-products/issues/1037))
+  ([8c5937a](https://github.com/carbon-design-system/ibm-products/commit/8c5937a865d3a0cfbaf33b9eca13c4d3b4c1365d))
 - update Carbon versions and dependencies
-  ([#1084](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1084))
-  ([3735ead](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3735ead9a96450015ec7aeafdb25deaa93d49aaa))
+  ([#1084](https://github.com/carbon-design-system/ibm-products/issues/1084))
+  ([3735ead](https://github.com/carbon-design-system/ibm-products/commit/3735ead9a96450015ec7aeafdb25deaa93d49aaa))
 - update Carbon versions and dependencies
-  ([#1110](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1110))
-  ([b41f433](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b41f4331e31cbd9e41d2364b24e6ef50c7fd2d8d))
+  ([#1110](https://github.com/carbon-design-system/ibm-products/issues/1110))
+  ([b41f433](https://github.com/carbon-design-system/ibm-products/commit/b41f4331e31cbd9e41d2364b24e6ef50c7fd2d8d))
 - update Carbon versions and dependencies
-  ([#1168](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1168))
-  ([674017f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/674017fabc13a7737c0d16deb04ffa9872d76fe6))
+  ([#1168](https://github.com/carbon-design-system/ibm-products/issues/1168))
+  ([674017f](https://github.com/carbon-design-system/ibm-products/commit/674017fabc13a7737c0d16deb04ffa9872d76fe6))
 - update Carbon versions and dependencies
-  ([#927](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/927))
-  ([5a8f7d6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5a8f7d6b81b6da26fd0cb933c1c3de4bd27b481b))
+  ([#927](https://github.com/carbon-design-system/ibm-products/issues/927))
+  ([5a8f7d6](https://github.com/carbon-design-system/ibm-products/commit/5a8f7d6b81b6da26fd0cb933c1c3de4bd27b481b))
 - update Carbon versions and dependencies
-  ([#974](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/974))
-  ([555509b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/555509b5ccb147ed0d794b5816f685aa8f7ae451))
+  ([#974](https://github.com/carbon-design-system/ibm-products/issues/974))
+  ([555509b](https://github.com/carbon-design-system/ibm-products/commit/555509b5ccb147ed0d794b5816f685aa8f7ae451))
 - update Carbon versions and dependencies to latest
-  ([#1282](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1282))
-  ([b1451cf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b1451cf5c91b75c1bd4e55ae2bdb47f025f33163))
+  ([#1282](https://github.com/carbon-design-system/ibm-products/issues/1282))
+  ([b1451cf](https://github.com/carbon-design-system/ibm-products/commit/b1451cf5c91b75c1bd4e55ae2bdb47f025f33163))
 - update Carbon versions and package dependencies
-  ([#994](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/994))
-  ([2ab4845](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2ab4845511573b999d41fcf77e6d412e0d446b9d))
+  ([#994](https://github.com/carbon-design-system/ibm-products/issues/994))
+  ([2ab4845](https://github.com/carbon-design-system/ibm-products/commit/2ab4845511573b999d41fcf77e6d412e0d446b9d))
 - update Carbon versions and package dependencies to latest
-  ([#1133](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1133))
-  ([4dfae1a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4dfae1a9b27f5676d0bde570e2c9ee9ce8550b52))
+  ([#1133](https://github.com/carbon-design-system/ibm-products/issues/1133))
+  ([4dfae1a](https://github.com/carbon-design-system/ibm-products/commit/4dfae1a9b27f5676d0bde570e2c9ee9ce8550b52))
 - update Carbon versions and package dependencies to latest
-  ([#1228](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1228))
-  ([4f5e24c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4f5e24cd3a36e7fa9a5cd62d1cafe75a090cf32e))
+  ([#1228](https://github.com/carbon-design-system/ibm-products/issues/1228))
+  ([4f5e24c](https://github.com/carbon-design-system/ibm-products/commit/4f5e24cd3a36e7fa9a5cd62d1cafe75a090cf32e))
 - update Carbon versions and package dependencies to latest
-  ([#1262](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1262))
-  ([ed4dcbe](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ed4dcbe5b6d92baa6ec39240bda6996ec55f7bc4))
+  ([#1262](https://github.com/carbon-design-system/ibm-products/issues/1262))
+  ([ed4dcbe](https://github.com/carbon-design-system/ibm-products/commit/ed4dcbe5b6d92baa6ec39240bda6996ec55f7bc4))
 - update Carbon versions and package dependencies to latest
-  ([#1296](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1296))
-  ([f1da0bd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f1da0bd9192c4d999032df0dbe20d67b6ece89b0))
+  ([#1296](https://github.com/carbon-design-system/ibm-products/issues/1296))
+  ([f1da0bd](https://github.com/carbon-design-system/ibm-products/commit/f1da0bd9192c4d999032df0dbe20d67b6ece89b0))
 - update Carbon versions and package dependencies to latest
-  ([#1309](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1309))
-  ([945bd3b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/945bd3ba5608078e961af9a04448f2abd7e7fc5e))
+  ([#1309](https://github.com/carbon-design-system/ibm-products/issues/1309))
+  ([945bd3b](https://github.com/carbon-design-system/ibm-products/commit/945bd3ba5608078e961af9a04448f2abd7e7fc5e))
 - update Carbon versions and package dependencies to latest
-  ([#1329](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1329))
-  ([fd3525e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fd3525ec3620b70ff19f85c300e7e0bb05577cd1))
+  ([#1329](https://github.com/carbon-design-system/ibm-products/issues/1329))
+  ([fd3525e](https://github.com/carbon-design-system/ibm-products/commit/fd3525ec3620b70ff19f85c300e7e0bb05577cd1))
 - update Carbon versions and package dependencies to latest
-  ([#1345](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1345))
-  ([3c7e6fe](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3c7e6fedfc46bffc38b889568133ee6c300ddb47))
+  ([#1345](https://github.com/carbon-design-system/ibm-products/issues/1345))
+  ([3c7e6fe](https://github.com/carbon-design-system/ibm-products/commit/3c7e6fedfc46bffc38b889568133ee6c300ddb47))
 
-## [0.19.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.19.0...@carbon/ibm-cloud-cognitive-security@0.19.1) (2021-10-27)
+## [0.19.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.19.0...@carbon/ibm-cloud-cognitive-security@0.19.1) (2021-10-27)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-# [0.19.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.18.0...@carbon/ibm-cloud-cognitive-security@0.19.0) (2021-10-20)
+# [0.19.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.18.0...@carbon/ibm-cloud-cognitive-security@0.19.0) (2021-10-20)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1345](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1345))
-  ([3c7e6fe](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3c7e6fedfc46bffc38b889568133ee6c300ddb47))
+  ([#1345](https://github.com/carbon-design-system/ibm-products/issues/1345))
+  ([3c7e6fe](https://github.com/carbon-design-system/ibm-products/commit/3c7e6fedfc46bffc38b889568133ee6c300ddb47))
 
-# [0.18.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.17.0...@carbon/ibm-cloud-cognitive-security@0.18.0) (2021-10-14)
-
-### Features
-
-- update Carbon versions and package dependencies to latest
-  ([#1329](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1329))
-  ([fd3525e](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/fd3525ec3620b70ff19f85c300e7e0bb05577cd1))
-
-# [0.17.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.16.0...@carbon/ibm-cloud-cognitive-security@0.17.0) (2021-10-07)
+# [0.18.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.17.0...@carbon/ibm-cloud-cognitive-security@0.18.0) (2021-10-14)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1309](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1309))
-  ([945bd3b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/945bd3ba5608078e961af9a04448f2abd7e7fc5e))
+  ([#1329](https://github.com/carbon-design-system/ibm-products/issues/1329))
+  ([fd3525e](https://github.com/carbon-design-system/ibm-products/commit/fd3525ec3620b70ff19f85c300e7e0bb05577cd1))
 
-# [0.16.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.15.0...@carbon/ibm-cloud-cognitive-security@0.16.0) (2021-10-02)
+# [0.17.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.16.0...@carbon/ibm-cloud-cognitive-security@0.17.0) (2021-10-07)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1296](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1296))
-  ([f1da0bd](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/f1da0bd9192c4d999032df0dbe20d67b6ece89b0))
+  ([#1309](https://github.com/carbon-design-system/ibm-products/issues/1309))
+  ([945bd3b](https://github.com/carbon-design-system/ibm-products/commit/945bd3ba5608078e961af9a04448f2abd7e7fc5e))
 
-# [0.15.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.14.0...@carbon/ibm-cloud-cognitive-security@0.15.0) (2021-09-23)
+# [0.16.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.15.0...@carbon/ibm-cloud-cognitive-security@0.16.0) (2021-10-02)
+
+### Features
+
+- update Carbon versions and package dependencies to latest
+  ([#1296](https://github.com/carbon-design-system/ibm-products/issues/1296))
+  ([f1da0bd](https://github.com/carbon-design-system/ibm-products/commit/f1da0bd9192c4d999032df0dbe20d67b6ece89b0))
+
+# [0.15.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.14.0...@carbon/ibm-cloud-cognitive-security@0.15.0) (2021-09-23)
 
 ### Features
 
 - update Carbon versions and dependencies to latest
-  ([#1282](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1282))
-  ([b1451cf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b1451cf5c91b75c1bd4e55ae2bdb47f025f33163))
+  ([#1282](https://github.com/carbon-design-system/ibm-products/issues/1282))
+  ([b1451cf](https://github.com/carbon-design-system/ibm-products/commit/b1451cf5c91b75c1bd4e55ae2bdb47f025f33163))
 
-# [0.14.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.13.1...@carbon/ibm-cloud-cognitive-security@0.14.0) (2021-09-21)
+# [0.14.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.13.1...@carbon/ibm-cloud-cognitive-security@0.14.0) (2021-09-21)
 
 ### Features
 
 - ensure prettier linting causes ci-check to fail
-  ([#1273](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1273))
-  ([ad6f347](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ad6f3479636d2b80b26338d9059429b4ae08ac6e))
+  ([#1273](https://github.com/carbon-design-system/ibm-products/issues/1273))
+  ([ad6f347](https://github.com/carbon-design-system/ibm-products/commit/ad6f3479636d2b80b26338d9059429b4ae08ac6e))
 - update Carbon versions and package dependencies to latest
-  ([#1262](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1262))
-  ([ed4dcbe](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/ed4dcbe5b6d92baa6ec39240bda6996ec55f7bc4))
+  ([#1262](https://github.com/carbon-design-system/ibm-products/issues/1262))
+  ([ed4dcbe](https://github.com/carbon-design-system/ibm-products/commit/ed4dcbe5b6d92baa6ec39240bda6996ec55f7bc4))
 
-## [0.13.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.13.0...@carbon/ibm-cloud-cognitive-security@0.13.1) (2021-09-14)
+## [0.13.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.13.0...@carbon/ibm-cloud-cognitive-security@0.13.1) (2021-09-14)
 
 ### Bug Fixes
 
 - **security:** add sideEffects for tree shaking
-  ([#1253](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1253))
-  ([12f9eef](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/12f9eefbdc238314dd13d6d06cc625a7658913c2))
+  ([#1253](https://github.com/carbon-design-system/ibm-products/issues/1253))
+  ([12f9eef](https://github.com/carbon-design-system/ibm-products/commit/12f9eefbdc238314dd13d6d06cc625a7658913c2))
 
-# [0.13.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.12.4...@carbon/ibm-cloud-cognitive-security@0.13.0) (2021-09-13)
-
-### Features
-
-- update Carbon versions and package dependencies to latest
-  ([#1228](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1228))
-  ([4f5e24c](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4f5e24cd3a36e7fa9a5cd62d1cafe75a090cf32e))
-
-## [0.12.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.12.3...@carbon/ibm-cloud-cognitive-security@0.12.4) (2021-09-09)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
-
-## [0.12.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.12.2...@carbon/ibm-cloud-cognitive-security@0.12.3) (2021-08-27)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
-
-## [0.12.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.12.1...@carbon/ibm-cloud-cognitive-security@0.12.2) (2021-08-25)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
-
-## [0.12.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.12.0...@carbon/ibm-cloud-cognitive-security@0.12.1) (2021-08-19)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
-
-# [0.12.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.11.1...@carbon/ibm-cloud-cognitive-security@0.12.0) (2021-08-19)
-
-### Features
-
-- update Carbon versions and dependencies
-  ([#1168](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1168))
-  ([674017f](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/674017fabc13a7737c0d16deb04ffa9872d76fe6))
-
-## [0.11.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.11.0...@carbon/ibm-cloud-cognitive-security@0.11.1) (2021-08-18)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
-
-# [0.11.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.10.0...@carbon/ibm-cloud-cognitive-security@0.11.0) (2021-08-11)
+# [0.13.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.12.4...@carbon/ibm-cloud-cognitive-security@0.13.0) (2021-09-13)
 
 ### Features
 
 - update Carbon versions and package dependencies to latest
-  ([#1133](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1133))
-  ([4dfae1a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/4dfae1a9b27f5676d0bde570e2c9ee9ce8550b52))
+  ([#1228](https://github.com/carbon-design-system/ibm-products/issues/1228))
+  ([4f5e24c](https://github.com/carbon-design-system/ibm-products/commit/4f5e24cd3a36e7fa9a5cd62d1cafe75a090cf32e))
 
-# [0.10.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.9.1...@carbon/ibm-cloud-cognitive-security@0.10.0) (2021-08-10)
-
-### Features
-
-- update Carbon versions and dependencies
-  ([#1110](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1110))
-  ([b41f433](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/b41f4331e31cbd9e41d2364b24e6ef50c7fd2d8d))
-
-## [0.9.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.9.0...@carbon/ibm-cloud-cognitive-security@0.9.1) (2021-08-03)
+## [0.12.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.12.3...@carbon/ibm-cloud-cognitive-security@0.12.4) (2021-09-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-# [0.9.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.8.0...@carbon/ibm-cloud-cognitive-security@0.9.0) (2021-07-28)
-
-### Features
-
-- update Carbon versions and dependencies
-  ([#1084](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1084))
-  ([3735ead](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/3735ead9a96450015ec7aeafdb25deaa93d49aaa))
-
-# [0.8.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.7.1...@carbon/ibm-cloud-cognitive-security@0.8.0) (2021-07-21)
-
-### Features
-
-- update Carbon versions and dependencies
-  ([#1037](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1037))
-  ([8c5937a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/8c5937a865d3a0cfbaf33b9eca13c4d3b4c1365d))
-
-## [0.7.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.7.0...@carbon/ibm-cloud-cognitive-security@0.7.1) (2021-07-16)
+## [0.12.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.12.2...@carbon/ibm-cloud-cognitive-security@0.12.3) (2021-08-27)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-# [0.7.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.6.0...@carbon/ibm-cloud-cognitive-security@0.7.0) (2021-07-14)
+## [0.12.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.12.1...@carbon/ibm-cloud-cognitive-security@0.12.2) (2021-08-25)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
+
+## [0.12.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.12.0...@carbon/ibm-cloud-cognitive-security@0.12.1) (2021-08-19)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
+
+# [0.12.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.11.1...@carbon/ibm-cloud-cognitive-security@0.12.0) (2021-08-19)
+
+### Features
+
+- update Carbon versions and dependencies
+  ([#1168](https://github.com/carbon-design-system/ibm-products/issues/1168))
+  ([674017f](https://github.com/carbon-design-system/ibm-products/commit/674017fabc13a7737c0d16deb04ffa9872d76fe6))
+
+## [0.11.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.11.0...@carbon/ibm-cloud-cognitive-security@0.11.1) (2021-08-18)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
+
+# [0.11.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.10.0...@carbon/ibm-cloud-cognitive-security@0.11.0) (2021-08-11)
+
+### Features
+
+- update Carbon versions and package dependencies to latest
+  ([#1133](https://github.com/carbon-design-system/ibm-products/issues/1133))
+  ([4dfae1a](https://github.com/carbon-design-system/ibm-products/commit/4dfae1a9b27f5676d0bde570e2c9ee9ce8550b52))
+
+# [0.10.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.9.1...@carbon/ibm-cloud-cognitive-security@0.10.0) (2021-08-10)
+
+### Features
+
+- update Carbon versions and dependencies
+  ([#1110](https://github.com/carbon-design-system/ibm-products/issues/1110))
+  ([b41f433](https://github.com/carbon-design-system/ibm-products/commit/b41f4331e31cbd9e41d2364b24e6ef50c7fd2d8d))
+
+## [0.9.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.9.0...@carbon/ibm-cloud-cognitive-security@0.9.1) (2021-08-03)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
+
+# [0.9.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.8.0...@carbon/ibm-cloud-cognitive-security@0.9.0) (2021-07-28)
+
+### Features
+
+- update Carbon versions and dependencies
+  ([#1084](https://github.com/carbon-design-system/ibm-products/issues/1084))
+  ([3735ead](https://github.com/carbon-design-system/ibm-products/commit/3735ead9a96450015ec7aeafdb25deaa93d49aaa))
+
+# [0.8.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.7.1...@carbon/ibm-cloud-cognitive-security@0.8.0) (2021-07-21)
+
+### Features
+
+- update Carbon versions and dependencies
+  ([#1037](https://github.com/carbon-design-system/ibm-products/issues/1037))
+  ([8c5937a](https://github.com/carbon-design-system/ibm-products/commit/8c5937a865d3a0cfbaf33b9eca13c4d3b4c1365d))
+
+## [0.7.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.7.0...@carbon/ibm-cloud-cognitive-security@0.7.1) (2021-07-16)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
+
+# [0.7.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.6.0...@carbon/ibm-cloud-cognitive-security@0.7.0) (2021-07-14)
 
 ### Features
 
 - update Carbon versions and package dependencies
-  ([#994](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/994))
-  ([2ab4845](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/2ab4845511573b999d41fcf77e6d412e0d446b9d))
+  ([#994](https://github.com/carbon-design-system/ibm-products/issues/994))
+  ([2ab4845](https://github.com/carbon-design-system/ibm-products/commit/2ab4845511573b999d41fcf77e6d412e0d446b9d))
 
-# [0.6.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.5.2...@carbon/ibm-cloud-cognitive-security@0.6.0) (2021-07-07)
-
-### Features
-
-- update Carbon versions and dependencies
-  ([#974](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/974))
-  ([555509b](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/555509b5ccb147ed0d794b5816f685aa8f7ae451))
-
-## [0.5.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.5.1...@carbon/ibm-cloud-cognitive-security@0.5.2) (2021-07-01)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
-
-## [0.5.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.5.0...@carbon/ibm-cloud-cognitive-security@0.5.1) (2021-06-30)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
-
-# [0.5.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.27...@carbon/ibm-cloud-cognitive-security@0.5.0) (2021-06-23)
+# [0.6.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.5.2...@carbon/ibm-cloud-cognitive-security@0.6.0) (2021-07-07)
 
 ### Features
 
 - update Carbon versions and dependencies
-  ([#927](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/927))
-  ([5a8f7d6](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/5a8f7d6b81b6da26fd0cb933c1c3de4bd27b481b))
+  ([#974](https://github.com/carbon-design-system/ibm-products/issues/974))
+  ([555509b](https://github.com/carbon-design-system/ibm-products/commit/555509b5ccb147ed0d794b5816f685aa8f7ae451))
 
-## [0.4.27](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.26...@carbon/ibm-cloud-cognitive-security@0.4.27) (2021-06-17)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
-
-## [0.4.26](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.25...@carbon/ibm-cloud-cognitive-security@0.4.26) (2021-06-09)
+## [0.5.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.5.1...@carbon/ibm-cloud-cognitive-security@0.5.2) (2021-07-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.25](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.24...@carbon/ibm-cloud-cognitive-security@0.4.25) (2021-06-07)
+## [0.5.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.5.0...@carbon/ibm-cloud-cognitive-security@0.5.1) (2021-06-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.24](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.23...@carbon/ibm-cloud-cognitive-security@0.4.24) (2021-06-07)
+# [0.5.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.27...@carbon/ibm-cloud-cognitive-security@0.5.0) (2021-06-23)
+
+### Features
+
+- update Carbon versions and dependencies
+  ([#927](https://github.com/carbon-design-system/ibm-products/issues/927))
+  ([5a8f7d6](https://github.com/carbon-design-system/ibm-products/commit/5a8f7d6b81b6da26fd0cb933c1c3de4bd27b481b))
+
+## [0.4.27](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.26...@carbon/ibm-cloud-cognitive-security@0.4.27) (2021-06-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.23](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.22...@carbon/ibm-cloud-cognitive-security@0.4.23) (2021-06-04)
+## [0.4.26](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.25...@carbon/ibm-cloud-cognitive-security@0.4.26) (2021-06-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.22](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.21...@carbon/ibm-cloud-cognitive-security@0.4.22) (2021-05-28)
+## [0.4.25](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.24...@carbon/ibm-cloud-cognitive-security@0.4.25) (2021-06-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.21](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.20...@carbon/ibm-cloud-cognitive-security@0.4.21) (2021-05-27)
+## [0.4.24](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.23...@carbon/ibm-cloud-cognitive-security@0.4.24) (2021-06-07)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.20](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.19...@carbon/ibm-cloud-cognitive-security@0.4.20) (2021-05-26)
+## [0.4.23](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.22...@carbon/ibm-cloud-cognitive-security@0.4.23) (2021-06-04)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.19](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.18...@carbon/ibm-cloud-cognitive-security@0.4.19) (2021-05-24)
+## [0.4.22](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.21...@carbon/ibm-cloud-cognitive-security@0.4.22) (2021-05-28)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.18](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.17...@carbon/ibm-cloud-cognitive-security@0.4.18) (2021-05-18)
+## [0.4.21](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.20...@carbon/ibm-cloud-cognitive-security@0.4.21) (2021-05-27)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.17](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.16...@carbon/ibm-cloud-cognitive-security@0.4.17) (2021-05-17)
+## [0.4.20](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.19...@carbon/ibm-cloud-cognitive-security@0.4.20) (2021-05-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.16](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.15...@carbon/ibm-cloud-cognitive-security@0.4.16) (2021-05-04)
+## [0.4.19](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.18...@carbon/ibm-cloud-cognitive-security@0.4.19) (2021-05-24)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.15](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.14...@carbon/ibm-cloud-cognitive-security@0.4.15) (2021-04-21)
+## [0.4.18](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.17...@carbon/ibm-cloud-cognitive-security@0.4.18) (2021-05-18)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.14](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.13...@carbon/ibm-cloud-cognitive-security@0.4.14) (2021-04-15)
+## [0.4.17](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.16...@carbon/ibm-cloud-cognitive-security@0.4.17) (2021-05-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.13](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.12...@carbon/ibm-cloud-cognitive-security@0.4.13) (2021-04-14)
+## [0.4.16](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.15...@carbon/ibm-cloud-cognitive-security@0.4.16) (2021-05-04)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.12](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.11...@carbon/ibm-cloud-cognitive-security@0.4.12) (2021-03-22)
+## [0.4.15](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.14...@carbon/ibm-cloud-cognitive-security@0.4.15) (2021-04-21)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.11](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.10...@carbon/ibm-cloud-cognitive-security@0.4.11) (2021-03-16)
+## [0.4.14](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.13...@carbon/ibm-cloud-cognitive-security@0.4.14) (2021-04-15)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.10](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.9...@carbon/ibm-cloud-cognitive-security@0.4.10) (2021-03-16)
+## [0.4.13](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.12...@carbon/ibm-cloud-cognitive-security@0.4.13) (2021-04-14)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.9](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.8...@carbon/ibm-cloud-cognitive-security@0.4.9) (2021-03-10)
+## [0.4.12](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.11...@carbon/ibm-cloud-cognitive-security@0.4.12) (2021-03-22)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.7...@carbon/ibm-cloud-cognitive-security@0.4.8) (2021-03-09)
+## [0.4.11](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.10...@carbon/ibm-cloud-cognitive-security@0.4.11) (2021-03-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.6...@carbon/ibm-cloud-cognitive-security@0.4.7) (2021-03-09)
+## [0.4.10](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.9...@carbon/ibm-cloud-cognitive-security@0.4.10) (2021-03-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.5...@carbon/ibm-cloud-cognitive-security@0.4.6) (2021-03-09)
+## [0.4.9](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.8...@carbon/ibm-cloud-cognitive-security@0.4.9) (2021-03-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.4...@carbon/ibm-cloud-cognitive-security@0.4.5) (2021-03-08)
+## [0.4.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.7...@carbon/ibm-cloud-cognitive-security@0.4.8) (2021-03-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.3...@carbon/ibm-cloud-cognitive-security@0.4.4) (2021-03-05)
+## [0.4.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.6...@carbon/ibm-cloud-cognitive-security@0.4.7) (2021-03-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.2...@carbon/ibm-cloud-cognitive-security@0.4.3) (2021-03-04)
+## [0.4.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.5...@carbon/ibm-cloud-cognitive-security@0.4.6) (2021-03-09)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.1...@carbon/ibm-cloud-cognitive-security@0.4.2) (2021-02-25)
+## [0.4.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.4...@carbon/ibm-cloud-cognitive-security@0.4.5) (2021-03-08)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.4.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.4.0...@carbon/ibm-cloud-cognitive-security@0.4.1) (2021-02-03)
+## [0.4.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.3...@carbon/ibm-cloud-cognitive-security@0.4.4) (2021-03-05)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-# [0.4.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.3.4...@carbon/ibm-cloud-cognitive-security@0.4.0) (2021-02-02)
+## [0.4.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.2...@carbon/ibm-cloud-cognitive-security@0.4.3) (2021-03-04)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
+
+## [0.4.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.1...@carbon/ibm-cloud-cognitive-security@0.4.2) (2021-02-25)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
+
+## [0.4.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.4.0...@carbon/ibm-cloud-cognitive-security@0.4.1) (2021-02-03)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
+
+# [0.4.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.3.4...@carbon/ibm-cloud-cognitive-security@0.4.0) (2021-02-02)
 
 ### Features
 
 - **combo-button:** add `renderIcon` support
-  ([#299](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/299))
-  ([794deaf](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/794deafaf8d091f8c2761e835e693bcaaacf32c7))
+  ([#299](https://github.com/carbon-design-system/ibm-products/issues/299))
+  ([794deaf](https://github.com/carbon-design-system/ibm-products/commit/794deafaf8d091f8c2761e835e693bcaaacf32c7))
 
-## [0.3.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.3.3...@carbon/ibm-cloud-cognitive-security@0.3.4) (2021-01-29)
+## [0.3.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.3.3...@carbon/ibm-cloud-cognitive-security@0.3.4) (2021-01-29)
 
 ### Bug Fixes
 
 - **combo-button:** add truncation
-  ([#308](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/308))
-  ([35b3517](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/35b351776107d23f6dafd30b9d4a24d626a9d9ec))
+  ([#308](https://github.com/carbon-design-system/ibm-products/issues/308))
+  ([35b3517](https://github.com/carbon-design-system/ibm-products/commit/35b351776107d23f6dafd30b9d4a24d626a9d9ec))
 
-## [0.3.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.3.2...@carbon/ibm-cloud-cognitive-security@0.3.3) (2021-01-28)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
-
-## [0.3.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.3.1...@carbon/ibm-cloud-cognitive-security@0.3.2) (2021-01-26)
+## [0.3.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.3.2...@carbon/ibm-cloud-cognitive-security@0.3.3) (2021-01-28)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.3.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.3.0...@carbon/ibm-cloud-cognitive-security@0.3.1) (2021-01-22)
+## [0.3.2](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.3.1...@carbon/ibm-cloud-cognitive-security@0.3.2) (2021-01-26)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
+
+## [0.3.1](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.3.0...@carbon/ibm-cloud-cognitive-security@0.3.1) (2021-01-22)
 
 ### Bug Fixes
 
 - **security:** remove circular dependency for `@carbon/ibm-security`
   consumption
-  ([#300](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/300))
-  ([a91d705](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a91d705cb499b9a7a8462853fde9d4eb6b6021d9))
+  ([#300](https://github.com/carbon-design-system/ibm-products/issues/300))
+  ([a91d705](https://github.com/carbon-design-system/ibm-products/commit/a91d705cb499b9a7a8462853fde9d4eb6b6021d9))
 
-# [0.3.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.2.8...@carbon/ibm-cloud-cognitive-security@0.3.0) (2021-01-20)
+# [0.3.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.2.8...@carbon/ibm-cloud-cognitive-security@0.3.0) (2021-01-20)
 
 ### Features
 
 - **combo-button:** add `ComboButton` logic, story, and styles
-  ([#233](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/233))
-  ([85e2b62](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/85e2b62de80166cda84fa8cc9af311e664d241af))
+  ([#233](https://github.com/carbon-design-system/ibm-products/issues/233))
+  ([85e2b62](https://github.com/carbon-design-system/ibm-products/commit/85e2b62de80166cda84fa8cc9af311e664d241af))
 
-## [0.2.8](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.2.7...@carbon/ibm-cloud-cognitive-security@0.2.8) (2020-12-16)
-
-**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
-
-## [0.2.7](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.2.6...@carbon/ibm-cloud-cognitive-security@0.2.7) (2020-12-10)
+## [0.2.8](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.2.7...@carbon/ibm-cloud-cognitive-security@0.2.8) (2020-12-16)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.2.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.2.5...@carbon/ibm-cloud-cognitive-security@0.2.6) (2020-12-08)
+## [0.2.7](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.2.6...@carbon/ibm-cloud-cognitive-security@0.2.7) (2020-12-10)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.2.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.2.4...@carbon/ibm-cloud-cognitive-security@0.2.5) (2020-12-02)
+## [0.2.6](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.2.5...@carbon/ibm-cloud-cognitive-security@0.2.6) (2020-12-08)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.2.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.2.3...@carbon/ibm-cloud-cognitive-security@0.2.4) (2020-12-01)
+## [0.2.5](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.2.4...@carbon/ibm-cloud-cognitive-security@0.2.5) (2020-12-02)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.2.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive-security@0.2.2...@carbon/ibm-cloud-cognitive-security@0.2.3) (2020-11-30)
+## [0.2.4](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.2.3...@carbon/ibm-cloud-cognitive-security@0.2.4) (2020-12-01)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.2.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/security/compare/@carbon/ibm-cloud-cognitive-security@0.2.1...@carbon/ibm-cloud-cognitive-security@0.2.2) (2020-11-26)
+## [0.2.3](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-cloud-cognitive-security@0.2.2...@carbon/ibm-cloud-cognitive-security@0.2.3) (2020-11-30)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.2.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/security/compare/@carbon/ibm-cloud-cognitive-security@0.2.0...@carbon/ibm-cloud-cognitive-security@0.2.1) (2020-11-26)
+## [0.2.2](https://github.com/carbon-design-system/ibm-products/tree/master/packages/security/compare/@carbon/ibm-cloud-cognitive-security@0.2.1...@carbon/ibm-cloud-cognitive-security@0.2.2) (2020-11-26)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-# [0.2.0](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/security/compare/@carbon/ibm-cloud-cognitive-security@0.1.4...@carbon/ibm-cloud-cognitive-security@0.2.0) (2020-11-24)
+## [0.2.1](https://github.com/carbon-design-system/ibm-products/tree/master/packages/security/compare/@carbon/ibm-cloud-cognitive-security@0.2.0...@carbon/ibm-cloud-cognitive-security@0.2.1) (2020-11-26)
+
+**Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
+
+# [0.2.0](https://github.com/carbon-design-system/ibm-products/tree/master/packages/security/compare/@carbon/ibm-cloud-cognitive-security@0.1.4...@carbon/ibm-cloud-cognitive-security@0.2.0) (2020-11-24)
 
 ### Features
 
 - add cdai apikey component
-  ([#223](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/security/issues/223))
-  ([4c09f15](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/security/commit/4c09f15c3c62c3965d98c91b9695fa7a1cba8f0b))
+  ([#223](https://github.com/carbon-design-system/ibm-products/tree/master/packages/security/issues/223))
+  ([4c09f15](https://github.com/carbon-design-system/ibm-products/tree/master/packages/security/commit/4c09f15c3c62c3965d98c91b9695fa7a1cba8f0b))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.1.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/security/compare/@carbon/ibm-cloud-cognitive-security@0.1.3...@carbon/ibm-cloud-cognitive-security@0.1.4) (2020-11-19)
+## [0.1.4](https://github.com/carbon-design-system/ibm-products/tree/master/packages/security/compare/@carbon/ibm-cloud-cognitive-security@0.1.3...@carbon/ibm-cloud-cognitive-security@0.1.4) (2020-11-19)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.1.3](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/security/compare/@carbon/ibm-cloud-cognitive-security@0.1.2...@carbon/ibm-cloud-cognitive-security@0.1.3) (2020-11-17)
+## [0.1.3](https://github.com/carbon-design-system/ibm-products/tree/master/packages/security/compare/@carbon/ibm-cloud-cognitive-security@0.1.2...@carbon/ibm-cloud-cognitive-security@0.1.3) (2020-11-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
-## [0.1.2](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/security/compare/@carbon/ibm-cloud-cognitive-security@0.1.1...@carbon/ibm-cloud-cognitive-security@0.1.2) (2020-11-17)
+## [0.1.2](https://github.com/carbon-design-system/ibm-products/tree/master/packages/security/compare/@carbon/ibm-cloud-cognitive-security@0.1.1...@carbon/ibm-cloud-cognitive-security@0.1.2) (2020-11-17)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
@@ -869,7 +869,7 @@ All notable changes to this project will be documented in this file. See
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.1.1](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/security/compare/@carbon/ibm-cloud-cognitive-security@0.1.0...@carbon/ibm-cloud-cognitive-security@0.1.1) (2020-11-11)
+## [0.1.1](https://github.com/carbon-design-system/ibm-products/tree/master/packages/security/compare/@carbon/ibm-cloud-cognitive-security@0.1.0...@carbon/ibm-cloud-cognitive-security@0.1.1) (2020-11-11)
 
 **Note:** Version bump only for package @carbon/ibm-cloud-cognitive-security
 
@@ -878,8 +878,8 @@ All notable changes to this project will be documented in this file. See
 ### Features
 
 - **decorator:** export component, add story
-  ([#43](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/security/issues/43))
-  ([15304ca](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/security/commit/15304ca5d4bbc0b5a70ab2d3b9a46e6590beaf56))
+  ([#43](https://github.com/carbon-design-system/ibm-products/tree/master/packages/security/issues/43))
+  ([15304ca](https://github.com/carbon-design-system/ibm-products/tree/master/packages/security/commit/15304ca5d4bbc0b5a70ab2d3b9a46e6590beaf56))
 - **storybook:** upgrade Storybook
-  ([#77](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/security/issues/77))
-  ([b1a3ad0](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/security/commit/b1a3ad02816de050fbc85d7fa4ef60c58204a9d9))
+  ([#77](https://github.com/carbon-design-system/ibm-products/tree/master/packages/security/issues/77))
+  ([b1a3ad0](https://github.com/carbon-design-system/ibm-products/tree/master/packages/security/commit/b1a3ad02816de050fbc85d7fa4ef60c58204a9d9))

--- a/packages/security/README.md
+++ b/packages/security/README.md
@@ -35,7 +35,7 @@ and changes to this directory will be overwritten.
 We're always looking for contributors to help us fix bugs, build new features,
 or help us improve the project documentation. If you're interested, definitely
 check out our
-[Contributing Guide](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/.github/CONTRIBUTING.md)
+[Contributing Guide](https://github.com/carbon-design-system/ibm-products/blob/master/.github/CONTRIBUTING.md)
 and
 [Carbon's Developer Handbook](https://github.com/carbon-design-system/carbon/blob/master/docs/developer-handbook.md)!
 👀
@@ -43,4 +43,4 @@ and
 ## 📝 License
 
 Licensed under the
-[Apache-2.0 License](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/LICENSE).
+[Apache-2.0 License](https://github.com/carbon-design-system/ibm-products/blob/master/LICENSE).

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -7,7 +7,7 @@
   "module": "es/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "url": "https://github.com/carbon-design-system/ibm-products.git",
     "directory": "packages/security"
   },
   "bugs": "https://github.com/carbon-design-system/ibm-products/issues",

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
     "directory": "packages/security"
   },
-  "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
+  "bugs": "https://github.com/carbon-design-system/ibm-products/issues",
   "files": [
     "css",
     "es",

--- a/packages/security/src/components/GettingStartedLayout/docs/Troubleshooting/index.mdx
+++ b/packages/security/src/components/GettingStartedLayout/docs/Troubleshooting/index.mdx
@@ -4,7 +4,7 @@ import slack from './images/slack.png';
 ### Troubleshooting
 
 Visit our
-[GitHub](https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/main/packages/security)
+[GitHub](https://github.com/carbon-design-system/ibm-products/tree/main/packages/security)
 to view and submit issues, or reach out on
 [Slack](https://ibm-security.slack.com/archives/C013ZTX0N6B) for additional
 support.
@@ -13,7 +13,7 @@ support.
   <Column>
     <a
       className="storybook__link--image"
-      href="https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/main/packages/security"
+      href="https://github.com/carbon-design-system/ibm-products/tree/main/packages/security"
       rel="noopener noreferrer"
       target="_blank"
     >

--- a/scripts/example-gallery-builder/gallery-config.js
+++ b/scripts/example-gallery-builder/gallery-config.js
@@ -80,7 +80,7 @@ const getExampleDirectoriesConfig = (
       // config url or default
       const url =
         config?.url ??
-        `https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/${dir}`;
+        `https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/${dir}`;
 
       const output = { label, url };
 

--- a/scripts/example-gallery-builder/index.js
+++ b/scripts/example-gallery-builder/index.js
@@ -20,7 +20,7 @@
  * By default the following mapping is made
  * {
  *   label: folder name,
- *   url: baseUrl + folder name, // baseUrl is `https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/`
+ *   url: baseUrl + folder name, // baseUrl is `https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/`
  *   thumbnail: folder name + '/thumbnail.png'
  * }
  *
@@ -28,7 +28,7 @@
  * NOTE2: A local config file allows examples not in this repo to  be added
  *
  * The resulting Carbon for IBM Products example gallery can be seen here
- * https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main_v1/examples/carbon-for-ibm-products/example-gallery
+ * https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main_v1/examples/carbon-for-ibm-products/example-gallery
  */
 
 const path = require('path');

--- a/yarn.lock
+++ b/yarn.lock
@@ -15138,9 +15138,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ibm-cloud-cognitive@workspace:.":
+"ibm-products@workspace:.":
   version: 0.0.0-use.local
-  resolution: "ibm-cloud-cognitive@workspace:."
+  resolution: "ibm-products@workspace:."
   dependencies:
     "@babel/core": ^7.20.12
     "@babel/eslint-parser": ^7.19.1


### PR DESCRIPTION
Contributes to #2884 

Changes alll links from `.../ibm-cloud-cognitive/...` to `.../ibm-products/...`

#### What did you change?

All files with a link in
- change logs
- package.json files
- readme
- some JS files

#### How did you test and verify your work?

- Unable to find `/ibm-cloud-cognitive/` in source after. 
- Opened a small number of the links.