### PR TITLE
fix(Datagrid): add initial width value to useResizeObserver and add batch actions test

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
@@ -6,12 +6,16 @@
  */
 
 import React, { useState, useEffect, forwardRef } from 'react';
-import { act, render, screen, fireEvent } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
+import { render, screen, fireEvent } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
 import uuidv4 from '../../global/js/utils/uuidv4';
 import { useDatagrid } from '.';
 import { makeData } from './utils/makeData';
 
-import { expectError, expectWarn, mockHTMLElement } from '../../global/js/utils/test-helper';
+import {
+  expectError,
+  expectWarn,
+  mockHTMLElement,
+} from '../../global/js/utils/test-helper';
 import { Datagrid } from '.';
 import { pkg } from '../../settings';
 
@@ -191,10 +195,10 @@ const DatagridActions = (datagridState) => {
         />
         <TableToolbarContent>
           <TableToolbarSearch
-            size="xl"
+            size="lg"
             id="columnSearch"
             persistent
-            placeHolderText={searchForAColumn}
+            placeholder={searchForAColumn}
             onChange={(e) => setGlobalFilter(e.target.value)}
           />
           <RowSizeDropdown {...rowSizeDropdownProps} />
@@ -865,35 +869,12 @@ beforeAll(() => {
 });
 
 describe(componentName, () => {
-  window.innerWidth = 2000;
-  window.innerHeight = 1080;
-
-  let mockElement;
-
-  const isTableToolbar = function () {
-    return this.classList?.contains(`c4p--datagrid__table-toolbar`) || false;
-  }
-
   beforeEach(() => {
     jest.spyOn(global.console, 'error').mockImplementation(() => {});
     //This will suppress the warning about Arrows16 Component (will be removed in the next major version of @carbon/icons-react).
     jest.spyOn(global.console, 'warn').mockImplementation(() => {});
     jest.useFakeTimers();
     jest.spyOn(global, 'setTimeout');
-    mockElement = mockHTMLElement({
-      offsetWidth: {
-        get: function () {
-          let width = 1000;
-          if (isTableToolbar.bind(this)()) {
-            width = 1000;
-          } else {
-            width = window.innerWidth;
-          }
-
-          return width;
-        }
-      }
-    });
     window.ResizeObserver = jest.fn().mockImplementation(() => ({
       observe: jest.fn(),
       unobserve: jest.fn(),
@@ -902,94 +883,9 @@ describe(componentName, () => {
   });
 
   afterEach(() => {
-    mockElement.mockRestore();
     jest.useRealTimers();
     window.ResizeObserver = ResizeObserver;
   });
-
-  const getBatchActions = () => {
-    return [
-      {
-        label: 'Duplicate',
-        renderIcon: (props) => <Add size={16} {...props} />,
-        onClick: () => {},
-      },
-      {
-        label: 'Add',
-        renderIcon: (props) => <Add size={16} {...props} />,
-        onClick: () => {},
-      },
-      {
-        label: 'Select all',
-        renderIcon: (props) => <Add size={16} {...props} />,
-        onClick: () => {},
-        type: 'select_all',
-      },
-      {
-        label: 'Publish to catalog',
-        renderIcon: (props) => <Add size={16} {...props} />,
-        onClick: () => {},
-      },
-      {
-        label: 'Download',
-        renderIcon: (props) => <Add size={16} {...props} />,
-        onClick: () => {},
-      },
-      {
-        label: 'Delete',
-        renderIcon: (props) => <Add size={16} {...props} />,
-        onClick: () => {},
-        hasDivider: true,
-        kind: 'danger',
-      },
-    ];
-  };
-
-  const TestBatch = () => {
-    const columns = React.useMemo(() => defaultHeader, []);
-    const [data] = useState(makeData(2));
-    const datagridState = useDatagrid(
-      {
-        columns,
-        data,
-        batchActions: true,
-        toolbarBatchActions: getBatchActions(),
-        DatagridActions,
-      },
-      useSelectRows,
-      useSelectAllWithToggle,
-      useStickyColumn
-    );
-  
-    return <Datagrid datagridState={datagridState} />;
-  }
-
-  it.only('renders batch action', async () => {
-    window.innerWidth = 1000;
-    const { container } = render(<TestBatch />);
-    const { click } = userEvent;
-    const firstCheckbox = screen.getByLabelText(/datagrid-table-id1-row-0/);
-    act(() => click(firstCheckbox));
-
-    // Problem here is that the width returned from useResizeObserver is always 0
-    // This causes all of the batch actions to render inside of the overflow button menu
-    // rather than being displayed by default (given that there is space available to render them)
-
-    // Thinking this might be another await scenario because when I look in the browser
-    // the width returned from the `useResizeObserver` hook is initially 0 as well and then
-    // it receives a value.
-
-    // You can see the width value here:
-    // https://github.com/carbon-design-system/ibm-products/blob/main/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.js#L178
-
-    // is what is being used to determine if there is enough space, and since in the test environment
-    // it is always 0, the overflow button menu always shows even when mocking offset widths.
-    
-    // screen.debug(undefined, Infinity);
-    expect(container.querySelector(`.cds--batch-actions.cds--batch-actions--active`)).toBeInTheDocument();
-    console.log('table toolbar width', container.querySelector('.c4p--datagrid__table-toolbar').offsetWidth);
-  });
-
 
   it('renders a basic data grid component with devTools attribute', () => {
     render(<BasicUsage data-testid={dataTestId} />);
@@ -2270,5 +2166,149 @@ describe(componentName, () => {
     expect(document.getElementsByTagName('h3')[0].textContent).toMatch(
       'Clicked [retire] on row:'
     );
+  });
+});
+
+const getBatchActions = () => {
+  return [
+    {
+      label: 'Duplicate',
+      renderIcon: (props) => <Add size={16} {...props} />,
+      onClick: () => {},
+    },
+    {
+      label: 'Add',
+      renderIcon: (props) => <Add size={16} {...props} />,
+      onClick: () => {},
+    },
+    {
+      label: 'Select all',
+      renderIcon: (props) => <Add size={16} {...props} />,
+      onClick: () => {},
+      type: 'select_all',
+    },
+    {
+      label: 'Publish to catalog',
+      renderIcon: (props) => <Add size={16} {...props} />,
+      onClick: () => {},
+    },
+    {
+      label: 'Download',
+      renderIcon: (props) => <Add size={16} {...props} />,
+      onClick: () => {},
+    },
+    {
+      label: 'Delete',
+      renderIcon: (props) => <Add size={16} {...props} />,
+      onClick: () => {},
+      hasDivider: true,
+      kind: 'danger',
+    },
+  ];
+};
+
+const TestBatch = () => {
+  const columns = React.useMemo(() => defaultHeader, []);
+  const [data] = useState(makeData(2));
+  const datagridState = useDatagrid(
+    {
+      columns,
+      data,
+      batchActions: true,
+      toolbarBatchActions: getBatchActions(),
+      DatagridActions,
+    },
+    useSelectRows,
+    useSelectAllWithToggle,
+    useStickyColumn
+  );
+
+  return <Datagrid datagridState={datagridState} />;
+};
+
+describe('batch action testing', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(global.console, 'error').mockImplementation(() => {});
+    //This will suppress the warning about Arrows16 Component (will be removed in the next major version of @carbon/icons-react).
+    jest.spyOn(global.console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+  window.innerWidth = 2000;
+  let mockElement;
+
+  const isTableToolbar = (el) => {
+    return (
+      el.classList?.contains(`${pkg.prefix}--datagrid__table-toolbar`) || false
+    );
+  };
+
+  const setMockWidths = (el, type = 'large') => {
+    let width = type === 'large' ? 2000 : type === 'medium' ? 1000 : 320;
+    if (isTableToolbar(el)) {
+      width = type === 'large' ? 3000 : type === 'medium' ? 1000 : 320;
+    } else {
+      width = type === 'large' ? 500 : type === 'medium' ? 400 : 320;
+    }
+
+    return width;
+  };
+
+  describe('with space for two actions and menu button', () => {
+    beforeEach(() => {
+      mockElement = mockHTMLElement({
+        offsetWidth: {
+          get: function () {
+            return setMockWidths(this);
+          },
+        },
+      });
+      window.ResizeObserver = jest.fn().mockImplementation(() => ({
+        observe: jest.fn(),
+        unobserve: jest.fn(),
+        disconnect: jest.fn(),
+      }));
+    });
+
+    afterEach(() => {
+      mockElement.mockRestore();
+      window.ResizeObserver = ResizeObserver;
+    });
+
+    it('renders batch action and checks for the appropriate rendering based on the current mocked widths', async () => {
+      const { container } = render(<TestBatch />);
+      const { click } = userEvent;
+      const firstCheckbox = screen.getAllByLabelText(/datagrid-table-id/)[0];
+      screen.debug(undefined, Infinity);
+      click(firstCheckbox);
+      expect(
+        container.querySelector(
+          `.${carbon.prefix}--batch-actions.${carbon.prefix}--batch-actions--active`
+        )
+      ).toBeInTheDocument();
+
+      // Given the default offsetWidth mocks, 2 batch actions should be visible
+      // in addition to the MenuButton
+      screen.getByLabelText(getBatchActions()[0].label);
+      screen.getByLabelText(getBatchActions()[1].label);
+      const menuButton = container.querySelector(`.${pkg.prefix}--button-menu`);
+      expect(menuButton).toBeInTheDocument();
+      click(menuButton);
+      const options = Array.from(
+        document.querySelector(`.${pkg.prefix}--button-menu__options`).children
+      );
+      const optionsText = options.map((o) => {
+        return o.textContent;
+      });
+      const remainingBatchActions = [...getBatchActions()].slice(2);
+
+      // Check that the items inside of the MenuButton match the leftover
+      // batch action items
+      remainingBatchActions.forEach((batchAction, index) => {
+        expect(batchAction.label).toEqual(optionsText[index]);
+      });
+    });
   });
 });

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
@@ -6,12 +6,12 @@
  */
 
 import React, { useState, useEffect, forwardRef } from 'react';
-import { render, screen, fireEvent } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
+import { act, render, screen, fireEvent } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
 import uuidv4 from '../../global/js/utils/uuidv4';
 import { useDatagrid } from '.';
 import { makeData } from './utils/makeData';
 
-import { expectError, expectWarn } from '../../global/js/utils/test-helper';
+import { expectError, expectWarn, mockHTMLElement } from '../../global/js/utils/test-helper';
 import { Datagrid } from '.';
 import { pkg } from '../../settings';
 
@@ -40,7 +40,7 @@ import {
   TableBatchActions,
   TableBatchAction,
 } from '@carbon/react';
-import { Download, Restart, Filter, Activity } from '@carbon/react/icons';
+import { Download, Restart, Filter, Activity, Add } from '@carbon/react/icons';
 import { carbon } from '../../settings';
 
 // import { DatagridActions, DatagridBatchActions, DatagridPagination, } from './Datagrid.stories';
@@ -865,12 +865,35 @@ beforeAll(() => {
 });
 
 describe(componentName, () => {
+  window.innerWidth = 2000;
+  window.innerHeight = 1080;
+
+  let mockElement;
+
+  const isTableToolbar = function () {
+    return this.classList?.contains(`c4p--datagrid__table-toolbar`) || false;
+  }
+
   beforeEach(() => {
     jest.spyOn(global.console, 'error').mockImplementation(() => {});
     //This will suppress the warning about Arrows16 Component (will be removed in the next major version of @carbon/icons-react).
     jest.spyOn(global.console, 'warn').mockImplementation(() => {});
     jest.useFakeTimers();
     jest.spyOn(global, 'setTimeout');
+    mockElement = mockHTMLElement({
+      offsetWidth: {
+        get: function () {
+          let width = 1000;
+          if (isTableToolbar.bind(this)()) {
+            width = 1000;
+          } else {
+            width = window.innerWidth;
+          }
+
+          return width;
+        }
+      }
+    });
     window.ResizeObserver = jest.fn().mockImplementation(() => ({
       observe: jest.fn(),
       unobserve: jest.fn(),
@@ -879,8 +902,94 @@ describe(componentName, () => {
   });
 
   afterEach(() => {
+    mockElement.mockRestore();
+    jest.useRealTimers();
     window.ResizeObserver = ResizeObserver;
   });
+
+  const getBatchActions = () => {
+    return [
+      {
+        label: 'Duplicate',
+        renderIcon: (props) => <Add size={16} {...props} />,
+        onClick: () => {},
+      },
+      {
+        label: 'Add',
+        renderIcon: (props) => <Add size={16} {...props} />,
+        onClick: () => {},
+      },
+      {
+        label: 'Select all',
+        renderIcon: (props) => <Add size={16} {...props} />,
+        onClick: () => {},
+        type: 'select_all',
+      },
+      {
+        label: 'Publish to catalog',
+        renderIcon: (props) => <Add size={16} {...props} />,
+        onClick: () => {},
+      },
+      {
+        label: 'Download',
+        renderIcon: (props) => <Add size={16} {...props} />,
+        onClick: () => {},
+      },
+      {
+        label: 'Delete',
+        renderIcon: (props) => <Add size={16} {...props} />,
+        onClick: () => {},
+        hasDivider: true,
+        kind: 'danger',
+      },
+    ];
+  };
+
+  const TestBatch = () => {
+    const columns = React.useMemo(() => defaultHeader, []);
+    const [data] = useState(makeData(2));
+    const datagridState = useDatagrid(
+      {
+        columns,
+        data,
+        batchActions: true,
+        toolbarBatchActions: getBatchActions(),
+        DatagridActions,
+      },
+      useSelectRows,
+      useSelectAllWithToggle,
+      useStickyColumn
+    );
+  
+    return <Datagrid datagridState={datagridState} />;
+  }
+
+  it.only('renders batch action', async () => {
+    window.innerWidth = 1000;
+    const { container } = render(<TestBatch />);
+    const { click } = userEvent;
+    const firstCheckbox = screen.getByLabelText(/datagrid-table-id1-row-0/);
+    act(() => click(firstCheckbox));
+
+    // Problem here is that the width returned from useResizeObserver is always 0
+    // This causes all of the batch actions to render inside of the overflow button menu
+    // rather than being displayed by default (given that there is space available to render them)
+
+    // Thinking this might be another await scenario because when I look in the browser
+    // the width returned from the `useResizeObserver` hook is initially 0 as well and then
+    // it receives a value.
+
+    // You can see the width value here:
+    // https://github.com/carbon-design-system/ibm-products/blob/main/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.js#L178
+
+    // is what is being used to determine if there is enough space, and since in the test environment
+    // it is always 0, the overflow button menu always shows even when mocking offset widths.
+    
+    // screen.debug(undefined, Infinity);
+    expect(container.querySelector(`.cds--batch-actions.cds--batch-actions--active`)).toBeInTheDocument();
+    console.log('table toolbar width', container.querySelector('.c4p--datagrid__table-toolbar').offsetWidth);
+  });
+
 
   it('renders a basic data grid component with devTools attribute', () => {
     render(<BasicUsage data-testid={dataTestId} />);

--- a/packages/ibm-products/src/global/js/hooks/useResizeObserver.js
+++ b/packages/ibm-products/src/global/js/hooks/useResizeObserver.js
@@ -13,11 +13,28 @@ export const useResizeObserver = (ref, callback) => {
   const cb = useRef(callback);
 
   useEffect(() => {
-    // ref for callback removes it as dependency fro useLayoutEffect
+    // ref for callback removes it as dependency from useLayoutEffect
     // This significantly reduces repeated calls if a function is redefined on every
     // render
     cb.current = callback;
   }, [callback]);
+
+  useEffect(() => {
+    const getInitialSize = () => {
+      if (ref.current) {
+        const refComputedStyle = window.getComputedStyle(ref.current);
+        const initialWidth =
+          (ref.current?.offsetWidth || 0) -
+          (parseFloat(refComputedStyle.paddingLeft),
+          parseFloat(refComputedStyle.paddingRight));
+        setWidth(initialWidth);
+      }
+    };
+    if (!ref?.current && width !== 0) {
+      return;
+    }
+    getInitialSize();
+  }, [width, ref]);
 
   useLayoutEffect(() => {
     if (!ref?.current) {
@@ -56,6 +73,5 @@ export const useResizeObserver = (ref, callback) => {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ref.current]);
-
   return { width, height };
 };


### PR DESCRIPTION
Contributes to #3370

When we moved from the `react-resize-observer` package to our own custom hook, it looks like there is a change in behavior in the initial `width` value that is returned. It hasn't been noticed because we didn't really have a great batch actions test to really notice the issue.

I added a useEffect to `useResizeObserver` so that an initial width is returned so that components that make use of the returned `width` from the hook are able to get an expected value back, particularly when writing tests.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid.test.js
packages/ibm-products/src/global/js/hooks/useResizeObserver.js
```
#### How did you test and verify your work?
Ran new batch action Datagrid test

fyi @lee-chase 