### PR TITLE
chore: `packages/core` version bump

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ibm-cloud-cognitive-core",
   "private": true,
-  "version": "1.0.1",
+  "version": "2.0.0",
   "license": "Apache-2.0",
   "main": "scripts/build.js",
   "repository": {


### PR DESCRIPTION
Contributes to #3151 #3154

Bump `core` version to 2.0.0.

#### What did you change?
`core/package.json`

#### How did you test and verify your work?
🥸