### PR TITLE
fix: use correct ci-check script in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         run: yarn
 
       - name: Continuous integration check (includes build)
-        run: yarn ci-check:v2
+        run: yarn ci-check
 
       # Dry run - `yarn lerna publish --dist-tag next --no-verify-access --create-release github --yes --no-push --no-git-tag-version`
       - name: Publish


### PR DESCRIPTION
Release yml has an incorrect ci-check script that doesn't exist anymore. This should use the correct one
