### PR TITLE
fix(Datagrid): add firefox style fixes to new column resizing

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -59,6 +59,10 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
           `--${blockClass}--grid-height`,
           px(gridHeight - scrollBuffer - tableToolbarHeight)
         );
+        headerRowElement.style.setProperty(
+          `--${blockClass}--header-height`,
+          px(headerRowElement.offsetHeight)
+        );
       };
       setCustomValues({
         gridHeight: gridElement.offsetHeight,

--- a/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
@@ -664,6 +664,7 @@
   width: 1rem;
   height: 100%;
   margin: 0;
+  -moz-appearance: initial;
   -webkit-appearance: none;
   appearance: none;
   background: transparent;
@@ -673,12 +674,14 @@
   outline: 0;
 }
 
-.#{$block-class} .#{$block-class}__col-resizer-range:focus::before {
+.#{$block-class}
+  .#{$block-class}__col-resizer-range:focus
+  + .#{$block-class}__col-resize-indicator::before {
   position: absolute;
   top: 50%;
   left: 50%;
   width: 2px;
-  height: 100%;
+  height: var(--#{$block-class}--header-height);
   background-color: $focus;
   content: '';
   transform: translate(-50%, -50%);
@@ -698,11 +701,13 @@
   transform: translate(-50%, 0);
 }
 
-.#{$block-class} .#{$block-class}__col-resizer-range:focus::after {
+.#{$block-class}
+  .#{$block-class}__col-resizer-range:focus
+  + .#{$block-class}__col-resize-indicator::after {
   position: absolute;
   /* stylelint-disable-next-line carbon/layout-token-use */
-  top: var(--#{$block-class}--row-height);
-  right: $spacing-03;
+  top: calc(var(--#{$block-class}--row-height) - 20px);
+  right: $spacing-02;
   width: 1px;
   height: calc(
     var(--#{$block-class}--grid-height) - var(--#{$block-class}--row-height)
@@ -719,4 +724,8 @@
   -webkit-appearance: none;
   appearance: none;
   background: transparent;
+}
+
+.#{$block-class} .#{$block-class}__col-resizer-range::-moz-range-thumb {
+  visibility: hidden;
 }


### PR DESCRIPTION
Contributes to #3430 

Adds some missing styles in order to render the new column resizer as expected across browsers.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
```
#### How did you test and verify your work?
Referenced Storybook in Firefox