### PR TITLE
fix: vertical alignment in larger row heights

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -39,7 +39,7 @@ export const DatagridContent = ({ datagridState, title }) => {
     CustomizeColumnsTearsheet,
     filterProps,
     fullHeightDatagrid,
-    verticalAlign = 'center',
+    verticalAlign = 'top',
     variableRowHeight,
     gridTitle,
     gridDescription,


### PR DESCRIPTION
Contributes to #3548

After this content is top-aligned in `Extra large` row height.

#### What did you change?

Changed the default value of `verticalAlign` property from `'center'` to `'top'` in DatagridContent.js file.

#### How did you test and verify your work?

https://github.com/carbon-design-system/ibm-products/assets/75922615/20d660ed-bf2b-40e6-a118-411d02064281

