### PR TITLE
fix: skip PR title validation in `merge_group` queue

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   main:
     name: validate title
+    if: ${{ github.event_name != 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v3.4.6 # cspell:disable-line

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+  merge_group:
+    types: [checks_requested]
+
 jobs:
   main:
     name: validate title


### PR DESCRIPTION
Adds some logic to skip PR title validation in the merge queue, while still requiring in the actual PR.