### PR TITLE
fix: some full screen docs pages

### DIFF
--- a/packages/core/.storybook/index.scss
+++ b/packages/core/.storybook/index.scss
@@ -9,7 +9,7 @@
 // Carbon styles at the end -- this is to obtain a "worst case" for our own CSS,
 // to ensure we are resilient against different CSS loading orders and our
 // styles have the specificity necessary to override Carbon styles when needed.
-@use 'ALIAS_STORY_STYLE_CONFIG'; // loads config.css or config-dev.scss from ibm-prodcuts/src (see main.js)
+@use 'ALIAS_STORY_STYLE_CONFIG' as c4p-settings; // loads config.css or config-dev.scss from ibm-prodcuts/src (see main.js)
 @use '../../ibm-products/src/index-without-carbon.scss';
 
 // Load all Carbon styles now
@@ -64,17 +64,4 @@ body {
 
 .preview__notification--feature-flag .#{config.$prefix}--list--unordered {
   margin-top: $spacing-04;
-}
-
-.c4p--story-docs-page--fullscreen .docs-story {
-  --doc-story-height: 50vh;
-
-  min-height: var(--doc-story-height);
-  /* stylelint-disable-next-line carbon/layout-token-use */
-  transform: translateZ(0);
-}
-
-.c4p--story-docs-page--fullscreen > div:first-child {
-  overflow: hidden;
-  width: 100%;
 }

--- a/packages/ibm-products/src/components/CreateSidePanel/CreateSidePanel.stories.js
+++ b/packages/ibm-products/src/components/CreateSidePanel/CreateSidePanel.stories.js
@@ -29,20 +29,9 @@ import { CreateSidePanel } from './CreateSidePanel';
 
 import styles from './_storybook-styles.scss';
 import DocsPage from './CreateSidePanel.docs-page';
+import { sidePanelDecorator } from '../../global/decorators/sidePanelDecorator';
 
 const blockClass = `${pkg.prefix}--create-side-panel`;
-
-export default {
-  title: getStoryTitle(CreateSidePanel.displayName),
-  component: CreateSidePanel,
-  tags: ['autodocs'],
-  parameters: {
-    styles,
-    docs: {
-      page: DocsPage,
-    },
-  },
-};
 
 const prefix = 'create-side-panel-stories__';
 
@@ -69,6 +58,19 @@ const renderUIShellHeader = () => (
     )}
   />
 );
+
+export default {
+  title: getStoryTitle(CreateSidePanel.displayName),
+  component: CreateSidePanel,
+  tags: ['autodocs'],
+  parameters: {
+    styles,
+    docs: {
+      page: DocsPage,
+    },
+  },
+  decorators: [sidePanelDecorator(renderUIShellHeader, prefix)],
+};
 
 const DefaultTemplate = ({ ...args }) => {
   const carbonPrefix = usePrefix();

--- a/packages/ibm-products/src/components/CreateSidePanel/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/CreateSidePanel/_storybook-styles.scss
@@ -8,6 +8,7 @@
 @use 'ALIAS_STORY_STYLE_CONFIG' as c4p-settings;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing';
+@use '../../global/decorators/side-panel-decorator' as *;
 
 $block-class: #{c4p-settings.$pkg-prefix}--create-side-panel;
 $story-prefix: create-side-panel-stories__;
@@ -27,3 +28,5 @@ $story-prefix: create-side-panel-stories__;
 .#{$block-class} .#{c4p-settings.$carbon-prefix}--number__control-btn::after {
   background-color: $field-02;
 }
+
+@include side-panel-decorator($story-prefix);

--- a/packages/ibm-products/src/components/DataSpreadsheet/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/DataSpreadsheet/_storybook-styles.scss
@@ -5,8 +5,13 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-$story-anchor: 'data-spreadsheet';
-div[id*='#{$story-anchor}'] .docs-story > div:first-child > div:first-child {
+$story-anchor: 'DataSpreadsheet';
+
+$story-anchor: 'DataSpreadsheet';
+div[data-story-title*='#{$story-anchor}']
+  .docs-story
+  > div:first-child
+  > div:first-child {
   overflow: auto;
   width: 100%;
 }

--- a/packages/ibm-products/src/components/Datagrid/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/Datagrid/_storybook-styles.scss
@@ -128,8 +128,11 @@ $block-class: #{c4p-settings.$pkg-prefix}--datagrid;
   }
 }
 
