### PR TITLE
fix: update release actions and `packages/core` version

### DIFF
--- a/.github/workflows/release-v1.yml
+++ b/.github/workflows/release-v1.yml
@@ -68,13 +68,3 @@ jobs:
           yarn lerna publish from-package --dist-tag v1-latest
           --yes
 
-      - name: Bump versions
-        run: yarn
-
-      - name: Commit lock file
-        run: |
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git config user.name $GITHUB_ACTOR
-          git add yarn.lock
-          git commit -m "chore: update lockfile"
-          git push origin main_v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,14 +43,3 @@ jobs:
         run:
           yarn lerna publish --no-verify-access --create-release
           github --yes
-
-      - name: Bump versions
-        run: yarn
-
-      - name: Commit lock file
-        run: |
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git config user.name $GITHUB_ACTOR
-          git add yarn.lock
-          git commit -m "chore: update lockfile"
-          git push origin main

--- a/.github/workflows/update-v1.yml
+++ b/.github/workflows/update-v1.yml
@@ -1,4 +1,4 @@
-name: Update v1 packages # Updates dependencies once a month
+name: Update v1 packages/dependencies # Updates dependencies once a month
 
 on:
   workflow_dispatch:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,4 +1,4 @@
-name: Update v2 packages # Updates dependencies twice a month
+name: Update v2 packages/dependencies # Updates dependencies twice a month
 
 on:
   workflow_dispatch:

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ibm-cloud-cognitive-core",
   "private": true,
-  "version": "0.44.6",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "main": "scripts/build.js",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1999,7 +1999,7 @@ __metadata:
     "@carbon/layout": ^11.15.0
     "@carbon/motion": ^11.12.0
     "@carbon/react": ~1.31.3
-    "@carbon/storybook-addon-theme": 2.0.1
+    "@carbon/storybook-addon-theme": ^2.0.2
     "@carbon/themes": ^11.20.0
     "@carbon/type": ^11.19.0
     "@storybook/addon-actions": ^7.0.18
@@ -2018,7 +2018,7 @@ __metadata:
     "@storybook/react-webpack5": ^7.0.18
     "@storybook/theming": ^7.0.18
     babel-loader: ^9.1.2
-    babel-preset-ibm-cloud-cognitive: ^0.14.36
+    babel-preset-ibm-cloud-cognitive: ^0.14.37
     css-loader: ^6.8.1
     dotenv-webpack: 8.0.1
     npm-check-updates: ^16.10.12
@@ -2046,7 +2046,7 @@ __metadata:
     "@babel/core": ^7.22.1
     "@babel/runtime": ^7.22.3
     "@carbon/telemetry": ^0.1.0
-    babel-preset-ibm-cloud-cognitive: ^0.14.36
+    babel-preset-ibm-cloud-cognitive: ^0.14.37
     chalk: ^4.1.2
     change-case: ^4.1.2
     copyfiles: ^2.4.1
@@ -2056,7 +2056,7 @@ __metadata:
     glob: ^10.2.6
     immutability-helper: ^3.1.1
     jest: ^29.5.0
-    jest-config-ibm-cloud-cognitive: ^0.24.23
+    jest-config-ibm-cloud-cognitive: ^0.24.24
     jest-environment-jsdom: ^29.5.0
     lodash: ^4.17.21
     namor: ^1.1.2
@@ -2148,7 +2148,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/storybook-addon-theme@2.0.1, @carbon/storybook-addon-theme@workspace:config/storybook-addon-carbon-theme":
+"@carbon/storybook-addon-theme@^2.0.2, @carbon/storybook-addon-theme@workspace:config/storybook-addon-carbon-theme":
   version: 0.0.0-use.local
   resolution: "@carbon/storybook-addon-theme@workspace:config/storybook-addon-carbon-theme"
   dependencies:
@@ -7505,7 +7505,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-preset-ibm-cloud-cognitive@^0.14.36, babel-preset-ibm-cloud-cognitive@workspace:config/babel-preset-ibm-cloud-cognitive":
+"babel-preset-ibm-cloud-cognitive@^0.14.37, babel-preset-ibm-cloud-cognitive@workspace:config/babel-preset-ibm-cloud-cognitive":
   version: 0.0.0-use.local
   resolution: "babel-preset-ibm-cloud-cognitive@workspace:config/babel-preset-ibm-cloud-cognitive"
   dependencies:
@@ -14192,7 +14192,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-config-ibm-cloud-cognitive@^0.24.23, jest-config-ibm-cloud-cognitive@workspace:config/jest-config-ibm-cloud-cognitive":
+"jest-config-ibm-cloud-cognitive@^0.24.24, jest-config-ibm-cloud-cognitive@workspace:config/jest-config-ibm-cloud-cognitive":
   version: 0.0.0-use.local
   resolution: "jest-config-ibm-cloud-cognitive@workspace:config/jest-config-ibm-cloud-cognitive"
   dependencies:
