### PR TITLE
chore(Datagrid): add skeleton story (v2)

### DIFF
--- a/packages/core/story-structure.js
+++ b/packages/core/story-structure.js
@@ -55,6 +55,7 @@ const s = [
               'c/Datagrid/Extensions/ClickableRow',
               'c/Datagrid/Extensions/EditableCell',
               'c/Datagrid/Extensions/ColumnCustomization',
+              'c/Datagrid/Extensions/Skeleton',
             ],
           },
         ],

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Skeleton/Skeleton.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Skeleton/Skeleton.stories.js
@@ -1,0 +1,223 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Edit, TrashCan } from '@carbon/react/icons';
+import { action } from '@storybook/addon-actions';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../../../global/js/utils/story-helper';
+import { Datagrid, useDatagrid } from '../../index';
+import styles from '../../_storybook-styles.scss';
+import { ARG_TYPES } from '../../utils/getArgTypes';
+import { StoryDocsPage } from '../../../../global/js/utils/StoryDocsPage';
+
+export default {
+  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/Skeleton`,
+  component: Datagrid,
+  tags: ['autodocs'],
+  parameters: {
+    styles,
+    layout: 'fullscreen',
+    docs: {
+      page: () => (
+        <StoryDocsPage
+          blocks={[
+            {
+              description: `Datagrid supports skeleton states with the use of the \`isFetching\` property when passed to the \`useDatagrid\` hook.`,
+              source: {
+                code: `
+const BasicUsage = ({ ...args }) => {
+  const columns = React.useMemo(() => [...defaultHeader], []);
+  const [data] = useState([]);
+
+  const datagridState = useDatagrid({
+    columns,
+    data,
+    isFetching: true,
+  });
+
+  return <Datagrid datagridState={datagridState} />;
+};
+            `,
+              },
+            },
+          ]}
+        />
+      ),
+    },
+  },
+};
+
+const defaultHeader = [
+  {
+    Header: 'Row Index',
+    accessor: (row, i) => i,
+    sticky: 'left',
+    id: 'rowIndex', // id is required when accessor is a function.
+  },
+  {
+    Header: 'First Name',
+    accessor: 'firstName',
+  },
+  {
+    Header: 'Last Name',
+    accessor: 'lastName',
+  },
+  {
+    Header: 'Age',
+    accessor: 'age',
+    width: 50,
+  },
+  {
+    Header: 'Visits',
+    accessor: 'visits',
+    width: 60,
+  },
+  {
+    Header: 'Someone 1',
+    accessor: 'someone1',
+  },
+  {
+    Header: 'Someone 2',
+    accessor: 'someone2',
+  },
+  {
+    Header: 'Someone 3',
+    accessor: 'someone3',
+  },
+  {
+    Header: 'Someone 4',
+    accessor: 'someone4',
+  },
+  {
+    Header: 'Someone 5',
+    accessor: 'someone5',
+  },
+  {
+    Header: 'Someone 6',
+    accessor: 'someone6',
+  },
+  {
+    Header: 'Someone 7',
+    accessor: 'someone7',
+  },
+  {
+    Header: 'Someone 8',
+    accessor: 'someone8',
+  },
+  {
+    Header: 'Someone 9',
+    accessor: 'someone9',
+  },
+  {
+    Header: 'Someone 10',
+    accessor: 'someone10',
+  },
+];
+
+const sharedDatagridProps = {
+  emptyStateTitle: 'Empty state title',
+  emptyStateDescription: 'Description text explaining why table is empty',
+  emptyStateSize: 'lg',
+  gridTitle: 'Data table title',
+  gridDescription: 'Additional information if needed',
+  useDenseHeader: false,
+  isFetching: true,
+  rowSize: 'lg',
+  rowSizes: [
+    {
+      value: 'xs',
+      labelText: 'Extra small',
+    },
+    {
+      value: 'sm',
+      labelText: 'Small',
+    },
+    {
+      value: 'md',
+      labelText: 'Medium',
+    },
+    {
+      value: 'lg',
+      labelText: 'Large',
+    },
+    {
+      value: 'xl',
+      labelText: 'Extra large',
+    },
+  ],
+  onRowSizeChange: (value) => {
+    console.log('row size changed to: ', value);
+  },
+  rowActions: [
+    {
+      id: 'edit',
+      itemText: 'Edit',
+      icon: Edit,
+      onClick: action('Clicked row action: edit'),
+    },
+
+    {
+      id: 'delete',
+      itemText: 'Delete',
+      icon: TrashCan,
+      isDelete: true,
+      onClick: action('Clicked row action: delete'),
+    },
+  ],
+};
+
+const BasicUsage = ({ ...args }) => {
+  const columns = React.useMemo(() => [...defaultHeader], []);
+  const [data] = useState([]);
+  const emptyStateTitle = 'Empty state title';
+  const emptyStateDescription = 'Description explaining why the table is empty';
+
+  const datagridState = useDatagrid({
+    columns,
+    data,
+    isFetching: true,
+    emptyStateDescription,
+    emptyStateTitle,
+    ...args.defaultGridProps,
+  });
+
+  return <Datagrid datagridState={datagridState} />;
+};
+
+const BasicTemplateWrapper = ({ ...args }) => {
+  return <BasicUsage defaultGridProps={{ ...args }} />;
+};
+
+const basicUsageControlProps = {
+  gridTitle: sharedDatagridProps.gridTitle,
+  gridDescription: sharedDatagridProps.gridDescription,
+  useDenseHeader: sharedDatagridProps.useDenseHeader,
+  isFetching: sharedDatagridProps.isFetching,
+  rowSize: sharedDatagridProps.rowSize,
+  rowSizes: sharedDatagridProps.rowSizes,
+  onRowSizeChange: sharedDatagridProps.onRowSizeChange,
+};
+const basicUsageStoryName = 'Skeleton';
+export const DefaultSkeletonStory = prepareStory(BasicTemplateWrapper, {
+  storyName: basicUsageStoryName,
+  argTypes: {
+    gridTitle: ARG_TYPES.gridTitle,
+    gridDescription: ARG_TYPES.gridDescription,
+    isFetching: ARG_TYPES.isFetching,
+    useDenseHeader: ARG_TYPES.useDenseHeader,
+    rowSize: ARG_TYPES.rowSize,
+    rowSizes: ARG_TYPES.rowSizes,
+    onRowSizeChange: ARG_TYPES.onRowSizeChange,
+  },
+  args: {
+    ...basicUsageControlProps,
+  },
+});

--- a/packages/ibm-products/src/components/Datagrid/utils/getArgTypes.js
+++ b/packages/ibm-products/src/components/Datagrid/utils/getArgTypes.js
@@ -35,6 +35,7 @@ export const ARG_TYPES = {
     type: { name: 'string', required: false },
   },
   emptyStateSize: { control: 'select', options: ['sm', 'lg'] },
+  isFetching: { control: 'radio', options: [true, false] },
   useDenseHeader: {
     control: { type: 'radio' },
     options: [true, false],


### PR DESCRIPTION
Contributes to #3120 

Adds a loading/skeleton story for Datagrid as requested during design review.

#### What did you change?
```
packages/core/story-structure.js
packages/ibm-products/src/components/Datagrid/Extensions/Skeleton/Skeleton.stories.js
packages/ibm-products/src/components/Datagrid/utils/getArgTypes.js
```
#### How did you test and verify your work?
Storybook