### PR TITLE
chore: disable codeowners for Security on main

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,4 @@
 * @carbon-design-system/ibm-cloud-cognitive-development
 
 # Carbon for IBM Products > Security package
-# cspell:disable-next-line
-/packages/security/ @amtoussam   @jlongshore
+# /packages/security/ @amtoussam   @jlongshore

--- a/cspell.contributors.txt
+++ b/cspell.contributors.txt
@@ -46,3 +46,7 @@ Glapa
 
 Marienella
 mgallo
+
+amtoussam
+
+jlongshore


### PR DESCRIPTION
Stop spamming @amtoussam and @jlongshore from getting IBM Products notifications (for now) 😉.

#### What did you change?
Commented out Security package line but decided not to fully remove for some tiny bit of visibility. Also unsure if this will be like actions where removing from `main` will stop defaulting to in `main_v1` based PRs. 👀 

#### How did you test and verify your work?
🤐 