### PR TITLE
chore: update prefix documentation and example

### DIFF
--- a/examples/carbon-for-ibm-products/gallery-examples.test.js
+++ b/examples/carbon-for-ibm-products/gallery-examples.test.js
@@ -38,6 +38,8 @@ import { Example as TearsheetExample } from './Tearsheet/src/Example/Example';
 import { Example as UserProfileImageExample } from './UserProfileImage/src/Example/Example';
 import { Example as WebTerminalExample } from './WebTerminal/src/Example/Example';
 import { Example as PrefixExampleExample } from './prefix-example/src/Example/Example';
+import { Example as React16ExampleExample } from './react-16-example/src/Example/Example';
+import { Example as React17ExampleExample } from './react-17-example/src/Example/Example';
 
 describe('All examples', () => {
   init(beforeEach, afterEach);
@@ -212,6 +214,18 @@ describe('All examples', () => {
 
   it('PrefixExample renders', () => {
     render(<PrefixExampleExample />);
+    // expect no errors int the console
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('React16Example renders', () => {
+    render(<React16ExampleExample />);
+    // expect no errors int the console
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('React17Example renders', () => {
+    render(<React17ExampleExample />);
     // expect no errors int the console
     expect(console.error).not.toHaveBeenCalled();
   });

--- a/examples/carbon-for-ibm-products/prefix-example/src/index.scss
+++ b/examples/carbon-for-ibm-products/prefix-example/src/index.scss
@@ -2,10 +2,13 @@
   $font-path: '@ibm/plex'
 );
 
-$pkg-prefix: 'tst';
-// Actually want to do this, but codesandbox does not load SCSS properly just yet
-// @use '@carbon/ibm-products/scss/index';
-//
-// replaced with
-//
-@use '@carbon/ibm-products/scss/components/AboutModal/index';
+// When importing many components from @carbon/ibm-products
+// @use "@carbon/ibm-products/scss" with (
+//   $pkg-prefix: "tst"
+// );
+
+// When using individual components from @carbon/ibm-products
+@use '@carbon/ibm-products/scss/config' with (
+  $pkg-prefix: 'tst'
+);
+@use '@carbon/ibm-products/scss/components/AboutModal';

--- a/packages/ibm-products/README.md
+++ b/packages/ibm-products/README.md
@@ -104,6 +104,44 @@ const App = () => {
 };
 ```
 
+### Package prefix
+
+The `@carbon/ibm-products` package uses a default prefix of `c4p` for CSS
+selectors and some IDs.
+
+#### Changing the prefix
+
+Before any `@carbon/ibm-products` components are loaded in script or styling
+ensure you have done the following.
+
+```js
+import { pkg } from '@carbon/ibm-products/es/settings';
+
+pkg.prefix = 'tst';
+```
+
+When using multiple components from the library:
+
+```css
+@use '@carbon/ibm-products/scss' with (
+  $pkg-prefix: 'tst'
+);
+```
+
+When using individual components e.g. AboutModal:
+
+```css
+@use '@carbon/ibm-products/scss/config' with (
+  $pkg-prefix: 'tst'
+);
+
+@use '@carbon/ibm-products/scss/components/AboutModal';
+```
+
+See the
+[example gallery](https://ibm-products.carbondesignsystem.com/?path=/story/overview-examples--c-4-p-gallery-code-sandbox)
+for the most up-to-date prefix examples.
+
 ### Enabling Canary components and flagged features
 
 Components that have not yet completed the release review process are considered


### PR DESCRIPTION
Contributes to #3173

The prefix example and documentation did not reflect how the prefix can be modified in V2 with `@use`. 

#### What did you change?

- Updated the prefix example 
- Added a prefix section to the documentation.

#### How did you test and verify your work?

Checked prefix example on codesandbox.
