### PR TITLE
fix: private true prevents lock file from updating

### DIFF
--- a/config/storybook-addon-carbon-theme/package.json
+++ b/config/storybook-addon-carbon-theme/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@carbon/storybook-addon-theme",
-  "private": true,
   "description": "Carbon theme switcher for Storybook",
   "version": "0.22.34",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1783,7 +1783,7 @@ __metadata:
     "@carbon/import-once": 10.7.0
     "@carbon/layout": 10.37.1
     "@carbon/motion": 10.29.0
-    "@carbon/storybook-addon-theme": ^0.22.33
+    "@carbon/storybook-addon-theme": ^0.22.34
     "@carbon/themes": 10.55.1
     "@carbon/type": 10.45.1
     "@storybook/addon-actions": ^6.5.16
@@ -1972,7 +1972,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/storybook-addon-theme@^0.22.33, @carbon/storybook-addon-theme@workspace:config/storybook-addon-carbon-theme":
+"@carbon/storybook-addon-theme@^0.22.34, @carbon/storybook-addon-theme@workspace:config/storybook-addon-carbon-theme":
   version: 0.0.0-use.local
   resolution: "@carbon/storybook-addon-theme@workspace:config/storybook-addon-carbon-theme"
   dependencies:


### PR DESCRIPTION
Removes `"private": true` from storybook-addon-theme package. This unfortunately prevents yarn.lock from updating when it needs. We will need to find another way to prevent this package from publishing in both the `release-v1.yml` and `release.yml` actions.