### PR TITLE
fix: Should our CSS use of carbon rem be to-rem

### DIFF
--- a/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
@@ -179,6 +179,7 @@ p.c4p--about-modal__copyright-text:first-child {
 .c4p--action-set.cds--btn-set.c4p--action-set--xl .c4p--action-set__action-button:not(.c4p--action-set__action-button--ghost),
 .c4p--action-set.cds--btn-set.c4p--action-set--2xl .c4p--action-set__action-button:not(.c4p--action-set__action-button--ghost),
 .c4p--action-set.cds--btn-set.c4p--action-set--row-quadruple .c4p--action-set__action-button:not(.c4p--action-set__action-button--ghost) {
+  /* stylelint-disable-next-line function-no-unknown -- to-rem carbon replacement for rem */
   max-width: 14.5rem;
   flex: 0 1 25%;
 }

--- a/packages/ibm-products/src/components/ActionSet/_action-set.scss
+++ b/packages/ibm-products/src/components/ActionSet/_action-set.scss
@@ -107,7 +107,8 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
   .#{$action-set-block-class}__action-button:not(
     .#{$action-set-block-class}__action-button--ghost
   ) {
-  max-width: rem(232px);
+  /* stylelint-disable-next-line function-no-unknown -- to-rem carbon replacement for rem */
+  max-width: to-rem(232px);
   flex: 0 1 25%;
 }
 

--- a/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
@@ -92,10 +92,10 @@
       &.#{c4p-settings.$carbon-prefix}--data-table--sm,
       &.#{c4p-settings.$carbon-prefix}--data-table--md {
         .#{$block-class}__cell {
-          /* stylelint-disable-next-line carbon/layout-token-use */
-          padding-top: rem(7px);
-          /* stylelint-disable-next-line carbon/layout-token-use */
-          padding-bottom: rem(6px);
+          /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
+          padding-top: to-rem(7px);
+          /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
+          padding-bottom: to-rem(6px);
         }
       }
 
@@ -123,8 +123,8 @@
       }
 
       .#{c4p-settings.$carbon-prefix}--table-column-checkbox {
-        /* stylelint-disable-next-line carbon/layout-token-use */
-        padding-top: rem(13px);
+        /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
+        padding-top: to-rem(13px);
       }
     }
 

--- a/packages/ibm-products/src/components/Datagrid/styles/addons/_CustomizeColumnsTearsheet.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/addons/_CustomizeColumnsTearsheet.scss
@@ -40,7 +40,7 @@
   .#{variables.$block-class}__customize-columns-checkbox-visible-label {
   // Disabling linter only to match the spacing that Carbon uses for the Checkbox label
   /* stylelint-disable-next-line */
-  padding-left: convert.rem(6px);
+  padding-left: convert.to-rem(6px);
 }
 
 .#{variables.$block-class}__customize-columns-column-list

--- a/packages/ibm-products/src/components/Datagrid/styles/addons/_FilterFlyout.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/addons/_FilterFlyout.scss
@@ -16,7 +16,8 @@
 @use '../../../../global/styles/project-settings' as c4p-settings;
 @use '../variables';
 
-$action-set-height: rem(64px);
+/* stylelint-disable-next-line -- to-rem carbon replacement for rem */
+$action-set-height: to-rem(64px);
 
 .#{variables.$block-class}-filter-flyout__container {
   position: relative;
@@ -27,9 +28,11 @@ $action-set-height: rem(64px);
   top: $spacing-09;
   right: 0;
   display: none;
-  width: rem(642px);
+  /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
+  width: to-rem(642px);
   background-color: $layer-02;
-  box-shadow: 0 1px rem(8px) 0 rgba(0, 0, 0, 0.25);
+  /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
+  box-shadow: 0 1px to-rem(8px) 0 rgba(0, 0, 0, 0.25);
 }
 
 .#{variables.$block-class}-filter-flyout--open {
@@ -37,12 +40,15 @@ $action-set-height: rem(64px);
 }
 
 .#{variables.$block-class}-filter-flyout--batch {
-  min-height: rem(346px);
-  grid-template-rows: 1fr rem(48px);
+  /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
+  min-height: to-rem(346px);
+  /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
+  grid-template-rows: 1fr to-rem(48px);
 }
 
 .#{variables.$block-class}-filter-flyout--instant {
-  min-height: rem(282px);
+  /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
+  min-height: to-rem(282px);
   grid-template-rows: 1fr;
 }
 
@@ -52,11 +58,14 @@ $action-set-height: rem(64px);
 
 .#{variables.$block-class}-filter-flyout__inner-container::before {
   position: absolute;
-  top: rem(-7px);
+  /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
+  top: to-rem(-7px);
   right: 1px;
   display: block;
-  width: rem(46px);
-  height: rem(15px);
+  /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
+  width: to-rem(46px);
+  /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
+  height: to-rem(15px);
   background-color: $layer-02;
   content: '';
 }
@@ -70,7 +79,8 @@ $action-set-height: rem(64px);
 
 .#{variables.$block-class}-filter-flyout__filters {
   display: grid;
-  gap: rem(16px) rem(32px);
+  /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
+  gap: to-rem(16px) rem(32px);
   grid-template-columns: 1fr 1fr;
 }
 
@@ -85,7 +95,8 @@ $action-set-height: rem(64px);
 .#{variables.$block-class}-filter-flyout__trigger--open.#{c4p-settings.$carbon-prefix}--btn.#{c4p-settings.$carbon-prefix}--btn--icon-only {
   position: relative;
   background-color: $layer-02;
-  box-shadow: 0 1px rem(8px) 0 rgba(0, 0, 0, 0.25);
+  /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
+  box-shadow: 0 1px to-rem(8px) 0 rgba(0, 0, 0, 0.25);
 }
 
 .#{variables.$block-class}-filter-flyout

--- a/packages/ibm-products/src/components/Datagrid/styles/addons/_FilterPanel.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/addons/_FilterPanel.scss
@@ -14,7 +14,8 @@
 
 .#{$block-class}-filter-panel__container {
   position: relative;
-  width: rem(320px);
+  /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
+  width: to-rem(320px);
   height: clamp(var(--filter-panel-min-height), 100%, 100vh);
   border-top: 1px $layer-accent-01 solid;
   background-color: $layer-01;
@@ -29,7 +30,8 @@
   top: -1px; // stylelint-disable-line
   left: 0;
   display: block;
-  width: rem(47px); // size of filter panel button
+  /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
+  width: to-rem(47px); // size of filter panel button
   height: 1px;
   background-color: $layer-01;
   content: '';
@@ -95,7 +97,8 @@
   position: sticky;
   z-index: 1; // To layer action set on top of content behind when sticky
   bottom: 0;
-  height: rem(64px);
+  /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
+  height: to-rem(64px);
   margin-top: auto;
 }
 

--- a/packages/ibm-products/src/components/FilterSummary/_filter-summary.scss
+++ b/packages/ibm-products/src/components/FilterSummary/_filter-summary.scss
@@ -13,7 +13,8 @@ $block-class: #{$pkg-prefix}--filter-summary;
 .#{$block-class} {
   display: flex;
   width: 100%;
-  height: rem(48px);
+  /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
+  height: to-rem(48px);
   align-items: center;
   padding: $spacing-03;
   border-top: 1px solid $border-subtle-01;


### PR DESCRIPTION
Moves away from use of `rem` function in favour of `to-rem` the former being a problem for current versions of SASS.