### PR TITLE
fix: move lottie-web package to ibm-products package

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "json": "^11.0.0",
     "lerna": "^6.6.2",
     "lint-staged": "^13.1.2",
-    "lottie-web": "^5.11.0",
     "npm-check-updates": "^16.7.4",
     "npm-run-all": "^4.1.5",
     "npm-upgrade": "^3.1.0",

--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -76,6 +76,7 @@
     "framer-motion": "^6.5.1 <7",
     "immutability-helper": "^3.1.1",
     "lodash": "^4.17.21",
+    "lottie-web": "^5.11.0",
     "react-dnd": "^15.1.2",
     "react-dnd-html5-backend": "^15.1.3",
     "react-table": "^7.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1846,6 +1846,7 @@ __metadata:
     jest-config-ibm-cloud-cognitive: ^0.25.0
     jest-environment-jsdom: ^29.4.2
     lodash: ^4.17.21
+    lottie-web: ^5.11.0
     namor: ^1.1.2
     npm-check-updates: ^16.7.4
     npm-run-all: ^4.1.5
@@ -15434,7 +15435,6 @@ __metadata:
     json: ^11.0.0
     lerna: ^6.6.2
     lint-staged: ^13.1.2
-    lottie-web: ^5.11.0
     npm-check-updates: ^16.7.4
     npm-run-all: ^4.1.5
     npm-upgrade: ^3.1.0


### PR DESCRIPTION
Contributes to #3353 

Having `lottie-web` in the root package.json and having it as a dev dependency is breaking the latest v1 release. Moving it to the `ibm-products` package as a dependency should resolve this problem.

#### What did you change?
```
package.json
packages/ibm-products/package.json
yarn.lock
```
#### How did you test and verify your work?
Verified in yarn.lock that `lottie-web` is listed under `ibm-products`