### PR TITLE
fix: upgrade to v2 codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,9 +26,9 @@ jobs:
         uses: actions/checkout@v2 # https://github.com/actions/checkout
 
       - name: Initialize
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: javascript
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
I have observed that the `codeql` action fails during the merge queue because v1 is now deprecated. I've moved our usage of it to v2 in `codeql.yml`.

`github/codeql-action/init@v2`
and
`github/codeql-action/analyze@v2`

#### What did you change?
`.github/workflows/codeql.yml`
#### How did you test and verify your work?
Followed upgrade guidance [here](https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/)