### PR TITLE
Bug: Replace h1 tag in NotificationsPanel with h2

### DIFF
--- a/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.js
+++ b/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.js
@@ -399,7 +399,7 @@ export let NotificationsPanel = React.forwardRef(
       >
         <div className={`${blockClass}__header-container`}>
           <div className={`${blockClass}__header-flex`}>
-            <h1 className={`${blockClass}__header`}>{title}</h1>
+            <h2 className={`${blockClass}__header`}>{title}</h2>
             <Button
               size="sm"
               kind="ghost"


### PR DESCRIPTION
Contributes to #3379 

## What did you change?

Changed `h1` tag in NotificationsPanel with `h2`.

#### How did you test and verify your work?
