### PR TITLE
chore: turn on v2 release

### DIFF
--- a/.github/workflows/release-v1.yml
+++ b/.github/workflows/release-v1.yml
@@ -41,7 +41,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LERNA }}
           NODE_AUTH_TOKEN: ${{ secrets.CARBON_BOT_NPM_TOKEN }}
         run:
-          yarn lerna publish --dist-tag=v1-latest --conventional-commits
+          yarn lerna publish --dist-tag v1-latest --conventional-commits
           --create-release github --yes
 
       - name: Rename to ibm-cloud-cognitive for legacy publish
@@ -65,5 +65,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LERNA }}
           NODE_AUTH_TOKEN: ${{ secrets.CARBON_BOT_NPM_TOKEN }}
         run:
-          yarn lerna publish from-package --dist-tag latest-v1
+          yarn lerna publish from-package --dist-tag v1-latest
           --yes

--- a/.github/workflows/release-v1.yml
+++ b/.github/workflows/release-v1.yml
@@ -1,4 +1,4 @@
-name: Releases @carbon/ibm-products with v10 support # Builds and releases @carbon/v10 supported version of @carbon/ibm-products
+name: v1 release # Builds and releases @carbon/v10 supported version of @carbon/ibm-products
 
 on:
   workflow_dispatch:
@@ -41,8 +41,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LERNA }}
           NODE_AUTH_TOKEN: ${{ secrets.CARBON_BOT_NPM_TOKEN }}
         run:
-          yarn lerna publish --dist-tag v1-latest --no-verify-access
-          --create-release --yes github
+          yarn lerna publish --dist-tag=v1-latest --conventional-commits
+          --create-release github --yes
 
       - name: Rename to ibm-cloud-cognitive for legacy publish
         run:
@@ -66,4 +66,4 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.CARBON_BOT_NPM_TOKEN }}
         run:
           yarn lerna publish from-package --dist-tag latest-v1
-          --no-verify-access --yes
+          --yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: v2 release # Builds and releases @carbon/v11 supported version of @carbon/
 on:
   workflow_dispatch:
   schedule:
-  - cron: '30 4 * * TUE' # Release every Tuesday at 4:30am EST
+    - cron: '30 4 * * TUE' # Release every Tuesday at 4:30am EST
 
 jobs:
   Release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
-name: Releases @carbon/ibm-products with v11 support # Builds and releases @carbon/v11 supported version of @carbon/ibm-products
+name: v2 release # Builds and releases @carbon/v11 supported version of @carbon/ibm-products
 
 on:
   workflow_dispatch:
   # schedule:
-  # - cron: '30 4 * * TUE' # Release every Tuesday at 4:30am EST
+  - cron: '30 4 * * TUE' # Release every Tuesday at 4:30am EST
 
 jobs:
   Release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: v2 release # Builds and releases @carbon/v11 supported version of @carbon/
 
 on:
   workflow_dispatch:
-  # schedule:
+  schedule:
   - cron: '30 4 * * TUE' # Release every Tuesday at 4:30am EST
 
 jobs:


### PR DESCRIPTION
Turns cron for v2 release back on.
~*Still looking into why v1 release action failed.~ Thanks @matthewgallo 


#### What did you change?
- Remove commented cron
- Also renamed for easier navigation in actions list

#### How did you test and verify your work?
🤐 