### PR TITLE
feat: with dnd kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,9 +152,6 @@
     ]
   },
   "dependencies": {
-    "@dnd-kit/core": "^6.0.8",
-    "@dnd-kit/sortable": "^7.0.2",
-    "@dnd-kit/utilities": "^3.2.1",
     "stylelint-plugin-carbon-tokens": "2.3.1"
   },
   "packageManager": "yarn@3.6.1"

--- a/package.json
+++ b/package.json
@@ -152,7 +152,9 @@
     ]
   },
   "dependencies": {
-    "react-beautiful-dnd": "^13.1.1",
+    "@dnd-kit/core": "^6.0.8",
+    "@dnd-kit/sortable": "^7.0.2",
+    "@dnd-kit/utilities": "^3.2.1",
     "stylelint-plugin-carbon-tokens": "2.3.1"
   },
   "packageManager": "yarn@3.6.1"

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     ]
   },
   "dependencies": {
+    "react-beautiful-dnd": "^13.1.1",
     "stylelint-plugin-carbon-tokens": "2.3.1"
   },
   "packageManager": "yarn@3.6.1"

--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -56,6 +56,9 @@
   "devDependencies": {
     "@babel/cli": "^7.22.10",
     "@babel/core": "^7.22.10",
+    "@dnd-kit/core": "^6.0.8",
+    "@dnd-kit/sortable": "^7.0.2",
+    "@dnd-kit/utilities": "^3.2.1",
     "babel-preset-ibm-cloud-cognitive": "^0.14.39",
     "chalk": "^4.1.2",
     "change-case": "^4.1.2",

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
@@ -44,11 +44,11 @@ const DraggableElement = ({
     <Draggable draggableId={id} index={index}>
       {(provided, snapshot) => (
         <li
-          className={cx({
-            [`${blockClass}__draggable-handleHolder-selected`]: selected,
+          className={cx(`${blockClass}__draggable-handleHolder`, {
+            [`${blockClass}__draggable-handleHolder--selected`]: selected,
             [`${blockClass}__draggable-handleHolder--sticky`]: isSticky,
-            [`${blockClass}__draggable-handleHolder`]: !selected,
-            [`${blockClass}--dragging`]: snapshot.isDragging,
+            [`${blockClass}__draggable-handleHolder--dragging`]:
+              snapshot.isDragging,
           })}
           ref={provided.innerRef}
           {...provided.draggableProps}

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
@@ -11,19 +11,28 @@ import PropTypes from 'prop-types';
 import { Draggable as DraggableIcon, Locked } from '@carbon/react/icons';
 import cx from 'classnames';
 import { pkg } from '../../../settings';
-import { Draggable } from 'react-beautiful-dnd';
+import { CSS } from '@dnd-kit/utilities';
+import { useSortable } from '@dnd-kit/sortable';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
 const DraggableElement = ({
   id,
-  index,
   children,
   disabled,
   ariaLabel,
   isSticky,
   selected,
 }) => {
+  const {
+    attributes,
+    isDragging,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({ id });
+
   const content = (
     <>
       <div
@@ -40,39 +49,41 @@ const DraggableElement = ({
     </>
   );
 
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
   return (
-    <Draggable draggableId={id} index={index}>
-      {(provided, snapshot) => (
-        <li
-          className={cx(`${blockClass}__draggable-handleHolder`, {
-            [`${blockClass}__draggable-handleHolder--selected`]: selected,
-            [`${blockClass}__draggable-handleHolder--sticky`]: isSticky,
-            [`${blockClass}__draggable-handleHolder--dragging`]:
-              snapshot.isDragging,
-          })}
-          ref={provided.innerRef}
-          {...provided.draggableProps}
-          {...provided.dragHandleProps}
-          disabled={disabled}
-          aria-selected={selected}
-          role="option"
-        >
-          <span className={`${blockClass}__shared-ui--assistive-text`}>
-            {ariaLabel}
-          </span>
-          <div
-            className={cx(
-              {
-                [`${blockClass}__draggable-handleStyle`]: !disabled,
-              },
-              [`${blockClass}__draggable-handleHolder-droppable`]
-            )}
-          >
-            {content}
-          </div>
-        </li>
-      )}
-    </Draggable>
+    <li
+      className={cx(`${blockClass}__draggable-handleHolder`, {
+        [`${blockClass}__draggable-handleHolder--selected`]: selected,
+        [`${blockClass}__draggable-handleHolder--sticky`]: isSticky,
+        [`${blockClass}__draggable-handleHolder--dragging`]: isDragging,
+      })}
+      id={id}
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      disabled={disabled}
+      aria-selected={selected}
+      role="option"
+    >
+      <span className={`${blockClass}__shared-ui--assistive-text`}>
+        {ariaLabel}
+      </span>
+      <div
+        className={cx(
+          {
+            [`${blockClass}__draggable-handleStyle`]: !disabled,
+          },
+          [`${blockClass}__draggable-handleHolder-droppable`]
+        )}
+      >
+        {content}
+      </div>
+    </li>
   );
 };
 
@@ -81,7 +92,6 @@ DraggableElement.propTypes = {
   children: PropTypes.element.isRequired,
   disabled: PropTypes.bool,
   id: PropTypes.string.isRequired,
-  index: PropTypes.number.isRequired,
   isSticky: PropTypes.bool,
   selected: PropTypes.bool,
 };

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
@@ -19,6 +19,7 @@ const blockClass = `${pkg.prefix}--datagrid`;
 const DraggableElement = ({
   id,
   children,
+  classList,
   disabled,
   ariaLabel,
   isSticky,
@@ -56,7 +57,7 @@ const DraggableElement = ({
 
   return (
     <li
-      className={cx(`${blockClass}__draggable-handleHolder`, {
+      className={cx(classList, `${blockClass}__draggable-handleHolder`, {
         [`${blockClass}__draggable-handleHolder--selected`]: selected,
         [`${blockClass}__draggable-handleHolder--sticky`]: isSticky,
         [`${blockClass}__draggable-handleHolder--dragging`]: isDragging,
@@ -90,6 +91,7 @@ const DraggableElement = ({
 DraggableElement.propTypes = {
   ariaLabel: PropTypes.string.isRequired,
   children: PropTypes.element.isRequired,
+  classList: PropTypes.string,
   disabled: PropTypes.bool,
   id: PropTypes.string.isRequired,
   isSticky: PropTypes.bool,

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
@@ -6,89 +6,24 @@
  * US Government Users Restricted Rights - Use, duplication or disclosure
  * restricted by GSA ADP Schedule Contract with IBM Corp.
  */
-import * as React from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { Draggable, Locked } from '@carbon/react/icons';
-// import { useDrag, useDrop } from 'react-dnd';
+import { Draggable as DraggableIcon, Locked } from '@carbon/react/icons';
 import cx from 'classnames';
 import { pkg } from '../../../settings';
+import { Draggable } from 'react-beautiful-dnd';
 
-const { useEffect, useRef, useState } = React;
 const blockClass = `${pkg.prefix}--datagrid`;
 
-// const DRAG_TYPE = `${blockClass}__shared-ui-draggable-element`;
-
 const DraggableElement = ({
-  // id,
+  id,
   index,
-  listData,
   children,
-  // type,
   disabled,
   ariaLabel,
-  onGrab,
-  onArrowKeyDown,
-  isFocused,
   isSticky,
-  // moveElement,
   selected,
-  positionLabel = 'Current position {index} of {total}',
-  grabbedLabel = '{itemName} grabbed.',
-  droppedLabel = '{itemName} dropped.',
 }) => {
-  const ref = useRef();
-
-  // const [{ isOver }, drop] = useDrop({
-  //   accept: DRAG_TYPE + type,
-  //   collect: (monitor) => ({
-  //     isOver: !!monitor.isOver(),
-  //   }),
-  //   drop: (item) => {
-  //     moveElement(item.index, index);
-  //   },
-  //   canDrop: () => !disabled,
-  //   hover(item) {
-  //     const dragIndex = item.index;
-  //     const hoverIndex = index;
-  //     // Don't replace items with themselves
-  //     if (dragIndex === hoverIndex || disabled) {
-  //       return;
-  //     }
-  //     // moveElement(dragIndex, hoverIndex);
-  //     // Time to actually perform the action
-  //     // Note: we're mutating the monitor item here!
-  //     // Generally it's better to avoid mutations,
-  //     // but it's good here for the sake of performance
-  //     // to avoid expensive index searches.
-  //     // eslint-disable-next-line no-param-reassign
-  //     item.index = hoverIndex;
-  //   },
-  // });
-
-  // const [{ isDragging }, drag, preview] = useDrag({
-  //   type: DRAG_TYPE + type,
-  //   item: { id, index },
-  //   canDrag: () => !disabled,
-  //   collect: (monitor) => ({
-  //     isDragging: monitor.isDragging(),
-  //   }),
-  // });
-
-  // Temporarily disable drag support because of commonjs support/issues with react-dnd in latest version
-  const [isDragging] = useState(false);
-  const [isOver] = useState(false);
-  const preview = useRef();
-  const drag = useRef();
-
-  useEffect(() => {
-    if (isFocused && ref && ref.current) {
-      ref.current.focus();
-    }
-  }, [isFocused]);
-
-  const [isGrabbed, setIsGrabbed] = useState(false);
-  const [isFocusedOnItem, setIsFocusedOnItem] = useState(isFocused);
-  // drop(ref);
   const content = (
     <>
       <div
@@ -99,76 +34,45 @@ const DraggableElement = ({
           `${blockClass}__draggable-handleStyle`
         )}
       >
-        {isSticky ? <Locked size={16} /> : <Draggable size={16} />}
+        {isSticky ? <Locked size={16} /> : <DraggableIcon size={16} />}
       </div>
       {children}
     </>
   );
+
   return (
-    <li
-      className={cx({
-        [`${blockClass}__draggable-handleHolder-isOver`]: isOver && !disabled,
-        [`${blockClass}__draggable-handleHolder-grabbed`]: isGrabbed,
-        [`${blockClass}__draggable-handleHolder-selected`]: selected,
-        [`${blockClass}__draggable-handleHolder--sticky`]: isSticky,
-        [`${blockClass}__draggable-handleHolder`]: !selected,
-      })}
-      ref={ref}
-      aria-selected={isFocused}
-      role="option"
-      tabIndex={isFocused ? 0 : -1}
-      onKeyPress={(e) => {
-        if (e.key === ' ' && e.target === e.currentTarget && !disabled) {
-          const positionText = positionLabel
-            .replace('{index}', index + 1)
-            .replace('{total}', listData.length);
-          const grabAriaText = (
-            isGrabbed ? droppedLabel : grabbedLabel
-          ).replace('{itemName}', ariaLabel);
-          onGrab(grabAriaText + positionText);
-          setIsGrabbed(!isGrabbed);
-          e.preventDefault();
-        }
-      }}
-      onKeyDown={(e) => {
-        if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
-          onArrowKeyDown(e, isGrabbed, index);
-        }
-      }}
-      onBlur={(e) => {
-        // handle when focus move to inner elements
-        setIsFocusedOnItem(e.currentTarget === e.target);
-      }}
-      onFocus={(e) => {
-        // handle when focus move to li element
-        setIsFocusedOnItem(e.currentTarget === e.target);
-      }}
-    >
-      <span className={`${blockClass}__shared-ui--assistive-text`}>
-        {ariaLabel}
-      </span>
-      {isDragging && !isOver ? (
-        <div
-          ref={preview}
-          className={`${blockClass}__draggable-handleHolder-droppable ${blockClass}__draggable-handleHolder-droppable--origin`}
+    <Draggable draggableId={id} index={index}>
+      {(provided, snapshot) => (
+        <li
+          className={cx({
+            [`${blockClass}__draggable-handleHolder-selected`]: selected,
+            [`${blockClass}__draggable-handleHolder--sticky`]: isSticky,
+            [`${blockClass}__draggable-handleHolder`]: !selected,
+            [`${blockClass}--dragging`]: snapshot.isDragging,
+          })}
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+          disabled={disabled}
+          aria-selected={selected}
+          role="option"
         >
-          {content}
-        </div>
-      ) : (
-        <div
-          ref={drag}
-          aria-hidden={isFocused && isFocusedOnItem} // if focus on li, hide the children from aria
-          className={cx(
-            {
-              [`${blockClass}__draggable-handleStyle`]: !disabled,
-            },
-            [`${blockClass}__draggable-handleHolder-droppable`]
-          )}
-        >
-          {(!isOver || disabled) && content}
-        </div>
+          <span className={`${blockClass}__shared-ui--assistive-text`}>
+            {ariaLabel}
+          </span>
+          <div
+            className={cx(
+              {
+                [`${blockClass}__draggable-handleStyle`]: !disabled,
+              },
+              [`${blockClass}__draggable-handleHolder-droppable`]
+            )}
+          >
+            {content}
+          </div>
+        </li>
       )}
-    </li>
+    </Draggable>
   );
 };
 
@@ -176,19 +80,10 @@ DraggableElement.propTypes = {
   ariaLabel: PropTypes.string.isRequired,
   children: PropTypes.element.isRequired,
   disabled: PropTypes.bool,
-  droppedLabel: PropTypes.string,
-  grabbedLabel: PropTypes.string,
   id: PropTypes.string.isRequired,
   index: PropTypes.number.isRequired,
-  isFocused: PropTypes.bool.isRequired,
   isSticky: PropTypes.bool,
-  listData: PropTypes.array.isRequired,
-  // moveElement: PropTypes.func.isRequired,
-  onArrowKeyDown: PropTypes.func.isRequired,
-  onGrab: PropTypes.func.isRequired,
-  positionLabel: PropTypes.string,
   selected: PropTypes.bool,
-  type: PropTypes.string.isRequired,
 };
 
 export default DraggableElement;

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Checkbox } from '@carbon/react';
 import update from 'immutability-helper';
@@ -13,7 +13,6 @@ import { pkg } from '../../../../../settings';
 import cx from 'classnames';
 import { DraggableItemsList } from './DraggableItemsList';
 import uuidv4 from '../../../../../global/js/utils/uuidv4';
-import { useScroll } from '../../../../../global/js/hooks/useWindowScroll';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
@@ -29,39 +28,28 @@ const Columns = ({
 }) => {
   const listId = useRef(uuidv4()); // keep id between renders
   const listRef = useRef(null);
-  const [scrollTopCSS, setScrollTopCSS] = useState(0);
 
   const [ariaRegionText, setAriaRegionText] = React.useState('');
   // after a drag/drop action set the columns
   const moveElement = React.useCallback(
-    (dragIndex, hoverIndex) => {
-      const dragCard = columns[dragIndex];
+    (from, to) => {
+      const fromCol = columns[from];
+
       setColumnsObject(
         update(columns, {
           $splice: [
-            [dragIndex, 1],
-            [hoverIndex, 0, dragCard],
+            [from, 1],
+            [to, 0, fromCol],
           ],
         })
       );
     },
-    [columns, setColumnsObject]
-  );
-
-  useScroll(
-    listRef,
-    () => {
-      if (listRef?.current) {
-        setScrollTopCSS(listRef.current.scrollTop);
-      }
-    },
-    [listRef.current]
+    [columns, setColumnsObject] // [columns, setColumnsObject]
   );
 
   return (
     <div
       className={`${blockClass}__customize-columns-column-list`}
-      style={{ '--scroll-top': `${scrollTopCSS}px` }}
       ref={listRef}
     >
       <ol

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
@@ -5,13 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Checkbox } from '@carbon/react';
 import update from 'immutability-helper';
 import { pkg } from '../../../../../settings';
 import cx from 'classnames';
 import { DraggableItemsList } from './DraggableItemsList';
+import uuidv4 from '../../../../../global/js/utils/uuidv4';
+import { useScroll } from '../../../../../global/js/hooks/useWindowScroll';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
@@ -25,6 +27,10 @@ const Columns = ({
   assistiveTextDisabledInstructionsLabel,
   selectAllLabel,
 }) => {
+  const listId = useRef(uuidv4()); // keep id between renders
+  const listRef = useRef(null);
+  const [scrollTopCSS, setScrollTopCSS] = useState(0);
+
   const [ariaRegionText, setAriaRegionText] = React.useState('');
   // after a drag/drop action set the columns
   const moveElement = React.useCallback(
@@ -42,8 +48,22 @@ const Columns = ({
     [columns, setColumnsObject]
   );
 
+  useScroll(
+    listRef,
+    () => {
+      if (listRef?.current) {
+        setScrollTopCSS(listRef.current.scrollTop);
+      }
+    },
+    [listRef.current]
+  );
+
   return (
-    <div className={`${blockClass}__customize-columns-column-list`}>
+    <div
+      className={`${blockClass}__customize-columns-column-list`}
+      style={{ '--scroll-top': `${scrollTopCSS}px` }}
+      ref={listRef}
+    >
       <ol
         className={`${blockClass}__customize-columns-column-list--focus`}
         role="listbox"
@@ -90,6 +110,7 @@ const Columns = ({
           />
         </div>
         <DraggableItemsList
+          id={listId.current}
           columns={columns}
           filterString={filterString}
           moveElement={moveElement}

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
@@ -15,17 +15,6 @@ import { DraggableItemsList } from './DraggableItemsList';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
-const getNextIndex = (array, currentIndex, key) => {
-  let newIndex = -1;
-  if (key === 'ArrowUp') {
-    newIndex = currentIndex - 1 >= 0 ? currentIndex - 1 : array.length - 1;
-  }
-  if (key === 'ArrowDown') {
-    newIndex = currentIndex + 1 < array.length ? currentIndex + 1 : 0;
-  }
-  return newIndex;
-};
-
 const Columns = ({
   getVisibleColumnsCount,
   filterString,
@@ -37,7 +26,6 @@ const Columns = ({
   selectAllLabel,
 }) => {
   const [ariaRegionText, setAriaRegionText] = React.useState('');
-  const [focusIndex, setFocusIndex] = React.useState(-1);
   // after a drag/drop action set the columns
   const moveElement = React.useCallback(
     (dragIndex, hoverIndex) => {
@@ -104,13 +92,9 @@ const Columns = ({
         <DraggableItemsList
           columns={columns}
           filterString={filterString}
-          focusIndex={focusIndex}
-          getNextIndex={getNextIndex}
           moveElement={moveElement}
-          onSelectColumn={onSelectColumn}
           setAriaRegionText={setAriaRegionText}
-          setColumnsObject={setColumnsObject}
-          setFocusIndex={setFocusIndex}
+          onSelectColumn={onSelectColumn}
         />
       </ol>
     </div>

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
@@ -44,7 +44,7 @@ const Columns = ({
         })
       );
     },
-    [columns, setColumnsObject] // [columns, setColumnsObject]
+    [columns, setColumnsObject]
   );
 
   return (

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
@@ -7,10 +7,8 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-// import { DndProvider } from 'react-dnd';
-// import { HTML5Backend } from 'react-dnd-html5-backend';
 import { Checkbox } from '@carbon/react';
-// import update from 'immutability-helper';
+import update from 'immutability-helper';
 import { pkg } from '../../../../../settings';
 import cx from 'classnames';
 import { DraggableItemsList } from './DraggableItemsList';
@@ -40,36 +38,28 @@ const Columns = ({
 }) => {
   const [ariaRegionText, setAriaRegionText] = React.useState('');
   const [focusIndex, setFocusIndex] = React.useState(-1);
-  // const moveElement = React.useCallback(
-  //   (dragIndex, hoverIndex) => {
-  //     const dragCard = columns[dragIndex];
-  //     setColumnsObject(
-  //       update(columns, {
-  //         $splice: [
-  //           [dragIndex, 1],
-  //           [hoverIndex, 0, dragCard],
-  //         ],
-  //       })
-  //     );
-  //   },
-  //   [columns, setColumnsObject]
-  // );
+  // after a drag/drop action set the columns
+  const moveElement = React.useCallback(
+    (dragIndex, hoverIndex) => {
+      const dragCard = columns[dragIndex];
+      setColumnsObject(
+        update(columns, {
+          $splice: [
+            [dragIndex, 1],
+            [hoverIndex, 0, dragCard],
+          ],
+        })
+      );
+    },
+    [columns, setColumnsObject]
+  );
 
   return (
     <div className={`${blockClass}__customize-columns-column-list`}>
-      {/* <DndProvider backend={HTML5Backend}> */}
       <ol
         className={`${blockClass}__customize-columns-column-list--focus`}
         role="listbox"
         aria-describedby={`${blockClass}__customize-columns--instructions`}
-        onKeyDown={(e) => {
-          const nextIndex = getNextIndex(columns, focusIndex, e.key);
-          if (nextIndex >= 0) {
-            setFocusIndex(nextIndex);
-            e.preventDefault();
-            e.stopPropagation();
-          }
-        }}
         tabIndex={0}
       >
         <span
@@ -116,14 +106,13 @@ const Columns = ({
           filterString={filterString}
           focusIndex={focusIndex}
           getNextIndex={getNextIndex}
-          // moveElement={moveElement}
+          moveElement={moveElement}
           onSelectColumn={onSelectColumn}
           setAriaRegionText={setAriaRegionText}
           setColumnsObject={setColumnsObject}
           setFocusIndex={setFocusIndex}
         />
       </ol>
-      {/* </DndProvider> */}
     </div>
   );
 };

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
@@ -27,6 +27,7 @@ import {
 } from '@dnd-kit/sortable';
 
 const blockClass = `${pkg.prefix}--datagrid`;
+const matchedColsById = (col1, col2) => col1 && col2 && col1.id === col2.id;
 
 export const DraggableItemsList = ({
   columns,
@@ -56,8 +57,12 @@ export const DraggableItemsList = ({
   const handleDragEnd = (event) => {
     const { active, over } = event;
 
-    const fromVisibleIndex = columns.findIndex((col) => col.id === active.id);
-    const toVisibleIndex = columns.findIndex((col) => col.id === over.id);
+    const fromVisibleIndex = columns.findIndex((col) =>
+      matchedColsById(col, active)
+    );
+    const toVisibleIndex = columns.findIndex((col) =>
+      matchedColsById(col, over)
+    );
     const colTitle = getColTitle(visibleCols[fromVisibleIndex]);
 
     setAriaRegionText(
@@ -66,8 +71,8 @@ export const DraggableItemsList = ({
       }.`
     );
 
-    const fromIndex = columns.findIndex((col) => col.id === active.id);
-    const toIndex = columns.findIndex((col) => col.id === over.id);
+    const fromIndex = columns.findIndex((col) => matchedColsById(col, active));
+    const toIndex = columns.findIndex((col) => matchedColsById(col, over));
 
     moveElement(fromIndex, toIndex);
   };
@@ -75,7 +80,9 @@ export const DraggableItemsList = ({
   const handleDragStart = (event) => {
     const { active } = event;
 
-    const fromIndex = visibleCols.findIndex((col) => col.id === active.id);
+    const fromIndex = visibleCols.findIndex((col) =>
+      matchedColsById(col, active)
+    );
     const colTitle = getColTitle(visibleCols[fromIndex]);
 
     setAriaRegionText(
@@ -88,8 +95,10 @@ export const DraggableItemsList = ({
   const handleDragUpdate = (event) => {
     const { active, over } = event;
 
-    const fromIndex = visibleCols.findIndex((col) => col.id === active.id);
-    const toIndex = visibleCols.findIndex((col) => col.id === over.id);
+    const fromIndex = visibleCols.findIndex((col) =>
+      matchedColsById(col, active)
+    );
+    const toIndex = visibleCols.findIndex((col) => matchedColsById(col, over));
 
     const colTitle = getColTitle(visibleCols[fromIndex]);
 

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
@@ -100,7 +100,6 @@ export const DraggableItemsList = ({
                 const listContents = (
                   <>
                     <Checkbox
-                      // wrapperClassName={`${blockClass}__customize-columns-checkbox-wrapper`}
                       checked={isColumnVisible(colDef)}
                       disabled={isFrozenColumn}
                       onChange={(_, { checked }) =>
@@ -133,7 +132,6 @@ export const DraggableItemsList = ({
                     ariaLabel={colHeaderTitle}
                     onGrab={setAriaRegionText}
                     isFocused={focusIndex === i}
-                    moveElement={moveElement}
                     isSticky={isFrozenColumn}
                     selected={isColumnVisible(colDef)}
                   >

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
@@ -36,6 +36,7 @@ export const DraggableItemsList = ({
   onSelectColumn,
   setAriaRegionText,
 }) => {
+  const draggableClass = `${blockClass}__draggable-item`;
   const visibleCols = columns
     // hide the columns without Header, e.g the sticky actions, spacer
     .filter((colDef) => {
@@ -105,7 +106,33 @@ export const DraggableItemsList = ({
       distance: 4,
     },
   });
-  const keyboardSensor = useSensor(KeyboardSensor);
+
+  const keyboardSensor = useSensor(KeyboardSensor, {
+    coordinateGetter: (event, args) => {
+      const { currentCoordinates } = args;
+
+      let target = event.target;
+
+      while (target && !target.classList.contains(draggableClass)) {
+        target = target.parentNode;
+      }
+
+      const delta = target.offsetHeight;
+
+      switch (event.code) {
+        case 'ArrowRight':
+        case 'ArrowLeft':
+          // ignore right and left
+          return currentCoordinates;
+        case 'ArrowUp':
+          return { ...currentCoordinates, y: currentCoordinates.y - delta };
+        case 'ArrowDown':
+          return { ...currentCoordinates, y: currentCoordinates.y + delta };
+        case 'Space':
+          break;
+      }
+    },
+  });
 
   const sensors = useSensors(pointerSensor, keyboardSensor);
 
@@ -176,6 +203,7 @@ export const DraggableItemsList = ({
 
             return (
               <DraggableElement
+                classList={draggableClass}
                 key={colDef.id}
                 id={colDef.id}
                 disabled={filterString.length > 0 || isFrozenColumn}

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
@@ -13,19 +13,18 @@ import DraggableElement from '../../DraggableElement';
 import { pkg } from '../../../../../settings';
 import getColTitle from '../../../utils/getColTitle';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
-import uuidv4 from '../../../../../global/js/utils/uuidv4';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
 export const DraggableItemsList = ({
   columns,
   filterString,
+  id,
   moveElement,
   onSelectColumn,
   setAriaRegionText,
 }) => {
-  const listId = uuidv4();
-
+  // let localRefCopy;
   const handleDragEnd = (result) => {
     const { source, destination } = result;
 
@@ -39,8 +38,6 @@ export const DraggableItemsList = ({
     }
 
     moveElement(source.index, destination.index);
-    // console.log(source, destination, draggableId);
-    // will need to call move element
   };
 
   const visibleCols = columns
@@ -58,10 +55,8 @@ export const DraggableItemsList = ({
       );
     });
 
-  const handleDragStart = ({ source, mode, ...rest }) => {
-    console.log(rest);
-
-    if (mode === 'SNAPx') {
+  const handleDragStart = ({ source, mode }) => {
+    if (mode === 'SNAP') {
       const grabbedCol = visibleCols[source.index];
       const colTitle = getColTitle(grabbedCol);
       setAriaRegionText(
@@ -72,9 +67,8 @@ export const DraggableItemsList = ({
     }
   };
 
-  const handleDragUpdate = ({ source, mode, destination }) => {
-    if (mode === 'SNAPx') {
-      console.log(destination);
+  const handleDragUpdate = ({ source, mode }) => {
+    if (mode === 'SNAP') {
       const grabbedCol = visibleCols[source.index];
       const colTitle = getColTitle(grabbedCol);
       setAriaRegionText(
@@ -91,14 +85,22 @@ export const DraggableItemsList = ({
       onDragStart={handleDragStart}
       onDragUpdate={handleDragUpdate}
     >
-      <Droppable droppableId={listId}>
+      <Droppable droppableId={id}>
         {(provided) => {
           return (
-            <div {...provided.droppableProps} ref={provided.innerRef}>
+            <div
+              {...provided.droppableProps}
+              ref={provided.innerRef}
+              // not currently needed but informative
+              // ref={(ref) => {
+              //   localRefCopy = ref;
+              //   provided.innerRef(ref);
+              // }}
+            >
               <div
                 className={`${blockClass}__draggable-underlay`}
                 aria-hidden="true"
-                key={`draggable-underlay-${listId}`}
+                key={`draggable-underlay-${id}`}
               >
                 {visibleCols.map((colDef) => (
                   <div
@@ -165,7 +167,7 @@ export const DraggableItemsList = ({
               })}
               <span
                 className="column__dnd-placeholder"
-                key={`placeholder-${listId}`}
+                key={`placeholder-${id}`}
               >
                 {/* Needed by react-beautiful-dnd */}
                 {provided.placeholder}
@@ -181,6 +183,7 @@ export const DraggableItemsList = ({
 DraggableItemsList.propTypes = {
   columns: PropTypes.array.isRequired,
   filterString: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
   moveElement: PropTypes.func.isRequired,
   onSelectColumn: PropTypes.func.isRequired,
   setAriaRegionText: PropTypes.func.isRequired,

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
@@ -20,11 +20,9 @@ const blockClass = `${pkg.prefix}--datagrid`;
 export const DraggableItemsList = ({
   columns,
   filterString,
-  focusIndex,
   moveElement,
   onSelectColumn,
   setAriaRegionText,
-  setColumnsObject,
 }) => {
   const listId = uuidv4();
 
@@ -60,8 +58,39 @@ export const DraggableItemsList = ({
       );
     });
 
+  const handleDragStart = ({ source, mode, ...rest }) => {
+    console.log(rest);
+
+    if (mode === 'SNAPx') {
+      const grabbedCol = visibleCols[source.index];
+      const colTitle = getColTitle(grabbedCol);
+      setAriaRegionText(
+        `${colTitle} grabbed. Current position ${source.index + 1} of ${
+          visibleCols.length
+        }.`
+      );
+    }
+  };
+
+  const handleDragUpdate = ({ source, mode, destination }) => {
+    if (mode === 'SNAPx') {
+      console.log(destination);
+      const grabbedCol = visibleCols[source.index];
+      const colTitle = getColTitle(grabbedCol);
+      setAriaRegionText(
+        `${colTitle} dropped. Current position ${source.index + 1} of ${
+          visibleCols.length
+        }.`
+      );
+    }
+  };
+
   return (
-    <DragDropContext onDragEnd={handleDragEnd}>
+    <DragDropContext
+      onDragEnd={handleDragEnd}
+      onDragStart={handleDragStart}
+      onDragUpdate={handleDragUpdate}
+    >
       <Droppable droppableId={listId}>
         {(provided) => {
           return (
@@ -124,14 +153,9 @@ export const DraggableItemsList = ({
                   <DraggableElement
                     key={colDef.id}
                     index={i}
-                    listData={columns}
-                    setListData={setColumnsObject}
                     id={`dnd-datagrid-columns-${colDef.id}`}
-                    type="column-customization"
                     disabled={filterString.length > 0 || isFrozenColumn}
                     ariaLabel={colHeaderTitle}
-                    onGrab={setAriaRegionText}
-                    isFocused={focusIndex === i}
                     isSticky={isFrozenColumn}
                     selected={isColumnVisible(colDef)}
                   >
@@ -157,11 +181,7 @@ export const DraggableItemsList = ({
 DraggableItemsList.propTypes = {
   columns: PropTypes.array.isRequired,
   filterString: PropTypes.string.isRequired,
-  focusIndex: PropTypes.number.isRequired,
-  getNextIndex: PropTypes.func.isRequired,
   moveElement: PropTypes.func.isRequired,
   onSelectColumn: PropTypes.func.isRequired,
   setAriaRegionText: PropTypes.func.isRequired,
-  setColumnsObject: PropTypes.func.isRequired,
-  setFocusIndex: PropTypes.func.isRequired,
 };

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
@@ -13,7 +13,14 @@ import DraggableElement from '../../DraggableElement';
 import { pkg } from '../../../../../settings';
 import getColTitle from '../../../utils/getColTitle';
 
-import { DndContext, closestCenter } from '@dnd-kit/core';
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
 import {
   SortableContext,
   verticalListSortingStrategy,
@@ -92,12 +99,23 @@ export const DraggableItemsList = ({
     );
   };
 
+  const pointerSensor = useSensor(PointerSensor, {
+    // Require the mouse to move by 10 pixels before activating
+    activationConstraint: {
+      distance: 4,
+    },
+  });
+  const keyboardSensor = useSensor(KeyboardSensor);
+
+  const sensors = useSensors(pointerSensor, keyboardSensor);
+
   return (
     <DndContext
       collisionDetection={closestCenter}
       onDragEnd={handleDragEnd}
       onDragStart={handleDragStart}
       onDragMove={handleDragUpdate}
+      sensors={sensors}
     >
       <>
         <div

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
@@ -12,6 +12,8 @@ import { isColumnVisible } from './common';
 import DraggableElement from '../../DraggableElement';
 import { pkg } from '../../../../../settings';
 import getColTitle from '../../../utils/getColTitle';
+import { DragDropContext, Droppable } from 'react-beautiful-dnd';
+import uuidv4 from '../../../../../global/js/utils/uuidv4';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
@@ -19,106 +21,138 @@ export const DraggableItemsList = ({
   columns,
   filterString,
   focusIndex,
-  getNextIndex,
-  // moveElement,
+  moveElement,
   onSelectColumn,
   setAriaRegionText,
   setColumnsObject,
-  setFocusIndex,
 }) => {
+  const listId = uuidv4();
+
+  const handleDragEnd = (result) => {
+    const { source, destination } = result;
+
+    if (
+      !destination ||
+      (source.droppableId === destination.droppableId &&
+        source.index === destination.index)
+    ) {
+      // do nothing if no destination or
+      // source and destination are the same
+    }
+
+    moveElement(source.index, destination.index);
+    // console.log(source, destination, draggableId);
+    // will need to call move element
+  };
+
+  const visibleCols = columns
+    // hide the columns without Header, e.g the sticky actions, spacer
+    .filter((colDef) => {
+      return !!getColTitle(colDef);
+    })
+    .filter(Boolean)
+    .filter((colDef) => !colDef.isAction)
+    .filter((colDef) => {
+      return (
+        filterString.length === 0 ||
+        (getColTitle(colDef)?.toLowerCase().includes(filterString) &&
+          colDef.id !== 'spacer')
+      );
+    });
+
   return (
-    <>
-      {columns
-        // hide the columns without Header, e.g the sticky actions, spacer
-        .filter((colDef) => {
-          return !!getColTitle(colDef);
-        })
-        .filter(Boolean)
-        .filter((colDef) => !colDef.isAction)
-        .filter((colDef) => {
+    <DragDropContext onDragEnd={handleDragEnd}>
+      <Droppable droppableId={listId}>
+        {(provided) => {
           return (
-            filterString.length === 0 ||
-            (getColTitle(colDef)?.toLowerCase().includes(filterString) &&
-              colDef.id !== 'spacer')
-          );
-        })
-        .map((colDef, i) => {
-          const colHeaderTitle = getColTitle(colDef);
-          const searchString = new RegExp('(' + filterString + ')');
-          const res = filterString.length
-            ? colHeaderTitle.toLowerCase().split(searchString)
-            : null;
-          const firstWord =
-            res !== null
-              ? res[0] === ''
-                ? res[1].charAt(0).toUpperCase() + res[1].substring(1)
-                : res[0].charAt(0).toUpperCase() + res[0].substring(1)
-              : null;
-          const highlightedText =
-            res !== null
-              ? res[0] === ''
-                ? `<strong>${firstWord}</strong>` + res[2]
-                : firstWord + `<strong>${res[1]}</strong>` + res[2]
-              : colHeaderTitle;
-          const isFrozenColumn = !!colDef.sticky;
-          const listContents = (
-            <>
-              <Checkbox
-                wrapperClassName={`${blockClass}__customize-columns-checkbox-wrapper`}
-                checked={isColumnVisible(colDef)}
-                disabled={isFrozenColumn}
-                onChange={(_, { checked }) => onSelectColumn(colDef, checked)}
-                id={`${blockClass}__customization-column-${colDef.id}`}
-                labelText={colHeaderTitle}
-                title={colHeaderTitle}
-                className={`${blockClass}__customize-columns-checkbox`}
-                hideLabel
-              />
-              {
-                <div
-                  dangerouslySetInnerHTML={{ __html: highlightedText }}
-                  className={`${blockClass}__customize-columns-checkbox-visible-label`}
-                ></div>
-              }
-            </>
-          );
+            <div {...provided.droppableProps} ref={provided.innerRef}>
+              <div
+                className={`${blockClass}__draggable-underlay`}
+                aria-hidden="true"
+                key={`draggable-underlay-${listId}`}
+              >
+                {visibleCols.map((colDef) => (
+                  <div
+                    className={`${blockClass}__draggable-underlay-item`}
+                    key={colDef.id}
+                  ></div>
+                ))}
+              </div>
+              {visibleCols.map((colDef, i) => {
+                const colHeaderTitle = getColTitle(colDef);
+                const searchString = new RegExp('(' + filterString + ')');
+                const res = filterString.length
+                  ? colHeaderTitle.toLowerCase().split(searchString)
+                  : null;
+                const firstWord =
+                  res !== null
+                    ? res[0] === ''
+                      ? res[1].charAt(0).toUpperCase() + res[1].substring(1)
+                      : res[0].charAt(0).toUpperCase() + res[0].substring(1)
+                    : null;
+                const highlightedText =
+                  res !== null
+                    ? res[0] === ''
+                      ? `<strong>${firstWord}</strong>` + res[2]
+                      : firstWord + `<strong>${res[1]}</strong>` + res[2]
+                    : colHeaderTitle;
+                const isFrozenColumn = !!colDef.sticky;
+                const listContents = (
+                  <>
+                    <Checkbox
+                      // wrapperClassName={`${blockClass}__customize-columns-checkbox-wrapper`}
+                      checked={isColumnVisible(colDef)}
+                      disabled={isFrozenColumn}
+                      onChange={(_, { checked }) =>
+                        onSelectColumn(colDef, checked)
+                      }
+                      id={`${blockClass}__customization-column-${colDef.id}`}
+                      labelText={colHeaderTitle}
+                      title={colHeaderTitle}
+                      className={`${blockClass}__customize-columns-checkbox`}
+                      hideLabel
+                    />
+                    {
+                      <div
+                        dangerouslySetInnerHTML={{ __html: highlightedText }}
+                        className={`${blockClass}__customize-columns-checkbox-visible-label`}
+                      ></div>
+                    }
+                  </>
+                );
 
-          return (
-            <DraggableElement
-              key={colDef.id}
-              index={i}
-              listData={columns}
-              setListData={setColumnsObject}
-              id={`dnd-datagrid-columns-${colDef.id}`}
-              type="column-customization"
-              disabled={filterString.length > 0 || isFrozenColumn}
-              ariaLabel={colHeaderTitle}
-              onGrab={setAriaRegionText}
-              isFocused={focusIndex === i}
-              // moveElement={moveElement}
-              onArrowKeyDown={(e, isGrabbed, currentIndex) => {
-                if (isGrabbed) {
-                  const nextIndex = getNextIndex(columns, currentIndex, e.key);
-                  e.preventDefault();
-                  e.stopPropagation();
-
-                  if (nextIndex >= 0 && !columns[nextIndex]?.sticky) {
-                    setFocusIndex(nextIndex);
-                    // moveElement(currentIndex, nextIndex);
-                    e.target.scrollIntoView({
-                      block: 'center',
-                    });
-                  }
-                }
-              }}
-              isSticky={isFrozenColumn}
-              selected={isColumnVisible(colDef)}
-            >
-              {listContents}
-            </DraggableElement>
+                return (
+                  <DraggableElement
+                    key={colDef.id}
+                    index={i}
+                    listData={columns}
+                    setListData={setColumnsObject}
+                    id={`dnd-datagrid-columns-${colDef.id}`}
+                    type="column-customization"
+                    disabled={filterString.length > 0 || isFrozenColumn}
+                    ariaLabel={colHeaderTitle}
+                    onGrab={setAriaRegionText}
+                    isFocused={focusIndex === i}
+                    moveElement={moveElement}
+                    isSticky={isFrozenColumn}
+                    selected={isColumnVisible(colDef)}
+                  >
+                    {listContents}
+                  </DraggableElement>
+                );
+              })}
+              <span
+                className="column__dnd-placeholder"
+                key={`placeholder-${listId}`}
+              >
+                {/* Needed by react-beautiful-dnd */}
+                {provided.placeholder}
+              </span>
+            </div>
           );
-        })}
-    </>
+        }}
+      </Droppable>
+    </DragDropContext>
   );
 };
 
@@ -127,7 +161,7 @@ DraggableItemsList.propTypes = {
   filterString: PropTypes.string.isRequired,
   focusIndex: PropTypes.number.isRequired,
   getNextIndex: PropTypes.func.isRequired,
-  // moveElement: PropTypes.func.isRequired,
+  moveElement: PropTypes.func.isRequired,
   onSelectColumn: PropTypes.func.isRequired,
   setAriaRegionText: PropTypes.func.isRequired,
   setColumnsObject: PropTypes.func.isRequired,

--- a/packages/ibm-products/src/components/Datagrid/styles/_draggableElement.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_draggableElement.scss
@@ -62,14 +62,7 @@
 }
 
 .#{variables.$block-class}__draggable-handleHolder--dragging {
-  /* stylelint-disable-next-line declaration-no-important */
-  top: auto !important; /* fixes out of position drag drop in react-beautiful-dnd */
-  /* stylelint-disable-next-line declaration-no-important */
-  left: auto !important; /* fixes out of position drag drop in react-beautiful-dnd */
-  // stylelint-disable-next-line carbon/layout-token-use
-  margin-top: calc(
-    -1 * var(--scroll-top)
-  ); /* fix for react-beautiful-dnd when in scrolled modal */
+  z-index: 2; // raise above other items in draggable list
 
   background-color: $highlight;
   color: $text-primary;

--- a/packages/ibm-products/src/components/Datagrid/styles/_draggableElement.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_draggableElement.scss
@@ -57,16 +57,23 @@
   outline: none;
 }
 
+.#{variables.$block-class}__draggable-handleHolder--selected {
+  background-color: $layer-selected;
+}
+
 .#{variables.$block-class}__draggable-handleHolder--dragging {
   /* stylelint-disable-next-line declaration-no-important */
   top: auto !important; /* fixes out of position drag drop in react-beautiful-dnd */
   /* stylelint-disable-next-line declaration-no-important */
   left: auto !important; /* fixes out of position drag drop in react-beautiful-dnd */
-  outline: none;
-}
+  // stylelint-disable-next-line carbon/layout-token-use
+  margin-top: calc(
+    -1 * var(--scroll-top)
+  ); /* fix for react-beautiful-dnd when in scrolled modal */
 
-.#{variables.$block-class}__draggable-handleHolder--selected {
-  background-color: $layer-selected;
+  background-color: $highlight;
+  color: $text-primary;
+  outline: none;
 }
 
 .#{variables.$block-class}__draggable-handleHolder-selected:hover {
@@ -86,11 +93,6 @@
 .#{variables.$block-class}__draggable-handleHolder-droppable.#{variables.$block-class}__draggable-handleHolder-droppable--origin {
   opacity: 0.5;
   transition: opacity $duration-moderate-01 motion(entrance, productive);
-}
-
-.#{variables.$block-class}__draggable-handleHolder--grabbed {
-  background-color: $highlight;
-  color: $text-primary;
 }
 
 .#{variables.$block-class}__draggable-handleHolder--sticky {

--- a/packages/ibm-products/src/components/Datagrid/styles/_draggableElement.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_draggableElement.scss
@@ -26,7 +26,22 @@
   fill: $icon-on-color-disabled;
 }
 
+.#{variables.$block-class}__draggable-underlay {
+  position: absolute;
+  width: 100%;
+}
+
+.#{variables.$block-class}__draggable-underlay-item {
+  // must match draggable item size
+  width: 100%;
+  height: $spacing-09;
+  border: 2px dashed $focus;
+  /* stylelint-disable-next-line carbon/theme-token-use */
+  background-color: colors.$blue-10; // not good in dark mode
+}
+
 .#{variables.$block-class}__draggable-handleHolder {
+  position: relative; // above underlay
   display: flex;
   height: $spacing-09;
   border-bottom: 1px solid $layer-active;
@@ -37,7 +52,15 @@
   background-color: $layer-hover;
 }
 
+.#{variables.$block-class}--dragging {
+  /* stylelint-disable-next-line declaration-no-important */
+  top: auto !important; /* fixes out of position drag drop in react-beautiful-dnd */
+  /* stylelint-disable-next-line declaration-no-important */
+  left: auto !important; /* fixes out of position drag drop in react-beautiful-dnd */
+}
+
 .#{variables.$block-class}__draggable-handleHolder-selected {
+  position: relative; // pull above underlay
   display: flex;
   height: $spacing-09;
   border-bottom: 1px solid $layer-active;
@@ -46,12 +69,6 @@
 
 .#{variables.$block-class}__draggable-handleHolder-selected:hover {
   background-color: $layer-selected-hover-01;
-}
-
-.#{variables.$block-class}__draggable-handleHolder-isOver {
-  border: 2px dashed $focus;
-  /* stylelint-disable-next-line carbon/theme-token-use */
-  background-color: colors.$blue-10;
 }
 
 .#{variables.$block-class}__draggable-handleHolder-droppable {

--- a/packages/ibm-products/src/components/Datagrid/styles/_draggableElement.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_draggableElement.scss
@@ -15,7 +15,6 @@
   display: flex;
   align-items: center;
   margin-right: $spacing-03;
-  cursor: grab;
 }
 
 .#{variables.$block-class}__draggable-handleStyle.disabled {
@@ -46,6 +45,7 @@
   height: $spacing-09;
   border-bottom: 1px solid $layer-active;
   background-color: $layer;
+  cursor: grab;
 }
 
 .#{variables.$block-class}__draggable-handleHolder:hover {
@@ -63,10 +63,14 @@
 
 .#{variables.$block-class}__draggable-handleHolder--dragging {
   z-index: 2; // raise above other items in draggable list
-
   background-color: $highlight;
   color: $text-primary;
   outline: none;
+}
+
+.#{variables.$block-class}__draggable-handleHolder:active,
+.#{variables.$block-class}__draggable-handleHolder--dragging {
+  cursor: grabbing;
 }
 
 .#{variables.$block-class}__draggable-handleHolder-selected:hover {

--- a/packages/ibm-products/src/components/Datagrid/styles/_draggableElement.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_draggableElement.scss
@@ -52,18 +52,20 @@
   background-color: $layer-hover;
 }
 
-.#{variables.$block-class}--dragging {
+.#{variables.$block-class}__draggable-handleHolder:focus {
+  box-shadow: inset 0 0 0 1px $focus;
+  outline: none;
+}
+
+.#{variables.$block-class}__draggable-handleHolder--dragging {
   /* stylelint-disable-next-line declaration-no-important */
   top: auto !important; /* fixes out of position drag drop in react-beautiful-dnd */
   /* stylelint-disable-next-line declaration-no-important */
   left: auto !important; /* fixes out of position drag drop in react-beautiful-dnd */
+  outline: none;
 }
 
-.#{variables.$block-class}__draggable-handleHolder-selected {
-  position: relative; // pull above underlay
-  display: flex;
-  height: $spacing-09;
-  border-bottom: 1px solid $layer-active;
+.#{variables.$block-class}__draggable-handleHolder--selected {
   background-color: $layer-selected;
 }
 
@@ -86,7 +88,7 @@
   transition: opacity $duration-moderate-01 motion(entrance, productive);
 }
 
-.#{variables.$block-class}__draggable-handleHolder-grabbed {
+.#{variables.$block-class}__draggable-handleHolder--grabbed {
   background-color: $highlight;
   color: $text-primary;
 }

--- a/packages/ibm-products/src/global/js/hooks/useWindowScroll.js
+++ b/packages/ibm-products/src/global/js/hooks/useWindowScroll.js
@@ -74,6 +74,7 @@ export function useWindowScroll(effect, deps, throttleInterval = 0) {
 
 export function useNearestScroll(ref, effect, deps, throttle = 0) {
   let scrollableTarget = scrollableAncestor(ref.current);
+  console.log(scrollableTarget, ref.current);
   if (
     scrollableTarget &&
     (document.body === scrollableTarget ||
@@ -82,4 +83,8 @@ export function useNearestScroll(ref, effect, deps, throttle = 0) {
     scrollableTarget = window;
   }
   return useTargetScroll(scrollableTarget, effect, deps, throttle);
+}
+
+export function useScroll(ref, effect, deps, throttle = 0) {
+  return useTargetScroll(ref?.current ?? null, effect, deps, throttle);
 }

--- a/packages/ibm-products/src/global/js/hooks/useWindowScroll.js
+++ b/packages/ibm-products/src/global/js/hooks/useWindowScroll.js
@@ -74,7 +74,6 @@ export function useWindowScroll(effect, deps, throttleInterval = 0) {
 
 export function useNearestScroll(ref, effect, deps, throttle = 0) {
   let scrollableTarget = scrollableAncestor(ref.current);
-  console.log(scrollableTarget, ref.current);
   if (
     scrollableTarget &&
     (document.body === scrollableTarget ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -1608,15 +1608,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.15.4":
-  version: 7.23.0
-  resolution: "@babel/runtime@npm:7.23.0"
-  dependencies:
-    regenerator-runtime: ^0.14.0
-  checksum: c1bcba6ed90de50bb98359f6764a1f1e255c7840280d08897f52bc8a87f3743a9a1b321ada2d7743fcedb5ac45b689fff283fb74f080293263799adc5e465e0b
-  languageName: node
-  linkType: hard
-
 "@babel/template@npm:^7.22.5, @babel/template@npm:^7.3.3":
   version: 7.22.5
   resolution: "@babel/template@npm:7.22.5"
@@ -2678,6 +2669,55 @@ __metadata:
   version: 0.5.7
   resolution: "@discoveryjs/json-ext@npm:0.5.7"
   checksum: 2176d301cc258ea5c2324402997cf8134ebb212469c0d397591636cea8d3c02f2b3cf9fd58dcb748c7a0dade77ebdc1b10284fa63e608c033a1db52fddc69918
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/accessibility@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "@dnd-kit/accessibility@npm:3.0.1"
+  dependencies:
+    tslib: ^2.0.0
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 0afc2c0fce9a1c107453620ca0da1778f182d340e74ffbc6e369ef0ac8943cafb929d3a6c0891d9b915aa23b2b92137ff4fad958f43118466586d8129a3359d5
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/core@npm:^6.0.8":
+  version: 6.0.8
+  resolution: "@dnd-kit/core@npm:6.0.8"
+  dependencies:
+    "@dnd-kit/accessibility": ^3.0.0
+    "@dnd-kit/utilities": ^3.2.1
+    tslib: ^2.0.0
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: abe48ff7395f84fd8c15e6c8b13da4df153dc1f1076096d783acd0c25539516c77e4854ea59be6621dde55739cb0df1d62924ad069df3267fe05ad90ef729b2f
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/sortable@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "@dnd-kit/sortable@npm:7.0.2"
+  dependencies:
+    "@dnd-kit/utilities": ^3.2.0
+    tslib: ^2.0.0
+  peerDependencies:
+    "@dnd-kit/core": ^6.0.7
+    react: ">=16.8.0"
+  checksum: 4ce705aceb15766a0deefe25a9d95a87e9413c3fb9088ea3eb0962e57f844895000117fcec7c0944a0d4ae4e1e889cfa69e3d3778164d4d23115fb1edb218283
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/utilities@npm:^3.2.0, @dnd-kit/utilities@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "@dnd-kit/utilities@npm:3.2.1"
+  dependencies:
+    tslib: ^2.0.0
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 038fd5cc1328bf4c9dca17cd48046e5a687bbf9d904c7197f851aab869ab52d9dee2734b2e255256fd6158245acd00063a23deed962c7673c0fadfbf061f04ca
   languageName: node
   linkType: hard
 
@@ -6059,16 +6099,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/hoist-non-react-statics@npm:^3.3.0":
-  version: 3.3.2
-  resolution: "@types/hoist-non-react-statics@npm:3.3.2"
-  dependencies:
-    "@types/react": "*"
-    hoist-non-react-statics: ^3.3.0
-  checksum: fe5d4b751e13f56010811fd6c4e49e53e2ccbcbbdc54bb8d86a413fbd08c5a83311bca9ef75a1a88d3ba62806711b5dea3f323c0e0f932b3a283dcebc3240238
-  languageName: node
-  linkType: hard
-
 "@types/html-minifier-terser@npm:^6.0.0":
   version: 6.1.0
   resolution: "@types/html-minifier-terser@npm:6.1.0"
@@ -6300,18 +6330,6 @@ __metadata:
   dependencies:
     "@types/react": "*"
   checksum: e02ea908289a7ad26053308248d2b87f6aeafd73d0e2de2a3d435947bcea0422599016ffd1c3e38ff36c42f5e1c87c7417f05b0a157e48649e4a02f21727d54f
-  languageName: node
-  linkType: hard
-
-"@types/react-redux@npm:^7.1.20":
-  version: 7.1.26
-  resolution: "@types/react-redux@npm:7.1.26"
-  dependencies:
-    "@types/hoist-non-react-statics": ^3.3.0
-    "@types/react": "*"
-    hoist-non-react-statics: ^3.3.0
-    redux: ^4.0.0
-  checksum: 7f299f15ca8790c2e2683ad776ea4cbd5c38247f7a9fbddbc64ff4b235883238c772dc0e2687e328ba690d3b0c6a51b026c5fad719183595df87a91a1060094c
   languageName: node
   linkType: hard
 
@@ -9524,15 +9542,6 @@ __metadata:
     cspell: bin.mjs
     cspell-esm: bin.mjs
   checksum: d9d7736fbbabec7fa7ba0aa3feef06f964254ffdf2c75f3fb3d3c93cd867988899d662ea310078ed1fcf1197e1f060d333d43e78f66cbe41ce1d6b606d20426a
-  languageName: node
-  linkType: hard
-
-"css-box-model@npm:^1.2.0":
-  version: 1.2.1
-  resolution: "css-box-model@npm:1.2.1"
-  dependencies:
-    tiny-invariant: ^1.0.6
-  checksum: 4d113f26fed6b9150e2c314502d00dabe06f12ae43a01a7e9b6e57f3de49b4281dbb0dc46a1158a7349618f8f34d9250af57cb43d7337e9485e73e6b821e470e
   languageName: node
   linkType: hard
 
@@ -12898,15 +12907,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
-  version: 3.3.2
-  resolution: "hoist-non-react-statics@npm:3.3.2"
-  dependencies:
-    react-is: ^16.7.0
-  checksum: b1538270429b13901ee586aa44f4cc3ecd8831c061d06cb8322e50ea17b3f5ce4d0e2e66394761e6c8e152cd8c34fb3b4b690116c6ce2bd45b18c746516cb9e8
-  languageName: node
-  linkType: hard
-
 "hosted-git-info@npm:^2.1.4":
   version: 2.8.9
   resolution: "hosted-git-info@npm:2.8.9"
@@ -13157,6 +13157,9 @@ __metadata:
     "@babel/eslint-parser": ^7.22.10
     "@commitlint/cli": ^17.7.1
     "@commitlint/config-conventional": ^17.7.0
+    "@dnd-kit/core": ^6.0.8
+    "@dnd-kit/sortable": ^7.0.2
+    "@dnd-kit/utilities": ^3.2.1
     "@testing-library/dom": ^8.11.4
     "@testing-library/react": ^14.0.0
     "@testing-library/react-hooks": ^8.0.1
@@ -13178,7 +13181,6 @@ __metadata:
     prettier: ^2.8.8
     prettier-config-carbon: ^0.11.0
     react: ^18.2.0
-    react-beautiful-dnd: ^13.1.1
     react-dom: ^18.2.0
     rimraf: ^5.0.1
     stylelint: ^15.10.2
@@ -16108,7 +16110,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"memoize-one@npm:>=3.1.1 <6, memoize-one@npm:^5.1.1":
+"memoize-one@npm:>=3.1.1 <6":
   version: 5.2.1
   resolution: "memoize-one@npm:5.2.1"
   checksum: a3cba7b824ebcf24cdfcd234aa7f86f3ad6394b8d9be4c96ff756dafb8b51c7f71320785fbc2304f1af48a0467cbbd2a409efc9333025700ed523f254cb52e3d
@@ -19115,13 +19117,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"raf-schd@npm:^4.0.2":
-  version: 4.0.3
-  resolution: "raf-schd@npm:4.0.3"
-  checksum: 45514041c5ad31fa96aef3bb3c572a843b92da2f2cd1cb4a47c9ad58e48761d3a4126e18daa32b2bfa0bc2551a42d8f324a0e40e536cb656969929602b4e8b58
-  languageName: node
-  linkType: hard
-
 "ramda@npm:0.29.0":
   version: 0.29.0
   resolution: "ramda@npm:0.29.0"
@@ -19180,24 +19175,6 @@ __metadata:
   bin:
     rc: ./cli.js
   checksum: 2e26e052f8be2abd64e6d1dabfbd7be03f80ec18ccbc49562d31f617d0015fbdbcf0f9eed30346ea6ab789e0fdfe4337f033f8016efdbee0df5354751842080e
-  languageName: node
-  linkType: hard
-
-"react-beautiful-dnd@npm:^13.1.1":
-  version: 13.1.1
-  resolution: "react-beautiful-dnd@npm:13.1.1"
-  dependencies:
-    "@babel/runtime": ^7.9.2
-    css-box-model: ^1.2.0
-    memoize-one: ^5.1.1
-    raf-schd: ^4.0.2
-    react-redux: ^7.2.0
-    redux: ^4.0.4
-    use-memo-one: ^1.1.1
-  peerDependencies:
-    react: ^16.8.5 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.5 || ^17.0.0 || ^18.0.0
-  checksum: 5f90f7c0ab77a14dfcd496cbd94bbde457612f380c6fc815f3bba7b52effd75132948fcaa661a902a184bb1e6ae5896dcf5b0c77c4ddf809a2c65288f3eed5a7
   languageName: node
   linkType: hard
 
@@ -19293,7 +19270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1, react-is@npm:^16.7.0":
+"react-is@npm:^16.13.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
@@ -19311,27 +19288,6 @@ __metadata:
   version: 18.2.0
   resolution: "react-is@npm:18.2.0"
   checksum: e72d0ba81b5922759e4aff17e0252bd29988f9642ed817f56b25a3e217e13eea8a7f2322af99a06edb779da12d5d636e9fda473d620df9a3da0df2a74141d53e
-  languageName: node
-  linkType: hard
-
-"react-redux@npm:^7.2.0":
-  version: 7.2.9
-  resolution: "react-redux@npm:7.2.9"
-  dependencies:
-    "@babel/runtime": ^7.15.4
-    "@types/react-redux": ^7.1.20
-    hoist-non-react-statics: ^3.3.2
-    loose-envify: ^1.4.0
-    prop-types: ^15.7.2
-    react-is: ^17.0.2
-  peerDependencies:
-    react: ^16.8.3 || ^17 || ^18
-  peerDependenciesMeta:
-    react-dom:
-      optional: true
-    react-native:
-      optional: true
-  checksum: 369a2bdcf87915659af9e5c55abfd9f52a84e43e0d12dcc108ed17dbe6933558b7b7fc12caa9c10c1a10a8be7df89454b6c96989d8573fedec1a772c94a1f145
   languageName: node
   linkType: hard
 
@@ -19674,15 +19630,6 @@ __metadata:
     indent-string: ^5.0.0
     strip-indent: ^4.0.0
   checksum: 6944e7b1d8f3fd28c2515f5c605b9f7f0ea0f4edddf41890bbbdd4d9ee35abb7540c3b278f03ff827bd278bb6ff4a5bd8692ca406b748c5c1c3ce7355e9fbf8f
-  languageName: node
-  linkType: hard
-
-"redux@npm:^4.0.0, redux@npm:^4.0.4":
-  version: 4.2.1
-  resolution: "redux@npm:4.2.1"
-  dependencies:
-    "@babel/runtime": ^7.9.2
-  checksum: f63b9060c3a1d930ae775252bb6e579b42415aee7a23c4114e21a0b4ba7ec12f0ec76936c00f546893f06e139819f0e2855e0d55ebfce34ca9c026241a6950dd
   languageName: node
   linkType: hard
 
@@ -21964,7 +21911,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-invariant@npm:^1.0.6, tiny-invariant@npm:^1.3.1":
+"tiny-invariant@npm:^1.3.1":
   version: 1.3.1
   resolution: "tiny-invariant@npm:1.3.1"
   checksum: 872dbd1ff20a21303a2fd20ce3a15602cfa7fcf9b228bd694a52e2938224313b5385a1078cb667ed7375d1612194feaca81c4ecbe93121ca1baebe344de4f84c
@@ -22801,15 +22748,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 7913df383a5a6fcb399212eedefaac2e0c6f843555202d4e3010bac3848afe38ecaa3d0d6500ad1d936fbeffd637e6c517e68edb024af5e6beca7f27f3ce7b21
-  languageName: node
-  linkType: hard
-
-"use-memo-one@npm:^1.1.1":
-  version: 1.1.3
-  resolution: "use-memo-one@npm:1.1.3"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 8f08eba26d69406b61bb4b8dacdd5a92bd6aef5b53d346dfe87954f7330ee10ecabc937cc7854635155d46053828e85c10b5a5aff7a04720e6a97b9f42999bac
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1608,6 +1608,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.15.4":
+  version: 7.23.0
+  resolution: "@babel/runtime@npm:7.23.0"
+  dependencies:
+    regenerator-runtime: ^0.14.0
+  checksum: c1bcba6ed90de50bb98359f6764a1f1e255c7840280d08897f52bc8a87f3743a9a1b321ada2d7743fcedb5ac45b689fff283fb74f080293263799adc5e465e0b
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.22.5, @babel/template@npm:^7.3.3":
   version: 7.22.5
   resolution: "@babel/template@npm:7.22.5"
@@ -6050,6 +6059,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/hoist-non-react-statics@npm:^3.3.0":
+  version: 3.3.2
+  resolution: "@types/hoist-non-react-statics@npm:3.3.2"
+  dependencies:
+    "@types/react": "*"
+    hoist-non-react-statics: ^3.3.0
+  checksum: fe5d4b751e13f56010811fd6c4e49e53e2ccbcbbdc54bb8d86a413fbd08c5a83311bca9ef75a1a88d3ba62806711b5dea3f323c0e0f932b3a283dcebc3240238
+  languageName: node
+  linkType: hard
+
 "@types/html-minifier-terser@npm:^6.0.0":
   version: 6.1.0
   resolution: "@types/html-minifier-terser@npm:6.1.0"
@@ -6281,6 +6300,18 @@ __metadata:
   dependencies:
     "@types/react": "*"
   checksum: e02ea908289a7ad26053308248d2b87f6aeafd73d0e2de2a3d435947bcea0422599016ffd1c3e38ff36c42f5e1c87c7417f05b0a157e48649e4a02f21727d54f
+  languageName: node
+  linkType: hard
+
+"@types/react-redux@npm:^7.1.20":
+  version: 7.1.26
+  resolution: "@types/react-redux@npm:7.1.26"
+  dependencies:
+    "@types/hoist-non-react-statics": ^3.3.0
+    "@types/react": "*"
+    hoist-non-react-statics: ^3.3.0
+    redux: ^4.0.0
+  checksum: 7f299f15ca8790c2e2683ad776ea4cbd5c38247f7a9fbddbc64ff4b235883238c772dc0e2687e328ba690d3b0c6a51b026c5fad719183595df87a91a1060094c
   languageName: node
   linkType: hard
 
@@ -9493,6 +9524,15 @@ __metadata:
     cspell: bin.mjs
     cspell-esm: bin.mjs
   checksum: d9d7736fbbabec7fa7ba0aa3feef06f964254ffdf2c75f3fb3d3c93cd867988899d662ea310078ed1fcf1197e1f060d333d43e78f66cbe41ce1d6b606d20426a
+  languageName: node
+  linkType: hard
+
+"css-box-model@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "css-box-model@npm:1.2.1"
+  dependencies:
+    tiny-invariant: ^1.0.6
+  checksum: 4d113f26fed6b9150e2c314502d00dabe06f12ae43a01a7e9b6e57f3de49b4281dbb0dc46a1158a7349618f8f34d9250af57cb43d7337e9485e73e6b821e470e
   languageName: node
   linkType: hard
 
@@ -12858,6 +12898,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "hoist-non-react-statics@npm:3.3.2"
+  dependencies:
+    react-is: ^16.7.0
+  checksum: b1538270429b13901ee586aa44f4cc3ecd8831c061d06cb8322e50ea17b3f5ce4d0e2e66394761e6c8e152cd8c34fb3b4b690116c6ce2bd45b18c746516cb9e8
+  languageName: node
+  linkType: hard
+
 "hosted-git-info@npm:^2.1.4":
   version: 2.8.9
   resolution: "hosted-git-info@npm:2.8.9"
@@ -13129,6 +13178,7 @@ __metadata:
     prettier: ^2.8.8
     prettier-config-carbon: ^0.11.0
     react: ^18.2.0
+    react-beautiful-dnd: ^13.1.1
     react-dom: ^18.2.0
     rimraf: ^5.0.1
     stylelint: ^15.10.2
@@ -16058,7 +16108,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"memoize-one@npm:>=3.1.1 <6":
+"memoize-one@npm:>=3.1.1 <6, memoize-one@npm:^5.1.1":
   version: 5.2.1
   resolution: "memoize-one@npm:5.2.1"
   checksum: a3cba7b824ebcf24cdfcd234aa7f86f3ad6394b8d9be4c96ff756dafb8b51c7f71320785fbc2304f1af48a0467cbbd2a409efc9333025700ed523f254cb52e3d
@@ -19065,6 +19115,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"raf-schd@npm:^4.0.2":
+  version: 4.0.3
+  resolution: "raf-schd@npm:4.0.3"
+  checksum: 45514041c5ad31fa96aef3bb3c572a843b92da2f2cd1cb4a47c9ad58e48761d3a4126e18daa32b2bfa0bc2551a42d8f324a0e40e536cb656969929602b4e8b58
+  languageName: node
+  linkType: hard
+
 "ramda@npm:0.29.0":
   version: 0.29.0
   resolution: "ramda@npm:0.29.0"
@@ -19123,6 +19180,24 @@ __metadata:
   bin:
     rc: ./cli.js
   checksum: 2e26e052f8be2abd64e6d1dabfbd7be03f80ec18ccbc49562d31f617d0015fbdbcf0f9eed30346ea6ab789e0fdfe4337f033f8016efdbee0df5354751842080e
+  languageName: node
+  linkType: hard
+
+"react-beautiful-dnd@npm:^13.1.1":
+  version: 13.1.1
+  resolution: "react-beautiful-dnd@npm:13.1.1"
+  dependencies:
+    "@babel/runtime": ^7.9.2
+    css-box-model: ^1.2.0
+    memoize-one: ^5.1.1
+    raf-schd: ^4.0.2
+    react-redux: ^7.2.0
+    redux: ^4.0.4
+    use-memo-one: ^1.1.1
+  peerDependencies:
+    react: ^16.8.5 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.5 || ^17.0.0 || ^18.0.0
+  checksum: 5f90f7c0ab77a14dfcd496cbd94bbde457612f380c6fc815f3bba7b52effd75132948fcaa661a902a184bb1e6ae5896dcf5b0c77c4ddf809a2c65288f3eed5a7
   languageName: node
   linkType: hard
 
@@ -19218,7 +19293,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1":
+"react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
@@ -19236,6 +19311,27 @@ __metadata:
   version: 18.2.0
   resolution: "react-is@npm:18.2.0"
   checksum: e72d0ba81b5922759e4aff17e0252bd29988f9642ed817f56b25a3e217e13eea8a7f2322af99a06edb779da12d5d636e9fda473d620df9a3da0df2a74141d53e
+  languageName: node
+  linkType: hard
+
+"react-redux@npm:^7.2.0":
+  version: 7.2.9
+  resolution: "react-redux@npm:7.2.9"
+  dependencies:
+    "@babel/runtime": ^7.15.4
+    "@types/react-redux": ^7.1.20
+    hoist-non-react-statics: ^3.3.2
+    loose-envify: ^1.4.0
+    prop-types: ^15.7.2
+    react-is: ^17.0.2
+  peerDependencies:
+    react: ^16.8.3 || ^17 || ^18
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+    react-native:
+      optional: true
+  checksum: 369a2bdcf87915659af9e5c55abfd9f52a84e43e0d12dcc108ed17dbe6933558b7b7fc12caa9c10c1a10a8be7df89454b6c96989d8573fedec1a772c94a1f145
   languageName: node
   linkType: hard
 
@@ -19578,6 +19674,15 @@ __metadata:
     indent-string: ^5.0.0
     strip-indent: ^4.0.0
   checksum: 6944e7b1d8f3fd28c2515f5c605b9f7f0ea0f4edddf41890bbbdd4d9ee35abb7540c3b278f03ff827bd278bb6ff4a5bd8692ca406b748c5c1c3ce7355e9fbf8f
+  languageName: node
+  linkType: hard
+
+"redux@npm:^4.0.0, redux@npm:^4.0.4":
+  version: 4.2.1
+  resolution: "redux@npm:4.2.1"
+  dependencies:
+    "@babel/runtime": ^7.9.2
+  checksum: f63b9060c3a1d930ae775252bb6e579b42415aee7a23c4114e21a0b4ba7ec12f0ec76936c00f546893f06e139819f0e2855e0d55ebfce34ca9c026241a6950dd
   languageName: node
   linkType: hard
 
@@ -21859,7 +21964,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-invariant@npm:^1.3.1":
+"tiny-invariant@npm:^1.0.6, tiny-invariant@npm:^1.3.1":
   version: 1.3.1
   resolution: "tiny-invariant@npm:1.3.1"
   checksum: 872dbd1ff20a21303a2fd20ce3a15602cfa7fcf9b228bd694a52e2938224313b5385a1078cb667ed7375d1612194feaca81c4ecbe93121ca1baebe344de4f84c
@@ -22696,6 +22801,15 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 7913df383a5a6fcb399212eedefaac2e0c6f843555202d4e3010bac3848afe38ecaa3d0d6500ad1d936fbeffd637e6c517e68edb024af5e6beca7f27f3ce7b21
+  languageName: node
+  linkType: hard
+
+"use-memo-one@npm:^1.1.1":
+  version: 1.1.3
+  resolution: "use-memo-one@npm:1.1.3"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 8f08eba26d69406b61bb4b8dacdd5a92bd6aef5b53d346dfe87954f7330ee10ecabc937cc7854635155d46053828e85c10b5a5aff7a04720e6a97b9f42999bac
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1772,6 +1772,9 @@ __metadata:
     "@babel/core": ^7.22.10
     "@babel/runtime": ^7.22.10
     "@carbon/telemetry": ^0.1.0
+    "@dnd-kit/core": ^6.0.8
+    "@dnd-kit/sortable": ^7.0.2
+    "@dnd-kit/utilities": ^3.2.1
     babel-preset-ibm-cloud-cognitive: ^0.14.39
     chalk: ^4.1.2
     change-case: ^4.1.2
@@ -13157,9 +13160,6 @@ __metadata:
     "@babel/eslint-parser": ^7.22.10
     "@commitlint/cli": ^17.7.1
     "@commitlint/config-conventional": ^17.7.0
-    "@dnd-kit/core": ^6.0.8
-    "@dnd-kit/sortable": ^7.0.2
-    "@dnd-kit/utilities": ^3.2.1
     "@testing-library/dom": ^8.11.4
     "@testing-library/react": ^14.0.0
     "@testing-library/react-hooks": ^8.0.1


### PR DESCRIPTION
Contributes to https://github.com/carbon-design-system/ibm-products/issues/3478

Using dnd-kit.

Probably chopped out more than needed to make sense of this, need to understand if it is working and if we've lost any features.

This works really nice, fewer issues than react-beautiful-dnd and less code. Looks correct on scrolling compared to react-beautiful-dnd.

Only niggle(s)
- Keyboard movement is 25px at a time, not sure why as I think it should be `cell height / 2` reading the code, but I must be missing a rounded pixel somewhere. This is noticeable on longer lists.
- Not visible if dragged out of modal (to be expected).

What did you change?
Datagrid customisable columns

How did you test and verify your work?
Storybook
