### PR TITLE
fix(Datagrid): add support for other extensions with customizable columns (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
@@ -37,7 +37,6 @@ const Columns = ({
   assistiveTextInstructionsLabel,
   assistiveTextDisabledInstructionsLabel,
   selectAllLabel,
-  isTableSortable,
 }) => {
   const [ariaRegionText, setAriaRegionText] = React.useState('');
   const [focusIndex, setFocusIndex] = React.useState(-1);
@@ -120,7 +119,6 @@ const Columns = ({
             filterString={filterString}
             focusIndex={focusIndex}
             getNextIndex={getNextIndex}
-            isTableSortable={isTableSortable}
             moveElement={moveElement}
             onSelectColumn={onSelectColumn}
             setAriaRegionText={setAriaRegionText}
@@ -141,7 +139,6 @@ Columns.propTypes = {
   filterString: PropTypes.string.isRequired,
   getVisibleColumnsCount: PropTypes.func.isRequired,
   instructionsLabel: PropTypes.string,
-  isTableSortable: PropTypes.bool.isRequired,
   onSelectColumn: PropTypes.func.isRequired,
   selectAllLabel: PropTypes.string,
   setColumnStatus: PropTypes.func,

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
@@ -31,7 +31,6 @@ const CustomizeColumnsTearsheet = ({
   assistiveTextInstructionsLabel = 'Press space bar to toggle drag drop mode, use arrow keys to move selected elements.',
   assistiveTextDisabledInstructionsLabel = 'Reordering columns are disabled because they are filtered currently.',
   selectAllLabel = 'Column name',
-  isTableSortable,
 }) => {
   const [visibleColumnsCount, setVisibleColumnsCount] = useState('');
   const [totalColumns, setTotalColumns] = useState('');
@@ -144,7 +143,6 @@ const CustomizeColumnsTearsheet = ({
             setDirty();
           }}
           selectAllLabel={selectAllLabel}
-          isTableSortable={isTableSortable}
         />
       )}
     </TearsheetNarrow>
@@ -159,7 +157,6 @@ CustomizeColumnsTearsheet.propTypes = {
   findColumnPlaceholderLabel: PropTypes.string,
   instructionsLabel: PropTypes.string,
   isOpen: PropTypes.bool.isRequired,
-  isTableSortable: PropTypes.bool.isRequired,
   onSaveColumnPrefs: PropTypes.func.isRequired,
   originalColumnDefinitions: PropTypes.array.isRequired,
   primaryButtonTextLabel: PropTypes.string,

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
@@ -19,48 +19,62 @@ export const DraggableItemsList = ({
   filterString,
   focusIndex,
   getNextIndex,
-  isTableSortable,
   moveElement,
   onSelectColumn,
   setAriaRegionText,
   setColumnsObject,
   setFocusIndex,
 }) => {
+  // This function recursively looks for the nested header element until we can find the key which contains the title.
+  // This can happen if multiple hooks are used together that manipulate the rendering of the column
+  // header, such as `useColumnCenterAlign` and `useSortableColumns`.
+  const getNestedTitle = (component) => {
+    if (component && !component.key) {
+      return getNestedTitle(component.children);
+    }
+    if (component && component.key && typeof component.key === 'string') {
+      return component.key;
+    }
+  };
+
+  const getColTitle = (col) => {
+    if (!col) {
+      return;
+    }
+    const checkTitle = () => {
+      if (
+        col.Header().props.children.props &&
+        col.Header().props.children.props.title
+      ) {
+        return col.Header().props.children.props.title;
+      }
+      return getNestedTitle(col.Header().props.children.props);
+    };
+    return typeof col?.Header === 'function'
+      ? checkTitle()
+      : col.Header.props.title;
+  };
   return (
     <>
       {columns
         // hide the columns without Header, e.g the sticky actions, spacer
         .filter((colDef) => {
-          const sortableTitle =
-            isTableSortable && colDef.Header().props.children.props?.title;
-          return (
-            (!!colDef.Header.props && !!colDef.Header.props?.title) ||
-            (isTableSortable && !!sortableTitle)
-          );
+          return !!getColTitle(colDef);
         })
+        .filter(Boolean)
         .filter((colDef) => !colDef.isAction)
         .filter((colDef) => {
-          const sortableTitle =
-            isTableSortable && colDef.Header().props.children.props?.title;
           return (
             filterString.length === 0 ||
-            ((isTableSortable
-              ? sortableTitle?.toLowerCase().includes(filterString)
-              : colDef.Header.props?.title
-                  ?.toLowerCase()
-                  .includes(filterString)) &&
+            (getColTitle(colDef)?.toLowerCase().includes(filterString) &&
               colDef.id !== 'spacer')
           );
         })
         .map((colDef, i) => {
-          const isSortableColumn = !!colDef.canSort && !!isTableSortable;
-          const sortableTitle =
-            isTableSortable && colDef.Header().props.children.props?.title;
+          const colHeaderTitle = getColTitle(colDef);
           const searchString = new RegExp('(' + filterString + ')');
           const res = filterString.length
-            ? isSortableColumn
-              ? sortableTitle.toLowerCase().split(searchString)
-              : colDef.Header.props.title.toLowerCase().split(searchString)
+            ? colHeaderTitle.toLowerCase().split(searchString)
             : null;
           const firstWord =
             res !== null
@@ -73,9 +87,7 @@ export const DraggableItemsList = ({
               ? res[0] === ''
                 ? `<strong>${firstWord}</strong>` + res[2]
                 : firstWord + `<strong>${res[1]}</strong>` + res[2]
-              : isSortableColumn
-              ? sortableTitle
-              : colDef.Header.props?.title;
+              : colHeaderTitle;
           const isFrozenColumn = !!colDef.sticky;
           const listContents = (
             <>
@@ -85,12 +97,8 @@ export const DraggableItemsList = ({
                 disabled={isFrozenColumn}
                 onChange={onSelectColumn.bind(null, colDef)}
                 id={`${blockClass}__customization-column-${colDef.id}`}
-                labelText={
-                  isSortableColumn ? sortableTitle : colDef.Header.props?.title
-                }
-                title={
-                  isSortableColumn ? sortableTitle : colDef.Header.props?.title
-                }
+                labelText={colHeaderTitle}
+                title={colHeaderTitle}
                 className={`${blockClass}__customize-columns-checkbox`}
                 hideLabel
               />
@@ -111,9 +119,7 @@ export const DraggableItemsList = ({
               id={`dnd-datagrid-columns-${colDef.id}`}
               type="column-customization"
               disabled={filterString.length > 0 || isFrozenColumn}
-              ariaLabel={
-                isSortableColumn ? sortableTitle : colDef.Header.props?.title
-              }
+              ariaLabel={colHeaderTitle}
               onGrab={setAriaRegionText}
               isFocused={focusIndex === i}
               moveElement={moveElement}
@@ -148,7 +154,6 @@ DraggableItemsList.propTypes = {
   filterString: PropTypes.string.isRequired,
   focusIndex: PropTypes.number.isRequired,
   getNextIndex: PropTypes.func.isRequired,
-  isTableSortable: PropTypes.bool,
   moveElement: PropTypes.func.isRequired,
   onSelectColumn: PropTypes.func.isRequired,
   setAriaRegionText: PropTypes.func.isRequired,

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/TearsheetWrapper.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/TearsheetWrapper.js
@@ -22,7 +22,6 @@ const TearsheetWrapper = ({ instance }) => {
       {...rest}
       {...labels}
       isOpen={isTearsheetOpen}
-      isTableSortable={instance?.isTableSortable}
       setIsTearsheetOpen={setIsTearsheetOpen}
       columnDefinitions={instance.allColumns}
       originalColumnDefinitions={instance.columns}

--- a/packages/ibm-products/src/components/Datagrid/styles/_useColumnCenterAlign.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_useColumnCenterAlign.scss
@@ -1,19 +1,19 @@
-/*
-* Licensed Materials - Property of IBM
-* 5724-Q36
-* (c) Copyright IBM Corp. 2020
-* US Government Users Restricted Rights - Use, duplication or disclosure
-* restricted by GSA ADP Schedule Contract with IBM Corp.
-*/
+//
+// Copyright IBM Corp. 2020, 2023
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
 
 @import './variables';
 
-.#{$block-class}__center-align-header {
+.#{$block-class}__center-align-header,
+.#{$block-class}__center-align-header .#{$block-class}--table-sort {
   width: 100%;
   text-align: center;
 }
 
-.#{$block-class}__center-align-cell-renderer.sortDisabled {
+.#{$block-class}__center-align-cell-renderer {
   margin-right: auto;
   margin-left: auto;
 }

--- a/packages/ibm-products/src/components/Datagrid/useDefaultStringRenderer.js
+++ b/packages/ibm-products/src/components/Datagrid/useDefaultStringRenderer.js
@@ -28,6 +28,7 @@ const useDefaultStringRenderer = (hooks) => {
     <div
       className={`${blockClass}__defaultStringRenderer`}
       title={typeof header === 'string' ? header : ''}
+      key={typeof header === 'string' ? header : ''}
     >
       {header}
     </div>

--- a/packages/ibm-products/src/components/Datagrid/useSortableColumns.js
+++ b/packages/ibm-products/src/components/Datagrid/useSortableColumns.js
@@ -27,7 +27,10 @@ const getAriaSortValue = (
     defaultSortableLabelText,
   }
 ) => {
-  const { isSorted, isSortedDesc } = col;
+  if (!col) {
+    return;
+  }
+  const { isSorted, isSortedDesc } = col || {};
   if (!isSorted) {
     return defaultSortableLabelText || 'none';
   }


### PR DESCRIPTION
Contributes to #2837 

This PR adds some logic to `DraggableItemsList` that will allow for use of `useCustomizeColumns` with one or more hooks that manipulate the column header (such as `useSortableColumns` or `useColumnCenterAlign`). This also allowed for refactoring how we get the column title if there is a hook being used which manipulates the column header structure.

We previously attempted to support customizable columns with `useSortableColumns` by passing down a prop called `isTableSortable` but this did not get at the root of the problem which is, the use of one or more extensions which may manipulate the structure of the column header. I added `getNestedTitle` which recursively checks for the title so this should account for instances when one or more hooks are used that deal with the column header.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/TearsheetWrapper.js
packages/ibm-products/src/components/Datagrid/styles/_useColumnCenterAlign.scss
packages/ibm-products/src/components/Datagrid/useDefaultStringRenderer.js
packages/ibm-products/src/components/Datagrid/useSortableColumns.js
```
#### How did you test and verify your work?
Storybook, for testing I added `useSortableColumns` and `useColumnCenterAlign` together and on their own with the `useCustomizeColumns` hook, to test this functionality