### PR TITLE
fix(non-linear): update stories and mdx

### DIFF
--- a/packages/ibm-products/src/components/NonLinearReading/NonLinearReading.mdx
+++ b/packages/ibm-products/src/components/NonLinearReading/NonLinearReading.mdx
@@ -34,91 +34,35 @@ explain, educate, and cultivate novice users into high-functioning power users._
 
 ## Example usage
 
-### Minimal
+### Single Level
 
 All you need for the basics.
 
 <Canvas>
-  <Story id={getStoryId(NonLinearReading.displayName, 'non-linear-reading')} />
+  <Story id={getStoryId(NonLinearReading.displayName, 'single-level')} />
 </Canvas>
 
-### In series
+### Multiple Level
 
-Multiple non-linear reading components can be used in the same text block.
+Multiple, embedded non-linear reading components can be used in the same text
+block.
 
 <Canvas>
-  <Story id={getStoryId(NonLinearReading.displayName, 'in-series')} />
+  <Story id={getStoryId(NonLinearReading.displayName, 'multiple-level')} />
 </Canvas>
 
-```jsx
-After we create your
-  <NonLinearReading
-    definition={
-      <>
-        <Link
-          href="https://www.ibm.com/products/qradar-xdr-connect"
-          target={'_blank'}
-          rel="noreferrer"
-        >
-          XDR Connect’s
-        </Link>{' '}
-        correlation engine <strong>creates the case for you</strong>, by
-        processing data from alerts across multiple security tools—including
-        your own connected security systems—in order to save you time.
-      </>
-    }
-  >
-    case,
-  </NonLinearReading>
-  we also
-  <NonLinearReading
-    definition="By starting the investigation, we help to reduce your manual workload. We gather all available evidence for you to review; use Watson Cybersecurity to scrape the web for additional, previously unknown threat intelligence; and start taking note of anything that happened before and after the incident, to get a more detailed view."
-  >
-    investigate
-  </NonLinearReading>
-for you. More insights are uncovered by analyzing relevant data from your
-tools, and enriching them. We visualize the incident’s progression on the
-Attack graph; and we recommend remediation steps.
-```
+### With Gradient Background
 
-### Embedded
+Some other Novice to pro components use a gradient background as shown.
 
-Non-linear reading components can be embedded one inside another.
+If using NonLinearReading inside one of these components, always use
+`theme="dark"`.
 
 <Canvas>
-  <Story id={getStoryId(NonLinearReading.displayName, 'embedded')} />
+  <Story
+    id={getStoryId(NonLinearReading.displayName, 'with-gradient-background')}
+  />
 </Canvas>
-
-```jsx
-Findings are created by the
-  <NonLinearReading
-    definition={
-      <>
-        We examine the alerts from each source, and
-        <NonLinearReading
-          definition="Correlation allows us to identify connections between common observables, tactics, and techniques, and to remove any duplicate data, thereby streamlining the investigation for you."
-        >
-          correlate
-        </NonLinearReading>
-        them together with rules. While a case can contain multiple alerts,
-        a single finding can only be created from a single alert. So, when
-        you select a finding, you can drill right down to the raw data
-        behind it: the payload. We also use our
-        <NonLinearReading
-          definition="Our threat intelligence service contains an enrichment capability. During the enrichment process, we add context that is used to establish the severity of artifacts associated with a finding. This is what determines the severity of the finding itself. Bear in mind that each case can have multiple findings, and every finding will have its own severity."
-        >
-          threat intelligence service
-        </NonLinearReading>
-        to establish the severity of the artifacts.
-      </>
-    }
-  >
-    alerts ingested
-  </NonLinearReading>
-from your own security systems. The findings here are confirmed findings
-that have been created from alerts ingested from your own sources, before
-being enriched to create cases.
-```
 
 <!-- ## Code sample -->
 

--- a/packages/ibm-products/src/components/NonLinearReading/NonLinearReading.stories.js
+++ b/packages/ibm-products/src/components/NonLinearReading/NonLinearReading.stories.js
@@ -42,37 +42,41 @@ export default {
   },
 };
 
-const defaultProps = {
-  definition: (
-    <>
-      This is a technical component that uses a set of rules to process alerts
-      from your{' '}
-      <a href="https://www.ibm.com/" target="_blank" rel="noreferrer">
-        sources
-      </a>
-      , and streamline threat analysis.
-    </>
-  ),
-  theme: 'light',
-};
-
-// As a standalone component, the "story" is meaningless:
+// As a standalone component, each "story" is meaningless:
 // just a pill for a keyword, expanding to show its definition.
 // Should always be shown in context with surrounding text.
 
