### PR TITLE
fix: scope `run` block to step when committing lock file

### DIFF
--- a/.github/workflows/release-v1.yml
+++ b/.github/workflows/release-v1.yml
@@ -72,7 +72,7 @@ jobs:
         run: yarn
 
       - name: Commit lock file
-      - run: |
+        run: |
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git config user.name $GITHUB_ACTOR
           git add yarn.lock

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         run: yarn
 
       - name: Commit lock file
-      - run: |
+        run: |
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git config user.name $GITHUB_ACTOR
           git add yarn.lock


### PR DESCRIPTION
Both release actions seem to be attempting to run after every commit. The screenshot below shows it with Lee's storybook docs PR, but I also noticed it with https://github.com/carbon-design-system/ibm-products/pull/3136 as well.

<img width="1286" alt="Screenshot 2023-06-15 at 9 54 45 AM" src="https://github.com/carbon-design-system/ibm-products/assets/10215203/7ad8553e-d160-448b-9429-6512568273f0">

Not sure if it is happening because of the indentation of the `run` block that commits the lock file, github actions vscode plugin seems to want it indented, as opposed to directly below the step (ie `- name`).

![image](https://github.com/carbon-design-system/ibm-products/assets/10215203/951d08ca-fdc5-4b85-9855-c4bd890a4e71)


#### What did you change?
`release.yml` and `release-v1.yml`
#### How did you test and verify your work?
😱 after merging this