### PR TITLE
fix(Datagrid): add disabled/locked col drag functionality back

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
@@ -32,7 +32,10 @@ const DraggableElement = ({
     setNodeRef,
     transform,
     transition,
-  } = useSortable({ id });
+  } = useSortable({
+    disabled,
+    id,
+  });
 
   const content = (
     <>

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
@@ -53,9 +53,27 @@ export const DraggableItemsList = ({
       );
     });
 
+  const getUpdatedDragCols = () => {
+    const tempCols = [...visibleCols];
+    tempCols.forEach((col) => {
+      if (col.sticky) {
+        col.disabled = true;
+      }
+    });
+    return tempCols;
+  };
+  const updatedDragCols = getUpdatedDragCols();
+
   // let localRefCopy;
   const handleDragEnd = (event) => {
     const { active, over } = event;
+
+    // Stop any re-ordering updates if the destination column is disabled
+    // ie: it is a frozen column.
+    const destOverCol = updatedDragCols.filter((item) => item.id === over.id);
+    if (destOverCol?.length && destOverCol[0]?.disabled) {
+      return;
+    }
 
     const fromVisibleIndex = columns.findIndex((col) =>
       matchedColsById(col, active)
@@ -63,11 +81,12 @@ export const DraggableItemsList = ({
     const toVisibleIndex = columns.findIndex((col) =>
       matchedColsById(col, over)
     );
-    const colTitle = getColTitle(visibleCols[fromVisibleIndex]);
+
+    const colTitle = getColTitle(updatedDragCols[fromVisibleIndex]);
 
     setAriaRegionText(
       `${colTitle} dropped. New position ${toVisibleIndex + 1} of ${
-        visibleCols.length
+        updatedDragCols.length
       }.`
     );
 
@@ -80,14 +99,14 @@ export const DraggableItemsList = ({
   const handleDragStart = (event) => {
     const { active } = event;
 
-    const fromIndex = visibleCols.findIndex((col) =>
+    const fromIndex = updatedDragCols.findIndex((col) =>
       matchedColsById(col, active)
     );
-    const colTitle = getColTitle(visibleCols[fromIndex]);
+    const colTitle = getColTitle(updatedDragCols[fromIndex]);
 
     setAriaRegionText(
       `${colTitle} grabbed. Current position ${fromIndex + 1} of ${
-        visibleCols.length
+        updatedDragCols.length
       }.`
     );
   };
@@ -95,17 +114,19 @@ export const DraggableItemsList = ({
   const handleDragUpdate = (event) => {
     const { active, over } = event;
 
-    const fromIndex = visibleCols.findIndex((col) =>
+    const fromIndex = updatedDragCols.findIndex((col) =>
       matchedColsById(col, active)
     );
-    const toIndex = visibleCols.findIndex((col) => matchedColsById(col, over));
+    const toIndex = updatedDragCols.findIndex((col) =>
+      matchedColsById(col, over)
+    );
 
-    const colTitle = getColTitle(visibleCols[fromIndex]);
+    const colTitle = getColTitle(updatedDragCols[fromIndex]);
 
     setAriaRegionText(
       `${colTitle} grabbed. Original position ${fromIndex + 1}, new position ${
         toIndex + 1
-      } of ${visibleCols.length}.`
+      } of ${updatedDragCols.length}.`
     );
   };
 
@@ -171,11 +192,11 @@ export const DraggableItemsList = ({
             <div
               className={`${blockClass}__draggable-underlay-item`}
               key={colDef.id}
-            ></div>
+            />
           ))}
         </div>
         <SortableContext
-          items={visibleCols}
+          items={updatedDragCols}
           strategy={verticalListSortingStrategy}
         >
           {visibleCols.map((colDef) => {
@@ -214,7 +235,7 @@ export const DraggableItemsList = ({
                   <div
                     dangerouslySetInnerHTML={{ __html: highlightedText }}
                     className={`${blockClass}__customize-columns-checkbox-visible-label`}
-                  ></div>
+                  />
                 }
               </>
             );

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
@@ -57,6 +57,7 @@ const defaultHeader = [
     Header: 'Row Index',
     accessor: (row, i) => i,
     id: 'rowIndex', // id is required when accessor is a function.
+    sticky: 'left',
   },
   {
     Header: 'First Name',


### PR DESCRIPTION
Contributes to #3455 

Adds back the functionality to:
1. Prevent dragging of columns that are disabled
2. Prevent items to be dropped/reordered to positions that are disabled

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
```
#### How did you test and verify your work?
Storybook