### PR TITLE
fix: use create tearsheet label in examples

### DIFF
--- a/examples/carbon-for-ibm-products/CreateTearsheet/gallery.config.json
+++ b/examples/carbon-for-ibm-products/CreateTearsheet/gallery.config.json
@@ -1,3 +1,3 @@
 {
-  "label": "Tearsheet"
+  "label": "Create Tearsheet"
 }

--- a/examples/carbon-for-ibm-products/example-gallery/src/gallery-config/index.js
+++ b/examples/carbon-for-ibm-products/example-gallery/src/gallery-config/index.js
@@ -65,7 +65,7 @@ const config = [
     thumbnail: `url(${imageCreateSidePanel}`,
   },
   {
-    label: 'Tearsheet',
+    label: 'Create Tearsheet',
     directory: 'CreateTearsheet',
     thumbnail: `url(${imageCreateTearsheet}`,
   },


### PR DESCRIPTION
Contributes to #3016

Fixed CreateTearsheet example label

#### What did you change?
```
examples/carbon-for-ibm-products/CreateTearsheet/gallery.config.json
examples/carbon-for-ibm-products/example-gallery/src/gallery-config/index.js
```
#### How did you test and verify your work?
Ran example gallery locally