### PR TITLE
chore: test initial width height of resizeObserver

### DIFF
--- a/packages/ibm-products/src/global/js/hooks/__tests__/useResizeObserver.test.js
+++ b/packages/ibm-products/src/global/js/hooks/__tests__/useResizeObserver.test.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright IBM Corp. 2020, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React, { useEffect, useRef, useState } from 'react';
+import { useResizeObserver } from '../useResizeObserver';
+import { mockHTMLElement } from '../../utils/test-helper';
+import { render, screen } from '@testing-library/react';
+
+const sizes = (base) => ({
+  offsetWidth: {
+    ['this-div']: base,
+  },
+  offsetHeight: { ['this-div']: base / 2 },
+});
+
+const testSizes = (el, property) => {
+  const classes = el.getAttribute('class').split(' ');
+  const container = el.closest('.test-container');
+
+  const base = container ? parseInt(container.style.width, 10) : 400;
+  const propSizes = sizes(base)[property];
+
+  if (propSizes) {
+    for (let cls of classes) {
+      const val = propSizes[cls] ? propSizes[cls] : -1;
+      if (val >= 0) {
+        // console.log(property, cls, val);
+        return val;
+      }
+    }
+  }
+
+  // The test should never get here as all cases should be catered for in setup.
+  // eslint-disable-next-line
+  console.log('testSizes found nothing.', property, el.outerHTML);
+  return base;
+};
+
+const mockSizes = () => {
+  const mocks = {};
+
+  const keys = Object.keys(sizes(-1));
+  for (let i = 0; i < keys.length; i++) {
+    mocks[keys[i]] = {
+      get: function () {
+        return testSizes(this, keys[i]);
+      },
+    };
+  }
+
+  return mocks;
+};
+
+const TestComponent = () => {
+  const thisDiv = useRef(null);
+  const { width, height } = useResizeObserver(thisDiv);
+  const [content, setContent] = useState(-1);
+
+  useEffect(() => {
+    // console.log('width', width);
+    setContent(`width: ${width}, height: ${height}`);
+  }, [height, width]);
+
+  return (
+    <div ref={thisDiv} className="this-div">
+      {content}
+    </div>
+  );
+};
+
+describe('useResizeObserver', () => {
+  const { ResizeObserver } = window;
+  let mockElement;
+
+  beforeEach(() => {
+    mockElement = mockHTMLElement(mockSizes());
+    window.ResizeObserver = jest.fn().mockImplementation(() => ({
+      observe: jest.fn(),
+      unobserve: jest.fn(),
+      disconnect: jest.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    mockElement.mockRestore();
+    window.ResizeObserver = ResizeObserver;
+  });
+
+  it('returns the initial size of the component', () => {
+    render(<TestComponent />);
+    screen.getByText('width: 400, height: 200');
+  });
+});

--- a/packages/ibm-products/src/global/js/hooks/useResizeObserver.js
+++ b/packages/ibm-products/src/global/js/hooks/useResizeObserver.js
@@ -7,8 +7,8 @@
 import { useRef, useState, useLayoutEffect, useEffect } from 'react';
 
 export const useResizeObserver = (ref, callback) => {
-  const [width, setWidth] = useState(0);
-  const [height, setHeight] = useState(0);
+  const [width, setWidth] = useState(-1);
+  const [height, setHeight] = useState(-1);
   const entriesToHandle = useRef(null);
   const cb = useRef(callback);
 
@@ -27,14 +27,21 @@ export const useResizeObserver = (ref, callback) => {
           (ref.current?.offsetWidth || 0) -
           (parseFloat(refComputedStyle?.paddingLeft || 0),
           parseFloat(refComputedStyle?.paddingRight || 0));
+
+        const initialHeight =
+          (ref.current?.offsetHeight || 0) -
+          (parseFloat(refComputedStyle?.paddingTop || 0),
+          parseFloat(refComputedStyle?.paddingLeft || 0));
+
         setWidth(initialWidth);
+        setHeight(initialHeight);
       }
     };
-    if (!ref?.current && width !== 0) {
+    if (!ref?.current || (width >= 0 && height >= 0)) {
       return;
     }
     getInitialSize();
-  }, [width, ref]);
+  }, [width, height, ref]);
 
   useLayoutEffect(() => {
     if (!ref?.current) {


### PR DESCRIPTION
Adds a test for resizeObserver initial sizes

#### What did you change?

- Resize observer to include an initial height.
- Added a resize observer test

#### How did you test and verify your work?

- Ran new test