### PR TITLE
feat(Datagrid): add column resize callback

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.docs-page.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.docs-page.js
@@ -138,6 +138,21 @@ const App = () => {
         },
       },
       {
+        description:
+          'There is also an optional resize callback when resizing columns, allowing you to save the widths of columns that have been resized. The resize callback returns the column that was just resized, in addition to all of the columns that have been resized',
+        source: {
+          language: 'jsx',
+          code: `
+useDatagrid({
+  columns,
+  data,
+  onColResizeEnd: (currentColumn, allColumns) =>
+      console.log(currentColumn, allColumns),
+});
+          `,
+        },
+      },
+      {
         title: 'Rendering the table toolbar',
         image: (
           <img

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.docs-page.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.docs-page.js
@@ -139,7 +139,7 @@ const App = () => {
       },
       {
         description:
-          'There is also an optional resize callback when resizing columns, allowing you to save the widths of columns that have been resized. The resize callback returns the column that was just resized, in addition to all of the columns that have been resized',
+          "There is also an optional resize callback when resizing columns, allowing you to save the widths of columns that have been resized. The resize callback returns the column that was just resized and it's width, in addition to all of the columns that have been resized and their widths.",
         source: {
           language: 'jsx',
           code: `

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
@@ -145,6 +145,8 @@ export const BasicUsage = () => {
     columns,
     data: rows,
     multiLineWrapAll: true, // If `multiLineWrap` is required for all columns in data grid
+    onColResizeEnd: (currentColumn, allColumns) =>
+      console.log(currentColumn, allColumns),
   });
 
   return <Datagrid datagridState={datagridState} title="Basic usage" />;

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -91,8 +91,13 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
   useEffect(() => {
     const { isResizing } = datagridState.state;
     if (isResizing) {
+      const { onColResizeEnd } = datagridState;
       document.addEventListener('mouseup', () => {
-        handleColumnResizeEndEvent(datagridState.dispatch);
+        handleColumnResizeEndEvent(
+          datagridState.dispatch,
+          onColResizeEnd,
+          isResizing
+        );
         document.activeElement.blur();
       });
     }
@@ -121,7 +126,8 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
             return header.render('Header', { key: header.id });
           }
           const { minWidth } = header || 50;
-          const { visibleColumns, state, dispatch } = datagridState;
+          const { visibleColumns, state, dispatch, onColResizeEnd } =
+            datagridState;
           const { columnResizing, isResizing } = state;
           const { columnWidths } = columnResizing;
           const originalCol = visibleColumns[index];
@@ -155,7 +161,9 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
                         }
                       }
                     }}
-                    onMouseDown={() => handleColumnResizeStartEvent(dispatch)}
+                    onMouseDown={() =>
+                      handleColumnResizeStartEvent(dispatch, header.id)
+                    }
                     onKeyDown={(event) => {
                       const { key } = event;
                       if (key === 'ArrowLeft' || key === 'ArrowRight') {
@@ -191,7 +199,13 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
                         }
                       }
                     }}
-                    onKeyUp={() => handleColumnResizeEndEvent(dispatch)}
+                    onKeyUp={() =>
+                      handleColumnResizeEndEvent(
+                        dispatch,
+                        onColResizeEnd,
+                        header.id
+                      )
+                    }
                     className={cx(`${blockClass}__col-resizer-range`)}
                     type="range"
                     defaultValue={originalCol.width}

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -10,12 +10,16 @@ const COLUMN_RESIZING = 'columnResizing';
 const COLUMN_RESIZE_END = 'columnDoneResizing';
 const INIT = 'init';
 
-export const handleColumnResizeStartEvent = (dispatch) => {
-  dispatch({ type: COLUMN_RESIZE_START });
+export const handleColumnResizeStartEvent = (dispatch, headerId) => {
+  dispatch({ type: COLUMN_RESIZE_START, payload: { headerId } });
 };
 
-export const handleColumnResizeEndEvent = (dispatch) => {
-  dispatch({ type: COLUMN_RESIZE_END });
+export const handleColumnResizeEndEvent = (
+  dispatch,
+  onColResizeEnd,
+  headerId
+) => {
+  dispatch({ type: COLUMN_RESIZE_END, payload: { onColResizeEnd, headerId } });
 };
 
 export const handleColumnResizingEvent = (
@@ -53,9 +57,10 @@ export const stateReducer = (newState, action) => {
       };
     }
     case COLUMN_RESIZE_START: {
+      const { headerId } = action.payload;
       return {
         ...newState,
-        isResizing: true,
+        isResizing: headerId,
       };
     }
     case COLUMN_RESIZING: {
@@ -67,14 +72,19 @@ export const stateReducer = (newState, action) => {
         };
       }
       newColumnWidth[headerId] = newWidth;
+      const cleanedWidths = Object.fromEntries(
+        Object.entries(newState.columnResizing.columnWidths).filter(
+          ([_, value]) => !isNaN(value)
+        )
+      );
       return {
         ...newState,
-        isResizing: true,
+        isResizing: headerId,
         columnResizing: {
           ...newState.columnResizing,
           columnWidth: defaultWidth,
           columnWidths: {
-            ...newState.columnResizing.columnWidths,
+            ...cleanedWidths,
             ...newColumnWidth,
           },
           headerIdWidths: [headerId, newWidth],
@@ -82,6 +92,11 @@ export const stateReducer = (newState, action) => {
       };
     }
     case COLUMN_RESIZE_END: {
+      const { onColResizeEnd, headerId } = action.payload;
+      const currentColumn = {};
+      currentColumn[headerId] = newState.columnResizing.columnWidths[headerId];
+      const allChangedColumns = newState.columnResizing.columnWidths;
+      onColResizeEnd?.(currentColumn, allChangedColumns);
       return {
         ...newState,
         isResizing: false,

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -96,7 +96,10 @@ export const stateReducer = (newState, action) => {
       const currentColumn = {};
       currentColumn[headerId] = newState.columnResizing.columnWidths[headerId];
       const allChangedColumns = newState.columnResizing.columnWidths;
-      onColResizeEnd?.(currentColumn, allChangedColumns);
+      const { isResizing } = newState;
+      if (isResizing) {
+        onColResizeEnd?.(currentColumn, allChangedColumns);
+      }
       return {
         ...newState,
         isResizing: false,


### PR DESCRIPTION
Contributes to #1923 and #2507 

@paul-balchin-ibm suggested adding a callback to allow consumers to optionally save the column widths that have been resized as opposed to us saving the updated column sizes. This definitely feels more appropriate, so I have included that new resize end callback in this PR, `onColResizeEnd`.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
```
#### How did you test and verify your work?
Storybook