### PR TITLE
fix: use correct directory name for legacy package name in v1 release action

### DIFF
--- a/.github/workflows/release-v1.yml
+++ b/.github/workflows/release-v1.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Rename to ibm-cloud-cognitive for legacy publish
         run:
-          yarn json -I -f packages/cloud-cognitive/package.json -e
+          yarn json -I -f packages/ibm-products/package.json -e
           'this.name="@carbon/ibm-cloud-cognitive"'
 
       # Run yarn again after renaming package, required after move to yarn berry


### PR DESCRIPTION
Legacy package name publish failed because we're still referencing the `cloud-cognitive` directory, this should update the legacy publish script to use `ibm-products` instead.

#### What did you change?
`release-v1.yml`