@@ -14202,7 +14202,7 @@ __metadata:
     accessibility-checker: ^3.1.49
     axe-core: ^4.7.2
     babel-jest: ^29.5.0
-    babel-preset-ibm-cloud-cognitive: ^0.14.36
+    babel-preset-ibm-cloud-cognitive: ^0.14.37
     chalk: ^4.1.2
     enzyme: ^3.11.0
     enzyme-to-json: ^3.6.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -1999,7 +1999,7 @@ __metadata:
     "@carbon/layout": ^11.15.0
     "@carbon/motion": ^11.12.0
     "@carbon/react": ~1.31.3
-    "@carbon/storybook-addon-theme": ^2.0.2
+    "@carbon/storybook-addon-theme": 2.0.1
     "@carbon/themes": ^11.20.0
     "@carbon/type": ^11.19.0
     "@storybook/addon-actions": ^7.0.18
@@ -2018,7 +2018,7 @@ __metadata:
     "@storybook/react-webpack5": ^7.0.18
     "@storybook/theming": ^7.0.18
     babel-loader: ^9.1.2
-    babel-preset-ibm-cloud-cognitive: ^0.14.37
+    babel-preset-ibm-cloud-cognitive: ^0.14.36
     css-loader: ^6.8.1
     dotenv-webpack: 8.0.1
     npm-check-updates: ^16.10.12
@@ -2046,7 +2046,7 @@ __metadata:
     "@babel/core": ^7.22.1
     "@babel/runtime": ^7.22.3
     "@carbon/telemetry": ^0.1.0
-    babel-preset-ibm-cloud-cognitive: ^0.14.37
+    babel-preset-ibm-cloud-cognitive: ^0.14.36
     chalk: ^4.1.2
     change-case: ^4.1.2
     copyfiles: ^2.4.1
@@ -2056,7 +2056,7 @@ __metadata:
     glob: ^10.2.6
     immutability-helper: ^3.1.1
     jest: ^29.5.0
-    jest-config-ibm-cloud-cognitive: ^0.24.24
+    jest-config-ibm-cloud-cognitive: ^0.24.23
     jest-environment-jsdom: ^29.5.0
     lodash: ^4.17.21
     namor: ^1.1.2
@@ -2148,7 +2148,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/storybook-addon-theme@^2.0.2, @carbon/storybook-addon-theme@workspace:config/storybook-addon-carbon-theme":
+"@carbon/storybook-addon-theme@2.0.1, @carbon/storybook-addon-theme@workspace:config/storybook-addon-carbon-theme":
   version: 0.0.0-use.local
   resolution: "@carbon/storybook-addon-theme@workspace:config/storybook-addon-carbon-theme"
   dependencies:
@@ -7505,7 +7505,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-preset-ibm-cloud-cognitive@^0.14.37, babel-preset-ibm-cloud-cognitive@workspace:config/babel-preset-ibm-cloud-cognitive":
+"babel-preset-ibm-cloud-cognitive@^0.14.36, babel-preset-ibm-cloud-cognitive@workspace:config/babel-preset-ibm-cloud-cognitive":
   version: 0.0.0-use.local
   resolution: "babel-preset-ibm-cloud-cognitive@workspace:config/babel-preset-ibm-cloud-cognitive"
   dependencies:
@@ -14192,7 +14192,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-config-ibm-cloud-cognitive@^0.24.24, jest-config-ibm-cloud-cognitive@workspace:config/jest-config-ibm-cloud-cognitive":
+"jest-config-ibm-cloud-cognitive@^0.24.23, jest-config-ibm-cloud-cognitive@workspace:config/jest-config-ibm-cloud-cognitive":
   version: 0.0.0-use.local
   resolution: "jest-config-ibm-cloud-cognitive@workspace:config/jest-config-ibm-cloud-cognitive"
   dependencies:
@@ -14202,7 +14202,7 @@ __metadata:
     accessibility-checker: ^3.1.49
     axe-core: ^4.7.2
     babel-jest: ^29.5.0
-    babel-preset-ibm-cloud-cognitive: ^0.14.37
+    babel-preset-ibm-cloud-cognitive: ^0.14.36
     chalk: ^4.1.2
     enzyme: ^3.11.0
     enzyme-to-json: ^3.6.2


### PR DESCRIPTION
Contributes to #3151

Addresses issues outlined in #3151, primarily removing the lock file step in `release.yml` and upgrading `packages/core` version. `packages/core` (ie `@carbon/ibm-cloud-cognitive-core`) will end up with `1.1.0` the next time `release.yml` is run but since it is a private package that seems ok.

#### What did you change?
```
.github/workflows/release.yml
.github/workflows/update-v1.yml
.github/workflows/update.yml
packages/core/package.json
```
#### How did you test and verify your work?
Will test in github