-$story-anchor: 'datagrid';
-div[id*='#{$story-anchor}'] .docs-story > div:first-child > div:first-child {
+$story-anchor: 'Datagrid';
+div[data-story-title*='#{$story-anchor}']
+  .docs-story
+  > div:first-child
+  > div:first-child {
   overflow: auto;
   width: 100%;
 }

--- a/packages/ibm-products/src/components/EditSidePanel/EditSidePanel.stories.js
+++ b/packages/ibm-products/src/components/EditSidePanel/EditSidePanel.stories.js
@@ -30,28 +30,7 @@ import { EditSidePanel } from '.';
 
 import styles from './_storybook-styles.scss';
 import { StoryDocsPage } from '../../global/js/utils/StoryDocsPage';
-
-export default {
-  title: getStoryTitle(EditSidePanel.displayName),
-  component: EditSidePanel,
-  tags: ['autodocs'],
-  // TODO: Define argTypes for props not represented by standard JS types.
-  argTypes: {
-    title: { control: { type: 'text' } },
-    subtitle: { control: { type: 'text' } },
-    formTitle: { control: { type: 'text' } },
-    formDescription: { control: { type: 'text' } },
-    open: { control: { disable: true } },
-  },
-  parameters: {
-    styles,
-    docs: {
-      page: () => (
-        <StoryDocsPage altGuidelinesHref="https://pages.github.ibm.com/cdai-design/pal/patterns/edit/usage#side-panel-edit" />
-      ),
-    },
-  },
-};
+import { sidePanelDecorator } from '../../global/decorators/sidePanelDecorator';
 
 const defaultStoryProps = {
   title: 'Edit platform quotas',
@@ -75,11 +54,36 @@ const renderUIShellHeader = () => (
   />
 );
 
+const prefix = 'edit-side-panel-stories__';
+
+export default {
+  title: getStoryTitle(EditSidePanel.displayName),
+  component: EditSidePanel,
+  tags: ['autodocs'],
+  // TODO: Define argTypes for props not represented by standard JS types.
+  argTypes: {
+    title: { control: { type: 'text' } },
+    subtitle: { control: { type: 'text' } },
+    formTitle: { control: { type: 'text' } },
+    formDescription: { control: { type: 'text' } },
+    open: { control: { disable: true } },
+  },
+  parameters: {
+    layout: 'fullscreen',
+    styles,
+    docs: {
+      page: () => (
+        <StoryDocsPage altGuidelinesHref="https://pages.github.ibm.com/cdai-design/pal/patterns/edit/usage#side-panel-edit" />
+      ),
+    },
+  },
+  decorators: [sidePanelDecorator(renderUIShellHeader, prefix)],
+};
+
 /**
  * TODO: Declare template(s) for one or more scenarios.
  */
 const Template = (args) => {
-  const prefix = 'edit-side-panel-stories__';
   const carbonPrefix = usePrefix();
   const items = ['Day(s)', 'Month(s)', 'Year(s)'];
   const [open, setOpen] = useState(false);
@@ -87,7 +91,7 @@ const Template = (args) => {
   return (
     <>
       {renderUIShellHeader()}
-      <Grid id="ibm-products-page-content">
+      <Grid id="ibm-products-page-content" className="story-content">
         <Column lg={{ span: 2, start: 8 }}>
           <Button onClick={() => setOpen(!open)}>
             {open ? 'Close side panel' : 'Open side panel'}

--- a/packages/ibm-products/src/components/EditSidePanel/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/EditSidePanel/_storybook-styles.scss
@@ -5,11 +5,12 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@use 'ALIAS_STORY_STYLE_CONFIG' as *;
+@use 'ALIAS_STORY_STYLE_CONFIG' as c4p-settings;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
+@use '../../global/decorators/side-panel-decorator' as *;
 
-$block-class: #{$pkg-prefix}--edit-side-panel;
+$block-class: #{c4p-settings.$pkg-prefix}--edit-side-panel;
 $story-prefix: edit-side-panel-stories__;
 
 .#{$story-prefix}example-container {
@@ -19,11 +20,13 @@ $story-prefix: edit-side-panel-stories__;
   grid-template-columns: 1fr 1fr;
 }
 
-.#{$story-prefix}example-form-group .#{$carbon-prefix}--label {
+.#{$story-prefix}example-form-group .#{c4p-settings.$carbon-prefix}--label {
   margin-bottom: 0;
 }
 
-.#{$block-class} .#{$carbon-prefix}--number__control-btn::before,
-.#{$block-class} .#{$carbon-prefix}--number__control-btn::after {
+.#{$block-class} .#{c4p-settings.$carbon-prefix}--number__control-btn::before,
+.#{$block-class} .#{c4p-settings.$carbon-prefix}--number__control-btn::after {
   background-color: $field-02;
 }
+
+@include side-panel-decorator($story-prefix);

--- a/packages/ibm-products/src/components/EditTearsheetNarrow/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/EditTearsheetNarrow/_storybook-styles.scss
@@ -5,6 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// @use 'ALIAS_STORY_STYLE_CONFIG';
+// @use 'ALIAS_STORY_STYLE_CONFIG' as c4p-settings;
 
 // TODO: add any additional styles used by EditTearsheetNarrow.stories.js

--- a/packages/ibm-products/src/components/ExportModal/ExportModal.stories.js
+++ b/packages/ibm-products/src/components/ExportModal/ExportModal.stories.js
@@ -58,12 +58,10 @@ const defaultProps = {
   inputType: 'text',
 };
 
-const Template = ({ open, ...args }, context) => {
-  return <ExportModal {...args} open={context.viewMode !== 'docs' && open} />;
-};
-
-const TemplateWithState = (args) => {
-  const [open, setOpen] = useState(false);
+const Template = ({ storyInitiallyOpen = false, ...args }, context) => {
+  const [open, setOpen] = useState(
+    context.viewMode !== 'docs' && storyInitiallyOpen
+  );
   const [loading, setLoading] = useState(false);
   const [successful, setSuccessful] = useState(false);
   const [error, setError] = useState(false);
@@ -104,14 +102,14 @@ const TemplateWithState = (args) => {
   );
 };
 
-export const WithSuccessMessage = prepareStory(TemplateWithState, {
+export const WithSuccessMessage = prepareStory(Template, {
   args: {
     ...defaultProps,
     successful: true,
   },
 });
 
-export const WithErrorMessage = prepareStory(TemplateWithState, {
+export const WithErrorMessage = prepareStory(Template, {
   args: {
     ...defaultProps,
     successful: false,
@@ -121,6 +119,7 @@ export const WithErrorMessage = prepareStory(TemplateWithState, {
 export const Standard = prepareStory(Template, {
   args: {
     ...defaultProps,
+    storyInitiallyOpen: true,
   },
 });
 
@@ -131,6 +130,7 @@ export const WithExtensionValidation = prepareStory(Template, {
     filename: '',
     invalidInputText: 'File must have valid extension .pdf',
     body: 'File must be exported in a PDF format.',
+    storyInitiallyOpen: true,
   },
 });
 
@@ -149,5 +149,6 @@ export const WithPreformattedExtensions = prepareStory(Template, {
       },
     ],
     preformattedExtensionsLabel: 'Choose an export format',
+    storyInitiallyOpen: true,
   },
 });

--- a/packages/ibm-products/src/components/SidePanel/SidePanel.js
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.js
@@ -431,12 +431,14 @@ export let SidePanel = React.forwardRef(
       if (includeOverlay && open) {
         bodyElement.style.overflow = 'hidden';
       } else if (includeOverlay && !open) {
-        bodyElement.style.overflow = 'initial';
+        bodyElement.style.overflow = '';
       }
       if (includeOverlay && !preventCloseOnClickOutside) {
         document.addEventListener('click', handleOutsideClick);
       }
       return () => {
+        const bodyElement = document.body;
+        bodyElement.style.overflow = '';
         document.removeEventListener('click', handleOutsideClick);
       };
     }, [

--- a/packages/ibm-products/src/components/SidePanel/SidePanel.stories.js
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.stories.js
@@ -32,47 +32,8 @@ import {
   prepareStory,
 } from '../../global/js/utils/story-helper';
 import { SidePanel } from './SidePanel';
+import { sidePanelDecorator } from '../../global/decorators/sidePanelDecorator';
 // import mdx from './SidePanel.mdx';
-
-export default {
-  title: getStoryTitle(SidePanel.displayName),
-  component: SidePanel,
-  tags: ['autodocs'],
-  parameters: {
-    styles,
-    /*
-docs: {
-      page: mdx,
-    },
-*/
-  },
-  argTypes: {
-    actions: {
-      control: {
-        type: 'select',
-        labels: {
-          0: 'One button',
-          1: 'One button (ghost)',
-          2: 'One button (danger)',
-          3: 'Two buttons',
-          4: 'Two buttons with ghost',
-          5: 'Two buttons with danger',
-          6: 'Three buttons with ghost',
-          7: 'Three buttons with danger',
-          8: 'Three buttons',
-          9: 'None',
-        },
-        default: 0,
-      },
-      options: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-    },
-    slideIn: {
-      table: {
-        disable: true,
-      },
-    },
-  },
-};
 
 const prefix = 'side-panel-stories__';
 
@@ -382,14 +343,55 @@ const renderUIShellHeader = () => (
   />
 );
 
+export default {
+  title: getStoryTitle(SidePanel.displayName),
+  component: SidePanel,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    styles,
+    /*
+docs: {
+      page: mdx,
+    },
+*/
+  },
+  argTypes: {
+    actions: {
+      control: {
+        type: 'select',
+        labels: {
+          0: 'One button',
+          1: 'One button (ghost)',
+          2: 'One button (danger)',
+          3: 'Two buttons',
+          4: 'Two buttons with ghost',
+          5: 'Two buttons with danger',
+          6: 'Three buttons with ghost',
+          7: 'Three buttons with danger',
+          8: 'Three buttons',
+          9: 'None',
+        },
+        default: 0,
+      },
+      options: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+    },
+    slideIn: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  decorators: [sidePanelDecorator(renderUIShellHeader, prefix)],
+};
+
 // eslint-disable-next-line react/prop-types
 const SlideOverTemplate = ({ minimalContent, actions, ...args }) => {
   const [open, setOpen] = useState(false);
   const testRef = useRef();
   return (
     <>
-      {renderUIShellHeader()}
-      <Button onClick={() => setOpen(!open)}>
+      <Button onClick={() => setOpen(!open)} className={`${prefix}toggle`}>
         {open ? 'Close side panel' : 'Open side panel'}
       </Button>
       <SidePanel
@@ -411,8 +413,7 @@ const StepTemplate = ({ actions, ...args }) => {
   const [currentStep, setCurrentStep] = useState(0);
   return (
     <>
-      {renderUIShellHeader()}
-      <Button onClick={() => setOpen(!open)}>
+      <Button onClick={() => setOpen(!open)} className={`${prefix}toggle`}>
         {open ? 'Close side panel' : 'Open side panel'}
       </Button>
       <SidePanel
@@ -437,10 +438,9 @@ const SlideInTemplate = ({ actions, ...args }) => {
   const [open, setOpen] = useState(false);
   return (
     <>
-      {renderUIShellHeader()}
-      <Grid id="ibm-products-page-content">
+      <Grid id="ibm-products-page-content" className={`${prefix}grid`}>
         <Column lg={16} md={8} sm={4}>
-          <Button onClick={() => setOpen(!open)}>
+          <Button onClick={() => setOpen(!open)} className={`${prefix}toggle`}>
             {open ? 'Close side panel' : 'Open side panel'}
           </Button>
         </Column>

--- a/packages/ibm-products/src/components/SidePanel/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/SidePanel/_storybook-styles.scss
@@ -9,6 +9,7 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/themes/scss/themes';
 @use '@carbon/styles/scss/type';
+@use '../../global/decorators/side-panel-decorator' as *;
 
 $story-prefix: side-panel-stories__;
 
@@ -43,3 +44,9 @@ $story-prefix: side-panel-stories__;
 .#{$story-prefix}header {
   @include theme(themes.$g100);
 }
+
+.#{$story-prefix}grid {
+  height: 100%;
+}
+
+@include side-panel-decorator($story-prefix);

--- a/packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.js
+++ b/packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.js
@@ -254,6 +254,7 @@ const StackedTemplate = ({ actions, ...args }) => {
   return (
     <>
       <style>{`.${pkg.prefix}--tearsheet { opacity: 0 }`};</style>
+      <div style={{ height: '3rem' }} data-reserve-space="for toggle buttons" />
       <ButtonSet
         style={{
           display: 'flex',
@@ -263,9 +264,15 @@ const StackedTemplate = ({ actions, ...args }) => {
           zIndex: 10000,
         }}
       >
-        <Button onClick={() => setOpen1(!open1)}>Toggle tearsheet 1</Button>
-        <Button onClick={() => setOpen2(!open2)}>Toggle tearsheet 2</Button>
-        <Button onClick={() => setOpen3(!open3)}>Toggle tearsheet 3</Button>
+        <Button onClick={() => setOpen1(!open1)}>
+          Toggle&nbsp;tearsheet&nbsp;1
+        </Button>
+        <Button onClick={() => setOpen2(!open2)}>
+          Toggle&nbsp;tearsheet&nbsp;2
+        </Button>
+        <Button onClick={() => setOpen3(!open3)}>
+          Toggle&nbsp;tearsheet&nbsp;3
+        </Button>
       </ButtonSet>
       <div ref={ref}>
         <Tearsheet

--- a/packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.stories.js
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.stories.js
@@ -37,7 +37,7 @@ export default {
   component: TearsheetNarrow,
   tags: ['autodocs'],
   subcomponents: { Tearsheet },
-  parameters: { styles /* docs: { page: mdx } */ },
+  parameters: { layout: 'fullscreen', styles /* docs: { page: mdx } */ },
   argTypes: {
     ...getDeprecatedArgTypes(deprecatedProps),
     actions: {
@@ -175,6 +175,7 @@ const StackedTemplate = ({ actions, ...args }) => {
   return (
     <>
       <style>{`.${pkg.prefix}--tearsheet { opacity: 0 }`};</style>
+      <div style={{ height: '3rem' }} data-reserve-space="for toggle buttons" />
       <div
         style={{
           display: 'flex',

--- a/packages/ibm-products/src/global/decorators/_side-panel-decorator.scss
+++ b/packages/ibm-products/src/global/decorators/_side-panel-decorator.scss
@@ -1,0 +1,18 @@
+@mixin side-panel-decorator($prefix) {
+  .#{$prefix}container {
+    display: flex;
+    height: 100vh;
+    flex-direction: column;
+  }
+
+  .#{$prefix}content {
+    flex-grow: 1;
+  }
+
+  .#{$prefix}toggle {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+}

--- a/packages/ibm-products/src/global/decorators/sidePanelDecorator.js
+++ b/packages/ibm-products/src/global/decorators/sidePanelDecorator.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { Content } from '@carbon/react';
+
+export const sidePanelDecorator = (renderHeader, prefix) => (Story) =>
+  (
+    <div className={`${prefix}container`}>
+      {renderHeader()}
+      <Content className={`${prefix}content`}>
+        <Story />
+      </Content>
+    </div>
+  );

--- a/packages/ibm-products/src/global/js/utils/StoryDocsPage.js
+++ b/packages/ibm-products/src/global/js/utils/StoryDocsPage.js
@@ -26,6 +26,8 @@ import {
   storyDocsPageInfo,
 } from './story-helper';
 
+import { pkg } from '../../../settings';
+
 export const CustomBlocks = ({ blocks }) => {
   return blocks.map((block, index) => {
     const source = { ...block?.source };
@@ -102,8 +104,9 @@ export const StoryDocsPage = ({
 
   const isFullScreen =
     csfFile?.meta?.parameters?.layout === 'fullscreen' || false;
+
   const storyHelperClass = isFullScreen
-    ? 'c4p--story-docs-page--fullscreen'
+    ? `${pkg.prefix}--story-docs-page--fullscreen`
     : '';
   const processedBlocks = processBlocks(
     blocks,
@@ -115,7 +118,7 @@ export const StoryDocsPage = ({
     processedBlocks?.filter((block) => !!block.story).length ?? 0;
 
   return (
-    <>
+    <div data-story-title={storyInfo.title}>
       <Title>{altTitle ?? storyInfo.title}</Title>
       {guidelinesHref ? (
         guidelinesHref && Array.isArray(guidelinesHref) ? (
@@ -224,7 +227,7 @@ export const StoryDocsPage = ({
         </p>
       )}
       <Controls />
-    </>
+    </div>
   );
 };
 

--- a/packages/ibm-products/src/global/js/utils/_story-as-full-page.scss
+++ b/packages/ibm-products/src/global/js/utils/_story-as-full-page.scss
@@ -1,0 +1,6 @@
+.story-helper__full-page {
+  display: flex;
+  width: 100vw;
+  height: 100vh;
+  flex-direction: column;
+}


### PR DESCRIPTION
Some stories are poorly formatted or present badly on the docs page. This is because Storybook has changed the way in which the stories are hosted on the docs page. 

We should as a result try to ensure
- All stories reserve the space they need to present themselves (some stories have no content or only content that does not reserve vertical space.
- Have the stories, not common CSS, specify the size of the viewport on the docs page.

e.g. 
![image](https://github.com/carbon-design-system/ibm-products/assets/15086604/26762657-ff8b-46e4-9417-636d0075f26b)

#### What did you change?
- Wrapped side panel stories to reserve the full height of the page.
- Removed the 50vh common minimum height in storybook styling.
- Added `layout: 'fullscreen'` to stories which should be full screen.
- Fixed CreateSidePanel, Datagrid, DataSpreadsheet, EditSidePanel, EditTearsheetNarrow, SidePanel and Tearsheet stories.
- Partially fixed ExportModal story (raised #3417)
- Noted WebTerminal has multiple issue with regards to viewing in the docs page. Raising #3418 

#### How did you test and verify your work?

Viewed in Storybook