### PR TITLE
fix: Storybook error "placeHolderText is not a DOM element"

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/utils/DatagridActions.js
+++ b/packages/ibm-products/src/components/Datagrid/utils/DatagridActions.js
@@ -146,7 +146,7 @@ export const DatagridActions = (datagridState) => {
           size="lg"
           id="columnSearch"
           persistent
-          placeHolderText={searchForAColumn}
+          placeholder={searchForAColumn}
           onChange={(e) => setGlobalFilter(e.target.value)}
         />
         {renderFilterFlyout()}
@@ -202,7 +202,7 @@ export const DatagridActions = (datagridState) => {
           size="xl"
           id="columnSearch"
           persistent
-          placeHolderText={searchForAColumn}
+          placeholder={searchForAColumn}
           onChange={(e) => setGlobalFilter(e.target.value)}
         />
         {renderFilterFlyout()}


### PR DESCRIPTION
Contributes to #3595

Fixes a console error in Storybook.

#### What did you change?

Changed a prop name from `placeHolderText` to `placeholder`

#### How did you test and verify your work?

- [x] Verified error no longer appeared in browser console.