### PR TITLE
fix(Datagrid): reset column order in CustomizeColumns onClose handler

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
@@ -54,6 +54,7 @@ const CustomizeColumnsTearsheet = ({
   const [isDirty, setIsDirty] = useState(false);
 
   const onRequestClose = () => {
+    setColumnObjects(columnDefinitions);
     setIsTearsheetOpen(false);
   };
   const onRequestSubmit = () => {


### PR DESCRIPTION
Contributes to #3454 

Fixes a bug where the column order does not reset to the default if the CustomizeColumns tearsheet is closed, instead it maintains the new sorting order.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
```
#### How did you test and verify your work?
Storybook