### PR TITLE
fix: possible solution for storybook styles custom prefix

### DIFF
--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -39,7 +39,7 @@ const Style = ({ children, styles }) => {
   return children;
 };
 
-const isDev = CONFIG_TYPE === 'DEVELOPMENT'; //  process.env?.NODE_ENV === 'development';
+export const isDev = CONFIG_TYPE === 'DEVELOPMENT'; //  process.env?.NODE_ENV === 'development';
 if (isDev) {
   // use a prefix in all development storybook
   pkg.prefix = `dev-prefix--${pkg.prefix}`;

--- a/packages/ibm-products/src/components/AboutModal/AboutModal.stories.js
+++ b/packages/ibm-products/src/components/AboutModal/AboutModal.stories.js
@@ -25,6 +25,8 @@ import grafanaLogo from './_story-assets/grafana-logo.png';
 import jsLogo from './_story-assets/js-logo.png';
 
 import styles from './_storybook-styles.scss';
+import prefixStyles from './_prefix-storybook-styles.scss';
+import { isDev } from '../../../../core/.storybook/preview';
 
 const blockClass = `${pkg.prefix}--about-modal`;
 
@@ -35,7 +37,8 @@ export default {
   component: AboutModal,
   tags: ['autodocs'],
   parameters: {
-    styles,
+    // styles,
+    styles: isDev ? prefixStyles : styles,
     docs: {
       page: DocsPage,
     },

--- a/packages/ibm-products/src/components/AboutModal/_prefix-storybook-styles.scss
+++ b/packages/ibm-products/src/components/AboutModal/_prefix-storybook-styles.scss
@@ -1,0 +1,12 @@
+//
+// Copyright IBM Corp. 2023, 2023
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '../../config.scss' with (
+  $pkg-prefix: 'dev-prefix--c4p'
+);
+
+@use './storybook-styles';

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
@@ -27,9 +27,10 @@ import {
 } from '.';
 
 import { SelectAllWithToggle } from './Datagrid.stories/index';
-// import mdx from './Datagrid.mdx';
 
 import styles from './_storybook-styles.scss';
+import prefixStyles from './_prefix-storybook-styles.scss';
+import { isDev } from '../../../../core/.storybook/preview';
 import { DatagridActions } from './utils/DatagridActions';
 import { DatagridPagination } from './utils/DatagridPagination';
 import { Wrapper } from './utils/Wrapper';
@@ -41,7 +42,7 @@ export default {
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {
-    styles,
+    styles: isDev ? prefixStyles : styles,
     docs: {
       page: DocsPage,
     },

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
@@ -21,6 +21,7 @@ import {
   useOnRowClick,
 } from '../../index';
 import styles from '../../_storybook-styles.scss';
+import prefixStyles from '../../_prefix-storybook-styles.scss';
 // import mdx from '../../Datagrid.mdx';
 import { DatagridActions } from '../../utils/DatagridActions';
 import { DatagridPagination } from '../../utils/DatagridPagination';
@@ -31,13 +32,14 @@ import { pkg } from '../../../../settings';
 import cx from 'classnames';
 import { SidePanel } from '../../../SidePanel';
 import { StoryDocsPage } from '../../../../global/js/utils/StoryDocsPage';
+import { isDev } from '../../../../../../core/.storybook/preview';
 
 export default {
   title: `${getStoryTitle(Datagrid.displayName)}/Extensions/ClickableRow`,
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {
-    styles,
+    styles: isDev ? prefixStyles : styles,
     docs: {
       page: () => (
         <StoryDocsPage

--- a/packages/ibm-products/src/components/Datagrid/_prefix-storybook-styles.scss
+++ b/packages/ibm-products/src/components/Datagrid/_prefix-storybook-styles.scss
@@ -1,0 +1,12 @@
+//
+// Copyright IBM Corp. 2023, 2023
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '../../config.scss' with (
+  $pkg-prefix: 'dev-prefix--c4p'
+);
+
+@use './storybook-styles';


### PR DESCRIPTION
Contributes to #3208 

Opening to start discussion about a possible solution to fixing `_storybook-styles.scss` from not picking up the custom prefix that we now set in development mode.

Downside to this approach is that every component that has a `_storybook-styles.scss` will need to adopt this approach.

One other option is not using the custom prefix in development at all and simply add an example to the example gallery.

#### What did you change?
Exported `isDev` from `preview.js` to conditionally use a set of storybook styles with the custom prefix.
#### How did you test and verify your work?
Storybook