### PR TITLE
chore: add merge queue to actions

### DIFF
--- a/.github/workflows/add-to-merge-queue.yml
+++ b/.github/workflows/add-to-merge-queue.yml
@@ -1,0 +1,27 @@
+name: Merge queue # Adopted from tay1orjones
+on:
+  pull_request_target:
+    types: [labeled, opened, reopened]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  add-to-merge-queue:
+    name: Add to queue when automerge label is present
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log github event
+        env:
+          $GITHUB_CONTEXT_LABELS:
+            ${{ toJson(github.event.pull_request.labels) }}
+        run: echo "$GITHUB_CONTEXT_LABELS"
+      - name: 'Add the PR to the merge queue via the GitHub CLI'
+        if:
+          ${{ contains(github.event.pull_request.labels.*.name,
+          format('status{0} ready to merge 🎉', ':'))}}
+        run: gh pr merge "$PR_URL"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - main_v1
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,9 @@ on:
       - main
       - main_v1
 
+  merge_group:
+    types: [checks_requested]
+
   schedule:
     - cron: '0 0 * * 0'
 

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,6 +1,0 @@
-# https://kodiakhq.com/docs/config-reference
-version = 1
-
-[merge]
-automerge_label = 'status: ready to merge'
-method = 'squash'

--- a/cspell.contributors.txt
+++ b/cspell.contributors.txt
@@ -58,3 +58,5 @@ kristastarr
 
 Olasov
 mikeolasov
+
+tay1orjones

--- a/cspell.json
+++ b/cspell.json
@@ -68,6 +68,7 @@
   "words": [
     "aboutmodal",
     "autodocs", // storybook
+    "automerge", // actions
     "actionbar",
     "apikey",
     "buildhome",


### PR DESCRIPTION
Thanks @tay1orjones for sharing this with us.

#### What did you change?
Add new action so we can continue to use `status: ready to merge` as is our typical workflow today.
  - **Note** — we kept the 🎉 and updated our label already because we deserve to celebrate each merge/win 😤 

Also updated CodeQL/CI actions to run on merge group and removed Kodiak after some discussion with Taylor. If we hate this, we can always put it back but feel like we should try it out first and see how it goes before that.

#### How did you test and verify your work?
In Taylor we trust — but really, adopted from Carbon’s working version. How to _actually test_ actions eludes us still.