### PR TITLE
feat(Datagrid): persist col resizing values in local storage

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -53,13 +53,17 @@ export const stateReducer = (newState, action) => {
   switch (action.type) {
     case INIT: {
       const localStorageColSizes = getLocalStorageItem(localStorageKey);
-      Object.keys(localStorageColSizes.columnResizing.columnWidths).forEach(
-        (key) => {
-          if (localStorageColSizes.columnResizing.columnWidths[key] === null) {
-            delete localStorageColSizes.columnResizing.columnWidths[key];
+      if (localStorageColSizes?.columnResizing?.columnWidths) {
+        Object.keys(localStorageColSizes.columnResizing.columnWidths).forEach(
+          (key) => {
+            if (
+              localStorageColSizes.columnResizing.columnWidths[key] === null
+            ) {
+              delete localStorageColSizes.columnResizing.columnWidths[key];
+            }
           }
-        }
-      );
+        );
+      }
       return {
         ...newState,
         ...localStorageColSizes,

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -5,10 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { getLocalStorageItem } from '../../../../global/js/utils/getLocalStorageItem';
+import { setLocalStorageItem } from '../../../../global/js/utils/setLocalStorageItem';
+import { pkg } from '../../../../settings';
+
 const COLUMN_RESIZE_START = 'columnStartResizing';
 const COLUMN_RESIZING = 'columnResizing';
 const COLUMN_RESIZE_END = 'columnDoneResizing';
 const INIT = 'init';
+const localStorageKey = `${pkg.prefix}--datagrid-col-sizing`;
 
 export const handleColumnResizeStartEvent = (dispatch) => {
   dispatch({ type: COLUMN_RESIZE_START });
@@ -47,8 +52,17 @@ export const handleColumnResizingEvent = (
 export const stateReducer = (newState, action) => {
   switch (action.type) {
     case INIT: {
+      const localStorageColSizes = getLocalStorageItem(localStorageKey);
+      Object.keys(localStorageColSizes.columnResizing.columnWidths).forEach(
+        (key) => {
+          if (localStorageColSizes.columnResizing.columnWidths[key] === null) {
+            delete localStorageColSizes.columnResizing.columnWidths[key];
+          }
+        }
+      );
       return {
         ...newState,
+        ...localStorageColSizes,
         isResizing: false,
       };
     }
@@ -82,6 +96,11 @@ export const stateReducer = (newState, action) => {
       };
     }
     case COLUMN_RESIZE_END: {
+      const localStorageColSizes = getLocalStorageItem(localStorageKey);
+      setLocalStorageItem(localStorageKey, localStorageColSizes, {
+        ...newState,
+        isResizing: false,
+      });
       return {
         ...newState,
         isResizing: false,

--- a/packages/ibm-products/src/global/js/utils/getLocalStorageItem.js
+++ b/packages/ibm-products/src/global/js/utils/getLocalStorageItem.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const getLocalStorageItem = (key) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const localStorageData = window.localStorage.getItem(key);
+  const parsedData = JSON.parse(localStorageData) || {};
+  return parsedData;
+};

--- a/packages/ibm-products/src/global/js/utils/setLocalStorageItem.js
+++ b/packages/ibm-products/src/global/js/utils/setLocalStorageItem.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const setLocalStorageItem = (key, parsedData, updatedData) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.setItem(
+    key,
+    JSON.stringify(Object.assign(parsedData, updatedData))
+  );
+};


### PR DESCRIPTION
Contributes to #1923 and #2507 

Now that we are controlling the column resizing we have the ability to persist the column widths to local storage after a column resize event and when the page refreshes the columns will maintain the resized width instead of reverting to the original width.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
packages/ibm-products/src/global/js/utils/getLocalStorageItem.js
packages/ibm-products/src/global/js/utils/setLocalStorageItem.js
```
#### How did you test and verify your work?
Storybook