### PR TITLE
docs: update release review template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-review.md
+++ b/.github/ISSUE_TEMPLATE/release-review.md
@@ -10,38 +10,43 @@ about: Review process before release of a new component or pattern from Canary
 - [ ] One or more scenarios for a design pattern have been identified as a
       useful unit of functionality to publish.
 - [ ] A functioning component or components delivering those scenarios have been
-      delivered and merged to main.
-- [ ] Design maintainer has approved the implementation for those scenarios (via
-      a comment on the relevant issue/epic).
+      delivered and merged to `main`.
+- [ ] The component or components have completed an [accessibility review](https://github.com/carbon-design-system/ibm-products/blob/main/.github/ISSUE_TEMPLATE/accessibilty-review.md).
+- [ ] One or more design maintainers have approved the implementation for those
+      scenarios, preferably via [design review](https://github.com/carbon-design-system/ibm-products/blob/main/.github/ISSUE_TEMPLATE/design-review.md).
 
 ### Engineering review
 
 - [ ] Breaking changes have only been introduced with prior approval, discussion
-      and documented in release notes. Ideally deprecation notices in the prior
-      major version must have been added in a timely fashion.
+      and are documented in release notes. Deprecation notices and/or feature
+      flags are included in the prior major version.
 - [ ] The implementation takes into account, and does not impair, remaining and
       anticipated design scenarios.
 - [ ] Public component features (names, props, etc) are consistent with
       Carbon-defined conventions and are consistent internally. Where there
-      isn't an existing convention to apply, ensure robust precedents are being
+      isn’t an existing convention to apply, ensure robust precedents are being
       established.
-- [ ] The UI produced is accessible, responsive, translatable, cross-browser,
-      and responds to the currently set Carbon theme.
+- [ ] The UI produced is
+  - [ ] responsive,
+  - [ ] translatable[^1],
+  - [ ] cross-browser,
+  - [ ] and responds to the currently set Carbon theme.
 - [ ] Components are functional components using hooks.
-- [ ] Public components which produce DOM structures support className.
-- [ ] Public components support a ref (via React.forwardRef).
+- [ ] Public components which produce DOM structures support `className`.
+- [ ] Public components support a ref (via `React.forwardRef`).
 - [ ] Public component supports a Devtools attribute
-- [ ] All significant DOM elements have meaningful classes.
-- [ ] Additional attributes that are not identified as props (such as title,
-      aria-\*, etc) are passed through to an appropriate DOM node of the
+- [ ] All significant DOM elements have meaningful classes[^2] and include
+      the package or Carbon prefix (no hardcoded prefixes).
+- [ ] Additional attributes that are not identified as props (such as `title`,
+      `aria-*`, etc) are passed through to an appropriate DOM node of the
       component as HTML attributes.
 - [ ] No warnings, errors or log messages in the console.
-- [ ] Each public component JS is exported in /src/components/index.js, each
-      public component SCSS is included in /src/components/\_index.scss, and
-      each public component has a flag in package-settings.js.
-- [ ] Each public component SCSS lists all of the Carbon and C&CS components
-      imported and used by the JavaScript code and explicitly imports the SCSS
-      for each of these components.
+- [ ] Each public component JS is exported in `/src/components/index.js`, each
+      public component SCSS is included in `/src/components/_index.scss`, and
+      each public component has a flag in `package-settings.js`.
+- [ ] Each public component SCSS lists all of the Carbon and IBM Products
+      components imported and used by the JavaScript code and explicitly imports
+      the SCSS for each of these components.
 
 ### Standards
 
@@ -49,9 +54,9 @@ about: Review process before release of a new component or pattern from Canary
 - [ ] Carbon tokens (theme, layout, motion) are used unless the design specifies
       otherwise.
 - [ ] All components utilizing motion must include reduced-motion queries for
-      accessibility purposes - read more here.
+      accessibility purposes.
 - [ ] Code is formatted according to prettier rules (no use of
-      //prettier-ignore).
+      `//prettier-ignore`).
 - [ ] Code is clear, maintainable and follows standard React practices and the
       code guidelines.
 - [ ] Copyright header in every source file (js, css, scss etc.) with the
@@ -64,9 +69,9 @@ about: Review process before release of a new component or pattern from Canary
       outputs.
 - [ ] The tests validate the behaviors and interactions defined in the design
       where practical.
-- [ ] The tests achieve 100% coverage. Usage of istanbul ignore is appropriate
-      and not extensive.
-- [ ] No warnings, errors or log messages in the test output.
+- [ ] The tests achieve at least 80% coverage. Usage of `istanbul ignore` is
+      appropriate and not extensive.
+- [ ] No warnings, errors, or log messages in the test output.
 
 ### Documentation
 
@@ -74,6 +79,9 @@ about: Review process before release of a new component or pattern from Canary
       all public components and their props.
 - [ ] There is a story for each design scenario. The stories expose all relevant
       props and actions, and additional usage documentation and code samples are
-      available on the 'Docs' tab along with the props table.
-- [ ] There is a sandbox (or multiple sandboxes if appropriate) on CodeSandbox
-      for the components.
+      available on the Docs story along with the props table.
+- [ ] There is an example (or multiple sandboxes if appropriate) on CodeSandbox
+      and Stackblitz for the components.
+
+[^1]: Any labels, text, or other strings within a component should use a prop.
+[^2]: See Carbon’s [Developer Handbook](https://github.com/carbon-design-system/carbon/blob/main/.github/CONTRIBUTING.md) for guidance on [class names](https://github.com/carbon-design-system/carbon/blob/main/docs/developer-handbook.md#class-names).

--- a/.github/ISSUE_TEMPLATE/release-review.md
+++ b/.github/ISSUE_TEMPLATE/release-review.md
@@ -11,9 +11,11 @@ about: Review process before release of a new component or pattern from Canary
       useful unit of functionality to publish.
 - [ ] A functioning component or components delivering those scenarios have been
       delivered and merged to `main`.
-- [ ] The component or components have completed an [accessibility review](https://github.com/carbon-design-system/ibm-products/blob/main/.github/ISSUE_TEMPLATE/accessibilty-review.md).
+- [ ] The component or components have completed an
+      [accessibility review](https://github.com/carbon-design-system/ibm-products/blob/main/.github/ISSUE_TEMPLATE/accessibilty-review.md).
 - [ ] One or more design maintainers have approved the implementation for those
-      scenarios, preferably via [design review](https://github.com/carbon-design-system/ibm-products/blob/main/.github/ISSUE_TEMPLATE/design-review.md).
+      scenarios, preferably via
+      [design review](https://github.com/carbon-design-system/ibm-products/blob/main/.github/ISSUE_TEMPLATE/design-review.md).
 
 ### Engineering review
 
@@ -35,8 +37,8 @@ about: Review process before release of a new component or pattern from Canary
 - [ ] Public components which produce DOM structures support `className`.
 - [ ] Public components support a ref (via `React.forwardRef`).
 - [ ] Public component supports a Devtools attribute
-- [ ] All significant DOM elements have meaningful classes[^2] and include
-      the package or Carbon prefix (no hardcoded prefixes).
+- [ ] All significant DOM elements have meaningful classes[^2] and include the
+      package or Carbon prefix (no hardcoded prefixes).
 - [ ] Additional attributes that are not identified as props (such as `title`,
       `aria-*`, etc) are passed through to an appropriate DOM node of the
       component as HTML attributes.
@@ -84,4 +86,8 @@ about: Review process before release of a new component or pattern from Canary
       and Stackblitz for the components.
 
 [^1]: Any labels, text, or other strings within a component should use a prop.
-[^2]: See Carbon’s [Developer Handbook](https://github.com/carbon-design-system/carbon/blob/main/.github/CONTRIBUTING.md) for guidance on [class names](https://github.com/carbon-design-system/carbon/blob/main/docs/developer-handbook.md#class-names).
+[^2]:
+    See Carbon’s
+    [Developer Handbook](https://github.com/carbon-design-system/carbon/blob/main/.github/CONTRIBUTING.md)
+    for guidance on
+    [class names](https://github.com/carbon-design-system/carbon/blob/main/docs/developer-handbook.md#class-names).

--- a/docs/reviews/RELEASE_REVIEW_GUIDELINES.md
+++ b/docs/reviews/RELEASE_REVIEW_GUIDELINES.md
@@ -4,16 +4,17 @@
 
 Reviews will be carried out by one or more members of the core contribution
 team. They will include as a minimum the following checks, which establish the
-"definition of done" for a component.
+“definition of done” for a component.
 
-Paste the following checklist into the epic or issue under which the component
-is being made ready, then check where criteria passed, and add notes to clarify
-how an item is complete or what remains to be done: for anything more than
-minor/simple items, open issues to track them.
+Create a
+[release review](https://github.com/carbon-design-system/ibm-products/issues/new?assignees=&labels=&projects=&template=release-review.md)
+for the component in question, then check where criteria passed, and add notes
+to clarify how an item is complete or what remains to be done: for anything more
+than minor or simple items, open issues to track them.
 
-**Tip** You should be able to copy and paste the section below directly into a
-GitHub comment, then check where criteria passed, strike out where not
-applicable, and add notes to each item where applicable.
+**Tip** You can leverage the review template or copy it into a GitHub comment,
+then check where criteria passed, strike out where not applicable, and add notes
+to each item where applicable.
 
 Once one or more components have been reviewed for readiness, the following
 steps are needed:
@@ -21,81 +22,7 @@ steps are needed:
 - the flags for the components in package-settings.js should be changed to
   `true`.
 - the component SCSS should be included in
-  /src/components/\_index-released-only.scss.
+  `/src/components/_index-released-only.scss.`
 - run the tests, recreating snapshots (using `-u`), and check in the updated
   public CSS snapshot. NB it is sufficient to run `yarn test:c4p:snapshot` to
   complete the snapshot updates.
-
-`## Review for release`
-
-`###` Readiness
-
-`- [ ]` One or more scenarios for a design pattern have been identified as a
-useful unit of functionality to publish.\
-`- [ ]` A functioning component or components delivering those scenarios have been
-delivered and merged to main.\
-`- [ ]` Design maintainer has approved the implementation for those scenarios
-(via a comment on the relevant issue/epic).
-
-`###` Engineering review
-
-`- [ ]` Breaking changes have only been introduced with prior approval,
-discussion and documented in release notes. Ideally deprecation notices in the
-prior major version must have been added in a timely fashion.\
-`- [ ]` The implementation takes into account, and does not impair, remaining and
-anticipated design scenarios.\
-`- [ ]` Public component features (names, props, etc) are consistent with
-Carbon-defined conventions and are consistent internally. Where there isn't an
-existing convention to apply, ensure robust precedents are being established.\
-`- [ ]` The UI produced is accessible, responsive, translatable, cross-browser, and
-responds to the currently set Carbon theme.\
-`- [ ]` Components are functional components using hooks.\
-`- [ ]` Public components which produce DOM structures support className.\
-`- [ ]` Public components support a ref (via React.forwardRef).\
-`- [ ]` Public component supports a [Devtools attribute](https://github.com/carbon-design-system/ibm-products/search?l=JavaScript&q=devtools&type=)
-\
-`- [ ]` All significant DOM elements have meaningful classes.\
-`- [ ]` Additional attributes that are not identified as props (such as title, aria-\*,
-etc) are passed through to an appropriate DOM node of the component as HTML attributes.\
-`- [ ]` No warnings, errors or log messages in the console.\
-`- [ ]` Each public component JS is exported in /src/components/index.js, each public
-component SCSS is included in /src/components/\_index.scss, and each public component
-has a flag in package-settings.js.\
- `- [ ]` Each public component SCSS lists all of the Carbon and C&CS components imported
-and used by the JavaScript code and explicitly imports the SCSS for each of these
-components.
-
-`###` Standards
-
-`- [ ]` No linter warnings or errors are produced.\
-`- [ ]` Carbon tokens (theme, layout, motion) are used unless the design specifies
-otherwise.\
-`- [ ]` All components utilizing motion must include reduced-motion queries for
-accessibility purposes -
-[read more here](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion).\
-`- [ ]` Code is formatted according to prettier rules (no use of //prettier-ignore).\
-`- [ ]` Code is clear, maintainable and follows standard React practices and the
-[code guidelines](https://github.com/carbon-design-system/ibm-products/blob/master/docs/CODE_GUIDELINES.md).\
-`- [ ]` Copyright header in every source file (js, css, scss etc.) with the appropriate
-years.
-
-`###` Testing
-
-`- [ ]` There is a set of test cases for the components.\
-`- [ ]` The tests exercise all inputs (props, slots, etc) and verify appropriate
-outputs.\
-`- [ ]` The tests validate the behaviors and interactions defined in the design
-where practical.\
-`- [ ]` The tests achieve 100% coverage. Usage of `istanbul ignore` is appropriate
-and not extensive.\
-`- [ ]` No warnings, errors or log messages in the test output.
-
-`###` Documentation
-
-`- [ ]` Source code is satisfactorily commented and provides DocGen comments for
-all public components and their props.\
-`- [ ]` There is a story for each design scenario. The stories expose all relevant
-props and actions, and additional usage documentation and code samples are available
-on the 'Docs' tab along with the props table.\
-`- [ ]` There is an online example (or multiple examples if appropriate) e.g.
-CodeSandbox/Stackblitz for the components.


### PR DESCRIPTION
Closes #2235 and #2232


#### What did you change?
- Add step to check for completed accessibility review
- Break `The UI produced is accessible, responsive, translatable, cross-browser, and responds to the currently set Carbon theme` into multiple steps
- Remove redundant template from release review guidelines

#### How did you test and verify your work?
Markdown preview 💁‍♀️ 