### PR TITLE
fix(InlineTip): accessibility review changes

### DIFF
--- a/packages/ibm-products/src/components/InlineTip/InlineTip.js
+++ b/packages/ibm-products/src/components/InlineTip/InlineTip.js
@@ -6,7 +6,7 @@
  */
 
 // Import portions of React that are needed.
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 // Other standard imports.
 import { Close16, Crossroads16, Idea20 } from '@carbon/icons-react';
@@ -17,6 +17,7 @@ import { getComponentText } from './utils';
 import { SteppedAnimatedMedia } from '../SteppedAnimatedMedia';
 
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
+import uuidv4 from '../../global/js/utils/uuidv4';
 import { pkg /*, carbon */ } from '../../settings';
 
 // Carbon and package components we use.
@@ -78,6 +79,7 @@ export let InlineTip = React.forwardRef(
     ref
   ) => {
     const [isCollapsed, setIsCollapsed] = useState(collapsible);
+    const labelId = useRef(uuidv4()).current;
 
     const previewText = useMemo(
       () => getComponentText(React.Children.toArray(children)),
@@ -102,6 +104,7 @@ export let InlineTip = React.forwardRef(
           // Pass through any other property values as HTML attributes.
           ...rest
         }
+        aria-labelledby={labelId}
         className={cx(
           blockClass, // Apply the block class to the main HTML element
           className, // Apply any supplied class names to the main HTML element.
@@ -130,7 +133,9 @@ export let InlineTip = React.forwardRef(
           </div>
         )}
         <div className={`${blockClass}__content`}>
-          <h6 className={`${blockClass}__title`}>{title}</h6>
+          <h6 id={labelId} className={`${blockClass}__title`}>
+            {title}
+          </h6>
 
           <section className={`${blockClass}__body`}>
             {childrenToRender}

--- a/packages/ibm-products/src/components/InlineTip/InlineTip.stories.js
+++ b/packages/ibm-products/src/components/InlineTip/InlineTip.stories.js
@@ -6,8 +6,7 @@
  */
 
 import React from 'react';
-// TODO: import action to handle events if required.
-// import { action } from '@storybook/addon-actions';
+import { action } from '@storybook/addon-actions';
 
 import cx from 'classnames';
 
@@ -62,10 +61,10 @@ const defaultProps = {
   expandButtonLabel: 'Read more',
   media: 'None',
   onClick: () => {
-    alert(`Clicked the tertiary button`);
+    action(`Clicked the tertiary button`)();
   },
   onClose: () => {
-    alert(`Clicked the close button`);
+    action(`Clicked the close button`)();
   },
   title: 'Use case-specific heading',
 };
@@ -74,12 +73,12 @@ const defaultProps = {
  * TODO: Declare template(s) for one or more scenarios.
  */
 const Template = (args) => {
-  const { media, narrow, action } = args;
+  const { media, narrow, action: componentAction } = args;
 
   const selectedMedia = (function () {
     switch (media) {
       case 'Render a static image':
-        return { render: () => <img alt="img" src={InlineTipImage} /> };
+        return { render: () => <img alt="" src={InlineTipImage} /> };
       case 'Render an animation':
         return {
           filePaths: [InlineTipAnimation],
@@ -89,12 +88,12 @@ const Template = (args) => {
     }
   })();
   const selectedAction = (function () {
-    switch (action) {
+    switch (componentAction) {
       case '<InlineTipButton>':
         return (
           <InlineTipButton
             onClick={() => {
-              alert(`Clicked the action button`);
+              action(`Clicked the action button`)();
             }}
           >
             Click me
@@ -102,7 +101,13 @@ const Template = (args) => {
         );
       case '<InlineTipLink>':
         return (
-          <InlineTipLink href="https://www.ibm.com" target="_blank">
+          <InlineTipLink
+            href="https://www.ibm.com"
+            onClick={() => {
+              action('Clicked the link')();
+            }}
+            target="_blank"
+          >
             Learn more
           </InlineTipLink>
         );

--- a/packages/ibm-products/src/components/InlineTip/InlineTip.test.js
+++ b/packages/ibm-products/src/components/InlineTip/InlineTip.test.js
@@ -35,7 +35,7 @@ describe(componentName, () => {
     expect(screen.getByRole('complementary')).toHaveClass(blockClass);
   });
 
-  it.skip('has no accessibility violations', async () => {
+  it('has no accessibility violations', async () => {
     const { container } = render(
       <InlineTip title={title}>{children}</InlineTip>
     );

--- a/packages/ibm-products/src/components/InlineTip/InlineTipButton.js
+++ b/packages/ibm-products/src/components/InlineTip/InlineTipButton.js
@@ -40,7 +40,7 @@ const componentName = 'InlineTipButton';
 // };
 
 /**
- * TODO: A description of the component.
+ * TODO: A standard Carbon button, styled specifically for use inside InlineTip.
  */
 export let InlineTipButton = React.forwardRef(
   (
@@ -81,13 +81,6 @@ export let InlineTipButton = React.forwardRef(
     );
   }
 );
-
-// Return a placeholder if not released and not enabled by feature flag
-InlineTipButton = pkg.checkComponentEnabled(InlineTipButton, componentName);
-
-// The display name of the component, used by React. Note that displayName
-// is used in preference to relying on function.name.
-InlineTipButton.displayName = componentName;
 
 // The types and DocGen commentary for the component props,
 // in alphabetical order (for consistency).

--- a/packages/ibm-products/src/components/InlineTip/InlineTipLink.js
+++ b/packages/ibm-products/src/components/InlineTip/InlineTipLink.js
@@ -41,7 +41,7 @@ const componentName = 'InlineTipLink';
 // };
 
 /**
- * TODO: A description of the component.
+ * TODO: A standard Carbon link, styled specifically for use inside InlineTip.
  */
 export let InlineTipLink = React.forwardRef(
   (
@@ -81,13 +81,6 @@ export let InlineTipLink = React.forwardRef(
     );
   }
 );
-
-// Return a placeholder if not released and not enabled by feature flag
-InlineTipLink = pkg.checkComponentEnabled(InlineTipLink, componentName);
-
-// The display name of the component, used by React. Note that displayName
-// is used in preference to relying on function.name.
-InlineTipLink.displayName = componentName;
 
 // The types and DocGen commentary for the component props,
 // in alphabetical order (for consistency).


### PR DESCRIPTION
Contributes to #3422

Reviewed code and styling to meet accessibility guidelines.

#### What did you change?

Nothing related to accessibility; it's a very simple component out of the box.

Removed `InlineTipButton` and `InlineTipLink` as exportable components.

#### How did you test and verify your work?

- [x] Updated Storybook, better use of `action()`.
- [ ] ~Design review.~ There were no design changes.
- [x] Followed accessibility guidelines.