### PR TITLE
fix(Datagrid): add batch actions to clickable row with panel story (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
@@ -50,6 +50,7 @@ export default {
       },
     },
   },
+  excludeStories: ['getBatchActions'],
 };
 
 const getColumns = (rows) => {
@@ -471,7 +472,7 @@ const DatagridBatchActions = (datagridState) => {
   );
 };
 
-const getBatchActions = () => {
+export const getBatchActions = () => {
   return [
     {
       label: 'Duplicate',

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
@@ -19,6 +19,7 @@ import {
   useColumnRightAlign,
   useColumnCenterAlign,
   useOnRowClick,
+  useSelectRows,
 } from '../../index';
 import styles from '../../_storybook-styles.scss';
 import mdx from '../../Datagrid.mdx';
@@ -30,6 +31,7 @@ import { Link } from 'carbon-components-react';
 import { pkg } from '../../../../settings';
 import cx from 'classnames';
 import { SidePanel } from '../../../SidePanel';
+import { getBatchActions } from '../../Datagrid.stories';
 
 export default {
   title: `${getStoryTitle(Datagrid.displayName)}/Extensions/ClickableRow`,
@@ -299,8 +301,12 @@ const ClickableRowWithPanel = ({ ...args }) => {
         setOpenSidePanel(true);
         setRowData(row);
       },
+      DatagridActions,
+      batchActions: true,
+      toolbarBatchActions: getBatchActions(),
       ...args.defaultGridProps,
     },
+    useSelectRows,
     useOnRowClick,
     useColumnRightAlign
   );

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
@@ -7,7 +7,6 @@
  */
 
 import React, { useState } from 'react';
-import { Add16 } from '@carbon/icons-react';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,
@@ -21,6 +20,7 @@ import { ARG_TYPES } from '../../utils/getArgTypes';
 import { DatagridActions } from '../../utils/DatagridActions';
 import { StatusIcon } from '../../../StatusIcon';
 import { pkg } from '../../../../settings';
+import { getBatchActions } from '../../Datagrid.stories';
 
 export default {
   title: `${getStoryTitle(Datagrid.displayName)}/Extensions/Filtering/Flyout`,
@@ -36,44 +36,6 @@ export default {
       },
     },
   },
-};
-
-const getBatchActions = () => {
-  return [
-    {
-      label: 'Duplicate',
-      renderIcon: Add16,
-      onClick: action('Clicked batch action button'),
-    },
-    {
-      label: 'Add',
-      renderIcon: Add16,
-      onClick: action('Clicked batch action button'),
-    },
-    {
-      label: 'Select all',
-      renderIcon: Add16,
-      onClick: action('Clicked batch action button'),
-      type: 'select_all',
-    },
-    {
-      label: 'Publish to catalog',
-      renderIcon: Add16,
-      onClick: action('Clicked batch action button'),
-    },
-    {
-      label: 'Download',
-      renderIcon: Add16,
-      onClick: action('Clicked batch action button'),
-    },
-    {
-      label: 'Delete',
-      renderIcon: Add16,
-      onClick: action('Clicked batch action button'),
-      hasDivider: true,
-      kind: 'danger',
-    },
-  ];
 };
 
 const FilteringUsage = ({ defaultGridProps }) => {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
@@ -7,7 +7,6 @@
  */
 
 import React, { useState } from 'react';
-import { Add16 } from '@carbon/icons-react';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,
@@ -20,6 +19,7 @@ import { makeData } from '../../utils/makeData';
 import { ARG_TYPES } from '../../utils/getArgTypes';
 import { DatagridActions } from '../../utils/DatagridActions';
 import { StatusIcon } from '../../../StatusIcon';
+import { getBatchActions } from '../../Datagrid.stories';
 
 export default {
   title: `${getStoryTitle(Datagrid.displayName)}/Extensions/Filtering/Panel`,
@@ -28,44 +28,6 @@ export default {
     styles,
     docs: { page: mdx },
   },
-};
-
-const getBatchActions = () => {
-  return [
-    {
-      label: 'Duplicate',
-      renderIcon: Add16,
-      onClick: action('Clicked batch action button'),
-    },
-    {
-      label: 'Add',
-      renderIcon: Add16,
-      onClick: action('Clicked batch action button'),
-    },
-    {
-      label: 'Select all',
-      renderIcon: Add16,
-      onClick: action('Clicked batch action button'),
-      type: 'select_all',
-    },
-    {
-      label: 'Publish to catalog',
-      renderIcon: Add16,
-      onClick: action('Clicked batch action button'),
-    },
-    {
-      label: 'Download',
-      renderIcon: Add16,
-      onClick: action('Clicked batch action button'),
-    },
-    {
-      label: 'Delete',
-      renderIcon: Add16,
-      onClick: action('Clicked batch action button'),
-      hasDivider: true,
-      kind: 'danger',
-    },
-  ];
 };
 
 const FilteringUsage = ({ defaultGridProps }) => {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.js
@@ -7,7 +7,7 @@
  */
 
 import React, { useState } from 'react';
-import { Add16, Edit16, TrashCan16, Checkmark16 } from '@carbon/icons-react';
+import { Edit16, TrashCan16, Checkmark16 } from '@carbon/icons-react';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,
@@ -28,6 +28,7 @@ import { DatagridPagination } from '../../utils/DatagridPagination';
 import { makeData } from '../../utils/makeData';
 import { ARG_TYPES } from '../../utils/getArgTypes';
 import { pkg } from '../../../../settings';
+import { getBatchActions } from '../../Datagrid.stories';
 
 export default {
   title: `${getStoryTitle(Datagrid.displayName)}/Extensions/RowActionButtons`,
@@ -307,44 +308,6 @@ const RowActionButtonsBatchActions = ({ ...args }) => {
   );
 
   return <Datagrid datagridState={datagridState} />;
-};
-
-const getBatchActions = () => {
-  return [
-    {
-      label: 'Duplicate',
-      renderIcon: Add16,
-      onClick: action('Clicked batch action button'),
-    },
-    {
-      label: 'Add',
-      renderIcon: Add16,
-      onClick: action('Clicked batch action button'),
-    },
-    {
-      label: 'Select all',
-      renderIcon: Add16,
-      onClick: action('Clicked batch action button'),
-      type: 'select_all',
-    },
-    {
-      label: 'Publish to catalog',
-      renderIcon: Add16,
-      onClick: action('Clicked batch action button'),
-    },
-    {
-      label: 'Download',
-      renderIcon: Add16,
-      onClick: action('Clicked batch action button'),
-    },
-    {
-      label: 'Delete',
-      renderIcon: Add16,
-      onClick: action('Clicked batch action button'),
-      hasDivider: true,
-      kind: 'danger',
-    },
-  ];
 };
 
 const RowActionButtonBatchTemplateWrapper = ({ ...args }) => {

--- a/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
@@ -500,7 +500,7 @@
 
 .#{$block-class}
   .#{$carbon-prefix}--data-table--selected:not(.#{$block-class}__active-row)
-  ::before {
+  :first-child:not(.#{$carbon-prefix}--checkbox--inline)::before {
   position: absolute;
   top: 0;
   left: 0;

--- a/packages/ibm-products/src/components/Datagrid/useOnRowClick.js
+++ b/packages/ibm-products/src/components/Datagrid/useOnRowClick.js
@@ -6,20 +6,41 @@
  * restricted by GSA ADP Schedule Contract with IBM Corp.
  */
 
+import { pkg, carbon } from '../../settings';
+
 const useOnRowClick = (hooks) => {
   const useInstance = (rowInstance) => {
     const { onRowClick } = rowInstance;
     const getRowProps = (props, datagridState) => {
       const { isFetching, row, instance } = datagridState;
       const { id, toggleRowSelected } = row;
+      const { withSelectRows, tableId } = instance;
       const onClick = (event) => {
         if (!isFetching && onRowClick) {
           onRowClick(row, event);
-          instance.selectedFlatRows &&
-            instance.selectedFlatRows.map((toggleRow) =>
-              toggleRow.toggleRowSelected(false)
-            );
-          toggleRowSelected(id, true);
+          // We do not want to change the list of selected rows if using the useSelectedRows hook, otherwise clicking on an entire row will mark the row as checked
+
+          // Remove selected class from all other clickable rows as only one clickable row can be selected at a time
+          const clickableSelectedRows = document.querySelectorAll(
+            `#${tableId}.${pkg.prefix}--datagrid .${carbon.prefix}--data-table--selected:not(.${pkg.prefix}--datagrid__active-row)`
+          );
+          if (clickableSelectedRows.length) {
+            Array.from(clickableSelectedRows).forEach((row) => {
+              row.classList.remove(`${carbon.prefix}--data-table--selected`);
+            });
+          }
+          const closestRow = event.target.closest(
+            `.${pkg.prefix}--datagrid__carbon-row`
+          );
+          closestRow.classList.add(`${carbon.prefix}--data-table--selected`);
+
+          if (!withSelectRows) {
+            instance.selectedFlatRows &&
+              instance.selectedFlatRows.map((toggleRow) =>
+                toggleRow.toggleRowSelected(false)
+              );
+            toggleRowSelected(id, true);
+          }
         }
       };
 


### PR DESCRIPTION
Contributes to #3226 and #2607

Adds batch actions to the clickable row with panel story to provide a more detailing use case. I also fix the alignment of the batch action buttons in this PR as well.

#### What did you change?
- Added batch actions to clickable with panel story
- Removed styling causing batch action layout issues

#### How did you test and verify your work?
Storybook

Also discovered a storybook config option to allow for non story exports within `*.stories.js` files. I've utilized it here for `getBatchActions` which reduces our overall footprint.