### PR TITLE
feat(CreateTearsheet): add optional `onPrevious` handler to step

### DIFF
--- a/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.js
+++ b/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.js
@@ -80,6 +80,8 @@ export let CreateTearsheet = forwardRef(
     const [currentStep, setCurrentStep] = useState(0);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [isDisabled, setIsDisabled] = useState(false);
+    const [loadingPrevious, setLoadingPrevious] = useState(false);
+    const [onPrevious, setOnPrevious] = useState();
     const [onNext, setOnNext] = useState();
     const [onMount, setOnMount] = useState();
     const [stepData, setStepData] = useState([]);
@@ -130,11 +132,14 @@ export let CreateTearsheet = forwardRef(
       firstIncludedStep,
       lastIncludedStep,
       stepData,
+      onPrevious,
       onNext,
       isSubmitDisabled: isDisabled,
       setCurrentStep,
       setIsSubmitting,
       setShouldViewAll,
+      setLoadingPrevious,
+      loadingPrevious,
       onClose,
       onRequestSubmit,
       componentName,
@@ -198,6 +203,7 @@ export let CreateTearsheet = forwardRef(
               value={{
                 currentStep,
                 setIsDisabled,
+                setOnPrevious: (fn) => setOnPrevious(() => fn),
                 setOnNext: (fn) => setOnNext(() => fn),
                 setOnMount: (fn) => setOnMount(() => fn),
                 setStepData,

--- a/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheetStep.js
+++ b/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheetStep.js
@@ -36,8 +36,9 @@ export let CreateTearsheetStep = forwardRef(
       hasFieldset = defaults.hasFieldset,
       includeStep = defaults.includeStep,
       introStep,
-      onNext,
       onMount,
+      onNext,
+      onPrevious,
       secondaryLabel,
       subtitle,
       title,
@@ -85,8 +86,9 @@ export let CreateTearsheetStep = forwardRef(
       if (stepNumber === stepsContext?.currentStep) {
         stepsContext.setIsDisabled(disableSubmit);
         stepsContext?.setOnNext(onNext); // needs to be updated here otherwise there could be stale state values from only initially setting onNext
+        stepsContext?.setOnPrevious(onPrevious);
       }
-    }, [stepsContext, stepNumber, disableSubmit, onNext]);
+    }, [stepsContext, stepNumber, disableSubmit, onNext, onPrevious]);
 
     return stepsContext ? (
       <Grid
@@ -196,11 +198,16 @@ CreateTearsheetStep.propTypes = {
   onMount: PropTypes.func,
 
   /**
-   * Optional function to be called on a step change.
+   * Optional function to be called when you move to the next step.
    * For example, this can be used to validate input fields before proceeding to the next step.
    * This function can _optionally_ return a promise that is either resolved or rejected and the CreateTearsheet will handle the submitting state of the next button.
    */
   onNext: PropTypes.func,
+
+  /**
+   * Optional function to be called when you move to the previous step.
+   */
+  onPrevious: PropTypes.func,
 
   /**
    * Sets the optional secondary label on the progress step component

--- a/packages/ibm-products/src/components/CreateTearsheet/preview-components/MultiStepTearsheet.js
+++ b/packages/ibm-products/src/components/CreateTearsheet/preview-components/MultiStepTearsheet.js
@@ -185,13 +185,18 @@ export const MultiStepTearsheet = ({
               <Checkbox
                 labelText={`Include additional step`}
                 id="include-additional-step-checkbox"
-                onChange={(value) => setShouldIncludeAdditionalStep(value)}
+                onChange={(event, { checked }) =>
+                  setShouldIncludeAdditionalStep(checked)
+                }
                 checked={shouldIncludeAdditionalStep}
               />
             </Column>
           </Grid>
         </CreateTearsheetStep>
         <CreateTearsheetStep
+          onPrevious={() => {
+            console.log('custom onPrevious handler');
+          }}
           title="Dynamic step"
           subtitle="Dynamic step subtitle"
           description="This is an example showing how to include a dynamic step into the CreateTearsheet"

--- a/packages/ibm-products/src/global/js/hooks/useCreateComponentStepChange.js
+++ b/packages/ibm-products/src/global/js/hooks/useCreateComponentStepChange.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,8 +16,8 @@ export const useCreateComponentStepChange = ({
   isSubmitDisabled,
   setCurrentStep,
   setIsSubmitting,
-  setLoadingPrevious,
-  loadingPrevious,
+  setLoadingPrevious = null,
+  loadingPrevious = false,
   onClose,
   onRequestSubmit,
   componentName,
@@ -45,7 +45,9 @@ export const useCreateComponentStepChange = ({
   }, [setCurrentStep, setIsSubmitting, stepData]);
 
   const moveToPreviousStep = useCallback(() => {
-    setLoadingPrevious(false);
+    if (componentName !== 'CreateFullPage') {
+      setLoadingPrevious(false);
+    }
     setCurrentStep((prev) => {
       // Find previous included step to render
       // There will always be a previous step otherwise we will
@@ -55,7 +57,7 @@ export const useCreateComponentStepChange = ({
       } while (!stepData[prev - 1]?.shouldIncludeStep);
       return prev;
     });
-  }, [setCurrentStep, stepData, setLoadingPrevious]);
+  }, [setCurrentStep, stepData, setLoadingPrevious, componentName]);
 
   // useEffect to handle multi step logic
   useEffect(() => {
@@ -77,6 +79,9 @@ export const useCreateComponentStepChange = ({
       }
     };
     const handlePrevious = async () => {
+      if (componentName === 'CreateFullPage') {
+        return;
+      }
       setLoadingPrevious(true);
       if (typeof onPrevious === 'function') {
         try {

--- a/packages/ibm-products/src/global/js/hooks/useRetrieveStepData.js
+++ b/packages/ibm-products/src/global/js/hooks/useRetrieveStepData.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/ibm-products/src/global/js/utils/StoryDocsPage.js
+++ b/packages/ibm-products/src/global/js/utils/StoryDocsPage.js
@@ -111,8 +111,6 @@ export const StoryDocsPage = ({
     omitUnreferencedStories
   );
 
-  console.log(processBlocks);
-
   const storyCount =
     processedBlocks?.filter((block) => !!block.story).length ?? 0;
 


### PR DESCRIPTION
Contributes to #3340 

Adds an optional `onPrevious` prop to the `CreateTearsheetStep` component. There were also remnants of an old version of this component when you could view all the steps together, `shouldViewAll`, inside the custom hook that contains the step changing logic, so I cleaned that up as well.

#### What did you change?
```
packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.js
packages/ibm-products/src/components/CreateTearsheet/CreateTearsheetStep.js
packages/ibm-products/src/components/CreateTearsheet/preview-components/MultiStepTearsheet.js
packages/ibm-products/src/global/js/hooks/useCreateComponentStepChange.js
```
#### How did you test and verify your work?
Storybook