### PR TITLE
feat(TagSet): enable filter property on tags

### DIFF
--- a/packages/ibm-products/src/components/FilterSummary/FilterSummary.js
+++ b/packages/ibm-products/src/components/FilterSummary/FilterSummary.js
@@ -24,10 +24,13 @@ let FilterSummary = React.forwardRef(
     },
     ref
   ) => {
-    const tagFilters = filters.map(({ key, value }) => ({
-      type: 'gray',
-      label: renderLabel?.(key, value) ?? `${key}: ${value}`,
-    }));
+    const tagFilters = filters.map(({ key, value, ...rest }) => {
+      return {
+        ...rest,
+        type: 'gray',
+        label: renderLabel?.(key, value) ?? `${key}: ${value}`,
+      };
+    });
 
     return (
       <div ref={ref} className={cx([blockClass, className])}>

--- a/packages/ibm-products/src/components/FilterSummary/FilterSummary.stories.js
+++ b/packages/ibm-products/src/components/FilterSummary/FilterSummary.stories.js
@@ -97,3 +97,46 @@ export const WithCustomLabel = prepareStory(Template, {
     containerWidth: 500,
   },
 });
+
+const TemplateWithClose = (args) => {
+  const [filters, setFilters] = useState(
+    args.filters.map((filter) => ({
+      ...filter,
+      filter: true,
+      onClose: () => handleFilterClose(filter.key),
+      title: 'Remove filter',
+    }))
+  );
+  const clearFilters = () => setFilters([]);
+
+  const handleFilterClose = (filterKey) => {
+    setFilters((prev) => prev.filter((filter) => filter.key !== filterKey));
+  };
+
+  return (
+    <div style={{ width: args.containerWidth }}>
+      <FilterSummary
+        clearFiltersText={args.clearFiltersText}
+        filters={filters}
+        clearFilters={clearFilters}
+        renderLabel={args.renderLabel}
+      />
+    </div>
+  );
+};
+// eslint-disable-next-line react/prop-types
+export const WithFilterClose = prepareStory(TemplateWithClose, {
+  args: {
+    clearFiltersText: 'Clear filters',
+    filters: [
+      //cspell: disable
+      { key: 'project', value: 'Goldmember' },
+      //cspell: enable
+      { key: 'owner', value: 'Austin Powers' },
+      { key: 'middle name', value: 'Danger' },
+      { key: 'spy', value: true },
+      { key: 'title', value: 'International man of mystery' },
+    ],
+    containerWidth: 500,
+  },
+});

--- a/packages/ibm-products/src/components/TagSet/TagSet.js
+++ b/packages/ibm-products/src/components/TagSet/TagSet.js
@@ -17,7 +17,7 @@ import { Tag } from '@carbon/react';
 import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
-import { prepareProps, isRequiredIf } from '../../global/js/utils/props-helper';
+import { isRequiredIf } from '../../global/js/utils/props-helper';
 import { pkg } from '../../settings';
 
 const componentName = 'TagSet';
@@ -96,7 +96,6 @@ export let TagSet = React.forwardRef(
                   <Tag
                     {...other} // ensure id is not duplicated
                     data-original-id={id}
-                    filter={false}
                   >
                     {label}
                   </Tag>
@@ -113,7 +112,7 @@ export let TagSet = React.forwardRef(
       let newDisplayedTags =
         tags && tags.length > 0
           ? tags.map(({ label, ...other }, index) => (
-              <Tag {...other} filter={false} key={`displayed-tag-${index}`}>
+              <Tag {...other} key={`displayed-tag-${index}`}>
                 {label}
               </Tag>
             ))
@@ -365,14 +364,12 @@ TagSet.propTypes = {
    * with properties: **label**\* (required) to supply the tag content, and
    * other properties will be passed to the Carbon Tag component, such as
    * **type**, **disabled**, **ref**, **className** , and any other Tag props.
-   * NOTE: **filter** is not supported. Any other fields in the object will be passed through to the HTML element
-   * as HTML attributes.
    *
    * See https://react.carbondesignsystem.com/?path=/docs/components-tag--default
    */
   tags: PropTypes.arrayOf(
     PropTypes.shape({
-      ...prepareProps(Tag.propTypes, 'filter'),
+      ...Tag.propTypes,
       label: PropTypes.string.isRequired,
       // we duplicate this prop to improve the DocGen
       type: PropTypes.oneOf(tagTypes),

--- a/packages/ibm-products/src/components/TagSet/TagSet.stories.js
+++ b/packages/ibm-products/src/components/TagSet/TagSet.stories.js
@@ -5,7 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 
 import { TYPES as tagTypes } from '../TagSet/constants';
 import { pkg } from '../../settings';
@@ -206,6 +206,44 @@ export const MultilineTags = prepareStory(Template, {
 export const HundredsOfTags = prepareStory(Template, {
   args: {
     tags: hundredsOfTags,
+    containerWidth: 500,
+    ...overflowAndModalStrings,
+  },
+});
+
+const TemplateWithClose = (argsIn) => {
+  const { containerWidth, allTagsModalTargetCustomDomNode, tags, ...args } = {
+    ...argsIn,
+  };
+  const [liveTags, setLiveTags] = useState(
+    tags.map((tag) => ({
+      ...tag,
+      filter: true,
+      onClose: () => handleTagClose(tag.label),
+    }))
+  );
+
+  const handleTagClose = (key) => {
+    setLiveTags((prev) => prev.filter((tag) => tag.label !== key));
+  };
+
+  const ref = useRef();
+  return (
+    <div style={{ width: containerWidth }} ref={ref}>
+      <TagSet
+        {...args}
+        tags={liveTags}
+        allTagsModalTarget={
+          allTagsModalTargetCustomDomNode ? ref.current : undefined
+        }
+      />
+    </div>
+  );
+};
+
+export const WithClose = prepareStory(TemplateWithClose, {
+  args: {
+    tags: manyTags,
     containerWidth: 500,
     ...overflowAndModalStrings,
   },


### PR DESCRIPTION
Possible starting point for #3402

Strictly speaking the Tagset was defined with 'filter' prohibited at the request of the designer. Rather than create a second Tagset component, this PR undoes that restriction.

#### What did you change?

- Tagset to allow 'filter' and 'onClose' properties.
- Added to FilterSummary story.

#### How did you test and verify your work?

Storybook.
