### PR TITLE
fix: filter flyout outside click

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -53,10 +53,10 @@ export const DatagridContent = ({ datagridState, title }) => {
   } = datagridState;
 
   const rows = (DatagridPagination && datagridState.page) || datagridState.rows;
-  const gridAreaRef = useRef();
   const multiKeyTrackingRef = useRef();
 
-  useClickOutside(gridAreaRef, (target) => {
+  const gridAreaRef = useClickOutside((event) => {
+    const { target } = event;
     if (!withInlineEdit) {
       return;
     }

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -56,8 +56,7 @@ export const DatagridContent = ({ datagridState, title }) => {
   const gridAreaRef = useRef();
   const multiKeyTrackingRef = useRef();
 
-  useClickOutside((event) => {
-    const { target } = event;
+  useClickOutside((target) => {
     if (!withInlineEdit) {
       return;
     }

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -56,7 +56,7 @@ export const DatagridContent = ({ datagridState, title }) => {
   const gridAreaRef = useRef();
   const multiKeyTrackingRef = useRef();
 
-  useClickOutside((target) => {
+  useClickOutside(gridAreaRef, (target) => {
     if (!withInlineEdit) {
       return;
     }

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -53,9 +53,10 @@ export const DatagridContent = ({ datagridState, title }) => {
   } = datagridState;
 
   const rows = (DatagridPagination && datagridState.page) || datagridState.rows;
+  const gridAreaRef = useRef();
   const multiKeyTrackingRef = useRef();
 
-  const gridAreaRef = useClickOutside((event) => {
+  useClickOutside((event) => {
     const { target } = event;
     if (!withInlineEdit) {
       return;

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
@@ -135,7 +135,7 @@ const FilterFlyout = ({
   };
 
   /** Effects */
-  const containerRef = useClickOutside((event) => {
+  useClickOutside(filterFlyoutRef, (event) => {
     const { target } = event;
     const hasClickedOnDatePicker = target.closest('.flatpickr-calendar');
     const hasClickedOnDropdown =
@@ -159,7 +159,7 @@ const FilterFlyout = ({
   );
 
   return (
-    <div className={`${componentClass}__container`} ref={containerRef}>
+    <div className={`${componentClass}__container`} ref={filterFlyoutRef}>
       <IconButton
         label={flyoutIconDescription}
         kind="ghost"
@@ -173,7 +173,6 @@ const FilterFlyout = ({
         <Filter />
       </IconButton>
       <div
-        ref={filterFlyoutRef}
         className={cx(componentClass, {
           [`${componentClass}--open`]: open,
           [`${componentClass}--batch`]: showActionSet,

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
@@ -135,8 +135,7 @@ const FilterFlyout = ({
   };
 
   /** Effects */
-  useClickOutside(filterFlyoutRef, (event) => {
-    const { target } = event;
+  useClickOutside(filterFlyoutRef, (target) => {
     const hasClickedOnDatePicker = target.closest('.flatpickr-calendar');
     const hasClickedOnDropdown =
       target.className === `${carbonPrefix}--list-box__menu-item__option`;

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
@@ -135,7 +135,8 @@ const FilterFlyout = ({
   };
 
   /** Effects */
-  useClickOutside(filterFlyoutRef, (target) => {
+  const containerRef = useClickOutside((event) => {
+    const { target } = event;
     const hasClickedOnDatePicker = target.closest('.flatpickr-calendar');
     const hasClickedOnDropdown =
       target.className === `${carbonPrefix}--list-box__menu-item__option`;
@@ -158,7 +159,7 @@ const FilterFlyout = ({
   );
 
   return (
-    <div className={`${componentClass}__container`}>
+    <div className={`${componentClass}__container`} ref={containerRef}>
       <IconButton
         label={flyoutIconDescription}
         kind="ghost"

--- a/packages/ibm-products/src/global/js/hooks/useClickOutside.js
+++ b/packages/ibm-products/src/global/js/hooks/useClickOutside.js
@@ -5,20 +5,24 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
-export const useClickOutside = (ref, callback) => {
-  const handleClick = (event) => {
-    if (ref.current && !ref.current.contains(event.target)) {
-      callback(event.target);
-    }
-  };
+export const useClickOutside = (callback) => {
+  const ref = useRef();
 
   useEffect(() => {
-    document.addEventListener('click', handleClick);
+    const handleClick = (event) => {
+      if (ref.current && !ref.current.contains(event.target)) {
+        callback(event);
+      }
+    };
+
+    document.addEventListener('click', handleClick, true);
 
     return () => {
-      document.removeEventListener('click', handleClick);
+      document.removeEventListener('click', handleClick, true);
     };
-  });
+  }, [callback]);
+
+  return ref;
 };

--- a/packages/ibm-products/src/global/js/hooks/useClickOutside.js
+++ b/packages/ibm-products/src/global/js/hooks/useClickOutside.js
@@ -11,14 +11,14 @@ export const useClickOutside = (ref, callback) => {
   useEffect(() => {
     const handleClick = (event) => {
       if (ref.current && !ref.current.contains(event.target)) {
-        callback(event);
+        callback(event.target);
       }
     };
 
-    document.addEventListener('click', handleClick, true);
+    document.addEventListener('click', handleClick);
 
     return () => {
-      document.removeEventListener('click', handleClick, true);
+      document.removeEventListener('click', handleClick);
     };
-  }, [ref, callback]);
+  }, [callback, ref]);
 };

--- a/packages/ibm-products/src/global/js/hooks/useClickOutside.js
+++ b/packages/ibm-products/src/global/js/hooks/useClickOutside.js
@@ -5,11 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
-export const useClickOutside = (callback) => {
-  const ref = useRef();
-
+export const useClickOutside = (ref, callback) => {
   useEffect(() => {
     const handleClick = (event) => {
       if (ref.current && !ref.current.contains(event.target)) {
@@ -22,7 +20,5 @@ export const useClickOutside = (callback) => {
     return () => {
       document.removeEventListener('click', handleClick, true);
     };
-  }, [callback]);
-
-  return ref;
+  }, [ref, callback]);
 };


### PR DESCRIPTION
Contributes to #3397 

clicking the flyout button was causing the outside click detector to be called. this refactors the `useOutsideClick` hook to provide the ref and fixes the aforementioned bug by applying the hook correctly to the container.