### PR TITLE
fix: resize observer infinite perspective issue

### DIFF
--- a/packages/ibm-products/src/global/js/hooks/useResizeObserver.js
+++ b/packages/ibm-products/src/global/js/hooks/useResizeObserver.js
@@ -55,7 +55,7 @@ export const useResizeObserver = (ref, callback) => {
       observer = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ref]);
+  }, [ref.current]);
 
   return { width, height };
 };


### PR DESCRIPTION
Contributes to #3172 

Resize observer was incorrectly setting up based on the target ref and not it's current value.

#### What did you change?

Updated the useLayoutEffect dependencies in useResizeObserver.

#### How did you test and verify your work?

Storybook stacked tearsheets.
