### PR TITLE
chore: remove `--frozen-lockfile`

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,6 @@
 {
   "version": "independent",
   "npmClient": "yarn",
-  "npmClientArgs": ["--frozen-lockfile"],
   "command": {
     "version": {
       "conventionalCommits": true,


### PR DESCRIPTION
Closes #3342 

`--frozen-lockfile` arg is causing release action to break due to a contraction with `update-lockfle` in the yarn.cjs

#### What did you change?
Remove `--frozen-lockfile` from lerna.json args.

#### How did you test and verify your work?
Compared against main branch `lerna.json` (minus Lerna 7 changes in main).