### PR TITLE
fix(Card): Update _card.scss

### DIFF
--- a/packages/ibm-products/src/components/Card/_card.scss
+++ b/packages/ibm-products/src/components/Card/_card.scss
@@ -108,7 +108,7 @@ $block-class: #{c4p-settings.$pkg-prefix}--card;
   background-color: $layer-hover-01;
 }
 
-#{$block-class}__icon:active {
+.#{$block-class}__icon:active {
   color: $link-primary-hover;
 }
 


### PR DESCRIPTION
~Contributes to #~ Inline edit.

Fix typo. `#{$block-class}...` → `.#{$block-class}...`. Added missing dot at beginning of selector.

