### PR TITLE
fix(DataGrid): remove td bottom border when state is empty (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridEmptyBody.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridEmptyBody.js
@@ -46,7 +46,10 @@ const DatagridEmptyBody = (datagridState) => {
       className={`${blockClass}__empty-state-body`}
     >
       <TableRow>
-        <TableCell colSpan={headers.length}>
+        <TableCell
+          colSpan={headers.length}
+          className={`${blockClass}__empty-state-cell`}
+        >
           {emptyStateType === 'error' && (
             <ErrorEmptyState {...emptyStateProps} />
           )}

--- a/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
@@ -288,6 +288,7 @@
 }
 
 .#{$block-class}__empty-state .#{$block-class}__table-simple tr:hover td {
+  border-bottom: none;
   background: transparent;
 }
 
@@ -297,6 +298,10 @@
 
 .#{$block-class}__empty-state .#{$block-class}__grid-container {
   flex: 1 1 auto;
+}
+
+.#{$block-class}__empty-state .#{$block-class}__empty-state-cell {
+  border-bottom: none;
 }
 
 .#{$block-class}__resizer {


### PR DESCRIPTION
v1 accompanying PR from @paul-balchin-ibm's initial work to fix this issue

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridEmptyBody.js
packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
```
#### How did you test and verify your work?
Storybook