### PR TITLE
chore: add stale action

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,2 +1,0 @@
-# https://github.com/probot/stale#usage  cspell:words wontfix
-staleLabel: 'status: wontfix'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: Stale # close stale issues
+on:
+  schedule:
+    - cron: '30 7 * * 4' # runs 7:30 on Thursdays
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          any-of-labels:
+            'status: needs reproduction,status: waiting for author 💬'
+          stale-issue-message: |
+            This issue is stale because it has been open for 30 days with no activity.
+            Remove the stale label or add a comment, otherwise this issue will be closed in 14 days.
+          close-issue-message: |
+            This issue was closed because it has received no activity for 14 days.
+          stale-issue-label: 'stale 🍞'
+          close-issue-label: 'status: won’t fix 🔚'
+          days-before-stale: 30
+          days-before-close: 14
+          days-before-pr-close: -1


### PR DESCRIPTION
Contributes to #3523 

Runs weekly on issues with the labels https://github.com/carbon-design-system/ibm-products/labels/status%3A%20needs%20reproduction or https://github.com/carbon-design-system/ibm-products/labels/status%3A%20waiting%20for%20author%20%F0%9F%92%AC

Should close issues with 30 https://github.com/carbon-design-system/ibm-products/labels/stale%20%F0%9F%8D%9E + 14 days https://github.com/carbon-design-system/ibm-products/labels/status%3A%20won%E2%80%99t%20fix%20%F0%9F%94%9A of no activity but excludes PRs.

#### What did you change?
Add new GitHub action[^1] and remove old stalebot

#### How did you test and verify your work?
🤫

[^1]: https://github.com/actions/stale