### PR TITLE
feat(Datagrid): add keyboard support for col resizing

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -152,7 +152,11 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
                       const { key } = event;
                       if (key === 'ArrowLeft' || key === 'ArrowRight') {
                         const currentColumnWidth =
-                          columnWidths[header.id] || originalCol.width;
+                          columnWidths[header.id] ||
+                          (datagridState.isTableSortable &&
+                          originalCol.width < 90
+                            ? 90
+                            : originalCol.width);
                         if (key === 'ArrowLeft') {
                           if (currentColumnWidth - incrementAmount > minWidth) {
                             dispatch({

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -88,6 +88,7 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
             // render directly without the wrapper TableHeader
             return header.render('Header', { key: header.id });
           }
+          const { minWidth } = header || 90;
           const { visibleColumns, state, dispatch } = datagridState;
           const { columnResizing, isResizing } = state;
           const { columnWidths } = columnResizing;
@@ -153,22 +154,24 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
                         const currentColumnWidth =
                           columnWidths[header.id] || originalCol.width;
                         if (key === 'ArrowLeft') {
-                          dispatch({
-                            type: COLUMN_RESIZE_START,
-                            payload: {
-                              newWidth: currentColumnWidth - incrementAmount,
-                              headerId: header.id,
-                              defaultWidth: header.originalWidth,
-                            },
-                          });
-                          dispatch({
-                            type: COLUMN_RESIZING,
-                            payload: {
-                              newWidth: currentColumnWidth - incrementAmount,
-                              headerId: header.id,
-                              defaultWidth: header.originalWidth,
-                            },
-                          });
+                          if (currentColumnWidth - incrementAmount > minWidth) {
+                            dispatch({
+                              type: COLUMN_RESIZE_START,
+                              payload: {
+                                newWidth: currentColumnWidth - incrementAmount,
+                                headerId: header.id,
+                                defaultWidth: header.originalWidth,
+                              },
+                            });
+                            dispatch({
+                              type: COLUMN_RESIZING,
+                              payload: {
+                                newWidth: currentColumnWidth - incrementAmount,
+                                headerId: header.id,
+                                defaultWidth: header.originalWidth,
+                              },
+                            });
+                          }
                         }
                         if (key === 'ArrowRight') {
                           dispatch({

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -76,6 +76,22 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
     return offsetValue;
   };
 
+  useEffect(() => {
+    const { isResizing } = datagridState.state;
+    if (isResizing) {
+      document.addEventListener('mouseup', () => {
+        handleColumnResizeEndEvent(datagridState.dispatch);
+        document.activeElement.blur();
+      });
+    }
+    return () => {
+      document.removeEventListener('mouseup', () =>
+        handleColumnResizeEndEvent(datagridState.dispatch)
+      );
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [datagridState.state.isResizing]);
+
   return (
     <TableRow
       {...headerGroup.getHeaderGroupProps({ role: false })}
@@ -120,14 +136,13 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
                     onMouseMove={(event) => {
                       if (isResizing) {
                         const newWidth = getClientXPosition(event);
-                        handleColumnResizingEvent(dispatch, header, newWidth);
+                        // Sets a min width for resizing so at least one character from the column header is visible
+                        if (newWidth >= 50) {
+                          handleColumnResizingEvent(dispatch, header, newWidth);
+                        }
                       }
                     }}
                     onMouseDown={() => handleColumnResizeStartEvent(dispatch)}
-                    onMouseUp={(event) => {
-                      event.target.blur();
-                      handleColumnResizeEndEvent(dispatch);
-                    }}
                     onKeyDown={(event) => {
                       const { key } = event;
                       if (key === 'ArrowLeft' || key === 'ArrowRight') {

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -1,62 +1,218 @@
 /**
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 // @flow
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import cx from 'classnames';
 import { DataTable } from 'carbon-components-react';
+import { px } from '@carbon/layout';
 import { selectionColumnId } from '../common-column-ids';
 import { pkg } from '../../../settings';
+import {
+  COLUMN_RESIZE_END,
+  COLUMN_RESIZE_START,
+  COLUMN_RESIZING,
+} from './addons/stateReducer';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
-const HeaderRow = (datagridState, headRef, headerGroup) => (
-  <TableRow
-    {...headerGroup.getHeaderGroupProps({ role: false })}
-    className={cx(
-      `${blockClass}__head`,
-      headerGroup.getHeaderGroupProps().className
-    )}
-    ref={headRef}
-  >
-    {datagridState.headers
-      .filter(({ isVisible }) => isVisible)
-      .map((header) => {
-        if (header.id === selectionColumnId) {
-          // render directly without the wrapper TableHeader
-          return header.render('Header', { key: header.id });
-        }
-        return (
-          <TableHeader
-            {...header.getHeaderProps({ role: false })}
-            className={cx(
-              {
-                [`${blockClass}__resizableColumn`]: header.getResizerProps,
-                [`${blockClass}__isResizing`]: header.isResizing,
-                [`${blockClass}__sortableColumn`]:
-                  datagridState.isTableSortable,
-                [`${blockClass}__isSorted`]: header.isSorted,
-              },
-              header.getHeaderProps().className
-            )}
-            key={header.id}
-          >
-            {header.render('Header')}
-            {header.getResizerProps && (
-              <div
-                {...header.getResizerProps()}
-                className={`${blockClass}__resizer`}
-              />
-            )}
-          </TableHeader>
+const HeaderRow = (datagridState, headRef, headerGroup) => {
+  // Used to measure the height of the table and uses that value
+  // to display a vertical line to indicate the column you are resizing
+  useEffect(() => {
+    const { tableId } = datagridState;
+    if (tableId) {
+      const gridElement = document.querySelector(`#${tableId}`);
+      const tableElement = gridElement.querySelector('table');
+      const headerRowElement = document.querySelector(
+        `#${tableId} .${blockClass}__head`
+      );
+      const hasHorizontalScrollbar =
+        tableElement.scrollWidth > tableElement.clientWidth;
+      const scrollBuffer = hasHorizontalScrollbar ? 18 : 2;
+      const setCustomValues = ({ rowHeight = 48, gridHeight }) => {
+        headerRowElement.style.setProperty(
+          `--${blockClass}--row-height`,
+          px(rowHeight)
         );
-      })}
-  </TableRow>
-);
+        headerRowElement.style.setProperty(
+          `--${blockClass}--grid-height`,
+          px(gridHeight - scrollBuffer)
+        );
+      };
+      setCustomValues({
+        gridHeight: gridElement.offsetHeight,
+        rowHeight: headerRowElement.clientHeight,
+      });
+    }
+  }, [datagridState.rowSize, datagridState.tableId, datagridState]);
+
+  const [incrementAmount] = useState(2);
+
+  const getClientXPosition = (event) => {
+    let isTouchEvent = false;
+    if (event.type === 'touchstart') {
+      // Do not respond to multiple touches (e.g. 2 or 3 fingers)
+      if (event.touches && event.touches.length > 1) {
+        return;
+      }
+      isTouchEvent = true;
+    }
+    const clientX = isTouchEvent
+      ? Math.round(event.touches[0].clientX)
+      : event.clientX;
+    const closestHeader = event.target.closest('th');
+    const closestHeaderCoords = closestHeader.getBoundingClientRect();
+    const headerOffset = closestHeaderCoords.left;
+    const offsetValue = clientX - headerOffset;
+    return offsetValue;
+  };
+
+  return (
+    <TableRow
+      {...headerGroup.getHeaderGroupProps({ role: false })}
+      className={cx(
+        `${blockClass}__head`,
+        headerGroup.getHeaderGroupProps().className
+      )}
+      ref={headRef}
+    >
+      {datagridState.headers
+        .filter(({ isVisible }) => isVisible)
+        .map((header, index) => {
+          if (header.id === selectionColumnId) {
+            // render directly without the wrapper TableHeader
+            return header.render('Header', { key: header.id });
+          }
+          const { visibleColumns, state, dispatch } = datagridState;
+          const { columnResizing, isResizing } = state;
+          const { columnWidths } = columnResizing;
+          const originalCol = visibleColumns[index];
+          return (
+            <TableHeader
+              {...header.getHeaderProps({ role: false })}
+              className={cx(
+                {
+                  [`${blockClass}__resizableColumn`]: header.getResizerProps,
+                  [`${blockClass}__isResizing`]: header.isResizing,
+                  [`${blockClass}__sortableColumn`]:
+                    datagridState.isTableSortable,
+                  [`${blockClass}__isSorted`]: header.isSorted,
+                },
+                header.getHeaderProps().className
+              )}
+              key={header.id}
+            >
+              {header.render('Header')}
+              {header.getResizerProps && (
+                <>
+                  <input
+                    {...header.getResizerProps()}
+                    onMouseMove={(event) => {
+                      if (isResizing) {
+                        dispatch({
+                          type: COLUMN_RESIZING,
+                          payload: {
+                            newWidth: getClientXPosition(event),
+                            headerId: header.id,
+                            defaultWidth: header.originalWidth,
+                          },
+                        });
+                      }
+                    }}
+                    onMouseDown={() => {
+                      const currentColumnWidth =
+                        columnWidths[header.id] || originalCol.width;
+                      dispatch({
+                        type: COLUMN_RESIZE_START,
+                        payload: {
+                          newWidth: currentColumnWidth,
+                          headerId: header.id,
+                          defaultWidth: header.originalWidth,
+                        },
+                      });
+                    }}
+                    onMouseUp={(event) => {
+                      event.target.blur();
+                      dispatch({
+                        type: COLUMN_RESIZE_END,
+                        payload: {
+                          newWidth: getClientXPosition(event),
+                          headerId: header.id,
+                          defaultWidth: header.originalWidth,
+                        },
+                      });
+                    }}
+                    onKeyDown={(event) => {
+                      const { key } = event;
+                      if (key === 'ArrowLeft' || key === 'ArrowRight') {
+                        const currentColumnWidth =
+                          columnWidths[header.id] || originalCol.width;
+                        if (key === 'ArrowLeft') {
+                          dispatch({
+                            type: COLUMN_RESIZE_START,
+                            payload: {
+                              newWidth: currentColumnWidth - incrementAmount,
+                              headerId: header.id,
+                              defaultWidth: header.originalWidth,
+                            },
+                          });
+                          dispatch({
+                            type: COLUMN_RESIZING,
+                            payload: {
+                              newWidth: currentColumnWidth - incrementAmount,
+                              headerId: header.id,
+                              defaultWidth: header.originalWidth,
+                            },
+                          });
+                        }
+                        if (key === 'ArrowRight') {
+                          dispatch({
+                            type: COLUMN_RESIZE_START,
+                            payload: {
+                              newWidth: currentColumnWidth + incrementAmount,
+                              headerId: header.id,
+                              defaultWidth: header.originalWidth,
+                            },
+                          });
+                          dispatch({
+                            type: COLUMN_RESIZING,
+                            payload: {
+                              newWidth: currentColumnWidth + incrementAmount,
+                              headerId: header.id,
+                              defaultWidth: header.originalWidth,
+                            },
+                          });
+                        }
+                      }
+                    }}
+                    onKeyUp={() => {
+                      const currentColumnWidth =
+                        columnWidths[header.id] || originalCol.width;
+                      dispatch({
+                        type: COLUMN_RESIZE_END,
+                        payload: currentColumnWidth,
+                        defaultWidth: header.originalWidth,
+                      });
+                    }}
+                    className={cx(`${blockClass}__col-resizer-range`)}
+                    type="range"
+                    defaultValue={originalCol.width}
+                    aria-label="Resize column"
+                  />
+                  <span className={`${blockClass}__col-resize-indicator`} />
+                </>
+              )}
+            </TableHeader>
+          );
+        })}
+    </TableRow>
+  );
+};
 
 const { TableHeader, TableRow } = DataTable;
 

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -34,6 +34,10 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
       const hasHorizontalScrollbar =
         tableElement.scrollWidth > tableElement.clientWidth;
       const scrollBuffer = hasHorizontalScrollbar ? 18 : 2;
+      const tableToolbar = gridElement.querySelector(
+        `.${blockClass}__table-toolbar`
+      );
+      const tableToolbarHeight = tableToolbar?.offsetHeight || 0;
       const setCustomValues = ({ rowHeight = 48, gridHeight }) => {
         headerRowElement.style.setProperty(
           `--${blockClass}--row-height`,
@@ -41,7 +45,7 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
         );
         headerRowElement.style.setProperty(
           `--${blockClass}--grid-height`,
-          px(gridHeight - scrollBuffer)
+          px(gridHeight - scrollBuffer - tableToolbarHeight)
         );
       };
       setCustomValues({

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -8,6 +8,7 @@
 const COLUMN_RESIZE_START = 'columnStartResizing';
 const COLUMN_RESIZING = 'columnResizing';
 const COLUMN_RESIZE_END = 'columnDoneResizing';
+const INIT = 'init';
 
 export const handleColumnResizeStartEvent = (dispatch) => {
   dispatch({ type: COLUMN_RESIZE_START });
@@ -45,6 +46,12 @@ export const handleColumnResizingEvent = (
 
 export const stateReducer = (newState, action) => {
   switch (action.type) {
+    case INIT: {
+      return {
+        ...newState,
+        isResizing: false,
+      };
+    }
     case COLUMN_RESIZE_START: {
       return {
         ...newState,

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export const COLUMN_RESIZE_START = 'columnStartResizing';
-export const COLUMN_RESIZING = 'columnResizing';
-export const COLUMN_RESIZE_END = 'columnDoneResizing';
+const COLUMN_RESIZE_START = 'columnStartResizing';
+const COLUMN_RESIZING = 'columnResizing';
+const COLUMN_RESIZE_END = 'columnDoneResizing';
 
 export const handleColumnResizeStartEvent = (dispatch) => {
   dispatch({ type: COLUMN_RESIZE_START });

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const COLUMN_RESIZE_START = 'columnStartResizing';
+export const COLUMN_RESIZING = 'columnResizing';
+export const COLUMN_RESIZE_END = 'columnDoneResizing';
+export const stateReducer = (newState, action) => {
+  switch (action.type) {
+    case COLUMN_RESIZE_START: {
+      return {
+        ...newState,
+        isResizing: true,
+      };
+    }
+    case COLUMN_RESIZING: {
+      const { headerId, newWidth, defaultWidth } = action.payload || {};
+      const newColumnWidth = {};
+      if (typeof headerId === 'undefined') {
+        return {
+          ...newState,
+        };
+      }
+      newColumnWidth[headerId] = newWidth;
+      return {
+        ...newState,
+        isResizing: true,
+        columnResizing: {
+          ...newState.columnResizing,
+          columnWidth: defaultWidth,
+          columnWidths: {
+            ...newState.columnResizing.columnWidths,
+            ...newColumnWidth,
+          },
+          headerIdWidths: [headerId, newWidth],
+        },
+      };
+    }
+    case COLUMN_RESIZE_END: {
+      return {
+        ...newState,
+        isResizing: false,
+      };
+    }
+  }
+};

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -8,6 +8,41 @@
 export const COLUMN_RESIZE_START = 'columnStartResizing';
 export const COLUMN_RESIZING = 'columnResizing';
 export const COLUMN_RESIZE_END = 'columnDoneResizing';
+
+export const handleColumnResizeStartEvent = (dispatch) => {
+  dispatch({ type: COLUMN_RESIZE_START });
+};
+
+export const handleColumnResizeEndEvent = (dispatch) => {
+  dispatch({ type: COLUMN_RESIZE_END });
+};
+
+export const handleColumnResizingEvent = (
+  dispatch,
+  header,
+  newWidth,
+  isKeyEvent
+) => {
+  if (isKeyEvent) {
+    dispatch({
+      type: COLUMN_RESIZE_START,
+      payload: {
+        newWidth,
+        headerId: header.id,
+        defaultWidth: header.originalWidth,
+      },
+    });
+  }
+  dispatch({
+    type: COLUMN_RESIZING,
+    payload: {
+      newWidth,
+      headerId: header.id,
+      defaultWidth: header.originalWidth,
+    },
+  });
+};
+
 export const stateReducer = (newState, action) => {
   switch (action.type) {
     case COLUMN_RESIZE_START: {

--- a/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
@@ -612,3 +612,68 @@
 .#{$block-class} .#{$pkg-prefix}--datagrid__head-wrap {
   background-color: $ui-03;
 }
+
+.#{$block-class} .#{$block-class}__col-resizer-range {
+  position: absolute;
+  z-index: 2;
+  top: 0;
+  right: calc(#{$spacing-03} * -1);
+  width: 1rem;
+  height: 100%;
+  margin: 0;
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+}
+
+.#{$block-class} .#{$block-class}__col-resizer-range:focus {
+  outline: 0;
+}
+
+.#{$block-class} .#{$block-class}__col-resizer-range:focus::before {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 2px;
+  height: 100%;
+  background-color: $focus;
+  content: '';
+  transform: translate(-50%, -50%);
+}
+
+.#{$block-class}
+  .#{$block-class}__col-resizer-range:focus
+  + .#{$block-class}__col-resize-indicator {
+  position: absolute;
+  z-index: 2;
+  right: calc(#{$spacing-03} * -1);
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 100%;
+  margin: 0;
+  background-color: $focus;
+  transform: translate(-50%, 0);
+}
+
+.#{$block-class} .#{$block-class}__col-resizer-range:focus::after {
+  position: absolute;
+  /* stylelint-disable-next-line carbon/layout-token-use */
+  top: var(--#{$block-class}--row-height);
+  right: $spacing-03;
+  width: 1px;
+  height: calc(
+    var(--#{$block-class}--grid-height) - var(--#{$block-class}--row-height)
+  );
+  background-color: $active-ui;
+  content: '';
+}
+
+.#{$block-class} .#{$block-class}__col-resizer-range::-webkit-slider-thumb {
+  width: 16px;
+  height: 16px;
+  border: none;
+  border-radius: 50%;
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+}

--- a/packages/ibm-products/src/components/Datagrid/useDatagrid.js
+++ b/packages/ibm-products/src/components/Datagrid/useDatagrid.js
@@ -25,6 +25,7 @@ import useRowSize from './useRowSize';
 import useHeaderRow from './Datagrid/DatagridHeaderRow';
 import useFlexResize from './useFlexResize';
 import useFloatingScroll from './useFloatingScroll';
+import { stateReducer } from './Datagrid/addons/stateReducer';
 
 const useDatagrid = (params, ...plugins) => {
   const defaultPlugins = [
@@ -50,7 +51,7 @@ const useDatagrid = (params, ...plugins) => {
 
   const tableId = useMemo(() => uniqueId('datagrid-table-id'), []);
   const tableState = useTable(
-    { tableId, ...params },
+    { tableId, ...params, stateReducer },
     ...defaultPlugins,
     ...plugins,
     ...defaultEndPlugins,


### PR DESCRIPTION
Contributes to #1923 and #2507

Took another look at adding keyboard support for resizable columns. This time around i discovered that we can pass a [custom stateReducer](https://github.com/TanStack/table/blob/v7/docs/src/pages/docs/api/useTable.md) to `useTable` that will allow us to manually track the resize events via the `dispatch` function they provide to us in the table state, giving us the ability to add the missing keyboard support.

I kept the same approach of using a slider input and changed the visual representation of the resizer, as the previous version felt a bit clunky.

New focus state of the resizer can be seen below:
<img width="1357" alt="image" src="https://github.com/carbon-design-system/ibm-products/assets/10215203/94215375-7b14-4c14-b092-fcf3e2ad5716">

Resizing with both mouse and key events enforce a minimum width so at least one character from the column header is displayed.


#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
packages/ibm-products/src/components/Datagrid/useDatagrid.js
```
#### How did you test and verify your work?
Storybook