### PR TITLE
fix(CreateTearsheet): use new onChange callback signature in v11

### DIFF
--- a/packages/ibm-products/src/components/CreateTearsheet/preview-components/MultiStepTearsheet.js
+++ b/packages/ibm-products/src/components/CreateTearsheet/preview-components/MultiStepTearsheet.js
@@ -185,7 +185,9 @@ export const MultiStepTearsheet = ({
               <Checkbox
                 labelText={`Include additional step`}
                 id="include-additional-step-checkbox"
-                onChange={(value) => setShouldIncludeAdditionalStep(value)}
+                onChange={(event, { checked }) =>
+                  setShouldIncludeAdditionalStep(checked)
+                }
                 checked={shouldIncludeAdditionalStep}
               />
             </Column>


### PR DESCRIPTION
After reviewing the CreateTearsheet with Turbo team, noticed that the checkbox used to dynamically include an additional step was not updated to use the new `onChange` callback signature that changed from Carbon v10 to v11.

#### What did you change?
```
packages/ibm-products/src/components/CreateTearsheet/preview-components/MultiStepTearsheet.js
```
#### How did you test and verify your work?
Storybook