### PR TITLE
fix(Datagrid): address row action disabled state logic (v2)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
@@ -12,6 +12,7 @@ import { getStoryTitle } from '../../global/js/utils/story-helper';
 import { action } from '@storybook/addon-actions';
 import { Activity, Add } from '@carbon/react/icons';
 import { TableBatchAction, TableBatchActions } from '@carbon/react';
+import { Edit, TrashCan } from '@carbon/react/icons';
 import {
   Datagrid,
   useDatagrid,
@@ -526,7 +527,38 @@ const getBatchActions = () => {
 
 export const BatchActions = () => {
   const [data] = useState(makeData(10));
-  const columns = React.useMemo(() => getColumns(data), []);
+  const columns = React.useMemo(
+    () => [
+      ...getColumns(data),
+      {
+        Header: '',
+        accessor: 'actions',
+        sticky: 'right',
+        isAction: true,
+      },
+    ],
+    []
+  );
+
+  const getRowActions = () => {
+    return [
+      {
+        id: 'edit',
+        itemText: 'Edit',
+        icon: Edit,
+        onClick: action('Clicked row action: edit'),
+      },
+
+      {
+        id: 'delete',
+        itemText: 'Delete',
+        icon: TrashCan,
+        isDelete: true,
+        onClick: action('Clicked row action: delete'),
+      },
+    ];
+  };
+
   const datagridState = useDatagrid(
     {
       columns,
@@ -535,9 +567,12 @@ export const BatchActions = () => {
       toolbarBatchActions: getBatchActions(),
       DatagridActions,
       DatagridBatchActions,
+      rowActions: getRowActions(),
     },
     useSelectRows,
-    useSelectAllWithToggle
+    useSelectAllWithToggle,
+    useActionsColumn,
+    useStickyColumn
   );
 
   return <Datagrid datagridState={{ ...datagridState }} />;

--- a/packages/ibm-products/src/components/Datagrid/useActionsColumn.js
+++ b/packages/ibm-products/src/components/Datagrid/useActionsColumn.js
@@ -17,7 +17,21 @@ const useActionsColumn = (hooks) => {
   }, []);
 
   const useAttachActionsOnInstance = (instance) => {
-    const { rowActions, isFetching, selectedFlatRows } = instance;
+    const {
+      rowActions,
+      isFetching,
+      state: { selectedRowIds },
+    } = instance;
+
+    const getDisabledState = (rowIndex) => {
+      const selectedRowIndexes = Object.keys(selectedRowIds).map((n) =>
+        Number(n)
+      );
+      if (selectedRowIndexes.includes(rowIndex)) {
+        return true;
+      }
+      return false;
+    };
 
     if (rowActions && Array.isArray(rowActions)) {
       const addActionsMenu = (props, cellData) => {
@@ -54,19 +68,13 @@ const useActionsColumn = (hooks) => {
                         if (hidden) {
                           return null;
                         }
-                        const selectedRowId = selectedFlatRows?.filter((item) =>
-                          item.id === row.id ? item.id : null
-                        );
                         return (
                           <div
                             className={cx(
                               `${blockClass}__actions-column-button`,
                               {
                                 [`${blockClass}__disabled-row-action-button`]:
-                                  selectedFlatRows &&
-                                  selectedFlatRows.length &&
-                                  selectedRowId &&
-                                  selectedRowId.length,
+                                  getDisabledState(row.index),
                               }
                             )}
                             key={`${itemText}__${index}`}
@@ -80,25 +88,17 @@ const useActionsColumn = (hooks) => {
                               kind="ghost"
                               className={cx({
                                 [`${blockClass}__disabled-row-action`]:
-                                  selectedFlatRows &&
-                                  selectedFlatRows.length &&
-                                  selectedRowId &&
-                                  selectedRowId.length,
+                                  getDisabledState(row.index),
                               })}
                               onClick={(e) => {
-                                if (
-                                  selectedFlatRows &&
-                                  selectedFlatRows.length &&
-                                  selectedRowId &&
-                                  selectedRowId.length
-                                ) {
+                                if (getDisabledState(row.index)) {
                                   // Row actions should be disabled if row is selected and batchActions toolbar is active
                                   return;
                                 }
                                 e.stopPropagation();
                                 onClick(id, row, e);
                               }}
-                            ></OverflowMenu>
+                            />
                           </div>
                         );
                       })}


### PR DESCRIPTION
Contributes to #3334

This PR allows row actions to become disabled when a row is selected with batch actions. There was some logic in place already, but wasn't correctly setup to disable the row actions as expected.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
packages/ibm-products/src/components/Datagrid/useActionsColumn.js
```
#### How did you test and verify your work?
Storybook, via BatchActions story (I added some row actions to this story in order to verify that the row actions become disabled when selecting the row)