### PR TITLE
fix(storybook-addon-carbon-theme): build storybook addon as CommonJS

### DIFF
--- a/config/storybook-addon-carbon-theme/.babelrc
+++ b/config/storybook-addon-carbon-theme/.babelrc
@@ -1,3 +1,9 @@
 {
-  "presets": ["@babel/preset-react"]
+  "presets": [
+    "@babel/preset-env",
+    "@babel/preset-react"
+  ],
+  "targets": {
+    "node": "16.0"
+  }
 }


### PR DESCRIPTION
In the current version 2.0.4, the dist directory contains files in ES modules format. However, the declared format of the bundle is traditional CommoJS. This causes usage issues:

```
WARN   Failed to load preset: {"type":"presets","name":"/redacted/node_modules/@carbon/storybook-addon-theme/dist/preset.js"} on level 1
./node_modules/@carbon/storybook-addon-theme/dist/preset.js:11
export default {
^^^^^^

SyntaxError: Unexpected token 'export'
    at internalCompileFunction (node:internal/vm:73:18)
    at wrapSafe (node:internal/modules/cjs/loader:1178:20)
    at Module._compile (node:internal/modules/cjs/loader:1220:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Object.newLoader (./node_modules/esbuild-register/dist/node.js:2262:9)
    at extensions..js (./node_modules/esbuild-register/dist/node.js:4838:24)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Module.require (node:internal/modules/cjs/loader:1143:19)
    at require (node:internal/modules/cjs/helpers:110:18)
```

#### What did you change?
Added babel-env preset which auto-detects the expected target module format and transpiles accordingly.
Also, configured targets to match the target storybook environment.

#### How did you test and verify your work?
1. Verified that ibm-products storybook launches without errors and that I can switch the theme inside the storybook.
2. Used `npm link` to connect changed addon package to an external project which uses the storybook addon. Verified that storybook launches without errors and that I can switch the theme inside the storybook.