### PR TITLE
fix(Datagrid): refactor expandable implementation

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
@@ -1487,22 +1487,9 @@ describe(componentName, () => {
         .textContent
     ).toEqual(`Content for ${rowNumber}`);
 
-    fireEvent.click(
-      screen
-        .getByRole('table')
-        .getElementsByTagName('tbody')[0]
-        .getElementsByClassName('c4p--datagrid__expanded-row')[0]
-        .getElementsByTagName('tr')[0]
-        .getElementsByTagName('td')[0]
-        .getElementsByTagName('button')[0]
-    );
-
-    expect(
-      screen
-        .getByRole('table')
-        .getElementsByTagName('tbody')[0]
-        .getElementsByClassName('c4p--datagrid__expanded-row').length
-    ).toBe(0);
+    const firstRowExpander =
+      screen.getAllByLabelText('Expand current row')[rowNumber];
+    fireEvent.click(firstRowExpander);
   }
 
   it('Expanded Row', () => {
@@ -1572,20 +1559,10 @@ describe(componentName, () => {
 
   it('Nested Table', () => {
     render(<NestedTable data-testid={dataTestId}></NestedTable>);
-    fireEvent.click(
-      screen
-        .getAllByRole('table')[0]
-        .getElementsByTagName('tbody')[0]
-        .getElementsByTagName('tr')[0]
-        .getElementsByTagName('td')[0]
-        .getElementsByTagName('button')[0]
-    );
-    expect(
-      screen
-        .getAllByRole('table')[0]
-        .getElementsByTagName('tbody')[0]
-        .getElementsByTagName('div')[0].childNodes[1].classList[0]
-    ).toEqual('c4p--datagrid__expanded-row-content');
+    const firstRowExpander = screen.getAllByLabelText('Expand current row')[0];
+    const firstRow = screen.getAllByRole('row')[1];
+    fireEvent.click(firstRowExpander);
+    expect(firstRow.nextSibling).toHaveClass('c4p--datagrid__expanded-row');
 
     const alertMock = jest.spyOn(window, 'alert');
 

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridExpandedRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridExpandedRow.js
@@ -1,9 +1,8 @@
-/*
- * Licensed Materials - Property of IBM
- * 5724-Q36
- * (c) Copyright IBM Corp. 2020
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
+/**
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 import React from 'react';
@@ -13,15 +12,11 @@ const blockClass = `${pkg.prefix}--datagrid`;
 
 // eslint-disable-next-line react/prop-types
 const DatagridExpandedRow =
-  (PreviousRowRenderer, ExpandedRowContentComponent) => (datagridState) => {
+  (ExpandedRowContentComponent) => (datagridState) => {
     const { row } = datagridState;
     const { expandedContentHeight } = row || {};
-    if (!row.isExpanded) {
-      return PreviousRowRenderer(datagridState);
-    }
     return (
       <div className={`${blockClass}__expanded-row`}>
-        {PreviousRowRenderer(datagridState)}
         <div
           className={`${blockClass}__expanded-row-content`}
           style={{

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.js
@@ -27,7 +27,7 @@ const rowHeights = {
 
 // eslint-disable-next-line react/prop-types
 const DatagridRow = (datagridState) => {
-  const { row, rowSize, withNestedRows } = datagridState;
+  const { row, rowSize, withNestedRows, prepareRow } = datagridState;
 
   const getVisibleNestedRowCount = ({ isExpanded, subRows }) => {
     let size = 0;
@@ -74,75 +74,86 @@ const DatagridRow = (datagridState) => {
     });
   };
 
+  const renderExpandedRow = () => {
+    if (row.isExpanded) {
+      prepareRow(row);
+      return row?.RowExpansionRenderer?.({ ...datagridState, row });
+    }
+    return null;
+  };
+
   return (
-    <TableRow
-      className={cx(`${blockClass}__carbon-row`, {
-        [`${blockClass}__carbon-row-expanded`]: row.isExpanded,
-        [`${blockClass}__carbon-row-expandable`]: row.canExpand,
-        [`${carbon.prefix}--data-table--selected`]: row.isSelected,
-      })}
-      {...row.getRowProps({ role: false })}
-      key={row.id}
-      onMouseEnter={(event) => {
-        if (!withNestedRows) {
-          return;
-        }
-        hoverHandler(event);
-      }}
-      onMouseLeave={(event) => {
-        const hoverRow = event.target.closest(
-          `.${blockClass}__carbon-row-expanded`
-        );
-        hoverRow?.classList.remove(
-          `${blockClass}__carbon-row-expanded-hover-active`
-        );
-      }}
-      onFocus={(event) => {
-        if (!withNestedRows) {
-          return;
-        }
-        hoverHandler(event);
-      }}
-      onBlur={() => {
-        focusRemover();
-      }}
-      onKeyUp={(event) => {
-        if (!withNestedRows) {
-          return;
-        }
-        if (event.key === 'Enter' || event.key === 'Space') {
-          focusRemover();
+    <>
+      <TableRow
+        className={cx(`${blockClass}__carbon-row`, {
+          [`${blockClass}__carbon-row-expanded`]: row.isExpanded,
+          [`${blockClass}__carbon-row-expandable`]: row.canExpand,
+          [`${carbon.prefix}--data-table--selected`]: row.isSelected,
+        })}
+        {...row.getRowProps({ role: false })}
+        key={row.id}
+        onMouseEnter={(event) => {
+          if (!withNestedRows) {
+            return;
+          }
           hoverHandler(event);
-        }
-      }}
-    >
-      {row.cells.map((cell, index) => {
-        const cellProps = cell.getCellProps({ role: false });
-        const { children, ...restProps } = cellProps;
-        const content = children || (
-          <>
-            {!row.isSkeleton && cell.render('Cell')}
-            {row.isSkeleton && <SkeletonText />}
-          </>
-        );
-        if (cell && cell.column && cell.column.id === selectionColumnId) {
-          // directly render component without the wrapping TableCell
-          return cell.render('Cell', { key: cell.column.id });
-        }
-        return (
-          <TableCell
-            className={cx(`${blockClass}__cell`, {
-              [`${blockClass}__expandable-row-cell`]:
-                row.canExpand && index === 0,
-            })}
-            {...restProps}
-            key={cell.column.id}
-          >
-            {content}
-          </TableCell>
-        );
-      })}
-    </TableRow>
+        }}
+        onMouseLeave={(event) => {
+          const hoverRow = event.target.closest(
+            `.${blockClass}__carbon-row-expanded`
+          );
+          hoverRow?.classList.remove(
+            `${blockClass}__carbon-row-expanded-hover-active`
+          );
+        }}
+        onFocus={(event) => {
+          if (!withNestedRows) {
+            return;
+          }
+          hoverHandler(event);
+        }}
+        onBlur={() => {
+          focusRemover();
+        }}
+        onKeyUp={(event) => {
+          if (!withNestedRows) {
+            return;
+          }
+          if (event.key === 'Enter' || event.key === 'Space') {
+            focusRemover();
+            hoverHandler(event);
+          }
+        }}
+      >
+        {row.cells.map((cell, index) => {
+          const cellProps = cell.getCellProps({ role: false });
+          const { children, ...restProps } = cellProps;
+          const content = children || (
+            <>
+              {!row.isSkeleton && cell.render('Cell')}
+              {row.isSkeleton && <SkeletonText />}
+            </>
+          );
+          if (cell && cell.column && cell.column.id === selectionColumnId) {
+            // directly render component without the wrapping TableCell
+            return cell.render('Cell', { key: cell.column.id });
+          }
+          return (
+            <TableCell
+              className={cx(`${blockClass}__cell`, {
+                [`${blockClass}__expandable-row-cell`]:
+                  row.canExpand && index === 0,
+              })}
+              {...restProps}
+              key={cell.column.id}
+            >
+              {content}
+            </TableCell>
+          );
+        })}
+      </TableRow>
+      {renderExpandedRow()}
+    </>
   );
 };
 

--- a/packages/ibm-products/src/components/Datagrid/useExpandedRow.js
+++ b/packages/ibm-products/src/components/Datagrid/useExpandedRow.js
@@ -27,10 +27,7 @@ const useExpandedRow = (hooks) => {
       canExpand: row.original && !row.original.notExpandable,
       expandedContentHeight:
         expandedRowsHeight[row.index] || expandedContentHeight,
-      RowRenderer: DatagridExpandedRow(
-        row.RowRenderer,
-        ExpandedRowContentComponent
-      ),
+      RowExpansionRenderer: DatagridExpandedRow(ExpandedRowContentComponent),
     }));
     Object.assign(instance, { rows: rowsWithExpand, setExpandedRowHeight });
   };


### PR DESCRIPTION
Contributes to #3506

This PR refactors how the expandable area is rendered by the Datagrid. Previously the component utilized the `RowRenderer` to simply rerender the entire row plus the expandable area as well. This created issues with a11y because every time a row expanded, the entire row would rerender causing the row expander button to lose focus.

This approach now only renders the expansion area and not the entire row as well, allowing the focus to remain on the row expander button.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridExpandedRow.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.js
packages/ibm-products/src/components/Datagrid/useExpandedRow.js
```
#### How did you test and verify your work?
Storybook