+// TODO: Bug? Even if not used, `args` must be passed to enable "Show code" in the docs.
+// eslint-disable-next-line no-unused-vars
 const TemplateSingleLevel = (args) => {
   const theme = getSelectedCarbonTheme();
 
   return (
     <div className={`${storyClass}__viewport`}>
       XDR Connect’s correlation
-      <NonLinearReading {...args} theme={theme} />
+      <NonLinearReading
+        definition={
+          <>
+            This is a technical component that uses a set of rules to process
+            alerts from your{' '}
+            <a href="https://www.ibm.com/" target="_blank" rel="noreferrer">
+              sources
+            </a>
+            , and streamline threat analysis.
+          </>
+        }
+        theme={theme}
+      >
+        engine,
+      </NonLinearReading>{' '}
       creates a case by processing data from alerts across multiple security
       tools.
     </div>
   );
 };
 
+// Even if not used, `args` must be passed to enable "Show code" in the docs.
+// eslint-disable-next-line no-unused-vars
 const TemplateMultipleLevel = (args) => {
   const theme = getSelectedCarbonTheme();
 
@@ -80,12 +84,10 @@ const TemplateMultipleLevel = (args) => {
     <div className={`${storyClass}__viewport`}>
       Findings are created by the alerts{' '}
       <NonLinearReading
-        {...args}
         definition={
           <>
             We examine the alerts from each source, and{' '}
             <NonLinearReading
-              {...args}
               definition="Correlation allows us to identify connections between common
                   observables, tactics, and techniques, and to remove any
                   duplicate data, thereby streamlining the investigation for
@@ -103,7 +105,6 @@ const TemplateMultipleLevel = (args) => {
             you can drill right down to the raw data behind it: the payload. We
             also use our
             <NonLinearReading
-              {...args}
               definition="
                   Our threat intelligence service contains an enrichment
                   capability. During the enrichment process, we add context that
@@ -130,44 +131,39 @@ const TemplateMultipleLevel = (args) => {
   );
 };
 
+// Even if not used, `args` must be passed to enable "Show code" in the docs.
+// eslint-disable-next-line no-unused-vars
 const TemplateWithGradientBackground = (args) => {
   return (
     <div className={`${storyClass}__viewport`}>
       <div className="gradient-bg">
         XDR Connect’s correlation
-        <NonLinearReading {...args} theme="dark" />
+        <NonLinearReading
+          definition={
+            <>
+              This is a technical component that uses a set of rules to process
+              alerts from your{' '}
+              <a href="https://www.ibm.com/" target="_blank" rel="noreferrer">
+                sources
+              </a>
+              , and streamline threat analysis.
+            </>
+          }
+          theme="dark"
+        >
+          engine,
+        </NonLinearReading>{' '}
         creates a case by processing data from alerts across multiple security
         tools.
       </div>
-      <br />
-      Some other Novice to pro components use a gradient background as shown
-      above.
-      <br />
-      If using NonLinearReading inside one of these components, always use{' '}
-      <code>theme=&quot;dark&quot;</code>.
     </div>
   );
 };
 
-export const SingleLevel = prepareStory(TemplateSingleLevel, {
-  args: {
-    ...defaultProps,
-    children: 'engine,',
-  },
-});
+export const SingleLevel = prepareStory(TemplateSingleLevel);
 
-export const MultipleLevel = prepareStory(TemplateMultipleLevel, {
-  args: {
-    ...defaultProps,
-  },
-});
+export const MultipleLevel = prepareStory(TemplateMultipleLevel);
 
 export const WithGradientBackground = prepareStory(
-  TemplateWithGradientBackground,
-  {
-    args: {
-      ...defaultProps,
-      children: 'engine,',
-    },
-  }
+  TemplateWithGradientBackground
 );


### PR DESCRIPTION
Contributes to #3001

Storybook examples under the Docs tab are now loading.

#### What did you change?

Stories updates
1. Removed `defaultProps` as they were overridden in every example.
2. _Wanted to_ remove `args` from each template, but there seems to be a bug where if `args` is missing as a template argument, then in the Docs tab the "Show code" button changes to the "No code available" button. (!?) I left `args` in along with a `TODO` comment explaining the problem.

Docs updates
1. Updated example titles.
2. Replaced old "Embedded" story with "With Gradient" story.

#### How did you test and verify your work?

1. Loaded [Storybook for Non-Linear Reading](https://deploy-preview-3002--v1-carbon-for-ibm-products.netlify.app/?path=/docs/ibm-products-novice-to-pro-nonlinearreading-canary--single-level) component.
2. Switched to Docs tab.
3. Saw that the examples had loaded correctly.

## Before

<img src="https://github.com/carbon-design-system/ibm-cloud-cognitive/assets/52505287/baf20bf3-f15a-406d-ac81-8e1b3e093b2c" width="600"/>

## After

<img src="https://github.com/carbon-design-system/ibm-products/assets/52505287/c821dbd8-e080-4ab1-ada5-7bba775f4f94" width="600"/>