### PR TITLE
chore(examples): update example package.json

### DIFF
--- a/examples/carbon-for-ibm-products/APIKeyModal/package.json
+++ b/examples/carbon-for-ibm-products/APIKeyModal/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/AboutModal/package.json
+++ b/examples/carbon-for-ibm-products/AboutModal/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/Cascade/package.json
+++ b/examples/carbon-for-ibm-products/Cascade/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/CreateFullPage/package.json
+++ b/examples/carbon-for-ibm-products/CreateFullPage/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/CreateModal/package.json
+++ b/examples/carbon-for-ibm-products/CreateModal/package.json
@@ -19,7 +19,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/CreateSidePanel/package.json
+++ b/examples/carbon-for-ibm-products/CreateSidePanel/package.json
@@ -19,7 +19,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/CreateTearsheet/package.json
+++ b/examples/carbon-for-ibm-products/CreateTearsheet/package.json
@@ -19,7 +19,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/CreateTearsheetNarrow/package.json
+++ b/examples/carbon-for-ibm-products/CreateTearsheetNarrow/package.json
@@ -20,7 +20,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/DataSpreadsheet/package.json
+++ b/examples/carbon-for-ibm-products/DataSpreadsheet/package.json
@@ -19,7 +19,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "namor": "^1.1.2",

--- a/examples/carbon-for-ibm-products/Datagrid/package.json
+++ b/examples/carbon-for-ibm-products/Datagrid/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "namor": "^1.1.2",

--- a/examples/carbon-for-ibm-products/EditInPlace/package.json
+++ b/examples/carbon-for-ibm-products/EditInPlace/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/EmptyStates/package.json
+++ b/examples/carbon-for-ibm-products/EmptyStates/package.json
@@ -19,7 +19,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/ExportModal/package.json
+++ b/examples/carbon-for-ibm-products/ExportModal/package.json
@@ -16,7 +16,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/ExpressiveCard/package.json
+++ b/examples/carbon-for-ibm-products/ExpressiveCard/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/HTTPErrors/package.json
+++ b/examples/carbon-for-ibm-products/HTTPErrors/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/ImportModal/package.json
+++ b/examples/carbon-for-ibm-products/ImportModal/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/NotificationsPanel/package.json
+++ b/examples/carbon-for-ibm-products/NotificationsPanel/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/OptionsTile/package.json
+++ b/examples/carbon-for-ibm-products/OptionsTile/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/OptionsTile/src/Example/Example.jsx
+++ b/examples/carbon-for-ibm-products/OptionsTile/src/Example/Example.jsx
@@ -54,7 +54,7 @@ export const Example = () => {
   return (
     <div className='container'>
       <OptionsTile
-        heading='Auto recovery'
+        title='Auto recovery'
         summary={summary}
         enabled={enabled}
         onToggle={setEnabled}

--- a/examples/carbon-for-ibm-products/PageHeader/package.json
+++ b/examples/carbon-for-ibm-products/PageHeader/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.29",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/ProductiveCard/package.json
+++ b/examples/carbon-for-ibm-products/ProductiveCard/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/RemoveModal/package.json
+++ b/examples/carbon-for-ibm-products/RemoveModal/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/Saving/package.json
+++ b/examples/carbon-for-ibm-products/Saving/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/SidePanel/package.json
+++ b/examples/carbon-for-ibm-products/SidePanel/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/StatusIcon/package.json
+++ b/examples/carbon-for-ibm-products/StatusIcon/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/TagSet/package.json
+++ b/examples/carbon-for-ibm-products/TagSet/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/Tearsheet/package.json
+++ b/examples/carbon-for-ibm-products/Tearsheet/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/UserProfileImage/package.json
+++ b/examples/carbon-for-ibm-products/UserProfileImage/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/WebTerminal/package.json
+++ b/examples/carbon-for-ibm-products/WebTerminal/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/example-gallery/package.json
+++ b/examples/carbon-for-ibm-products/example-gallery/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/examples/carbon-for-ibm-products/prefix-example/package.json
+++ b/examples/carbon-for-ibm-products/prefix-example/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/ibm-products": "^2.0.0-rc.28",
+    "@carbon/ibm-products": "^2.0.1",
     "@carbon/react": "^1.28.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",


### PR DESCRIPTION
Contributes to #2884 

Manually move examples to `@carbon/ibm-products@2.0.1`

#### What did you change?
- update `@carbon/ibm-products`
- change `heading` to `title` in OptionsTile example

#### How did you test and verify your work?
