### PR TITLE
feat(Datagrid): remove filter tags individually from `FilterSummary`

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/Datagrid.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/Datagrid.js
@@ -47,7 +47,7 @@ export let Datagrid = React.forwardRef(
     };
 
     return (
-      <FilterProvider filters={filters}>
+      <FilterProvider filters={filters} filterProps={filterProps}>
         <InlineEditProvider>
           <div
             {...rest}

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -22,7 +22,12 @@ import { useMultipleKeyTracking } from '../../DataSpreadsheet/hooks';
 import FilterPanel from './addons/Filtering/FilterPanel';
 import { FilterSummary } from '../../FilterSummary';
 import { FilterContext } from './addons/Filtering';
-import { CLEAR_FILTERS } from './addons/Filtering/constants';
+import {
+  CLEAR_FILTERS,
+  CLEAR_SINGLE_FILTER,
+} from './addons/Filtering/constants';
+import { useSubscribeToEventEmitter } from './addons/Filtering/hooks';
+import { clearSingleFilter } from './addons/Filtering/FilterProvider';
 
 const { TableContainer, Table } = DataTable;
 
@@ -51,6 +56,7 @@ export const DatagridContent = ({ datagridState, title }) => {
     DatagridActions,
     totalColumnsWidth,
     gridRef,
+    setAllFilters,
     state,
     page,
     rows,
@@ -143,6 +149,10 @@ export const DatagridContent = ({ datagridState, title }) => {
       );
     }
   }, [withInlineEdit, tableId, totalColumnsWidth, datagridState, gridActive]);
