### PR TITLE
fix: Storybook error "future version of React will block javascript: URLs" 

### DIFF
--- a/packages/ibm-products/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/ibm-products/src/components/PageHeader/PageHeader.stories.js
@@ -838,7 +838,12 @@ const TemplateDemo = ({
           isFixedNav
         >
           <SideNavItems>
-            <SideNavLink href="javascript:void(0)">Sample side bar</SideNavLink>
+            <SideNavLink
+              href="https://pages.github.ibm.com/cdai-design/pal/"
+              target="_blank"
+            >
+              Sample link: Carbon for IBM Products
+            </SideNavLink>
           </SideNavItems>
         </SideNav>
       </Header>


### PR DESCRIPTION
Contributes to #3593 

Fixes a console error in Storybook.

#### What did you change?

Replaced `href="javascript:void(0);" with a valid URL.

#### How did you test and verify your work?

- [x] Verified error no longer appeared in browser console.
- [ ] Verified by @lee-chase that I didn't break anything.
