### PR TITLE
docs: update Storybook links v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ## 🚀 Getting started
 
 If you’re just getting started and looking to browse our React components, take
-a look at [our Storybook](https://carbon-for-ibm-products.netlify.app).
+a look at [our Storybook](https://ibm-products.carbondesignsystem.com).
 
 All of our source code and documentation, including this readme, can be found on
 [our GitHub repo](https://github.com/carbon-design-system/ibm-products), which

--- a/examples/carbon-for-ibm-products/ccs-base-react-16/src/Example/Example.js
+++ b/examples/carbon-for-ibm-products/ccs-base-react-16/src/Example/Example.js
@@ -33,7 +33,7 @@ export const Example = () => {
         copyrightText={<>Copyright &copy; 2020 IBM corporation</>}
         links={[
           <Link
-            href="https://carbon-for-ibm-products.netlify.app/"
+            href="https://ibm-products.carbondesignsystem.com/"
             key="View storybook"
           >
             View the components

--- a/examples/carbon-for-ibm-products/ccs-base-react-17/src/Example/Example.js
+++ b/examples/carbon-for-ibm-products/ccs-base-react-17/src/Example/Example.js
@@ -33,7 +33,7 @@ export const Example = () => {
         copyrightText={<>Copyright &copy; 2020 IBM corporation</>}
         links={[
           <Link
-            href="https://carbon-for-ibm-products.netlify.app/"
+            href="https://ibm-products.carbondesignsystem.com/"
             key="View storybook"
           >
             View the components

--- a/packages/core/.storybook/manager-head.html
+++ b/packages/core/.storybook/manager-head.html
@@ -7,8 +7,8 @@
 <meta property="og:site_name" content="Carbon for IBM Products" />
 <meta property="og:description"
   content="This is the React implementation of the Carbon for IBM Products components which build on top of the Carbon Design System. It is a set of styled patterns and components, designed and implemented for IBM Products." />
-<meta property="og:image" content="https://carbon-for-ibm-products.netlify.app/social.jpg" />
-<meta property="og:url" content="https://carbon-for-ibm-products.netlify.app" />
+<meta property="og:image" content="https://ibm-products.carbondesignsystem.com/social.jpg" />
+<meta property="og:url" content="https://ibm-products.carbondesignsystem.com" />
 
 <!-- Favicon -->
 <link rel="icon" type="image/svg+xml" href="favicon.svg" sizes="any" />
@@ -16,7 +16,7 @@
 <!-- Social -->
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image:alt" content="Carbon for IBM Products" />
-<meta name="twitter:image" content="https://carbon-for-ibm-products.netlify.app/social.jpg" />
+<meta name="twitter:image" content="https://ibm-products.carbondesignsystem.com/social.jpg" />
 
 <!-- Storybook override -->
 <script>

--- a/packages/ibm-products/README.md
+++ b/packages/ibm-products/README.md
@@ -20,7 +20,7 @@
 ## 🚀 Getting started
 
 If you’re just getting started and looking to browse our React components, take
-a look at [our Storybook](https://carbon-for-ibm-products.netlify.app).
+a look at [our Storybook](https://ibm-products.carbondesignsystem.com).
 
 ### 📦 Installing Carbon for IBM Products
 

--- a/packages/ibm-products/carbon.yml
+++ b/packages/ibm-products/carbon.yml
@@ -20,7 +20,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-generating-an-api-key-apikeymodal
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-generating-an-api-key-apikeymodal
     tags:
       - system-feedback
       - form
@@ -36,7 +36,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-about-modal-aboutmodal
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-about-modal-aboutmodal
     tags:
       - system-feedback
       - content-block
@@ -51,7 +51,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-internal-actionbar
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-internal-actionbar
     tags:
       - input-control
   action-set:
@@ -65,7 +65,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-internal-actionset
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-internal-actionset
     tags:
       - data-display
   breadcrumb-with-overflow:
@@ -79,7 +79,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-internal-breadcrumbwithoverflow
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-internal-breadcrumbwithoverflow
     tags:
       - structural-navigation
       - contextual-navigation
@@ -94,7 +94,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-internal-buttonmenu
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-internal-buttonmenu
     tags:
       - input-control
   button-set-with-overflow:
@@ -108,7 +108,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-internal-buttonsetwithoverflow
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-internal-buttonsetwithoverflow
     tags:
       - input-control
   cascade:
@@ -123,7 +123,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-cascade-cascade
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-cascade-cascade
     tags:
       - content-block
   combo-button:
@@ -138,7 +138,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-internal-combobutton
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-internal-combobutton
     tags:
       - input-control
   create-full-page:
@@ -153,7 +153,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-create-flows-createfullpage
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-create-flows-createfullpage
     tags:
       - content-block
       - system-feedback
@@ -170,7 +170,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-create-flows-createmodal
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-create-flows-createmodal
     tags:
       - input-control
       - form
@@ -186,7 +186,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-create-flows-createtearsheet
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-create-flows-createtearsheet
     tags:
       - form
       - input-control
@@ -202,7 +202,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-create-flows-createtearsheetnarrow
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-create-flows-createtearsheetnarrow
     tags:
       - form
       - input-control
@@ -218,7 +218,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-dataspreadsheet-dataspreadsheet-canary
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-components-dataspreadsheet-dataspreadsheet-canary
     tags:
       - input-control
       - data-display
@@ -233,7 +233,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-datagrid-datagrid-canary
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-components-datagrid-datagrid-canary
     tags:
       - input-control
       - content-block
@@ -250,7 +250,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-edit-and-update-editsidepanel-canary
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-edit-and-update-editsidepanel-canary
     tags:
       - input-control
       - form
@@ -266,7 +266,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-empty-state-emptystate
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-empty-state-emptystate
     tags:
       - content-element
   export-modal:
@@ -281,7 +281,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-export-exportmodal
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-export-exportmodal
     tags:
       - system-feedback
       - form
@@ -297,7 +297,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-cards-expressivecard
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-components-cards-expressivecard
     tags:
       - content-block
       - contextual-navigation
@@ -313,7 +313,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-http-errors
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-http-errors
     tags:
       - system-feedback
       - content-block
@@ -330,7 +330,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-import-and-upload-importmodal
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-import-and-upload-importmodal
     tags:
       - system-feedback
       - input-control
@@ -347,7 +347,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-edit-and-update-inlineedit
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-edit-and-update-inlineedit
     tags:
       - input-control
   modified-tabs:
@@ -362,7 +362,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-modified-tabs-modifiedtabs-canary
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-components-modified-tabs-modifiedtabs-canary
     tags:
       - input-control
   multi-add-select:
@@ -377,7 +377,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-add-select-multiaddselect-canary
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-add-select-multiaddselect-canary
     tags:
       - form
       - content-block
@@ -393,7 +393,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-notifications-notificationspanel
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-notifications-notificationspanel
     tags:
       - input-control
       - system-feedback
@@ -409,7 +409,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-options-tile-optionstile
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-components-options-tile-optionstile
     tags:
       - input-control
       - form
@@ -426,7 +426,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-page-header-pageheader
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-components-page-header-pageheader
     tags:
       - structural-navigation
       - shell
@@ -443,7 +443,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-cards-productivecard
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-components-cards-productivecard
     tags:
       - content-block
       - input-control
@@ -459,7 +459,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-remove-removemodal
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-remove-removemodal
     tags:
       - system-feedback
       - input-control
@@ -475,7 +475,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-saving-saving
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-saving-saving
     tags:
       - input-control
       - system-feedback
@@ -491,7 +491,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-side-panel-sidepanel
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-components-side-panel-sidepanel
     tags:
       - input-control
       - form
@@ -509,7 +509,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-add-select-singleaddselect-canary
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-add-select-singleaddselect-canary
     tags:
       - form
   status-icon:
@@ -524,7 +524,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-status-icons-statusicon
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-status-icons-statusicon
     tags:
       - media
       - content-element
@@ -541,7 +541,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-tag-set-tagset
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-components-tag-set-tagset
     tags:
       - data-display
   tearsheet:
@@ -556,7 +556,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-tearsheet-tearsheet
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-components-tearsheet-tearsheet
     tags:
       - input-control
       - form
@@ -572,7 +572,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-toolbars-toolbar-canary
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-toolbars-toolbar-canary
     tags:
       - input-control
   user-profile-image:
@@ -587,7 +587,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-user-profile-images-userprofileimage
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-user-profile-images-userprofileimage
     tags:
       - media
   web-terminal:
@@ -602,7 +602,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-web-terminal-webterminal-canary
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-web-terminal-webterminal-canary
     tags:
       - content-block
       - shell

--- a/packages/ibm-products/src/components/Datagrid/utils/makeData.js
+++ b/packages/ibm-products/src/components/Datagrid/utils/makeData.js
@@ -63,10 +63,10 @@ const renderDocLink = () => {
   const docLinkObj = {
     href:
       chance > 0.66
-        ? 'http://carbondesignsystem.com/'
+        ? 'https://carbondesignsystem.com/'
         : chance > 0.33
         ? 'https://pages.github.ibm.com/cdai-design/pal/'
-        : 'http://carbon-for-ibm-products.netlify.app/',
+        : 'https://ibm-products.carbondesignsystem.com/',
     text:
       chance > 0.66
         ? 'Carbon Design System'

--- a/packages/security/carbon.yml
+++ b/packages/security/carbon.yml
@@ -19,7 +19,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/security-components-decorator
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-components-decorator
     tags:
       - content-element
   delimited-list:
@@ -33,7 +33,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/security-components-delimitedlist
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-components-delimitedlist
     tags:
       - content-element
       - data-display
@@ -48,7 +48,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/security-components-externallink
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-components-externallink
     tags:
       - content-element
       - contextual-navigation
@@ -63,7 +63,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/security-components-ica
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-components-ica
     tags:
       - content-element
   nav:
@@ -77,7 +77,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/security-components-nav
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-components-nav
     tags:
       - structural-navigation
   stacked-notification:
@@ -91,7 +91,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-components-stackednotification
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-components-stackednotification
     tags:
       - system-feedback
   status-icon:
@@ -105,7 +105,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-components-statusicon
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-components-statusicon
     tags:
       - system-feedback
   string-formatter:
@@ -119,7 +119,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-components-stringformatter
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-components-stringformatter
     tags:
       - content-element
   time-indicator:
@@ -133,7 +133,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-components-timeindicator
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-components-timeindicator
     tags:
       - system-feedback
       - content-element 
@@ -148,7 +148,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-components-truncatedlist
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-components-truncatedlist
     tags:
       - data-display
       - content-element
@@ -163,7 +163,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-components-typelayout
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-components-typelayout
     tags:
       - data-display
       - content-element
@@ -178,7 +178,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-combobutton
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-patterns-combobutton
     tags:
       - input-control
   filter-panel:
@@ -192,7 +192,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-filterpanel
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-patterns-filterpanel
     tags:
       - form
   icon-button-bar:
@@ -206,7 +206,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-iconbuttonbar
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-patterns-iconbuttonbar
     tags:
       - input-control
   non-entitled-section:
@@ -220,7 +220,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-nonentitledsection
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-patterns-nonentitledsection
     tags:
       - content-block
   search-bar:
@@ -234,7 +234,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-searchbar
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-patterns-searchbar
     tags:
       - input-control
       - form
@@ -249,7 +249,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-statusindicator
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-patterns-statusindicator
     tags:
       - system-feedback
   tag-wall:
@@ -263,7 +263,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-tagwall
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-patterns-tagwall
     tags:
       - input-control
       - data-display
@@ -278,7 +278,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-tagwallfilter
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-patterns-tagwallfilter
     tags:
       - input-control
       - data-display
@@ -294,7 +294,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-layouts-detail
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-layouts-detail
     tags:
       - content-block
       - data-display
@@ -309,7 +309,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-layouts-overview
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-layouts-overview
     tags:
       - content-block
       - data-display

--- a/packages/security/src/components/Card/Card-story.js
+++ b/packages/security/src/components/Card/Card-story.js
@@ -52,7 +52,7 @@ storiesOf(components('Card#legacy'), module)
         className="page-layouts__banner"
         actions={
           <NotificationActionButton
-            href="https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-cards-productivecard--default"
+            href="https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-components-cards-productivecard--default"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/packages/security/src/components/DataDecorator/DataDecorator-story.js
+++ b/packages/security/src/components/DataDecorator/DataDecorator-story.js
@@ -67,7 +67,7 @@ storiesOf(patterns('DataDecorator#legacy'), module)
         className="page-layouts__banner"
         actions={
           <NotificationActionButton
-            href="https://carbon-for-ibm-products.netlify.app/?path=/story/security-components-decorator--default&knob-Delimiter%20(delimiter)=,%20&knob-Items%20(items)=Item%201,Item%202,Item%203,Item%204,Item%205,Item%206,Item%207,Item%208,Item%209,Item%2010&knob-Lines%20(`lines`)=1&knob-Score%20(`score`)=3&knob-Title%20(`title`)=10.0.0.0&knob-Truncate%20(`truncate`)=true&knob-Truncate%20(truncate)=true&knob-Type%20(`type`)=IP&knob-Value%20(`value`)=10.0.0.0.563409u53250u&knob-Width%20(`width`)=100px&knob-type=IP&knob-value=127.0.0.1"
+            href="https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-components-decorator--default&knob-Delimiter%20(delimiter)=,%20&knob-Items%20(items)=Item%201,Item%202,Item%203,Item%204,Item%205,Item%206,Item%207,Item%208,Item%209,Item%2010&knob-Lines%20(`lines`)=1&knob-Score%20(`score`)=3&knob-Title%20(`title`)=10.0.0.0&knob-Truncate%20(`truncate`)=true&knob-Truncate%20(truncate)=true&knob-Type%20(`type`)=IP&knob-Value%20(`value`)=10.0.0.0.563409u53250u&knob-Width%20(`width`)=100px&knob-type=IP&knob-value=127.0.0.1"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/packages/security/src/components/ErrorPage/ErrorPage-story.js
+++ b/packages/security/src/components/ErrorPage/ErrorPage-story.js
@@ -41,7 +41,7 @@ disableCenteredStories(storiesOf(patterns('ErrorPage#legacy'), module))
         className="page-layouts__banner"
         actions={
           <NotificationActionButton
-            href="https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-http-errors-httperror403--with-all-props-set"
+            href="https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-http-errors-httperror403--with-all-props-set"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/packages/security/src/components/Panel/Panel-story.js
+++ b/packages/security/src/components/Panel/Panel-story.js
@@ -52,7 +52,7 @@ storiesOf(patterns('Panel#legacy'), module)
         className="page-layouts__banner"
         actions={
           <NotificationActionButton
-            href="https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-side-panel-sidepanel--slide-over"
+            href="https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-components-side-panel-sidepanel--slide-over"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/packages/security/src/components/PanelV2/PanelV2-story.js
+++ b/packages/security/src/components/PanelV2/PanelV2-story.js
@@ -73,7 +73,7 @@ disableCenteredStories(storiesOf(patterns('PanelV2#legacy'), module))
         className="page-layouts__banner"
         actions={
           <NotificationActionButton
-            href="https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-side-panel-sidepanel--slide-over"
+            href="https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-components-side-panel-sidepanel--slide-over"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/packages/security/src/components/Pill/Pill-story.js
+++ b/packages/security/src/components/Pill/Pill-story.js
@@ -23,7 +23,7 @@ storiesOf(components('Pill#legacy'), module)
         className="page-layouts__banner"
         actions={
           <NotificationActionButton
-            href="https://carbon-for-ibm-products.netlify.app/?path=/story/security-components-decorator--default"
+            href="https://v1-ibm-products.carbondesignsystem.com/?path=/story/security-components-decorator--default"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/packages/security/src/components/ProfileImage/ProfileImage-story.js
+++ b/packages/security/src/components/ProfileImage/ProfileImage-story.js
@@ -28,7 +28,7 @@ storiesOf(components('ProfileImage#legacy'), module)
         className="page-layouts__banner"
         actions={
           <NotificationActionButton
-            href="https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-user-profile-images-userprofileimage--default"
+            href="https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-patterns-user-profile-images-userprofileimage--default"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/packages/security/src/components/SummaryCard/SummaryCard-story.js
+++ b/packages/security/src/components/SummaryCard/SummaryCard-story.js
@@ -42,7 +42,7 @@ storiesOf(patterns('SummaryCard#legacy'), module)
         className="page-layouts__banner"
         actions={
           <NotificationActionButton
-            href="https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-cards-productivecard--default"
+            href="https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-components-cards-productivecard--default"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/packages/security/src/components/TrendingCard/TrendingCard-story.js
+++ b/packages/security/src/components/TrendingCard/TrendingCard-story.js
@@ -28,7 +28,7 @@ export default {
           className="page-layouts__banner"
           actions={
             <NotificationActionButton
-              href="https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-cards-productivecard--default"
+              href="https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-components-cards-productivecard--default"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/packages/security/src/components/Wizard/Wizard-story.js
+++ b/packages/security/src/components/Wizard/Wizard-story.js
@@ -247,7 +247,7 @@ storiesOf(patterns('Wizard#legacy'), module)
         className="page-layouts__banner"
         actions={
           <NotificationActionButton
-            href="https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-tearsheet-tearsheet--tearsheet"
+            href="https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-components-tearsheet-tearsheet--tearsheet"
             rel="noopener noreferrer"
             target="_blank"
           >


### PR DESCRIPTION
Closes #3011
Contributes to #2884 

Replace Netlify links.
In Security `carbon.yml` and Stories, these will point to https://v1-ibm-products.carbondesignsystem.com/.

#### What did you change?
Replace links with https://ibm-products.carbondesignsystem.com/ or https://v1-ibm-products.carbondesignsystem.com/

#### How did you test and verify your work?
Find and replace and <kbd>option</kbd> + click