### PR TITLE
chore(Datagrid): address rerender issues with filter flyout button

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -84,7 +84,7 @@ export const DatagridContent = ({ datagridState }) => {
           getTableProps()?.className
         )}
         role={withInlineEdit && 'grid'}
-        tabIndex={withInlineEdit && 0}
+        tabIndex={withInlineEdit ? 0 : -1}
         onKeyDown={
           withInlineEdit
             ? (event) =>

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
@@ -7,7 +7,7 @@
  */
 
 import { Filter } from '@carbon/react/icons';
-import { Button, usePrefix } from '@carbon/react';
+import { IconButton, usePrefix } from '@carbon/react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useRef, useState, useEffect } from 'react';
@@ -159,18 +159,18 @@ const FilterFlyout = ({
 
   return (
     <div className={`${componentClass}__container`}>
-      <Button
+      <IconButton
+        label={flyoutIconDescription}
         kind="ghost"
-        hasIconOnly
-        tooltipPosition="bottom"
-        renderIcon={() => <Filter size={16} />}
-        iconDescription={flyoutIconDescription}
+        align="bottom"
         onClick={open ? closeFlyout : openFlyout}
         className={cx(`${componentClass}__trigger`, {
           [`${componentClass}__trigger--open`]: open,
         })}
         disabled={data.length === 0}
-      />
+      >
+        <Filter />
+      </IconButton>
       <div
         ref={filterFlyoutRef}
         className={cx(componentClass, {

--- a/packages/ibm-products/src/components/Datagrid/styles/addons/_FilterFlyout.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/addons/_FilterFlyout.scss
@@ -75,6 +75,13 @@ $action-set-height: rem(64px);
 }
 
 // Carbon overrides
+.#{variables.$block-class}-filter-flyout__trigger.#{c4p-settings.$carbon-prefix}--btn {
+  display: flex;
+  width: 3rem;
+  height: 3rem;
+  justify-content: center;
+}
+
 .#{variables.$block-class}-filter-flyout__trigger--open.#{c4p-settings.$carbon-prefix}--btn.#{c4p-settings.$carbon-prefix}--btn--icon-only {
   position: relative;
   background-color: $layer-02;

--- a/packages/ibm-products/src/components/Datagrid/styles/addons/_FilterPanel.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/addons/_FilterPanel.scss
@@ -124,6 +124,10 @@
 }
 
 .#{c4p-settings.$carbon-prefix}--btn.c4p--datagrid-filter-panel-open-button {
+  display: flex;
+  width: 3rem;
+  height: 3rem;
+  justify-content: center;
   border-right: 1px solid $layer-accent-01;
   border-bottom: none;
 }

--- a/packages/ibm-products/src/components/Datagrid/utils/DatagridActions.js
+++ b/packages/ibm-products/src/components/Datagrid/utils/DatagridActions.js
@@ -10,6 +10,7 @@ import {
   TableToolbarContent,
   TableToolbarSearch,
   Button,
+  IconButton,
   OverflowMenu,
   OverflowMenuItem,
   ComposedModal,
@@ -67,17 +68,16 @@ export const DatagridActions = (datagridState) => {
 
   const renderFilterPanelButton = () =>
     filterProps?.variation === 'panel' && (
-      <Button
+      <IconButton
         kind="ghost"
-        hasIconOnly
-        tooltipPosition="bottom"
-        renderIcon={(props) => <Filter size={16} {...props} />}
-        iconDescription={filterProps.panelIconDescription}
+        align="bottom"
+        label={filterProps.panelIconDescription}
         className={`${blockClass}-filter-panel-open-button`}
         onClick={() => setPanelOpen((open) => !open)}
         disabled={data.length === 0}
-        tooltipAlignment="start"
-      />
+      >
+        <Filter />
+      </IconButton>
     );
 
   const [modalOpen, setModalOpen] = useState(false);


### PR DESCRIPTION
Contributes to #2725 

I was able to narrow down the re-rendering issues with the `FilterFlyout` button, which caused the trigger to have to be clicked twice before opening the flyout. From what I can tell so far, it stems from the `renderIcon` prop from Carbon's `Button` component. I simply changed from using `Button` with the `renderIcon` prop to `IconButton` and the issue is gone.

I'm going to continue doing some investigating, because things like the ButtonMenu still have this problem.

I also made a small change to the `tabIndex` of the containing element for the Datagrid to remove a console error.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
packages/ibm-products/src/components/Datagrid/styles/addons/_FilterFlyout.scss
```
#### How did you test and verify your work?
Storybook