### PR TITLE
chore: update dependency and release actions

### DIFF
--- a/.github/workflows/release-v1.yml
+++ b/.github/workflows/release-v1.yml
@@ -67,3 +67,14 @@ jobs:
         run:
           yarn lerna publish from-package --dist-tag v1-latest
           --yes
+
+      - name: Bump versions
+        run: yarn
+
+      - name: Commit lock file
+      - run: |
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git config user.name $GITHUB_ACTOR
+          git add yarn.lock
+          git commit -m "chore: update lockfile"
+          git push origin main_v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,3 +43,14 @@ jobs:
         run:
           yarn lerna publish --no-verify-access --create-release
           github --yes
+
+      - name: Bump versions
+        run: yarn
+
+      - name: Commit lock file
+      - run: |
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git config user.name $GITHUB_ACTOR
+          git add yarn.lock
+          git commit -m "chore: update lockfile"
+          git push origin main

--- a/.github/workflows/update-v1.yml
+++ b/.github/workflows/update-v1.yml
@@ -1,0 +1,99 @@
+name: Update v1 packages # Updates dependencies once a month
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 22 * *' # Updates will happen every 22nd of the month
+
+jobs:
+  carbon:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: 'main_v1'
+
+      - name: Install
+        run: yarn
+
+      - name: Update Carbon packages
+        run: |
+          yarn upgrade:carbon
+          yarn
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
+
+      - name: Create PR
+        id: create-pr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.CREATE_PR_ACCESS_TOKEN }}
+          commit-message: 'fix: update Carbon 10 compatible versions to latest'
+          committer: GitHub <noreply@github.com>
+          author:
+            ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          branch: 'update-packages'
+          branch-suffix: random
+          title: 'fix: update to Carbon 10 compatible versions to latest'
+          body: |
+            This PR was automatically generated to update Carbon 10 compatible versions on a regular basis. This is not intended to create any breaking changes, and will be reflected as a minor version bump for affected packages. NB we'll run all tests and do visual verifications, but there is always the opportunity for unexpected regressions. If you're using one of the packages in a stable or production context you may want to check this before taking the next minor version, and do let us know ASAP if you see anything problematic.
+
+            The goal is to update to the latest Carbon 10 compatible versions each Friday, to ensure we remain up-to-date with the latest changes (often published on Thursdays) and to ensure interoperability with other packages that also depend on Carbon. We will normally update all other dependencies at the same time to their latest versions, except for specific cases where we have found the updates to be problematic or require further work before they can be used. By using the latest stable version of each dependency we ensure we get fixes and improvements in a timely fashion and reduce the impact of updating the versions that can arise if versions are allowed to become stale for an extended period.
+
+            #### What did you change?
+
+            This action ran `yarn upgrade:carbon` to upgrade all carbon-related packages to the latest versions.
+
+            This PR includes the various `package.json` that pull our dependencies forward to the latest versions, and updates the offline mirror.
+
+            #### How did you test and verify your work?
+
+            This PR should not be merged until the following checks have been made:
+            - [ ] `yarn ci-check` runs cleanly and all tests pass (done automatically as part of the PR checks).
+            - [ ] the Netlify deploy-preview has been used to ensure that storybook runs and the main published components render correctly.
+
+  # dependencies:
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - uses: actions/checkout@v3
+
+  #     - name: Install
+  #       run: yarn
+
+  #     - name: Update packages
+  #       run: |
+  #         yarn upgrade:automatic
+  #         rm yarn.lock
+  #         yarn
+  #       env:
+  #         YARN_ENABLE_IMMUTABLE_INSTALLS: false
+
+  #     - name: Create PR
+  #       id: create-pr
+  #       uses: peter-evans/create-pull-request@v3
+  #       with:
+  #         token: ${{ secrets.CREATE_PR_ACCESS_TOKEN }}
+  #         commit-message: 'chore: update dev dependencies'
+  #         committer: GitHub <noreply@github.com>
+  #         author:
+  #           ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+  #         branch: 'update-packages'
+  #         branch-suffix: random
+  #         title: 'chore: update dev dependencies'
+  #         body: |
+  #           This PR was automatically generated to update versions of dev dependencies to their latest versions. This helps ensure we get fixes and improvements in a timely fashion and reduces the impact of updating the versions that can arise if versions are allowed to become stale for an extended period.
+
+  #           #### What did you change?
+
+  #           This action ran `yarn upgrade:automatic` to update `package.json` files to request the latest versions of each package. Certain critical packages are intentionally excluded.
+
+  #           This action also deleted the `yarn.lock` file in order to recreate it with the latest matching versions of secondary dependencies.
+
+  #           This PR includes the various `package.json` that pull our dependencies forward to the latest versions, the `yarn.lock` update that maps required versions to the actual versions to be used, and updates the offline mirror.
+
+  #           #### How did you test and verify your work?
+
+  #           This PR should not normally significantly affect the build outputs or runtime packages. Ensure that `yarn ci-check` runs cleanly and all tests pass (done automatically as part of the PR checks).

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,4 +1,4 @@
-name: Update packages # Updates dependencies every Friday
+name: Update v2 packages # Updates dependencies every Friday
 
 on:
   workflow_dispatch:
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install
         run: yarn
