### PR TITLE
fix(Datagrid): prevent undefined value for isTableSortable prop

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/TearsheetWrapper.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/TearsheetWrapper.js
@@ -21,7 +21,7 @@ const TearsheetWrapper = ({ instance }) => {
       {...rest}
       {...labels}
       isOpen={isTearsheetOpen}
-      isTableSortable={instance?.isTableSortable}
+      isTableSortable={instance?.isTableSortable || false}
       setIsTearsheetOpen={setIsTearsheetOpen}
       columnDefinitions={instance.allColumns}
       originalColumnDefinitions={instance.columns}


### PR DESCRIPTION
Contributes to [ibm-products](https://github.com/carbon-design-system/ibm-products)

when using tearsheet isTableSortable prop is undefined and since it is a required prop it causes error

#### What did you change?
i added default value false for prop

#### How did you test and verify your work?
checked it in storybook and my production version of my project
