### PR TITLE
fix(DataGrid): remove td bottom border when state is empty

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridEmptyBody.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridEmptyBody.js
@@ -44,7 +44,10 @@ const DatagridEmptyBody = (datagridState) => {
       className={`${blockClass}__empty-state-body`}
     >
       <TableRow>
-        <TableCell colSpan={headers.length}>
+        <TableCell
+          colSpan={headers.length}
+          className={`${blockClass}__empty-state-cell`}
+        >
           {emptyStateType === 'error' && (
             <ErrorEmptyState {...emptyStateProps} />
           )}

--- a/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
@@ -299,6 +299,10 @@
   flex: 1 1 auto;
 }
 
+.#{$block-class}__empty-state .#{$block-class}__empty-state-cell {
+  border-bottom: none;
+}
+
 .#{$block-class}__resizer {
   position: absolute;
   z-index: 1;


### PR DESCRIPTION
Contributes to #3483

Removed `<td>` bottom border when table shows an empty state.

#### What did you change?

Added a class to the `<td>`; updated SCSS.

#### How did you test and verify your work?

Verified in Storybook.