### PR TITLE
build: pin current sass version and remove `yarn dlx` to prevent rem issue

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build": "run-s build:carbon build:storybook",
-    "build:carbon": "yarn dlx sass --style=expanded --load-path ../ibm-products/node_modules --load-path ../../node_modules --load-path node_modules .storybook/carbon.scss:css/carbon.css",
+    "build:carbon": "sass --style=expanded --load-path ../ibm-products/node_modules --load-path ../../node_modules --load-path node_modules .storybook/carbon.scss:css/carbon.css",
     "build:storybook": "yarn dlx cross-env \"NODE_OPTIONS=--max_old_space_size=8192\" && storybook build -s ./public",
     "clean": "yarn dlx rimraf storybook-static css",
     "start": "run-s build:carbon start:storybook",
@@ -62,7 +62,7 @@
     "react-dom": "^16.14.0",
     "regenerator-runtime": "^0.13.11",
     "rimraf": "^5.0.1",
-    "sass": "^1.63.6",
+    "sass": "1.63.6",
     "sass-loader": "^13.3.2",
     "storybook": "^7.0.27",
     "style-loader": "^3.3.3",

--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -70,7 +70,7 @@
     "npm-check-updates": "^16.10.15",
     "npm-run-all": "^4.1.5",
     "rimraf": "^5.0.1",
-    "sass": "^1.63.6",
+    "sass": "1.63.6",
     "yargs": "^17.7.2"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2040,7 +2040,7 @@ __metadata:
     react-dom: ^16.14.0
     regenerator-runtime: ^0.13.11
     rimraf: ^5.0.1
-    sass: ^1.63.6
+    sass: 1.63.6
     sass-loader: ^13.3.2
     storybook: ^7.0.27
     style-loader: ^3.3.3
@@ -2079,7 +2079,7 @@ __metadata:
     react-table: ^7.8.0
     react-window: ^1.8.9
     rimraf: ^5.0.1
-    sass: ^1.63.6
+    sass: 1.63.6
     yargs: ^17.7.2
   peerDependencies:
     "@carbon/grid": ^11.16.1
@@ -19993,7 +19993,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass@npm:^1.63.6":
+"sass@npm:1.63.6":
   version: 1.63.6
   resolution: "sass@npm:1.63.6"
   dependencies:


### PR DESCRIPTION
We were not able to pin to a version prior to `1.65.0` because we are using `yarn dlx sass` in one of the build scripts from `packages/core` which pulls in the latest sass version (thus explaining why we kept seeing the issue).

I changed `yarn dlx sass` to just `sass` and everything seems to be working ok now.

#### What did you change?
```
packages/core/package.json
packages/ibm-products/package.json
yarn.lock
```
#### How did you test and verify your work?
Ran build scripts and confirmed that storybook server starts as expected