### PR TITLE
cannot read offsetWidth from undefined

### DIFF
--- a/packages/ibm-products/src/components/TagSet/TagSet.js
+++ b/packages/ibm-products/src/components/TagSet/TagSet.js
@@ -166,7 +166,7 @@ export let TagSet = React.forwardRef(
         let spaceAvailable = tagSetRef.current.offsetWidth;
 
         for (let i in sizingTags) {
-          const tagWidth = sizingTags[i].offsetWidth;
+          const tagWidth = sizingTags[i]?.offsetWidth || 0;
 
           if (spaceAvailable >= tagWidth) {
             spaceAvailable -= tagWidth;


### PR DESCRIPTION
Contributes to DataGrid FilterSummay

There is an error in the DataGrid FilterSummary component which is using TagSets for clear FIlters and when I click on clearFilters an error will raise that causes to not be able to open filters again.

#### What did you change?
I added optional chaining to sizingTags elements to avoid that error.

#### How did you test and verify your work?
I ran ```yarn test``` and QA it by my self to assure it will work
