### PR TITLE
fix(DataGrid): remove td bottom border when state is empty and tr hover

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
@@ -288,6 +288,7 @@
 }
 
 .#{$block-class}__empty-state .#{$block-class}__table-simple tr:hover td {
+  border-bottom: none;
   background: transparent;
 }
 


### PR DESCRIPTION
Contributes to #3483, is an addendum to PR #3498

Removed <td> bottom border when table shows an empty state _and the user mouseovers the table row_.

#### What did you change?

Updated SCSS

#### How did you test and verify your work?

- [x] Verified in Storybook
- [x] Verified by @youngjunekoh
