### PR TITLE
fix(create-full-page): header extensions

### DIFF
--- a/packages/core/story-structure.js
+++ b/packages/core/story-structure.js
@@ -129,6 +129,7 @@ const s = [
           'c/FilterSummary',
           'c/TooltipTrigger',
           'c/TearsheetShell',
+          'c/BasicHeader',
         ],
       },
     ],

--- a/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1895,6 +1895,14 @@ p.c4p--about-modal__copyright-text:first-child {
   margin-left: 0;
 }
 
+.c4p--create-full-page__header {
+  position: sticky;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 9;
+}
+
 .c4p--create-full-page .c4p--create-full-page__step__step--hidden-step {
   display: none;
 }
@@ -1931,7 +1939,7 @@ p.c4p--about-modal__copyright-text:first-child {
   display: none;
 }
 
-.c4p--create-full-page {
+.c4p--create-full-page__influencer-and-body-container {
   display: flex;
   height: 100vh;
   padding: 0;

--- a/packages/ibm-products/src/components/BasicHeader/BasicHeader.js
+++ b/packages/ibm-products/src/components/BasicHeader/BasicHeader.js
@@ -1,0 +1,95 @@
+/**
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Breadcrumb, BreadcrumbItem } from '@carbon/react';
+import PropTypes from 'prop-types';
+
+import React, { useCallback, useEffect } from 'react';
+import cx from 'classnames';
+import { pkg } from '../../settings';
+import pconsole from '../../global/js/utils/pconsole';
+
+const blockClass = `${pkg.prefix}--basic-header`;
+const componentName = 'BasicHeader';
+/**
+ * The BasicHeader is not not public and only used internally by CreateFullPage.
+ *
+ * Component varieties:
+ * - Header with Breadcrumbs
+ * - Header with Title
+ * - Header with Breadcrumbs and Title
+ *
+ *
+ * The component will throw a warning message if neither a title nor breadcrumbs are provided
+ * since it requires at least one of them.
+ * */
+const BasicHeader = ({
+  breadcrumbs,
+  className,
+  title,
+  noTrailingSlash,
+  ...rest
+}) => {
+  const warnIfNoTitleOrBreadcrumbs = useCallback(() => {
+    if (!title && !breadcrumbs?.length) {
+      pconsole.error(
+        `Warning: You have tried using a ${componentName} component without specifying a title nor breadcrumbs props`
+      );
+    }
+  }, [breadcrumbs?.length, title]);
+
+  useEffect(() => {
+    warnIfNoTitleOrBreadcrumbs();
+  }, [title, breadcrumbs, warnIfNoTitleOrBreadcrumbs]);
+
+  return (
+    <header className={cx(blockClass, className)} {...rest}>
+      {breadcrumbs?.length > 0 && (
+        <Breadcrumb
+          noTrailingSlash={noTrailingSlash}
+          className={cx(`${blockClass}__breadcrumbs`)}
+        >
+          {breadcrumbs.map(({ key, label, href }) => (
+            <BreadcrumbItem key={key} href={href}>
+              {label}
+            </BreadcrumbItem>
+          ))}
+        </Breadcrumb>
+      )}
+      {title && <h1 className={cx(`${blockClass}__title`)}>{title}</h1>}
+    </header>
+  );
+};
+
+BasicHeader.propTypes = {
+  /** Header breadcrumbs */
+  breadcrumbs: PropTypes.arrayOf(
+    PropTypes.shape({
+      /** breadcrumb item key */
+      key: PropTypes.string.isRequired,
+      /** breadcrumb item label */
+      label: PropTypes.string.isRequired,
+      /** breadcrumb item link */
+      link: PropTypes.string,
+    })
+  ),
+
+  /** Header classname */
+  className: PropTypes.string,
+
+  /** A prop to omit the trailing slash for the breadcrumbs */
+  noTrailingSlash: PropTypes.bool,
+
+  /** Header title */
+  title: PropTypes.string,
+};
+
+BasicHeader.defaultProps = {
+  noTrailingSlash: false,
+};
+
+export { BasicHeader };

--- a/packages/ibm-products/src/components/BasicHeader/BasicHeader.stories.js
+++ b/packages/ibm-products/src/components/BasicHeader/BasicHeader.stories.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
+import { BasicHeader } from './BasicHeader';
+
+const breadcrumbs = {
+  'No breadcrumb': null,
+  'A single breadcrumb': [{ href: '/', key: '0', label: 'Home page' }],
+  'Two breadcrumbs': [
+    { key: '0', href: '/', label: 'Home page' },
+    { key: '1', href: '/', label: 'Application name' },
+  ],
+};
+
+export default {
+  title: getStoryTitle(BasicHeader.displayName),
+  component: BasicHeader,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    breadcrumbs: {
+      control: {
+        type: 'select',
+        labels: Object.keys(breadcrumbs),
+      },
+      options: Object.values(breadcrumbs).map((_k, i) => i),
+      mapping: Object.values(breadcrumbs),
+    },
+  },
+};
+
+// eslint-disable-next-line no-unused-vars -- args not used in this template
+const Template = (args) => <BasicHeader {...args} />;
+
+export const Default = prepareStory(Template, {
+  args: {
+    title: 'Page title',
+    noTrailingSlash: false,
+    className: 'custom-classname',
+    breadcrumbs: 2,
+  },
+});

--- a/packages/ibm-products/src/components/BasicHeader/BasicHeader.test.js
+++ b/packages/ibm-products/src/components/BasicHeader/BasicHeader.test.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ComboButton } from '..';
+import { BasicHeader } from './BasicHeader';
+
+describe(ComboButton.name, () => {
+  const renderComponent = (args) => render(<BasicHeader {...args} />);
+
+  beforeAll(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('renders the header title without breadcrumbs', async () => {
+    renderComponent({ title: 'Page title' });
+
+    expect(screen.getByRole('heading')).toBeInTheDocument();
+    expect(screen.getByRole('heading')).toHaveTextContent('Page title');
+
+    expect(
+      screen.queryByRole('navigation', { name: 'Breadcrumb' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the header breadcrumbs without title', async () => {
+    renderComponent({
+      breadcrumbs: [
+        { key: '0', href: '/', label: 'Home page' },
+        { key: '1', href: '/', label: 'Application name' },
+      ],
+    });
+
+    expect(
+      screen.getByRole('navigation', { name: 'Breadcrumb' })
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole('link')).toHaveLength(2);
+    expect(screen.getByRole('link', { name: 'Home page' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Application name' })
+    ).toBeInTheDocument();
+
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+  });
+
+  it('renders the header title and breadcrumbs', async () => {
+    renderComponent({
+      title: 'Page title',
+      breadcrumbs: [
+        { key: '0', href: '/', label: 'Home page' },
+        { key: '1', href: '/', label: 'Application name' },
+      ],
+    });
+
+    expect(screen.getByRole('heading')).toBeInTheDocument();
+    expect(screen.getByRole('heading')).toHaveTextContent('Page title');
+
+    expect(
+      screen.getByRole('navigation', { name: 'Breadcrumb' })
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole('link')).toHaveLength(2);
+    expect(screen.getByRole('link', { name: 'Home page' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Application name' })
+    ).toBeInTheDocument();
+  });
+
+  it('throws an error if no title or breadcrumbs is provided', async () => {
+    renderComponent();
+
+    expect(console.error).toHaveBeenCalled();
+    expect(console.error.mock.calls[0][0]).toContain(
+      'Warning: You have tried using a BasicHeader component without specifying a title nor breadcrumbs props'
+    );
+  });
+});

--- a/packages/ibm-products/src/components/BasicHeader/_basic-header.scss
+++ b/packages/ibm-products/src/components/BasicHeader/_basic-header.scss
@@ -1,0 +1,30 @@
+//
+// Copyright IBM Corp. 2020, 2023
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/type';
+
+@use '../../global/styles/project-settings' as *;
+
+$block-class: #{$pkg-prefix}--basic-header;
+
+.#{$block-class} {
+  background-color: $layer-01;
+  border-bottom: 1px solid $border-subtle-01;
+  padding: $spacing-04 $spacing-07;
+  width: 100%;
+}
+
+.#{$block-class}__title {
+  @include type.type-style('heading-04');
+}
+
+.#{$block-class}__breadcrumbs + .#{$block-class}__title {
+  // add margin top to the title if breadcrumbs exist
+  margin-top: $spacing-02;
+}

--- a/packages/ibm-products/src/components/BasicHeader/_carbon-imports.scss
+++ b/packages/ibm-products/src/components/BasicHeader/_carbon-imports.scss
@@ -1,0 +1,11 @@
+//
+// Copyright IBM Corp. 2022, 2023
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// BasicHeader uses the following Carbon components:
+// Breadcrumb, BreadcrumbItem
+
+@use '@carbon/styles/scss/components/breadcrumb';

--- a/packages/ibm-products/src/components/BasicHeader/_index-with-carbon.scss
+++ b/packages/ibm-products/src/components/BasicHeader/_index-with-carbon.scss
@@ -1,0 +1,9 @@
+//
+// Copyright IBM Corp. 2022, 2023
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use './carbon-imports';
+@use './basic-header';

--- a/packages/ibm-products/src/components/BasicHeader/_index.scss
+++ b/packages/ibm-products/src/components/BasicHeader/_index.scss
@@ -1,0 +1,10 @@
+//
+// Copyright IBM Corp. 2020, 2023
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// An index file is most useful when you have multiple components
+
+@use './basic-header';

--- a/packages/ibm-products/src/components/BasicHeader/index.js
+++ b/packages/ibm-products/src/components/BasicHeader/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export { CreateFullPageHeader } from './BasicHeader';

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.stories.js
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.stories.js
@@ -35,6 +35,15 @@ import {
 } from '@carbon/react';
 import DocsPage from './CreateFullPage.docs-page';
 
+const breadcrumbs = {
+  'No breadcrumb': null,
+  'A single breadcrumb': [{ href: '/', key: '0', label: 'Home page' }],
+  'Two breadcrumbs': [
+    { key: '0', href: '/', label: 'Home page' },
+    { key: '1', href: '/', label: 'Application name' },
+  ],
+};
+
 export default {
   title: getStoryTitle(CreateFullPage.displayName),
   component: CreateFullPage,
@@ -49,10 +58,21 @@ export default {
   decorators: [
     (story) => <div className={`${storyClass}__viewport`}>{story()}</div>,
   ],
+  argTypes: {
+    breadcrumbs: {
+      control: {
+        type: 'select',
+        labels: Object.keys(breadcrumbs),
+      },
+      options: Object.values(breadcrumbs).map((_k, i) => i),
+      mapping: Object.values(breadcrumbs),
+    },
+  },
 };
 
 const defaultFullPageProps = {
-  title: 'Create topic',
+  title: 'Page title',
+  secondaryTitle: 'Create topic',
   nextButtonText: 'Next',
   backButtonText: 'Back',
   cancelButtonText: 'Cancel',
@@ -64,6 +84,10 @@ const defaultFullPageProps = {
   modalSecondaryButtonText: 'Return to form',
   onRequestSubmit: action('Submit handler called'),
   onClose: action('Close handler called'),
+  breadcrumbs: [
+    { href: '/', key: '0', label: 'Home page' },
+    { href: '/', key: '1', label: 'Application name' },
+  ],
 };
 
 const Template = ({ ...args }) => {

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.test.js
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.test.js
@@ -473,4 +473,35 @@ describe(componentName, () => {
       createFullPageSteps[0].classList.contains(`.${blockClass}__step-fieldset`)
     );
   });
+
+  it('renders a header if title is provided ', () => {
+    const { container } = renderCreateFullPage({
+      ...defaultFullPageProps,
+      title: 'Page title',
+    });
+    const headerSelector = container.querySelector(`.${blockClass}__header`);
+
+    expect(headerSelector).toBeInTheDocument();
+  });
+
+  it('renders a header if breadcrumbs are provided', () => {
+    const { container } = renderCreateFullPage({
+      ...defaultFullPageProps,
+      breadcrumbs: [
+        { key: '0', href: '/', label: 'Home page' },
+        { key: '1', href: '/', label: 'Application name' },
+      ],
+    });
+    const headerSelector = container.querySelector(`.${blockClass}__header`);
+
+    expect(headerSelector).toBeInTheDocument();
+  });
+
+  it("doesn't render a header if title or breadcrumbs are not provided  ", () => {
+    const { container } = renderCreateFullPage({
+      ...defaultFullPageProps,
+    });
+    const headerSelector = container.querySelector(`.${blockClass}__header`);
+    expect(headerSelector).not.toBeInTheDocument();
+  });
 });

--- a/packages/ibm-products/src/components/CreateFullPage/_create-full-page.scss
+++ b/packages/ibm-products/src/components/CreateFullPage/_create-full-page.scss
@@ -12,9 +12,10 @@
 @use '../../global/styles/project-settings' as c4p-settings;
 
 // CreateFullPage uses the following IBM Products components:
-// ActionSet, CreateInfluencer
+// ActionSet, CreateInfluencer and BasicHeader
 @use '../CreateInfluencer/index' as *;
 @use '../ActionSet/action-set' as *;
+@use '../BasicHeader' as *;
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 $block-class: #{c4p-settings.$pkg-prefix}--create-full-page;
@@ -30,6 +31,14 @@ $step-block-class: #{c4p-settings.$pkg-prefix}--create-full-page__step;
   padding-top: $spacing-06;
   margin-right: 0;
   margin-left: 0;
+}
+
+.#{$block-class}__header {
+  position: sticky;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 9;
 }
 
 .#{$block-class} .#{$step-block-class}__step--hidden-step {
@@ -64,7 +73,7 @@ $step-block-class: #{c4p-settings.$pkg-prefix}--create-full-page__step;
   display: none;
 }
 
-.#{$block-class} {
+.#{$block-class}__influencer-and-body-container {
   display: flex;
   height: 100vh;
   padding: 0;

--- a/packages/ibm-products/src/components/_index-with-carbon.scss
+++ b/packages/ibm-products/src/components/_index-with-carbon.scss
@@ -46,3 +46,4 @@
 @use './DataSpreadsheet/index-with-carbon' as *;
 @use './Datagrid/index-with-carbon' as *;
 @use './EditUpdateCards/index-with-carbon' as *;
+@use './BasicHeader/index-with-carbon' as *;


### PR DESCRIPTION
Contributes to #3486 

The header is defined in the designs, but it has not been incorporated into the code. This Pull-request adds an extension to the CreateFullPage to allow users to optionally provide a title and/or breadcrumbs to show a header at the top of the page

#### What did you change?
- Added BasicHeader component for internal use only
  - Supports page title
  - Supports breadcrumbs
- Added the BasicHeader to the CreateFullPage
- Dynamic height setup for the content area to ensure that the addition of the BasicHeader doesn't introduce vertical scrolling behaviour

#### How did you test and verify your work?
- Added unit-tests for the BasicHeader and the CreateFullPage component test files
- Added the functionality to the CreateFullPage storybook story
- Added an internal storybook story for the BasicHeader component
