### PR TITLE
chore(Datagrid): address layout of expander icon button

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -84,7 +84,7 @@ export const DatagridContent = ({ datagridState, title }) => {
           { [`${blockClass}__table-grid-active`]: gridActive },
           getTableProps()?.className
         )}
-        role={withInlineEdit && 'grid'}
+        role={withInlineEdit ? 'grid' : undefined}
         tabIndex={withInlineEdit ? 0 : -1}
         onKeyDown={
           withInlineEdit

--- a/packages/ibm-products/src/components/Datagrid/styles/_useExpandedRow.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_useExpandedRow.scss
@@ -52,6 +52,7 @@
   width: $spacing-07;
   height: $spacing-07;
   min-height: $spacing-07;
+  align-items: center;
   justify-content: center;
   padding: 0;
   .#{variables.$block-class}__row-expander--icon {


### PR DESCRIPTION
Contributes to #3506 

Small styling update to address the layout of the row expander, used for both nested and expandable rows. I also included a fix for a console error we've had about how we've specified a `role` attribute.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
packages/ibm-products/src/components/Datagrid/styles/_useExpandedRow.scss
```
#### How did you test and verify your work?
Storybook