### PR TITLE
chore: publish storybook 6 theme addon to v1

### DIFF
--- a/config/storybook-addon-carbon-theme/package.json
+++ b/config/storybook-addon-carbon-theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/storybook-addon-theme",
   "description": "Carbon theme switcher for Storybook",
-  "version": "0.22.41",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "main": "dist/react.js",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
     "@carbon/layout": "^11.14.0",
     "@carbon/motion": "^11.11.0",
     "@carbon/react": "~1.30.0",
-    "@carbon/storybook-addon-theme": "^0.22.41",
+    "@carbon/storybook-addon-theme": "^1.0.0",
     "@carbon/themes": "^11.19.0",
     "@carbon/type": "^11.18.0",
     "@storybook/addon-actions": "^6.5.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1843,7 +1843,7 @@ __metadata:
     "@carbon/layout": ^11.14.0
     "@carbon/motion": ^11.11.0
     "@carbon/react": ~1.30.0
-    "@carbon/storybook-addon-theme": ^0.22.41
+    "@carbon/storybook-addon-theme": ^1.0.0
     "@carbon/themes": ^11.19.0
     "@carbon/type": ^11.18.0
     "@storybook/addon-actions": ^6.5.16
@@ -1993,7 +1993,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/storybook-addon-theme@^0.22.41, @carbon/storybook-addon-theme@workspace:config/storybook-addon-carbon-theme":
+"@carbon/storybook-addon-theme@^1.0.0, @carbon/storybook-addon-theme@workspace:config/storybook-addon-carbon-theme":
   version: 0.0.0-use.local
   resolution: "@carbon/storybook-addon-theme@workspace:config/storybook-addon-carbon-theme"
   dependencies:


### PR DESCRIPTION
Contributes to #2846 

Before publishing a theme add-on with storybook 7 support, make the storybook 6 support v1.

#### What did you change?

Just the version number of the theme switching package.

#### How did you test and verify your work?

Built the software and ran CI-Check.
