### PR TITLE
chore(release): publish [skip ci]

### DIFF
--- a/.github/workflows/release-v1.yml
+++ b/.github/workflows/release-v1.yml
@@ -64,4 +64,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LERNA }}
           NODE_AUTH_TOKEN: ${{ secrets.CARBON_BOT_NPM_TOKEN }}
-        run: yarn lerna publish from-package --no-verify-access --yes
+        run:
+          yarn lerna publish from-package --dist-tag latest-v1
+          --no-verify-access --yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LERNA }}
           NODE_AUTH_TOKEN: ${{ secrets.CARBON_BOT_NPM_TOKEN }}
-        run:
-          yarn lerna publish --dist-tag next --no-verify-access --create-release
-          github --yes
+        run: yarn lerna publish --no-verify-access --create-release github --yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,4 +40,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LERNA }}
           NODE_AUTH_TOKEN: ${{ secrets.CARBON_BOT_NPM_TOKEN }}
-        run: yarn lerna publish --no-verify-access --create-release github --yes
+        run:
+          yarn lerna publish from-package --no-verify-access --create-release
+          github --yes

--- a/packages/ibm-products/CHANGELOG.md
+++ b/packages/ibm-products/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@2.0.0-rc.39...@carbon/ibm-products@2.0.0) (2023-05-17)
+
+**Note:** Version bump only for package @carbon/ibm-products
+
+
+
+
+
 # [2.0.0-rc.39](https://github.com/carbon-design-system/ibm-products/compare/@carbon/ibm-products@2.0.0-rc.35...@carbon/ibm-products@2.0.0-rc.39) (2023-05-17)
 
 

--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ibm-products",
   "description": "Carbon for IBM Products",
-  "version": "2.0.0-rc.39",
+  "version": "2.0.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
 - @carbon/ibm-products@2.0.0

Contributes to #

Attempted v2 release. Bumps version number of @carbon/ibm-products to v2.

