### PR TITLE
fix(Datagrid): expandable row add background on row hover

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridExpandedRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridExpandedRow.js
@@ -15,8 +15,28 @@ const DatagridExpandedRow =
   (ExpandedRowContentComponent) => (datagridState) => {
     const { row } = datagridState;
     const { expandedContentHeight } = row || {};
+
+    const toggleParentHoverClass = (event, eventType) => {
+      if (
+        event &&
+        event.target &&
+        event.target.parentNode.previousElementSibling
+      ) {
+        const parentNode = event.target.parentNode.previousElementSibling;
+        if (eventType === 'enter') {
+          parentNode.classList.add(`${blockClass}__expandable-row--hover`);
+        } else {
+          parentNode.classList.remove(`${blockClass}__expandable-row--hover`);
+        }
+      }
+    };
+
     return (
-      <div className={`${blockClass}__expanded-row`}>
+      <tr
+        className={`${blockClass}__expanded-row`}
+        onMouseEnter={(event) => toggleParentHoverClass(event, 'enter')}
+        onMouseLeave={(event) => toggleParentHoverClass(event)}
+      >
         <div
           className={`${blockClass}__expanded-row-content`}
           style={{
@@ -25,7 +45,7 @@ const DatagridExpandedRow =
         >
           {ExpandedRowContentComponent(datagridState)}
         </div>
-      </div>
+      </tr>
     );
   };
 

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridExpandedRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridExpandedRow.js
@@ -17,11 +17,7 @@ const DatagridExpandedRow =
     const { expandedContentHeight } = row || {};
 
     const toggleParentHoverClass = (event, eventType) => {
-      if (
-        event &&
-        event.target &&
-        event.target.parentNode.previousElementSibling
-      ) {
+      if (event?.target?.parentNode?.previousElementSibling) {
         const parentNode = event.target.parentNode.previousElementSibling;
         if (eventType === 'enter') {
           parentNode.classList.add(`${blockClass}__expandable-row--hover`);

--- a/packages/ibm-products/src/components/Datagrid/styles/_useExpandedRow.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_useExpandedRow.scss
@@ -65,6 +65,9 @@
   tbody
   tr:hover
   + .#{variables.$block-class}__expanded-row,
-.#{variables.$block-class} .#{variables.$block-class}__expanded-row:hover {
+.#{variables.$block-class} .#{variables.$block-class}__expanded-row:hover,
+.#{variables.$block-class}
+  .#{variables.$block-class}__expandable-row--hover
+  td {
   background: $layer-hover;
 }

--- a/packages/ibm-products/src/components/Datagrid/styles/_useExpandedRow.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_useExpandedRow.scss
@@ -65,5 +65,5 @@
   tbody
   tr:hover
   + .#{variables.$block-class}__expanded-row {
-  background: var(--cds-layer-hover);
+  background: $layer-hover;
 }

--- a/packages/ibm-products/src/components/Datagrid/styles/_useExpandedRow.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_useExpandedRow.scss
@@ -64,6 +64,7 @@
   .#{c4p-settings.$carbon-prefix}--data-table
   tbody
   tr:hover
-  + .#{variables.$block-class}__expanded-row {
+  + .#{variables.$block-class}__expanded-row,
+.#{variables.$block-class} .#{variables.$block-class}__expanded-row:hover {
   background: $layer-hover;
 }

--- a/packages/ibm-products/src/components/Datagrid/styles/_useExpandedRow.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_useExpandedRow.scss
@@ -59,3 +59,11 @@
     fill: $layer-selected-inverse;
   }
 }
+
+.#{variables.$block-class}
+  .#{c4p-settings.$carbon-prefix}--data-table
+  tbody
+  tr:hover
+  + .#{variables.$block-class}__expanded-row {
+  background: var(--cds-layer-hover);
+}


### PR DESCRIPTION
Contributes to #3324 

Adds background color to expanded area when hovering on the expanded row.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/styles/_useExpandedRow.scss
```
#### How did you test and verify your work?
Storybook