### PR TITLE
chore: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security policy
+
+## Version support
+
+| Version | Status  | Ongoing support |
+| ------- | ------- | --------------- |
+| 2.x     | Active  | ✅              |
+| 1.x     | Active  | ✅              |
+
+Version 2.x corresponds with Carbon v11 while 1.x corresponds with Carbon v10.
+
+Support for these versions includes the discrete version numbers of
+individual packages as listed in the
+[release changelogs](https://github.com/carbon-design-system/ibm-products/releases).
+
+Please note that the **1.x version is anticipated to reach maintenance phase near the end of 2023**.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, report a vulnerability through GitHub’s [security advisory feature](https://github.com/carbon-design-system/ibm-products/security/advisories/new) via new issues.
+
+Please include a description of the issue, the steps you took to create the
+issue, affected versions, and, if known, mitigation steps for the issue. Our team
+aims to respond to all new vulnerability reports within 7 business days.
+
+Additional information on reporting vulnerabilities to IBM is available at
+<https://www.ibm.com/trust/security-psirt>
+
+## Preferred languages
+
+We prefer all communications to be in English.
+
+## Comments on this policy
+
+If you have suggestions on how to improve this process, please
+[submit a pull request](https://github.com/carbon-design-system/ibm-products/compare),
+[start a discussion](https://github.com/carbon-design-system/ibm-products/discussions),
+or [open an issue](https://github.com/carbon-design-system/carbon/issues/new).


### PR DESCRIPTION
Contributes to #3565 
Adapted from [Carbon’s security policy](https://github.com/carbon-design-system/carbon/blob/5078eb5204b21763244768af3b0b283551561d47/SECURITY.md#security-policy) from @tay1orjones.

#### What did you change?
Add new SECURITY.md file.

#### How did you test and verify your work?
Markdown Preview