### PR TITLE
fix: Storybook console error 'role=boolean'

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridEmptyBody.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridEmptyBody.js
@@ -43,7 +43,7 @@ const DatagridEmptyBody = (datagridState) => {
 
   return (
     <TableBody
-      {...getTableBodyProps({ role: false })}
+      {...getTableBodyProps({ role: 'none' })}
       className={`${blockClass}__empty-state-body`}
     >
       <TableRow>

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridEmptyBody.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridEmptyBody.js
@@ -43,7 +43,7 @@ const DatagridEmptyBody = (datagridState) => {
 
   return (
     <TableBody
-      {...getTableBodyProps({ role: 'none' })}
+      {...getTableBodyProps()}
       className={`${blockClass}__empty-state-body`}
     >
       <TableRow>

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -115,7 +115,7 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
 
   return (
     <TableRow
-      {...headerGroup.getHeaderGroupProps({ role: 'none' })}
+      {...headerGroup.getHeaderGroupProps()}
       className={cx(
         `${blockClass}__head`,
         headerGroup.getHeaderGroupProps().className

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -115,7 +115,7 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
 
   return (
     <TableRow
-      {...headerGroup.getHeaderGroupProps({ role: false })}
+      {...headerGroup.getHeaderGroupProps({ role: 'none' })}
       className={cx(
         `${blockClass}__head`,
         headerGroup.getHeaderGroupProps().className

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRefBody.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRefBody.js
@@ -19,7 +19,7 @@ const DatagridRefBody = (datagridState) => {
   const { getTableBodyProps, rows, prepareRow } = datagridState;
   return (
     <tbody
-      {...getTableBodyProps({ role: false })}
+      {...getTableBodyProps({ role: 'none' })}
       className={cx(
         `${blockClass}__simple-body`,
         getTableBodyProps().className

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRefBody.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRefBody.js
@@ -19,7 +19,7 @@ const DatagridRefBody = (datagridState) => {
   const { getTableBodyProps, rows, prepareRow } = datagridState;
   return (
     <tbody
-      {...getTableBodyProps({ role: 'none' })}
+      {...getTableBodyProps()}
       className={cx(
         `${blockClass}__simple-body`,
         getTableBodyProps().className

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.js
@@ -111,7 +111,7 @@ const DatagridRow = (datagridState) => {
     <>
       <TableRow
         className={rowClassNames}
-        {...row.getRowProps({ role: 'none' })}
+        {...row.getRowProps()}
         key={row.id}
         onMouseEnter={hoverHandler}
         onMouseLeave={handleMouseLeave}
@@ -120,7 +120,7 @@ const DatagridRow = (datagridState) => {
         onKeyUp={handleOnKeyUp}
       >
         {row.cells.map((cell, index) => {
-          const cellProps = cell.getCellProps({ role: 'none' });
+          const cellProps = cell.getCellProps();
           const { children, ...restProps } = cellProps;
           const content = children || (
             <>

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.js
@@ -111,7 +111,7 @@ const DatagridRow = (datagridState) => {
     <>
       <TableRow
         className={rowClassNames}
-        {...row.getRowProps({ role: false })}
+        {...row.getRowProps({ role: 'none' })}
         key={row.id}
         onMouseEnter={hoverHandler}
         onMouseLeave={handleMouseLeave}
@@ -120,7 +120,7 @@ const DatagridRow = (datagridState) => {
         onKeyUp={handleOnKeyUp}
       >
         {row.cells.map((cell, index) => {
-          const cellProps = cell.getCellProps({ role: false });
+          const cellProps = cell.getCellProps({ role: 'none' });
           const { children, ...restProps } = cellProps;
           const content = children || (
             <>

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSimpleBody.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSimpleBody.js
@@ -16,7 +16,7 @@ const DatagridSimpleBody = (datagridState) => {
   const { getTableBodyProps, rows, prepareRow } = datagridState;
   return (
     <TableBody
-      {...getTableBodyProps({ role: false })}
+      {...getTableBodyProps({ role: 'none' })}
       className={cx(
         `${blockClass}__simple-body`,
         getTableBodyProps().className

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSimpleBody.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSimpleBody.js
@@ -16,7 +16,7 @@ const DatagridSimpleBody = (datagridState) => {
   const { getTableBodyProps, rows, prepareRow } = datagridState;
   return (
     <TableBody
-      {...getTableBodyProps({ role: 'none' })}
+      {...getTableBodyProps()}
       className={cx(
         `${blockClass}__simple-body`,
         getTableBodyProps().className

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
@@ -85,10 +85,7 @@ const DatagridVirtualBody = (datagridState) => {
       >
         <DatagridHead {...datagridState} />
       </div>
-      <TableBody
-        {...getTableBodyProps({ role: 'none' })}
-        onScroll={(e) => syncScroll(e)}
-      >
+      <TableBody {...getTableBodyProps()} onScroll={(e) => syncScroll(e)}>
         <VariableSizeList
           height={virtualHeight || tableHeight}
           itemCount={visibleRows.length}

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
@@ -86,7 +86,7 @@ const DatagridVirtualBody = (datagridState) => {
         <DatagridHead {...datagridState} />
       </div>
       <TableBody
-        {...getTableBodyProps({ role: false })}
+        {...getTableBodyProps({ role: 'none' })}
         onScroll={(e) => syncScroll(e)}
       >
         <VariableSizeList


### PR DESCRIPTION
Contributes to #3595

Fixes console errors in Storybook.

#### What did you change?

Changed value assignment from a `boolean` to the correct `string`.

#### How did you test and verify your work?

- [x] Verified error no longer appeared in browser console.
- [ ] Verified by @lee-chase that I didn't break anything.