### PR TITLE
fix: errors raised by the storybook addon

### DIFF
--- a/config/storybook-addon-carbon-theme/react.js
+++ b/config/storybook-addon-carbon-theme/react.js
@@ -4,4 +4,4 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-module.exports = require('./dist/react');
+export { withCarbonTheme } from './dist/react';

--- a/config/storybook-addon-carbon-theme/register.js
+++ b/config/storybook-addon-carbon-theme/register.js
@@ -4,4 +4,4 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-require('./dist/register');
+import './dist/register';

--- a/config/storybook-addon-carbon-theme/vue.js
+++ b/config/storybook-addon-carbon-theme/vue.js
@@ -4,4 +4,4 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-module.exports = require('./dist/vue');
+export { withCarbonTheme } from './dist/vue';


### PR DESCRIPTION
An attempt to update storbyook to v7 highlighted this use of require which will not be compatible with V7.

Changed to use import/export. Verified storybook still works.