### PR TITLE
fix(Datagrid): remove sort styles hook not in use v1

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -37,7 +37,7 @@ const HeaderRow = (datagridState, headRef, headerGroup) => (
               {
                 [`${blockClass}__resizableColumn`]: header.getResizerProps,
                 [`${blockClass}__isResizing`]: header.isResizing,
-                [`${blockClass}__sortableColumn`]: header.canSort,
+                [`${blockClass}__sortableColumn`]: datagridState.isTableSortable,
                 [`${blockClass}__isSorted`]: header.isSorted,
               },
               header.getHeaderProps().className

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -37,7 +37,8 @@ const HeaderRow = (datagridState, headRef, headerGroup) => (
               {
                 [`${blockClass}__resizableColumn`]: header.getResizerProps,
                 [`${blockClass}__isResizing`]: header.isResizing,
-                [`${blockClass}__sortableColumn`]: datagridState.isTableSortable,
+                [`${blockClass}__sortableColumn`]:
+                  datagridState.isTableSortable,
                 [`${blockClass}__isSorted`]: header.isSorted,
               },
               header.getHeaderProps().className


### PR DESCRIPTION
Contributes to #3227 

Always adding the class for `__sortableColumn` in header rows even when the useSortableColumns hook is not included.

#### What did you change?

`__sortableColumn` class is conditionally added when `isTableSortable` is `true`. 

#### How did you test and verify your work?
Storybook
