### PR TITLE
fix(Datagrid): clickable row stories

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
@@ -258,6 +258,11 @@ const DataTableSidePanelContent = (selectedRowValues) => {
 
   return (
     <div className={`${blockClass}__side-panel-content`}>
+      <div className={`${blockClass}__side-panel-link`}>
+        <Link href="" id="side-panel-story__view-link">
+          View details
+        </Link>
+      </div>
       <SidePanelSectionContent
         sectionTitle="Section title"
         rowData={rowData && rowData}
@@ -310,6 +315,7 @@ const ClickableRowWithPanel = ({ ...args }) => {
       <Datagrid datagridState={{ ...datagridState }} />
       <SidePanel
         selectorPageContent={true && '.page-content-wrapper'} // Only if SlideIn
+        selectorPrimaryFocus="#side-panel-story__view-link"
         open={openSidePanel}
         onRequestClose={() => setOpenSidePanel(false)}
         size={'sm'}

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
@@ -44,17 +44,17 @@ const blockClass = `${pkg.prefix}--datagrid`;
 const storyBlockClass = `${pkg.prefix}--datagrid-story`;
 const defaultHeader = [
   {
-    Header: 'Row Index',
+    Header: 'Row index',
     accessor: (row, i) => i,
     sticky: 'left',
     id: 'rowIndex', // id is required when accessor is a function.
   },
   {
-    Header: 'First Name',
+    Header: 'First name',
     accessor: 'firstName',
   },
   {
-    Header: 'Last Name',
+    Header: 'Last name',
     accessor: 'lastName',
   },
   {
@@ -65,6 +65,7 @@ const defaultHeader = [
         <Link
           className={`${storyBlockClass}__custom-cell-wrapper`}
           href={cell?.value?.href}
+          title={cell?.value?.text}
         >
           {cell?.value?.text}
         </Link>
@@ -76,11 +77,13 @@ const defaultHeader = [
     Header: 'Age',
     accessor: 'age',
     width: 120,
+    rightAlignedColumn: true,
   },
   {
     Header: 'Visits',
     accessor: 'visits',
     width: 120,
+    rightAlignedColumn: true,
   },
   {
     Header: 'Bonus',
@@ -293,7 +296,8 @@ const ClickableRowWithPanel = ({ ...args }) => {
       },
       ...args.defaultGridProps,
     },
-    useOnRowClick
+    useOnRowClick,
+    useColumnRightAlign
   );
   return (
     <div

--- a/packages/ibm-products/src/components/Datagrid/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/Datagrid/_storybook-styles.scss
@@ -54,6 +54,11 @@ $block-class: #{$pkg-prefix}--datagrid;
   padding-bottom: $spacing-06;
 }
 
+.#{$block-class}__side-panel-link {
+  padding-top: $spacing-01;
+  padding-bottom: $spacing-06;
+}
+
 .#{$block-class}__side-panel-section-inner {
   display: flex;
   padding: $spacing-01 0;


### PR DESCRIPTION
Contributes to #2608 

Address quick fixes from clickable row design review.
- Add `title` to link
- Align numerical data
- Use sentence case in headers
- Add **View details** in side panels

#### What did you change?
Clickable row stories

#### How did you test and verify your work?
Storybook