### PR TITLE
fix: Storybook warning "light prop is deprecated"

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useActionsColumn.js
+++ b/packages/ibm-products/src/components/Datagrid/useActionsColumn.js
@@ -84,7 +84,6 @@ const useActionsColumn = (hooks) => {
                               {...rest}
                               align={align || 'top'}
                               renderIcon={icon}
-                              light
                               iconDescription={itemText}
                               kind="ghost"
                               className={cx({
@@ -110,7 +109,6 @@ const useActionsColumn = (hooks) => {
                       <OverflowMenu
                         align="top-right"
                         size="sm"
-                        light
                         flipped
                         onClick={(e) => {
                           e.stopPropagation();


### PR DESCRIPTION
Contributes to #3595 

Fixes a console warning in Storybook.

#### What did you change?

Removed a prop.

#### How did you test and verify your work?

- [x] Verified error no longer appeared in browser console.