### PR TITLE
fix(build): move jest config package to v1 to prevent version clashes

### DIFF
--- a/config/jest-config-ibm-cloud-cognitive/package.json
+++ b/config/jest-config-ibm-cloud-cognitive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jest-config-ibm-cloud-cognitive",
   "private": true,
-  "version": "0.24.25",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "main": "index.js",
   "repository": {

--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -64,7 +64,7 @@
     "fs-extra": "^11.1.1",
     "glob": "^10.3.3",
     "jest": "^29.6.1",
-    "jest-config-ibm-cloud-cognitive": "^0.24.25",
+    "jest-config-ibm-cloud-cognitive": "^1.0.0",
     "jest-environment-jsdom": "^29.6.1",
     "namor": "^1.1.2",
     "npm-check-updates": "^16.10.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1764,7 +1764,7 @@ __metadata:
     glob: ^10.3.3
     immutability-helper: ^3.1.1
     jest: ^29.6.1
-    jest-config-ibm-cloud-cognitive: ^0.24.25
+    jest-config-ibm-cloud-cognitive: ^1.0.0
     jest-environment-jsdom: ^29.6.1
     lodash: ^4.17.21
     namor: ^1.1.2
@@ -14084,7 +14084,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-config-ibm-cloud-cognitive@^0.24.25, jest-config-ibm-cloud-cognitive@workspace:config/jest-config-ibm-cloud-cognitive":
+"jest-config-ibm-cloud-cognitive@^1.0.0, jest-config-ibm-cloud-cognitive@workspace:config/jest-config-ibm-cloud-cognitive":
   version: 0.0.0-use.local
   resolution: "jest-config-ibm-cloud-cognitive@workspace:config/jest-config-ibm-cloud-cognitive"
   dependencies:


### PR DESCRIPTION
This week's v2 release failed because of the jest config package being published from both our v1 and v2 release actions which caused a clash in versioning. Moving it to `v1.0.0` on `main` should solve this problem.
