### PR TITLE
fix(Datagrid): add text overflow styling to title/desc

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
@@ -9,6 +9,7 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/react/scss/components/button/tokens' as *;
 @use '../../../global/styles/project-settings' as c4p-settings;
+@use '@carbon/styles/scss/breakpoint';
 @use './variables' as *;
 
 .#{$block-class}__table-toolbar > section {
@@ -162,6 +163,23 @@
   display: block;
   width: 100%;
   padding-top: 0;
+
+  .#{c4p-settings.$carbon-prefix}--data-table-header__description {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .#{c4p-settings.$carbon-prefix}--data-table-header__title {
+    overflow: hidden;
+    max-width: 80ch;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    @include breakpoint.breakpoint(md) {
+      max-width: 55ch;
+    }
+  }
 
   .#{c4p-settings.$carbon-prefix}--data-table-content {
     width: 100%;


### PR DESCRIPTION
Contributes to #3158 

Adds some missing styles to allow for handling text overflow in the Datagrid title and descriptions.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
```
#### How did you test and verify your work?
Storybook, was able to use the controls in the `Header` Datagrid story to confirm the expected behavior