### PR TITLE
feat(Datagrid): add column resize callback

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.mdx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.mdx
@@ -177,6 +177,20 @@ const columns = [
 ];
 ```
 
+There is also an optional resize callback when resizing columns, allowing you to
+save the widths of columns that have been resized. The resize callback returns
+the column that was just resized and it's width, in addition to all of the
+columns that have been resized and their widths.
+
+```jsx
+useDatagrid({
+  columns,
+  data,
+  onColResizeEnd: (currentColumn, allColumns) =>
+    console.log(currentColumn, allColumns),
+});
+```
+
 ## Rendering the table toolbar
 
 <img src={datagridActionsExample} />

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
@@ -143,6 +143,8 @@ export const BasicUsage = () => {
     columns,
     data: rows,
     multiLineWrapAll: true, // If `multiLineWrap` is required for all columns in data grid
+    onColResizeEnd: (currentColumn, allColumns) =>
+      console.log(currentColumn, allColumns),
   });
 
   return <Datagrid datagridState={datagridState} />;

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -79,8 +79,13 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
   useEffect(() => {
     const { isResizing } = datagridState.state;
     if (isResizing) {
+      const { onColResizeEnd } = datagridState;
       document.addEventListener('mouseup', () => {
-        handleColumnResizeEndEvent(datagridState.dispatch);
+        handleColumnResizeEndEvent(
+          datagridState.dispatch,
+          onColResizeEnd,
+          isResizing
+        );
         document.activeElement.blur();
       });
     }
@@ -109,7 +114,8 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
             return header.render('Header', { key: header.id });
           }
           const { minWidth } = header || 50;
-          const { visibleColumns, state, dispatch } = datagridState;
+          const { visibleColumns, state, dispatch, onColResizeEnd } =
+            datagridState;
           const { columnResizing, isResizing } = state;
           const { columnWidths } = columnResizing;
           const originalCol = visibleColumns[index];
@@ -142,7 +148,9 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
                         }
                       }
                     }}
-                    onMouseDown={() => handleColumnResizeStartEvent(dispatch)}
+                    onMouseDown={() =>
+                      handleColumnResizeStartEvent(dispatch, header.id)
+                    }
                     onKeyDown={(event) => {
                       const { key } = event;
                       if (key === 'ArrowLeft' || key === 'ArrowRight') {
@@ -178,7 +186,13 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
                         }
                       }
                     }}
-                    onKeyUp={() => handleColumnResizeEndEvent(dispatch)}
+                    onKeyUp={() =>
+                      handleColumnResizeEndEvent(
+                        dispatch,
+                        onColResizeEnd,
+                        header.id
+                      )
+                    }
                     className={cx(`${blockClass}__col-resizer-range`)}
                     type="range"
                     defaultValue={originalCol.width}


### PR DESCRIPTION
Contributes to #1923 and #2507 

@paul-balchin-ibm suggested adding a callback to allow consumers to optionally save the column widths that have been resized as opposed to us saving the updated column sizes. This definitely feels more appropriate, so I have included that new resize end callback in this PR, `onColResizeEnd`.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
```
#### How did you test and verify your work?
Storybook