### PR TITLE
fix(Pattern-Saving): Reversed the icons for default and success states

### DIFF
--- a/packages/ibm-products/src/components/Saving/Saving.js
+++ b/packages/ibm-products/src/components/Saving/Saving.js
@@ -46,7 +46,7 @@ export let Saving = forwardRef(
       default: {
         text: defaultText,
         iconDescription: defaultIconDescription,
-        icon: (props) => <CheckmarkOutline size={16} {...props} />,
+        icon: (props) => <Save size={16} {...props} />,
       },
       ['in-progress']: {
         text: inProgressText,
@@ -56,7 +56,7 @@ export let Saving = forwardRef(
       success: {
         text: successText,
         iconDescription: successIconDescription,
-        icon: (props) => <Save size={16} {...props} />,
+        icon: (props) => <CheckmarkOutline size={16} {...props} />,
       },
       fail: {
         text: failText,


### PR DESCRIPTION
Contributes to #2849

#### What did you change?
Reversed the the icons shown for  default state and success state to save and checkmark icons respectively.

#### How did you test and verify your work?
storybook
