### PR TITLE
chore: always use prefix in dev storybook

### DIFF
--- a/packages/core/.storybook/_prefix-index.scss
+++ b/packages/core/.storybook/_prefix-index.scss
@@ -1,0 +1,12 @@
+//
+// Copyright IBM Corp. 2023, 2023
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '../../ibm-products/src/config.scss' with (
+  $pkg-prefix: 'dev-prefix--c4p'
+);
+
+@use './index';

--- a/packages/core/.storybook/index.scss
+++ b/packages/core/.storybook/index.scss
@@ -9,7 +9,7 @@
 // Carbon styles at the end -- this is to obtain a "worst case" for our own CSS,
 // to ensure we are resilient against different CSS loading orders and our
 // styles have the specificity necessary to override Carbon styles when needed.
-@use '../../ibm-products/src/index-without-carbon' as *;
+@use '../../ibm-products/src/index-without-carbon.scss';
 
 // Load all Carbon styles now
 @use '../css/carbon';

--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -19,6 +19,7 @@ import React, { useEffect } from 'react';
 import { pkg } from '../../ibm-products/src/settings';
 
 import index from './index.scss';
+import prefixedIndex from './_prefix-index.scss';
 import { getSectionSequence } from '../story-structure';
 import { StoryDocsPage } from '../../ibm-products/src/global/js/utils/StoryDocsPage';
 
@@ -38,6 +39,12 @@ const Style = ({ children, styles }) => {
   return children;
 };
 
+let isDev = CONFIG_TYPE === 'DEVELOPMENT'; //  process.env?.NODE_ENV === 'development';
+if (isDev) {
+  // use a prefix in all development storybook
+  pkg.prefix = `dev-prefix--${pkg.prefix}`;
+}
+
 const decorators = [
   (storyFn, { args, parameters: { styles } }) => {
     const story = storyFn();
@@ -46,7 +53,7 @@ const decorators = [
 
     return (
       <div className="preview-position-fix">
-        <Style styles={index}>
+        <Style styles={isDev ? prefixedIndex : index}>
           {args.featureFlags ? (
             <ActionableNotification
               className="preview__notification--feature-flag"

--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -39,7 +39,7 @@ const Style = ({ children, styles }) => {
   return children;
 };
 
-let isDev = CONFIG_TYPE === 'DEVELOPMENT'; //  process.env?.NODE_ENV === 'development';
+const isDev = CONFIG_TYPE === 'DEVELOPMENT'; //  process.env?.NODE_ENV === 'development';
 if (isDev) {
   // use a prefix in all development storybook
   pkg.prefix = `dev-prefix--${pkg.prefix}`;


### PR DESCRIPTION
Contributes to #1154 

Propose changing all development storybook stories to use a custom prefix.

#### What did you change?

Core storybook preview and styling to set a prefix when in development mode.

#### How did you test and verify your work?

- yarn storybook
- Viewed in storybook and inspected the DOM and noted prefix
- yarn build
- npx serve packages/core/storybook-static and checked the prefix in the DOM
