### PR TITLE
fix: Card CSS typo

### DIFF
--- a/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
@@ -3570,7 +3570,7 @@ p.c4p--about-modal__copyright-text:first-child {
   background-color: var(--cds-layer-hover-01, #e8e8e8);
 }
 
-c4p--card__icon:active {
+.c4p--card__icon:active {
   color: var(--cds-link-primary-hover, #0043ce);
 }
 

--- a/packages/ibm-products/src/components/Card/_card.scss
+++ b/packages/ibm-products/src/components/Card/_card.scss
@@ -108,7 +108,7 @@ $block-class: #{c4p-settings.$pkg-prefix}--card;
   background-color: $layer-hover-01;
 }
 
-#{$block-class}__icon:active {
+.#{$block-class}__icon:active {
   color: $link-primary-hover;
 }
 


### PR DESCRIPTION
#### What did you change?

Fixes typo `#{$block-class}...` to `.#{$block-class}...`. Prepended a dot.

#### How did you test and verify your work?

- [x] Verified in Storybook