### PR TITLE
fix(Datagrid): add text overflow styling to title/desc

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
@@ -164,6 +164,23 @@
   width: 100%;
   padding-top: 0;
 
+  .#{$carbon-prefix}--data-table-header__description {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .#{$carbon-prefix}--data-table-header__title {
+    overflow: hidden;
+    max-width: 80ch;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    @include carbon--breakpoint(md) {
+      max-width: 55ch;
+    }
+  }
+
   .#{$carbon-prefix}--data-table-content {
     width: 100%;
     height: 100%;


### PR DESCRIPTION
Contributes to #3158 

Adds some missing styles to allow for handling text overflow in the Datagrid title and descriptions.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
```
#### How did you test and verify your work?
Storybook, was able to use the controls in the `Header` Datagrid story to confirm the expected behavior