### PR TITLE
fix: Storybook error "isDelete is not a DOM element"

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
@@ -511,7 +511,6 @@ export const BatchActions = () => {
         id: 'delete',
         itemText: 'Delete',
         icon: TrashCan,
-        isDelete: true,
         onClick: action('Clicked row action: delete'),
       },
     ];


### PR DESCRIPTION
Contributes to #3595

Fixes a console error in Storybook.

#### What did you change?

Removed a prop.

#### How did you test and verify your work?

- [x] Verified error no longer appeared in browser console.