### PR TITLE
build: add `merge_group` event to PR workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - main_v1
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - main_v1
+  merge_group:
+    types: [checks_requested]
 
   push:
     branches:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,8 @@ on:
       - opened
       - edited
       - synchronize
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   main:


### PR DESCRIPTION
If I remember correctly from Taylor's share this morning, we need to add the `merge_group` event to the workflows that run during PR checks

#### What did you change?
```
.github/workflows/ci.yml
.github/workflows/codeql.yml
.github/workflows/pr.yml
```
