### PR TITLE
feat(CreateTearsheet): allow node to be passed to description prop

### DIFF
--- a/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheetStep.js
+++ b/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheetStep.js
@@ -5,7 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { forwardRef, useContext, useEffect, useState } from 'react';
+import React, {
+  forwardRef,
+  useContext,
+  useEffect,
+  useState,
+  isValidElement,
+} from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Column, FormGroup, Grid } from '@carbon/react';
@@ -88,6 +94,20 @@ export let CreateTearsheetStep = forwardRef(
       }
     }, [stepsContext, stepNumber, disableSubmit, onNext]);
 
+    const renderDescription = () => {
+      if (description) {
+        if (typeof description === 'string') {
+          return <p className={`${blockClass}--description`}>{description}</p>;
+        }
+        if (isValidElement(description)) {
+          return (
+            <div className={`${blockClass}--description`}>{description}</div>
+          );
+        }
+      }
+      return null;
+    };
+
     return stepsContext ? (
       <Grid
         {
@@ -109,9 +129,7 @@ export let CreateTearsheetStep = forwardRef(
             <h6 className={`${blockClass}--subtitle`}>{subtitle}</h6>
           )}
 
-          {description && (
-            <p className={`${blockClass}--description`}>{description}</p>
-          )}
+          {renderDescription()}
         </Column>
 
         <Column span={100}>
@@ -155,7 +173,7 @@ CreateTearsheetStep.propTypes = {
   /**
    * Sets an optional description on the step component
    */
-  description: PropTypes.string,
+  description: PropTypes.node,
 
   /**
    * This will conditionally disable the submit button in the multi step Tearsheet

--- a/packages/ibm-products/src/components/CreateTearsheet/preview-components/MultiStepTearsheet.js
+++ b/packages/ibm-products/src/components/CreateTearsheet/preview-components/MultiStepTearsheet.js
@@ -136,7 +136,7 @@ export const MultiStepTearsheet = ({
             <div>
               It will also be used by your producers and consumers as part of
               the connection information, so make it something easy to
-              recognize. <Link>Learn more.</Link>
+              recognize. <Link href="#">Learn more.</Link>
             </div>
           }
         >

--- a/packages/ibm-products/src/components/CreateTearsheet/preview-components/MultiStepTearsheet.js
+++ b/packages/ibm-products/src/components/CreateTearsheet/preview-components/MultiStepTearsheet.js
@@ -18,6 +18,7 @@ import {
   Toggle,
   NumberInput,
   Checkbox,
+  Link,
 } from '@carbon/react';
 import cx from 'classnames';
 import { pkg } from '../../../settings';
@@ -131,8 +132,13 @@ export const MultiStepTearsheet = ({
           fieldsetLegendText="Topic information"
           disableSubmit={!stepOneTextInputValue}
           subtitle="This is the unique name used to recognize your topic"
-          description="It will also be used by your producers and consumers as part of the
-          connection information, so make it something easy to recognize."
+          description={
+            <div>
+              It will also be used by your producers and consumers as part of
+              the connection information, so make it something easy to
+              recognize. <Link>Learn more.</Link>
+            </div>
+          }
         >
           <Grid>
             <Column xlg={8} lg={8} md={8} sm={4}>


### PR DESCRIPTION
Contributes to #3345 

Allows nodes to be passed to `CreateTearsheetStep` description.

#### What did you change?
```
packages/ibm-products/src/components/CreateTearsheet/CreateTearsheetStep.js
packages/ibm-products/src/components/CreateTearsheet/preview-components/MultiStepTearsheet.js
```
#### How did you test and verify your work?
Storybook