### PR TITLE
fix: remove filter revert on close

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
@@ -334,7 +334,8 @@ const useFilters = ({
   const cancel = () => {
     // Reverting to previous filters only applies when using batch actions
     if (updateMethod === BATCH) {
-      revertToPreviousFilters();
+      // commenting the below function as this is reverting to previous value even after we clear the filter and close the filter panel
+      //revertToPreviousFilters();
       onCancel();
     }
   };


### PR DESCRIPTION
Contributes to #3328 

Previously selected filters re-appear after closing the fliter panel using the 'X' close button in the top right.
Only happens after clearing filter selections using the 'clear filters' button in the filter tag summary.



#### What did you change?
Commented the function revertToPreviousFilters(); which is setting the previous filters even after clearing the filters
#### How did you test and verify your work?
Working in storybook