### PR TITLE
fix(DataGrid): header misalignment when modal open - v1

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/Datagrid/_storybook-styles.scss
@@ -137,8 +137,8 @@ $block-class: #{$pkg-prefix}--datagrid;
 
 .#{$carbon-prefix}--body--with-modal-open {
   .#{$block-class}__mobile-toolbar-modal.#{$carbon-prefix}--modal {
-    top: -2rem;
-    left: -2rem;
+    top: calc($spacing-07 * -1);
+    left: calc($spacing-07 * -1);
     width: 100vw;
   }
 }

--- a/packages/ibm-products/src/components/Datagrid/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/Datagrid/_storybook-styles.scss
@@ -134,3 +134,11 @@ $block-class: #{$pkg-prefix}--datagrid;
   flex: 0 1 calc($spacing-05 * 30);
   margin-right: $spacing-07;
 }
+
+.#{$carbon-prefix}--body--with-modal-open {
+  .#{$block-class}__mobile-toolbar-modal.#{$carbon-prefix}--modal {
+    top: -2rem;
+    left: -2rem;
+    width: 100vw;
+  }
+}

--- a/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
@@ -575,11 +575,6 @@
   width: 100%;
 }
 
-.#{$carbon-prefix}--body--with-modal-open .#{$block-class}__grid-container {
-  overflow: hidden;
-  height: 100vh;
-}
-
 .#{$carbon-prefix}--overflow-menu.#{$block-class}__toolbar-menu__trigger {
   flex-shrink: 0;
   background-color: $interactive-01;


### PR DESCRIPTION
Contributes to #2724 
`.#{c4p-settings.$carbon-prefix}--body--with-modal-open
  .#{$block-class}__grid-container {
  overflow: hidden;
  height: 100vh;
}`

The above style caused the issue. This is added as part of toolbar responsiveness and affected other modals inside Datagrid. 

#### What did you change?
The changes are only required in the storybook demo to override `#root` element padding. This is managed to add styles in `_storybook-styles.scss`.
#### How did you test and verify your work?
Storybook.
Toolbar mobile modal now
![image](https://github.com/carbon-design-system/ibm-products/assets/305492/2589275f-105a-4484-86f9-1e6a5b1060fb)

Customize column modal now
![image](https://github.com/carbon-design-system/ibm-products/assets/305492/7b628429-7326-45d0-8d31-3cf92a738e43)