### PR TITLE
chore(Datagrid): remove warning about drag and drop rework

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
@@ -8,7 +8,6 @@
 
 import React, { useState } from 'react';
 import { Checkmark, Edit, TrashCan } from '@carbon/react/icons';
-import { ActionableNotification } from '@carbon/react';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,
@@ -50,36 +49,6 @@ export default {
     },
   },
 };
-
-const CustomizeColRework = () => (
-  <ActionableNotification
-    className="preview__notification--feature-flag"
-    kind="warning"
-    inline
-    lowContrast
-    actionButtonLabel="Learn more"
-    statusIconDescription="Close icon button"
-    title={
-      <>
-        This extension is currently being reworked after{' '}
-        <CodeSnippet type="inline" hideCopyButton>
-          2.8.1
-        </CodeSnippet>
-      </>
-    }
-    onActionButtonClick={() => {
-      window.open(
-        'https://github.com/carbon-design-system/ibm-products/issues/3446'
-      );
-    }}
-  >
-    Support will be added back shortly and can be tracked{' '}
-    <a href="https://github.com/carbon-design-system/ibm-products/issues/3446">
-      here
-    </a>
-    .
-  </ActionableNotification>
-);
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
@@ -247,7 +216,6 @@ const ColumnCustomizationUsage = ({ ...args }) => {
 
   return (
     <>
-      <CustomizeColRework />
       <Datagrid datagridState={datagridState} />
       <div className={`${blockClass}-story__hidden-column-id-snippet`}>
         <p>Hidden column ids:</p>
@@ -362,7 +330,6 @@ const ColumnCustomizationWithFixedColumn = ({ ...args }) => {
 
   return (
     <>
-      <CustomizeColRework />
       <Datagrid datagridState={datagridState} />
       <div className={`${blockClass}-story__hidden-column-id-snippet`}>
         <p>Hidden column ids:</p>


### PR DESCRIPTION
Contributes to https://github.com/carbon-design-system/ibm-products/issues/3478

We can safely remove the warning notification we added on the ColumnCustomization story for the Datagrid now that we have the `dnd-kit` approach merged. Thanks to @lee-chase! 🥳 🎉 

#### What did you change?
Removed notification from ColumnCustomization story
#### How did you test and verify your work?
Storybook