### PR TITLE
fix: Storybook errors 'Invalid argument ... oneOf(...), oneOfType(…)'

### DIFF
--- a/packages/ibm-products/src/global/js/utils/StoryDocsPage.js
+++ b/packages/ibm-products/src/global/js/utils/StoryDocsPage.js
@@ -244,12 +244,12 @@ StoryDocsPage.propTypes = {
   /**
    * location if any of guidelines on the PAL site, constructed by default
    */
-  altGuidelinesHref: PropTypes.oneOfType(
+  altGuidelinesHref: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.arrayOf(
       PropTypes.shape({ href: PropTypes.string, label: PropTypes.string })
-    )
-  ),
+    ),
+  ]),
   /**
    * Uses component name by default
    */
@@ -284,7 +284,7 @@ StoryDocsPage.propTypes = {
        * default language `jsx`
        */
       source: PropTypes.shape({
-        language: PropTypes.oneOf('javascript', 'css', 'jsx', 'json'),
+        language: PropTypes.oneOf(['javascript', 'css', 'jsx', 'json']),
         code: PropTypes.string,
       }),
     })


### PR DESCRIPTION
Contributes to #3591 and #3592 

Fixes console errors in Storybook.

#### What did you change?

Updated two `propTypes`.

#### How did you test and verify your work?

- [x] Verified error no longer appeared in browser console.
- [ ] Verified by @lee-chase that I didn't break anything.