### PR TITLE
feat(NotificationsPanel): include target attribute inside the link

### DIFF
--- a/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.js
+++ b/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.js
@@ -346,6 +346,9 @@ export let NotificationsPanel = React.forwardRef(
                 <Link
                   href={notification.link.url}
                   className={`${blockClass}__notifications-link`}
+                  {...(notification.link.target
+                    ? { target: notification.link.target }
+                    : {})}
                 >
                   {notification.link.text}
                 </Link>
@@ -518,6 +521,7 @@ NotificationsPanel.propTypes = {
       link: PropTypes.shape({
         url: PropTypes.string,
         text: PropTypes.string,
+        target: PropTypes.string,
       }),
       unread: PropTypes.bool,
       onNotificationClick: PropTypes.func,


### PR DESCRIPTION
Contributes to #3202 

Enhancement Request for NotificationsPanel Component ‘link’ object to have the ability to ‘open in new window’ when clicked by user

#### What did you change?
- Included target property inside the link object.

<img width="550" alt="256222812-a9ba2cae-8787-4a5f-bc02-e0874e6d92fa" src="https://github.com/carbon-design-system/ibm-products/assets/40118548/40f5ca9e-1d35-437b-a8e2-41dd97668d60">

#### How did you test and verify your work?
- Storybook