+
+  useSubscribeToEventEmitter(CLEAR_SINGLE_FILTER, (id) =>
+    clearSingleFilter(id, setAllFilters, state)
+  );
 
   const renderFilterSummary = () =>
     state.filters.length > 0 && (

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
@@ -59,6 +59,9 @@ const FilterPanel = ({
   /** State */
   const [showDividerLine, setShowDividerLine] = useState(false);
 
+  /** Context */
+  const { panelOpen, setPanelOpen } = useContext(FilterContext);
+
   const {
     filtersState,
     prevFiltersObjectArrayRef,
@@ -75,6 +78,7 @@ const FilterPanel = ({
     variation: PANEL,
     reactTableFiltersState,
     onCancel,
+    panelOpen,
   });
 
   /** Refs */
@@ -93,9 +97,6 @@ const FilterPanel = ({
 
   /** Memos */
   const showActionSet = useMemo(() => updateMethod === BATCH, [updateMethod]);
-
-  /** Context */
-  const { panelOpen, setPanelOpen } = useContext(FilterContext);
 
   /** Methods */
   const closePanel = () => {

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterProvider.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterProvider.js
@@ -1,12 +1,19 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 import React, { createContext, useState } from 'react';
 import PropTypes from 'prop-types';
-import { DATE, DROPDOWN, NUMBER, RADIO, CHECKBOX } from './constants';
+import {
+  DATE,
+  DROPDOWN,
+  NUMBER,
+  RADIO,
+  CHECKBOX,
+  CLEAR_SINGLE_FILTER,
+} from './constants';
 
 export const FilterContext = createContext();
 
@@ -27,22 +34,101 @@ const EventEmitter = {
   },
 };
 
-const prepareFiltersForTags = (filters) => {
+const removeFilterItem = (state, index) => state.splice(index, 1);
+
+const updateFilterState = (state, type, value) => {
+  if (type === CHECKBOX) {
+    return;
+  }
+  if (type === DATE) {
+    const filterTagIndex = state.findIndex(
+      (val) =>
+        formatDateRange(val.value[0], val.value[1]) ===
+        formatDateRange(value[0], value[1])
+    );
+    return removeFilterItem(state, filterTagIndex);
+  }
+  const filterTagIndex = state.findIndex((val) => val.value === value);
+  return removeFilterItem(state, filterTagIndex);
+};
+
+export const clearSingleFilter = ({ key, value }, setAllFilters, state) => {
+  const tempState = [...state.filters];
+  tempState.forEach((f, filterIndex) => {
+    if (f.id === key) {
+      const filterValues = f.value;
+      const filterType = f.type;
+      updateFilterState(tempState, filterType, value);
+      if (filterType === CHECKBOX) {
+        /**
+          When all checkboxes of a group are all unselected the value still exists in the filtersObjectArray
+          This checks if all the checkboxes are selected = false and removes it from the array
+        */
+        const valueIndex = filterValues.findIndex((val) => val.id === value);
+        filterValues[valueIndex].selected = false;
+        const updatedFilterObject = {
+          ...f,
+          value: [...filterValues],
+        };
+        tempState[filterIndex] = updatedFilterObject;
+        const index = tempState.findIndex((filter) => filter.id === key);
+
+        // If all the selected state is false remove from array
+        const shouldRemoveFromArray = tempState[index].value.every(
+          (val) => val.selected === false
+        );
+
+        if (shouldRemoveFromArray) {
+          removeFilterItem(tempState, index);
+        }
+      }
+    }
+  });
+  setAllFilters(tempState);
+};
+
+const handleSingleFilterRemoval = (key, value) => {
+  EventEmitter.dispatch(CLEAR_SINGLE_FILTER, { key, value });
+};
+
+const formatDateRange = (startDate, endDate) => {
+  const startDateObj = new Date(startDate);
+  const endDateObj = new Date(endDate);
+  return `${startDateObj.toLocaleDateString()} - ${endDateObj.toLocaleDateString()}`;
+};
+
+const prepareFiltersForTags = (filters, renderDateLabel) => {
   const tags = [];
 
   filters.forEach(({ id, type, value }) => {
+    const sharedFilterProps = {
+      filter: true,
+      onClose: () => handleSingleFilterRemoval(id, value),
+    };
     if (type === DROPDOWN || type === RADIO || type === NUMBER) {
-      tags.push({ key: id, value });
+      tags.push({
+        key: id,
+        value,
+        ...sharedFilterProps,
+      });
     } else if (type === DATE) {
       const [startDate, endDate] = value;
       tags.push({
         key: id,
-        value: `${startDate.toLocaleDateString()} - ${endDate.toLocaleDateString()}`,
+        value:
+          renderDateLabel?.(startDate, endDate) ??
+          formatDateRange(startDate, endDate),
+        ...sharedFilterProps,
       });
     } else if (type === CHECKBOX) {
       value.forEach((checkbox) => {
         if (checkbox.selected) {
-          tags.push({ key: id, value: checkbox.value });
+          tags.push({
+            key: id,
+            value: checkbox.value,
+            ...sharedFilterProps,
+            onClose: () => handleSingleFilterRemoval(id, checkbox.value),
+          });
         }
       });
     }
@@ -51,8 +137,9 @@ const prepareFiltersForTags = (filters) => {
   return tags;
 };
 
-export const FilterProvider = ({ children, filters }) => {
-  const filterTags = prepareFiltersForTags(filters);
+export const FilterProvider = ({ children, filters, filterProps }) => {
+  const { renderDateLabel } = filterProps || {};
+  const filterTags = prepareFiltersForTags(filters, renderDateLabel);
   const [panelOpen, setPanelOpen] = useState(false);
 
   const value = { filterTags, EventEmitter, panelOpen, setPanelOpen };
@@ -67,5 +154,6 @@ FilterProvider.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]).isRequired,
+  filterProps: PropTypes.object,
   filters: PropTypes.arrayOf(PropTypes.object).isRequired,
 };

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/constants.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/constants.js
@@ -21,6 +21,7 @@ export const DROPDOWN = 'dropdown';
 
 /** Constants for event emitters */
 export const CLEAR_FILTERS = 'clearFilters';
+export const CLEAR_SINGLE_FILTER = 'clearSingleFilter';
 
 /** Constants for panel dimensions */
 export const PANEL_WIDTH = 320;

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
@@ -5,7 +5,7 @@
  * US Government Users Restricted Rights - Use, duplication or disclosure
  * restricted by GSA ADP Schedule Contract with IBM Corp.
  */
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import {
   Checkbox,
   DatePicker,
@@ -27,6 +27,7 @@ import {
   PANEL,
 } from '../constants';
 import { getInitialStateFromFilters } from '../utils';
+import { usePreviousValue } from '../../../../../../global/js/hooks';
 
 const useFilters = ({
   updateMethod,
@@ -35,6 +36,7 @@ const useFilters = ({
   variation,
   reactTableFiltersState,
   onCancel = () => {},
+  panelOpen,
 }) => {
   /** State */
   const [filtersState, setFiltersState] = useState(
@@ -45,10 +47,16 @@ const useFilters = ({
     reactTableFiltersState
   );
 
+  const previousState = usePreviousValue({ panelOpen });
+
   // When using batch actions we have to store the filters to then apply them later
   const prevFiltersRef = useRef(JSON.stringify(filtersState));
   const lastAppliedFilters = useRef(JSON.stringify(reactTableFiltersState));
   const prevFiltersObjectArrayRef = useRef(JSON.stringify(filtersObjectArray));
+
+  const holdingPrevFiltersRef = useRef();
+  const holdingLastAppliedFiltersRef = useRef([]);
+  const holdingPrevFiltersObjectArrayRef = useRef([]);
 
   /** Methods */
   // If the user decides to cancel or click outside the flyout, it reverts back to the filters that were
@@ -57,9 +65,19 @@ const useFilters = ({
     setFiltersState(JSON.parse(prevFiltersRef.current));
     setFiltersObjectArray(JSON.parse(prevFiltersObjectArrayRef.current));
     setAllFilters(JSON.parse(lastAppliedFilters.current));
+
+    // Set the temp prev refs, these will be used to populate the prev values once the
+    // panel opens again
+    holdingPrevFiltersRef.current = JSON.parse(prevFiltersRef.current);
+    holdingLastAppliedFiltersRef.current = JSON.parse(
+      prevFiltersObjectArrayRef.current
+    );
+    holdingPrevFiltersObjectArrayRef.current = JSON.parse(
+      lastAppliedFilters.current
+    );
   };
 
-  const reset = () => {
+  const reset = useCallback(() => {
     // When we reset we want the "initialFilters" to be an empty array
     const resetFiltersArray = [];
 
@@ -81,7 +99,7 @@ const useFilters = ({
     prevFiltersObjectArrayRef.current = JSON.stringify(
       initialFiltersObjectArray
     );
-  };
+  }, [filters, setAllFilters, variation]);
 
   const applyFilters = ({ column, value, type }) => {
     // If no end date is selected return because we need the end date to do computations
@@ -327,6 +345,35 @@ const useFilters = ({
 
     return <React.Fragment key={column}>{filter}</React.Fragment>;
   };
+
+  /** This useEffect will properly handle the previous filters when the panel closes
+   * 1. If the panel closes we need to call the reset fn but also store the
+   * previous filters in a (new) temporary place.
+   * 2. When the panel opens again, take the values from the temporary place
+   * and populate the filter state with them
+   */
+  useEffect(() => {
+    if (!panelOpen && previousState?.panelOpen) {
+      setAllFilters(holdingLastAppliedFiltersRef.current);
+    }
+    if (panelOpen && !previousState?.panelOpen) {
+      if (
+        holdingPrevFiltersRef.current &&
+        holdingLastAppliedFiltersRef.current &&
+        holdingPrevFiltersObjectArrayRef.current
+      ) {
+        setFiltersState(holdingPrevFiltersRef.current);
+        setFiltersObjectArray(holdingLastAppliedFiltersRef.current);
+        setAllFilters(JSON.parse(prevFiltersObjectArrayRef.current));
+      }
+    }
+  }, [
+    panelOpen,
+    previousState,
+    previousState?.panelOpen,
+    reset,
+    setAllFilters,
+  ]);
 
   const cancel = () => {
     // Reverting to previous filters only applies when using batch actions

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
@@ -298,6 +298,11 @@ export const PanelBatch = prepareStory(FilteringTemplateWrapper, {
       onPanelOpen: action('onPanelOpen'),
       onPanelClose: action('onPanelClose'),
       panelTitle: 'Filter',
+      renderDateLabel: (start, end) => {
+        const startDateObj = new Date(start);
+        const endDateObj = new Date(end);
+        return `${startDateObj.toLocaleDateString()} - ${endDateObj.toLocaleDateString()}`;
+      },
     },
   },
 });

--- a/packages/ibm-products/src/components/Datagrid/useFiltering.js
+++ b/packages/ibm-products/src/components/Datagrid/useFiltering.js
@@ -20,9 +20,13 @@ const useFiltering = (hooks) => {
       date: (rows, id, [startDate, endDate]) => {
         return rows.filter((row) => {
           const rowValue = row.values[id];
+          const startDateObj =
+            typeof startDate === 'object' ? startDate : new Date(startDate);
+          const endDateObj =
+            typeof endDate === 'object' ? endDate : new Date(endDate);
           if (
-            rowValue.getTime() <= endDate.getTime() &&
-            rowValue.getTime() >= startDate.getTime()
+            rowValue.getTime() <= endDateObj.getTime() &&
+            rowValue.getTime() >= startDateObj.getTime()
           ) {
             // In date range
             return true;

--- a/packages/ibm-products/src/components/FilterSummary/FilterSummary.js
+++ b/packages/ibm-products/src/components/FilterSummary/FilterSummary.js
@@ -24,7 +24,8 @@ let FilterSummary = React.forwardRef(
     },
     ref
   ) => {
-    const tagFilters = filters.map(({ key, value }) => ({
+    const tagFilters = filters.map(({ key, value, ...rest }) => ({
+      ...rest,
       type: 'gray',
       label: renderLabel?.(key, value) ?? `${key}: ${value}`,
     }));

--- a/packages/ibm-products/src/components/FilterSummary/FilterSummary.stories.js
+++ b/packages/ibm-products/src/components/FilterSummary/FilterSummary.stories.js
@@ -95,3 +95,46 @@ export const WithCustomLabel = prepareStory(Template, {
     ],
   },
 });
+
+const TemplateWithClose = (args) => {
+  const [filters, setFilters] = useState(
+    args.filters.map((filter) => ({
+      ...filter,
+      filter: true,
+      onClose: () => handleFilterClose(filter.key),
+      title: 'Remove filter',
+    }))
+  );
+  const clearFilters = () => setFilters([]);
+
+  const handleFilterClose = (filterKey) => {
+    setFilters((prev) => prev.filter((filter) => filter.key !== filterKey));
+  };
+
+  return (
+    <div style={{ width: args.containerWidth }}>
+      <FilterSummary
+        clearFiltersText={args.clearFiltersText}
+        filters={filters}
+        clearFilters={clearFilters}
+        renderLabel={args.renderLabel}
+      />
+    </div>
+  );
+};
+// eslint-disable-next-line react/prop-types
+export const WithFilterClose = prepareStory(TemplateWithClose, {
+  args: {
+    clearFiltersText: 'Clear filters',
+    filters: [
+      //cspell: disable
+      { key: 'project', value: 'Goldmember' },
+      //cspell: enable
+      { key: 'owner', value: 'Austin Powers' },
+      { key: 'middle name', value: 'Danger' },
+      { key: 'spy', value: true },
+      { key: 'title', value: 'International man of mystery' },
+    ],
+    containerWidth: 500,
+  },
+});

--- a/packages/ibm-products/src/components/TagSet/TagSet.js
+++ b/packages/ibm-products/src/components/TagSet/TagSet.js
@@ -17,7 +17,7 @@ import { Tag } from 'carbon-components-react';
 import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
-import { prepareProps, isRequiredIf } from '../../global/js/utils/props-helper';
+import { isRequiredIf } from '../../global/js/utils/props-helper';
 import { pkg } from '../../settings';
 
 const componentName = 'TagSet';
@@ -98,7 +98,6 @@ export let TagSet = React.forwardRef(
                   <Tag
                     {...other} // ensure id is not duplicated
                     data-original-id={id}
-                    filter={false}
                   >
                     {label}
                   </Tag>
@@ -115,7 +114,7 @@ export let TagSet = React.forwardRef(
       let newDisplayedTags =
         tags && tags.length > 0
           ? tags.map(({ label, ...other }, index) => (
-              <Tag {...other} filter={false} key={`displayed-tag-${index}`}>
+              <Tag {...other} key={`displayed-tag-${index}`}>
                 {label}
               </Tag>
             ))
@@ -360,14 +359,12 @@ TagSet.propTypes = {
    * with properties: **label**\* (required) to supply the tag content, and
    * other properties will be passed to the Carbon Tag component, such as
    * **type**, **disabled**, **ref**, **className** , and any other Tag props.
-   * NOTE: **filter** is not supported. Any other fields in the object will be passed through to the HTML element
-   * as HTML attributes.
    *
    * See https://react.carbondesignsystem.com/?path=/docs/components-tag--default
    */
   tags: PropTypes.arrayOf(
     PropTypes.shape({
-      ...prepareProps(Tag.propTypes, 'filter'),
+      ...Tag.propTypes,
       label: PropTypes.string.isRequired,
       // we duplicate this prop to improve the DocGen
       type: PropTypes.oneOf(tagTypes),

--- a/packages/ibm-products/src/components/TagSet/TagSet.stories.js
+++ b/packages/ibm-products/src/components/TagSet/TagSet.stories.js
@@ -1,11 +1,11 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2023
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
 
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 
 import { types as tagTypes } from 'carbon-components-react/es/components/Tag/Tag';
 import { pkg } from '../../settings';
@@ -204,6 +204,44 @@ export const MultilineTags = prepareStory(Template, {
 export const HundredsOfTags = prepareStory(Template, {
   args: {
     tags: hundredsOfTags,
+    containerWidth: 500,
+    ...overflowAndModalStrings,
+  },
+});
+
+const TemplateWithClose = (argsIn) => {
+  const { containerWidth, allTagsModalTargetCustomDomNode, tags, ...args } = {
+    ...argsIn,
+  };
+  const [liveTags, setLiveTags] = useState(
+    tags.map((tag) => ({
+      ...tag,
+      filter: true,
+      onClose: () => handleTagClose(tag.label),
+    }))
+  );
+
+  const handleTagClose = (key) => {
+    setLiveTags((prev) => prev.filter((tag) => tag.label !== key));
+  };
+
+  const ref = useRef();
+  return (
+    <div style={{ width: containerWidth }} ref={ref}>
+      <TagSet
+        {...args}
+        tags={liveTags}
+        allTagsModalTarget={
+          allTagsModalTargetCustomDomNode ? ref.current : undefined
+        }
+      />
+    </div>
+  );
+};
+
+export const WithClose = prepareStory(TemplateWithClose, {
+  args: {
+    tags: manyTags,
     containerWidth: 500,
     ...overflowAndModalStrings,
   },


### PR DESCRIPTION
Contributes to #3402 

This PR adds functionality to remove individual filter tags from the filter summary component used in the Datagrid. This change works with both the flyout and panel variants.

Note: In order to achieve this, I had to include updates to the `FilterSummary` and `TagSet` components that I did not make in the corresponding v2 PR because @lee-chase had already done this on the `main` branch/v2.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/Datagrid.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterProvider.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/constants.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
packages/ibm-products/src/components/Datagrid/useFiltering.js
packages/ibm-products/src/components/FilterSummary/FilterSummary.js
packages/ibm-products/src/components/FilterSummary/FilterSummary.stories.js
packages/ibm-products/src/components/TagSet/TagSet.js
packages/ibm-products/src/components/TagSet/TagSet.stories.js
```
#### How did you test and verify your work?
Storybook