### PR TITLE
fix(Datagrid): address `saveCellData` loop, crashes Datagrid editable cell stories

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -36,7 +36,7 @@ export const InlineEditCell = ({
   placeholder = '',
   tabIndex,
   value,
-  nonEditCell,
+  nonEditCell = false,
   totalInlineEditColumns,
   type,
 }) => {
@@ -61,27 +61,7 @@ export const InlineEditCell = ({
   const outerButtonElement = useRef();
 
   const { rowSize, onDataUpdate } = instance;
-
-  // Saves the new cell data, onDataUpdate is a required function to be
-  // passed to useDatagrid when using useInlineEdit
-  const saveCellData = useCallback(
-    (newValue) => {
-      const columnId = cell.column.id;
-      const rowIndex = cell.row.index;
-      onDataUpdate((prev) =>
-        prev.map((row, index) => {
-          if (index === rowIndex) {
-            return {
-              ...prev[rowIndex],
-              [columnId]: newValue,
-            };
-          }
-          return row;
-        })
-      );
-    },
-    [cell, onDataUpdate]
-  );
+  let saveCellData;
 
   useEffect(() => {
     setInitialValue(value);
@@ -190,6 +170,27 @@ export const InlineEditCell = ({
       }
     }
   }, [inEditMode, type]);
+
+  // Saves the new cell data, onDataUpdate is a required function to be
+  // passed to useDatagrid when using useInlineEdit
+  saveCellData = saveCellData = useCallback(
+    (newValue) => {
+      const columnId = cell.column.id;
+      const rowIndex = cell.row.index;
+      onDataUpdate((prev) =>
+        prev.map((row, index) => {
+          if (index === rowIndex) {
+            return {
+              ...prev[rowIndex],
+              [columnId]: newValue,
+            };
+          }
+          return row;
+        })
+      );
+    },
+    [cell, onDataUpdate]
+  );
 
   // Initialize cellValue from value prop
   useEffect(() => {

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
@@ -173,7 +173,7 @@ export const InlineEditCell = ({
 
   // Saves the new cell data, onDataUpdate is a required function to be
   // passed to useDatagrid when using useInlineEdit
-  saveCellData = saveCellData = useCallback(
+  saveCellData = useCallback(
     (newValue) => {
       const columnId = cell.column.id;
       const rowIndex = cell.row.index;

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/handleGridKeyPress.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/handleGridKeyPress.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -106,7 +106,8 @@ export const handleGridKeyPress = ({
   ) {
     event.preventDefault();
   }
-  const isDisabledCell = !!focusedCell.getAttribute('data-disabled');
+  const isDisabledCell =
+    focusedCell.getAttribute('data-disabled') === 'false' ? false : true;
   const sharedUpdateParams = {
     oldId: activeCellId,
     instance,


### PR DESCRIPTION
Contributes to #3135 

Moving `saveCellData` before it is used somehow caused it to be called in some sort of loop which ended up causing the component to fall over. Because storybook complained about that function being defined after it was used, I created a `saveCellData` variable with `let` and assigned it a value where it was initially given one prior to the storybook change.

There also appeared to be an issue in `handleGridKeyPress` which I addressed as well (`!!` will only convert `'true'` to `true` but will not convert `'false'` to `false`).

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/handleGridKeyPress.js
```
#### How did you test and verify your work?
Storybook