### PR TITLE
fix: make storybook addon theme package private

### DIFF
--- a/config/storybook-addon-carbon-theme/package.json
+++ b/config/storybook-addon-carbon-theme/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@carbon/storybook-addon-theme",
+  "private": true,
   "description": "Carbon theme switcher for Storybook",
   "version": "0.22.32",
   "license": "Apache-2.0",


### PR DESCRIPTION
Contributes to current v1 release action updates.

Makes storybook addon theme package private so we don't publish that package from `main` and `main_v1` to avoid version conflicts.