### PR TITLE
fix(EditTearsheet): Derive influencer nav items from form titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Carbon for IBM Products
 
 > Carbon for IBM Products is an open source implementation of the closed source
-> [Carbon for Cloud & Cognitive pattern asset library (PAL)](https://pages.github.ibm.com/cdai-design/pal/).
+> [IBM Software pattern asset library (PAL)](https://pages.github.ibm.com/cdai-design/pal/).
 > These PAL designs build on the foundation of IBM’s open source Carbon Design
 > System and React implementation to offer components and patterns beyond the
 > typical component library. Carbon for IBM Products was previously known as
-> Carbon for IBM Cloud and Cognitive, and this name can still be encountered in
+> Carbon for Cloud and Cognitive, and this name can still be encountered in
 > various places and historical logs.
 
 [![All Contributors](https://img.shields.io/github/all-contributors/carbon-design-system/ibm-products?color=ee8449)](#contributors-)
@@ -38,8 +38,8 @@ npm:
 | Package name                                          | Description                                                                                                       |
 | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | [`@carbon/ibm-products`](./packages/ibm-products)     | A curated set of components and patterns, built on top of Carbon and designed by the Carbon for IBM Products team |
-| [`@carbon/ibm-cloud-cognitive-cdai`](./packages/cdai) | (V1 branch/tags only) Legacy and non-curated design implementations used in application integration               |
-| [`@carbon/ibm-security`](./packages/security)         | (V1 branch/tags only) Legacy and non-curated design implementations used in security                              |
+| [`@carbon/ibm-cloud-cognitive-cdai`](https://github.com/carbon-design-system/ibm-products/tree/main_v1/packages/cdai) | (**v1 only**) Legacy and non-curated design implementations used in application integration               |
+| [`@carbon/ibm-security`](https://github.com/carbon-design-system/ibm-products/tree/main_v1/packages/security)         | (**v1 only**) Legacy and non-curated design implementations used in security                              |
 
 Also the following additional utility packages are published on npm:
 
@@ -49,6 +49,23 @@ Also the following additional utility packages are published on npm:
 
 The remaining packages are part of our project infrastructure and are not
 published on npm.
+
+### Version support
+
+Carbon 11 support is introduced in Carbon for IBM Products <https://github.com/carbon-design-system/ibm-products/labels/v2>
+
+| Package name                                | Carbon package                         | React version    |
+| --------------------------------- | ------------------------------ | ---------------  |
+| `@carbon/ibm-products`              | **`@carbon/react`**                 | 18, 17, 16
+
+The following packages support Carbon 10 and are considered <https://github.com/carbon-design-system/ibm-products/labels/v1> packages.
+
+| Package name                                       | Carbon package                   | React version    |
+| ------------------------------------- | --------------------------- | ---------------  |
+| `@carbon/ibm-products`<br/> `@carbon/ibm-cloud-cognitive-cdai`<br/> `@carbon/ibm-security` <br/>  | **`carbon-components-react`**<br/> `carbon-components`<br/> `@carbon/icons-react`<br/> `@carbon/icons` <br/> `@carbon/colors` <br/> `@carbon/elements` <br/> etc  | 17, 16 |
+
+If you’d like to learn more about migrating from Carbon 10 to Carbon 11, please see the Carbon [v11 migration guide](https://github.com/carbon-design-system/carbon/blob/main/docs/migration/v11.md) (which includes codemods via [`@carbon/upgrade`](https://github.com/carbon-design-system/carbon/blob/main/packages/upgrade/README.md)) and the Carbon for IBM Products [v2 migration guide](https://github.com/carbon-design-system/ibm-products/blob/main/docs/guides/v2.md).
+
 
 ## 🙌 Contributing
 

--- a/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.js
+++ b/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.js
@@ -50,6 +50,7 @@ export let EditTearsheet = forwardRef(
       title,
       verticalPosition = defaults.verticalPosition,
       onHandleModalClick,
+      onFormChange,
 
       // Collect any other property values passed in.
       ...rest
@@ -57,43 +58,42 @@ export let EditTearsheet = forwardRef(
     ref
   ) => {
     const [currentForm, setCurrentForm] = useState(0);
+    const [formTitles, setFormTitles] = useState([]);
     const contentRef = useRef();
 
-    const handleCurrentForm = (form) => {
-      setCurrentForm(form);
+    const handleCurrentForm = (formIndex) => {
+      setCurrentForm(formIndex);
+      if (onFormChange) {
+        onFormChange(formIndex);
+      }
     };
 
-    const sideNavItems = [
-      { label: 'Topic Name' },
-      { label: 'Location' },
-      { label: 'Partitions' },
-      { label: 'Message retention' },
-    ];
-
-    const influencer = (
-      <div className="tearsheet-stories__dummy-influencer-block">
-        <SideNav
-          aria-label="Side navigation"
-          className={`${blockClass}__side-nav`}
-          expanded={true}
-          isFixedNav={false}
-        >
-          <SideNavItems>
-            {sideNavItems.map((item, index) => {
-              return (
-                <SideNavMenuItem
-                  key={index}
-                  onClick={() => handleCurrentForm(index)}
-                  isActive={currentForm === index}
-                >
-                  {item.label}
-                </SideNavMenuItem>
-              );
-            })}
-          </SideNavItems>
-        </SideNav>
-      </div>
-    );
+    function defaultInfluencer() {
+      return (
+        <div className={`${blockClass}__side-nav-wrapper`}>
+          <SideNav
+            aria-label="Side navigation"
+            className={`${blockClass}__side-nav`}
+            expanded={true}
+            isFixedNav={false}
+          >
+            <SideNavItems>
+              {formTitles.map((title, index) => {
+                return (
+                  <SideNavMenuItem
+                    key={index}
+                    onClick={() => handleCurrentForm(index)}
+                    isActive={currentForm === index}
+                  >
+                    {title}
+                  </SideNavMenuItem>
+                );
+              })}
+            </SideNavItems>
+          </SideNav>
+        </div>
+      );
+    }
 
     return (
       <TearsheetShell
@@ -114,7 +114,7 @@ export let EditTearsheet = forwardRef(
         className={cx(blockClass, className)}
         description={description}
         hasCloseIcon={false}
-        influencer={influencer}
+        influencer={defaultInfluencer()}
         influencerPosition="left"
         influencerWidth={influencerWidth}
         label={label}
@@ -130,6 +130,7 @@ export let EditTearsheet = forwardRef(
             <FormContext.Provider
               value={{
                 currentForm,
+                setFormTitles,
               }}
             >
               {React.Children.map(children, (child, index) => (
@@ -176,13 +177,6 @@ EditTearsheet.propTypes = {
   description: PropTypes.node,
 
   /**
-   * The content for the influencer section of the tearsheet, displayed
-   * alongside the main content. This is typically a menu, or filter, or
-   * progress indicator, or similar.
-   */
-  influencer: PropTypes.element,
-
-  /**
    * Used to set the size of the influencer
    */
   influencerWidth: PropTypes.oneOf(['narrow', 'wide']),
@@ -200,6 +194,13 @@ EditTearsheet.propTypes = {
    * Returning `false` here prevents the modal from closing.
    */
   onClose: PropTypes.func,
+
+  /**
+   * An optional handler that is called when a user changes forms via clicking
+   * an influencer nav item.
+   * Returns the index of the selected form.
+   */
+  onFormChange: PropTypes.func,
 
   /**
    * Specifies whether the tearsheet is currently open.

--- a/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.js
+++ b/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.js
@@ -52,7 +52,7 @@ export let EditTearsheet = forwardRef(
       verticalPosition = defaults.verticalPosition,
       onHandleModalClick,
       onFormChange,
-      sideNavAriaLabel,
+      sideNavAriaLabel = defaults.sideNavAriaLabel,
 
       // Collect any other property values passed in.
       ...rest

--- a/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.js
+++ b/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -29,6 +29,7 @@ export const FormNumberContext = createContext(0);
 const defaults = {
   verticalPosition: 'normal',
   influencerWidth: 'narrow',
+  sideNavAriaLabel: 'Side navigation',
 };
 
 /**
@@ -51,6 +52,7 @@ export let EditTearsheet = forwardRef(
       verticalPosition = defaults.verticalPosition,
       onHandleModalClick,
       onFormChange,
+      sideNavAriaLabel,
 
       // Collect any other property values passed in.
       ...rest
@@ -72,7 +74,7 @@ export let EditTearsheet = forwardRef(
       return (
         <div className={`${blockClass}__side-nav-wrapper`}>
           <SideNav
-            aria-label="Side navigation"
+            aria-label={sideNavAriaLabel}
             className={`${blockClass}__side-nav`}
             expanded={true}
             isFixedNav={false}
@@ -211,6 +213,11 @@ EditTearsheet.propTypes = {
    * Specifies whether the tearsheet is currently open.
    */
   open: PropTypes.bool,
+
+  /**
+   * Specifies the aria label for the SideNav from Carbon UIShell
+   */
+  sideNavAriaLabel: PropTypes.string,
 
   /**
    * The submit button text

--- a/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.test.js
+++ b/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.test.js
@@ -181,4 +181,30 @@ describe(componentName, () => {
     const editTearsheet = document.querySelector(`.${carbon.prefix}--modal`);
     expect(editTearsheet).toHaveClass(className);
   });
+
+  it('renders the influencer with a nav item that matches the form title', async () => {
+    const { container } = renderEditTearsheet({ ...defaultProps });
+
+    expect(
+      container.querySelector(`.${carbon.prefix}--side-nav__link-text`)
+    ).toHaveTextContent(form1Title);
+    expect(
+      screen.getByRole('heading', { name: form1Title })
+    ).toBeInTheDocument();
+  });
+
+  it('should call the provided callback function when the form is changed', async () => {
+    const onFormChange = jest.fn();
+    const { container } = renderEditTearsheet({
+      ...defaultProps,
+      onFormChange,
+    });
+    const form2NavLink = container.querySelectorAll(
+      `.${carbon.prefix}--side-nav__link-text`
+    )[2];
+
+    await act(() => click(form2NavLink));
+    expect(onFormChange).toHaveBeenCalledTimes(1);
+    expect(onFormChange).toHaveBeenCalledWith(2);
+  });
 });

--- a/packages/ibm-products/src/components/EditTearsheet/EditTearsheetForm.js
+++ b/packages/ibm-products/src/components/EditTearsheet/EditTearsheetForm.js
@@ -12,6 +12,7 @@ import { Column, FormGroup, Grid } from '@carbon/react';
 import { FormContext, FormNumberContext } from './EditTearsheet';
 import { pkg } from '../../settings';
 import pconsole from '../../global/js/utils/pconsole';
+import { useRetrieveFormTitles } from '../../global/js/hooks/useRetrieveFormTitles';
 
 const componentName = 'EditTearsheetForm';
 const blockClass = `${pkg.prefix}--tearsheet-edit__form`;
@@ -41,6 +42,7 @@ export let EditTearsheetForm = forwardRef(
   ) => {
     const formContext = useContext(FormContext);
     const formNumber = useContext(FormNumberContext);
+    useRetrieveFormTitles({ formContext, formNumber, title });
 
     return formContext ? (
       <div

--- a/packages/ibm-products/src/components/EditTearsheet/preview-components/MultiFormEditTearsheet.js
+++ b/packages/ibm-products/src/components/EditTearsheet/preview-components/MultiFormEditTearsheet.js
@@ -21,6 +21,7 @@ import cx from 'classnames';
 import { pkg } from '../../../settings';
 import { EditTearsheet } from '../EditTearsheet';
 import { EditTearsheetForm } from '../EditTearsheetForm';
+import { action } from '@storybook/addon-actions';
 
 const blockClass = `${pkg.prefix}--tearsheet-edit-multi-form`;
 
@@ -64,6 +65,10 @@ export const MultiFormEditTearsheet = ({
     setOpen(!open);
   };
 
+  const handleFormChange = () => {
+    action('handleFormChange')();
+  };
+
   return (
     <div>
       <style>{`.${blockClass} { opacity: 0 }`};</style>
@@ -81,6 +86,7 @@ export const MultiFormEditTearsheet = ({
         open={open}
         onHandleModalClick={handleModalClick}
         onClose={clearCreateData}
+        onFormChange={handleFormChange}
       >
         <EditTearsheetForm
           title="Topic name"

--- a/packages/ibm-products/src/global/js/hooks/useRetrieveFormTitles.js
+++ b/packages/ibm-products/src/global/js/hooks/useRetrieveFormTitles.js
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+
+export const useRetrieveFormTitles = ({ formContext, formNumber, title }) => {
+  useEffect(() => {
+    if (formContext) {
+      formContext.setFormTitles((prev) => {
+        const prevTitle = prev[formNumber];
+        if (prevTitle !== title) {
+          const clone = [...prev];
+          clone[formNumber] = title;
+          return clone;
+        }
+        return prev;
+      });
+    }
+  }, [title, formContext, formNumber]);
+};


### PR DESCRIPTION
Contributes to #3554

## Intent

Replace hardcoded implementation of influencer with one derived from form titles.

## Background

Currently, the EditTearsheet component uses a hardcoded sample influencer rather than a dynamic or user provided one.

#### What did you change?

- Removed hardcoded nav item definitions
- Created state variable `formTitles`
- Created custom hook `useRetrieveFormTitles` to set form titles used for influencer nav items
- Added unit tests
- Added usage in storybook sample
- Also replaced influencer prop from component API with onFormChange handler

#### How did you test and verify your work?

##### Manual Test

https://github.com/carbon-design-system/ibm-products/assets/12387334/24e1ff19-2492-4051-847e-b273fdde13d4

_Observe how the influencer nav item responds to the change made to the form title. Also observe how the new onFormChange handler is fired on click._

##### Unit Test

Passing.

![Screenshot 2023-10-11 at 3 22 51 PM](https://github.com/carbon-design-system/ibm-products/assets/12387334/f3d7514b-fbb1-47ae-9331-eb5371642160)



