### PR TITLE
fix(Datagrid): expander title / aria-label updates (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.mdx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.mdx
@@ -1101,6 +1101,8 @@ const datagridState = useDatagrid(
   {
     columns,
     data,
+    expanderButtonTitleExpanded: 'Collapse row',
+    expanderButtonTitleCollapsed: 'Expand row',
   },
   useNestedRows
 );

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
@@ -1462,16 +1462,16 @@ describe(componentName, () => {
   });
 
   function clickRow(rowNumber) {
-    const row = screen
-      .getByRole('table')
-      .getElementsByTagName('tbody')[0]
-      .getElementsByTagName('tr')[rowNumber];
-    const rowExpander = row.querySelector(
-      `button[aria-label="Expand current row"]`
+    const rows = screen.getAllByRole('row');
+    const bodyRows = rows.filter(
+      (r) =>
+        !r.classList.contains('c4p--datagrid__head') &&
+        !r.classList.contains('c4p--datagrid__expanded-row')
     );
-    fireEvent.click(rowExpander);
+    const row = bodyRows[rowNumber];
 
-    setTimeout(1000);
+    const rowExpander = row.querySelector(`button[aria-label="Expand row"]`);
+    fireEvent.click(rowExpander);
 
     expect(
       screen
@@ -1483,17 +1483,17 @@ describe(componentName, () => {
       screen
         .getByRole('table')
         .getElementsByTagName('tbody')[0]
-        .getElementsByClassName('c4p--datagrid__expanded-row')[0].lastChild
-        .textContent
+        .getElementsByClassName('c4p--datagrid__expanded-row')[0].textContent
     ).toEqual(`Content for ${rowNumber}`);
 
-    const firstRowExpander =
-      screen.getAllByLabelText('Expand current row')[rowNumber];
-    fireEvent.click(firstRowExpander);
+    const rowExpanderCollapse = row.querySelector(
+      `button[aria-label="Collapse row"]`
+    );
+    fireEvent.click(rowExpanderCollapse);
   }
 
   it('Expanded Row', () => {
-    render(<ExpandedRow data-testid={dataTestId}></ExpandedRow>);
+    render(<ExpandedRow data-testid={dataTestId} />);
     clickRow(1);
     clickRow(4);
     clickRow(8);
@@ -1558,8 +1558,8 @@ describe(componentName, () => {
   });
 
   it('Nested Table', () => {
-    render(<NestedTable data-testid={dataTestId}></NestedTable>);
-    const firstRowExpander = screen.getAllByLabelText('Expand current row')[0];
+    render(<NestedTable data-testid={dataTestId} />);
+    const firstRowExpander = screen.getAllByLabelText('Expand row')[0];
     const firstRow = screen.getAllByRole('row')[1];
     fireEvent.click(firstRowExpander);
     expect(firstRow.nextSibling).toHaveClass('c4p--datagrid__expanded-row');

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
@@ -239,6 +239,8 @@ const expandableRowControlProps = {
   gridTitle: sharedDatagridProps.gridTitle,
   gridDescription: sharedDatagridProps.gridDescription,
   expandedContentAlign: sharedDatagridProps.expandedContentAlign,
+  expanderButtonTitleExpanded: 'Collapse row',
+  expanderButtonTitleCollapsed: 'Expand row',
 };
 const expandableRowStoryName = 'With expandable row';
 export const ExpandableRowStory = prepareStory(BasicTemplateWrapper, {
@@ -247,6 +249,8 @@ export const ExpandableRowStory = prepareStory(BasicTemplateWrapper, {
     gridTitle: ARG_TYPES.gridTitle,
     gridDescription: ARG_TYPES.gridDescription,
     expandedContentAlign: ARG_TYPES.expandedContentAlign,
+    expanderButtonTitleExpanded: ARG_TYPES.expanderButtonTitleExpanded,
+    expanderButtonTitleCollapsed: ARG_TYPES.expanderButtonTitleCollapsed,
   },
   args: {
     ...expandableRowControlProps,

--- a/packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.js
@@ -185,6 +185,8 @@ const nestedRowsControlProps = {
   rowSize: sharedDatagridProps.rowSize,
   rowSizes: sharedDatagridProps.rowSizes,
   onRowSizeChange: sharedDatagridProps.onRowSizeChange,
+  expanderButtonTitleExpanded: 'Collapse row',
+  expanderButtonTitleCollapsed: 'Expand row',
 };
 const nestedRowsStoryName = 'With nested rows';
 export const NestedRowsUsageStory = prepareStory(BasicTemplateWrapper, {
@@ -196,6 +198,8 @@ export const NestedRowsUsageStory = prepareStory(BasicTemplateWrapper, {
     rowSize: ARG_TYPES.rowSize,
     rowSizes: ARG_TYPES.rowSizes,
     onRowSizeChange: ARG_TYPES.onRowSizeChange,
+    expanderButtonTitleExpanded: ARG_TYPES.expanderButtonTitleExpanded,
+    expanderButtonTitleCollapsed: ARG_TYPES.expanderButtonTitleCollapsed,
   },
   args: {
     ...nestedRowsControlProps,

--- a/packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
+++ b/packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
@@ -1,45 +1,60 @@
 /* eslint-disable react/prop-types */
-/*
- * Licensed Materials - Property of IBM
- * 5724-Q36
- * (c) Copyright IBM Corp. 2020
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
+/**
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
-import React from 'react';
+
+import React, { useRef } from 'react';
 import { ChevronRight16 } from '@carbon/icons-react';
 import cx from 'classnames';
 import { pkg, carbon } from '../../settings';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 const useNestedRowExpander = (hooks) => {
+  const tempState = useRef();
+  const useInstance = (instance) => {
+    tempState.current = instance;
+  };
   const visibleColumns = (columns) => {
     const expanderColumn = {
       id: 'expander',
-      Cell: ({ row }) =>
-        row.canExpand && (
-          <button
-            type="button"
-            aria-label="Expand current row"
-            className={cx(
-              `${blockClass}__row-expander`,
-              `${carbon.prefix}--btn`,
-              `${carbon.prefix}--btn--ghost`
-            )}
-            {...row.getToggleRowExpandedProps()}
-          >
-            <ChevronRight16
+      Cell: ({ row }) => {
+        const {
+          expanderButtonTitleExpanded = 'Collapse row',
+          expanderButtonTitleCollapsed = 'Expand row',
+        } = tempState?.current || {};
+        const expanderTitle = row.isExpanded
+          ? expanderButtonTitleExpanded
+          : expanderButtonTitleCollapsed;
+        return (
+          row.canExpand && (
+            <button
+              type="button"
+              aria-label={expanderTitle}
               className={cx(
-                `${blockClass}__expander-icon`,
-                `${blockClass}__row-expander--icon`,
-                {
-                  [`${blockClass}__expander-icon--not-open`]: !row.isExpanded,
-                  [`${blockClass}__expander-icon--open`]: row.isExpanded,
-                }
+                `${blockClass}__row-expander`,
+                `${carbon.prefix}--btn`,
+                `${carbon.prefix}--btn--ghost`
               )}
-            />
-          </button>
-        ),
+              {...row.getToggleRowExpandedProps()}
+              title={expanderTitle}
+            >
+              <ChevronRight16
+                className={cx(
+                  `${blockClass}__expander-icon`,
+                  `${blockClass}__row-expander--icon`,
+                  {
+                    [`${blockClass}__expander-icon--not-open`]: !row.isExpanded,
+                    [`${blockClass}__expander-icon--open`]: row.isExpanded,
+                  }
+                )}
+              />
+            </button>
+          )
+        );
+      },
       width: 48,
       disableResizing: true,
       disableSortBy: true,
@@ -48,6 +63,7 @@ const useNestedRowExpander = (hooks) => {
     return [expanderColumn, ...columns];
   };
   hooks.visibleColumns.push(visibleColumns);
+  hooks.useInstance.push(useInstance);
 };
 
 export default useNestedRowExpander;

--- a/packages/ibm-products/src/components/Datagrid/useRowExpander.js
+++ b/packages/ibm-products/src/components/Datagrid/useRowExpander.js
@@ -1,12 +1,12 @@
 /* eslint-disable react/prop-types */
-/*
- * Licensed Materials - Property of IBM
- * 5724-Q36
- * (c) Copyright IBM Corp. 2020
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
+/**
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
-import React from 'react';
+
+import React, { useRef } from 'react';
 import { ChevronDown16, ChevronUp16 } from '@carbon/icons-react';
 import cx from 'classnames';
 import { pkg, carbon } from '../../settings';
@@ -14,21 +14,33 @@ import { pkg, carbon } from '../../settings';
 const blockClass = `${pkg.prefix}--datagrid`;
 
 const useRowExpander = (hooks) => {
+  const tempState = useRef();
+  const useInstance = (instance) => {
+    tempState.current = instance;
+  };
   const visibleColumns = (columns) => {
     const expanderColumn = {
       id: 'expander',
       Cell: ({ row }) => {
+        const {
+          expanderButtonTitleExpanded = 'Collapse row',
+          expanderButtonTitleCollapsed = 'Expand row',
+        } = tempState?.current || {};
+        const expanderTitle = row.isExpanded
+          ? expanderButtonTitleExpanded
+          : expanderButtonTitleCollapsed;
         return (
           row.canExpand && (
             <button
               type="button"
-              aria-label="Expand current row"
+              aria-label={expanderTitle}
               className={cx(
                 `${blockClass}__row-expander`,
                 `${carbon.prefix}--btn`,
                 `${carbon.prefix}--btn--ghost`
               )}
               {...row.getToggleRowExpandedProps()}
+              title={expanderTitle}
             >
               {row.isExpanded ? (
                 <ChevronUp16 className={`${blockClass}__row-expander--icon`} />
@@ -49,6 +61,7 @@ const useRowExpander = (hooks) => {
     return [expanderColumn, ...columns];
   };
   hooks.visibleColumns.push(visibleColumns);
+  hooks.useInstance.push(useInstance);
 };
 
 export default useRowExpander;

--- a/packages/ibm-products/src/components/Datagrid/utils/getArgTypes.js
+++ b/packages/ibm-products/src/components/Datagrid/utils/getArgTypes.js
@@ -77,6 +77,20 @@ export const ARG_TYPES = {
     description:
       'This value controls the height of the expanded content area. _This value is set/passed inside of the `datagridState` object._',
   },
+  expanderButtonTitleExpanded: {
+    control: {
+      type: 'text',
+    },
+    description:
+      'This value controls the expander title/aria-label when expanded. _This value is set/passed inside of the `datagridState` object._',
+  },
+  expanderButtonTitleCollapsed: {
+    control: {
+      type: 'text',
+    },
+    description:
+      'This value controls the expander title/aria-label when expanded. _This value is set/passed inside of the `datagridState` object._',
+  },
   customizeColumnsProps: {
     control: 'object',
     description:


### PR DESCRIPTION
Contributes to #3561

Properly assigns a more logical value to the row expander `title` and `aria-label` attributes, as opposed to using the default value that `react-table` provides via `{...row.getToggleRowExpandedProps()}`.

This change has been applied to both expanded and nested rows.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridExpandedRow.js
packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.docs-page.js
packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.js
packages/ibm-products/src/components/Datagrid/styles/_useExpandedRow.scss
packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
packages/ibm-products/src/components/Datagrid/useRowExpander.js
packages/ibm-products/src/components/Datagrid/utils/getArgTypes.js
```
#### How did you test and verify your work?
Storybook