### PR TITLE
fix: Storybook error "renderIcon is not a DOM element"

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/utils/DatagridActions.js
+++ b/packages/ibm-products/src/components/Datagrid/utils/DatagridActions.js
@@ -178,7 +178,7 @@ export const DatagridActions = (datagridState) => {
         <RowSizeDropdown {...rowSizeDropdownProps} />
         <MenuButton
           label="Primary button"
-          renderIcon={ChevronDown}
+          // renderIcon={ChevronDown}
           className={`${blockClass}__toolbar-options`}
         >
           <MenuItem

--- a/packages/ibm-products/src/components/Datagrid/utils/DatagridActions.js
+++ b/packages/ibm-products/src/components/Datagrid/utils/DatagridActions.js
@@ -178,7 +178,6 @@ export const DatagridActions = (datagridState) => {
         <RowSizeDropdown {...rowSizeDropdownProps} />
         <MenuButton
           label="Primary button"
-          // renderIcon={ChevronDown}
           className={`${blockClass}__toolbar-options`}
         >
           <MenuItem


### PR DESCRIPTION
Contributes to #3595

Fixes a console error in Storybook.

#### What did you change?

Removed a prop.

#### How did you test and verify your work?

- [x] Verified error no longer appeared in browser console.