@@ -27,13 +27,13 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.CREATE_PR_ACCESS_TOKEN }}
-          commit-message: 'fix: update Carbon v10 compatible versions to latest'
+          commit-message: 'fix: update Carbon 11 compatible versions to latest'
           committer: GitHub <noreply@github.com>
           author:
             ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           branch: 'update-packages'
           branch-suffix: random
-          title: 'fix: update to Carbon v10 compatible versions to latest'
+          title: 'fix: update to Carbon 11 compatible versions to latest'
           body: |
             This PR was automatically generated to update Carbon v10 compatible versions on a regular basis. This is not intended to create any breaking changes, and will be reflected as a minor version bump for affected packages. NB we'll run all tests and do visual verifications, but there is always the opportunity for unexpected regressions. If you're using one of the packages in a stable or production context you may want to check this before taking the next minor version, and do let us know ASAP if you see anything problematic.
 
@@ -48,7 +48,7 @@ jobs:
             #### How did you test and verify your work?
 
             This PR should not be merged until the following checks have been made:
-            - [ ] A reminder message has been posted onto the ccs-pal-dev Slack channel that a version update PR is going through.
+            - [ ] A reminder message has been posted onto the ibmproducts-pal-dev Slack channel that a version update PR is going through.
             - [ ] `yarn ci-check` runs cleanly and all tests pass (done automatically as part of the PR checks).
             - [ ] the Netlify deploy-preview has been used to ensure that storybook runs and the main published components render correctly.
 
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install
         run: yarn

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,4 +1,4 @@
-name: Update v2 packages # Updates dependencies every Friday
+name: Update v2 packages # Updates dependencies twice a month
 
 on:
   workflow_dispatch:
@@ -35,9 +35,9 @@ jobs:
           branch-suffix: random
           title: 'fix: update to Carbon 11 compatible versions to latest'
           body: |
-            This PR was automatically generated to update Carbon v10 compatible versions on a regular basis. This is not intended to create any breaking changes, and will be reflected as a minor version bump for affected packages. NB we'll run all tests and do visual verifications, but there is always the opportunity for unexpected regressions. If you're using one of the packages in a stable or production context you may want to check this before taking the next minor version, and do let us know ASAP if you see anything problematic.
+            This PR was automatically generated to update Carbon 11 compatible versions on a regular basis. This is not intended to create any breaking changes, and will be reflected as a minor version bump for affected packages. NB we'll run all tests and do visual verifications, but there is always the opportunity for unexpected regressions. If you're using one of the packages in a stable or production context you may want to check this before taking the next minor version, and do let us know ASAP if you see anything problematic.
 
-            The goal is to update to the latest Carbon V10 compatible versions each Friday, to ensure we remain up-to-date with the latest changes (often published on Thursdays) and to ensure interoperability with other packages that also depend on Carbon. We will normally update all other dependencies at the same time to their latest versions, except for specific cases where we have found the updates to be problematic or require further work before they can be used. By using the latest stable version of each dependency we ensure we get fixes and improvements in a timely fashion and reduce the impact of updating the versions that can arise if versions are allowed to become stale for an extended period.
+            The goal is to update to the latest Carbon 11 compatible versions each Friday, to ensure we remain up-to-date with the latest changes (often published on Thursdays) and to ensure interoperability with other packages that also depend on Carbon. We will normally update all other dependencies at the same time to their latest versions, except for specific cases where we have found the updates to be problematic or require further work before they can be used. By using the latest stable version of each dependency we ensure we get fixes and improvements in a timely fashion and reduce the impact of updating the versions that can arise if versions are allowed to become stale for an extended period.
 
             #### What did you change?
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 
 # Carbon for IBM Products > Security package
 # cspell:disable-next-line
-/packages/security/ @amtoussam   @jlongshore
+/packages/security/ @jlongshore   @paul-balchin-ibm

--- a/cspell.packages.txt
+++ b/cspell.packages.txt
@@ -7,6 +7,7 @@ commitlint
 docgen
 dsag
 flatpickr
+ibmproducts
 kube
 kubernetes
 markdownlint


### PR DESCRIPTION
Closes to #3112 and #3113

#### What did you change?
- Update to `actions/checkout@v3`
- Fix naming in v2 update action
- Add v1 update action for Carbon dependencies
  -  Commented out other dependencies updates for now to limit workload and will look into whether dependabot can support multiple branches

**Note:** v1 dependency updates will be once a month offset from the v2 dependency updates 2x a month

#### How did you test and verify your work?
👀 