### PR TITLE
fix: Remove 'subcomponents' from Storybook settings

### DIFF
--- a/packages/ibm-products/src/components/ComboButton/ComboButton.stories.js
+++ b/packages/ibm-products/src/components/ComboButton/ComboButton.stories.js
@@ -22,9 +22,6 @@ export default {
   title: getStoryTitle(ComboButton.displayName),
   component: ComboButton,
   tags: ['autodocs'],
-  subcomponents: {
-    ComboButtonItem,
-  },
   parameters: {
     // styles
   },

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.stories.js
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.stories.js
@@ -48,7 +48,6 @@ export default {
   title: getStoryTitle(CreateFullPage.displayName),
   component: CreateFullPage,
   tags: ['autodocs'],
-  subcomponents: { CreateFullPageStep },
   parameters: {
     styles,
     layout: 'fullscreen',

--- a/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.stories.js
+++ b/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.stories.js
@@ -12,7 +12,6 @@ import {
 import styles from './_storybook-styles.scss';
 import { CreateTearsheet } from './CreateTearsheet';
 import DocsPage from './CreateTearsheet.docs-page';
-import { CreateTearsheetStep } from './CreateTearsheetStep';
 import { MultiStepTearsheet } from './preview-components/MultiStepTearsheet';
 import { MultiStepWithIntro } from './preview-components/MultiStepWithIntro';
 
@@ -20,9 +19,6 @@ export default {
   title: getStoryTitle(CreateTearsheet.displayName),
   component: CreateTearsheet,
   tags: ['autodocs'],
-  subcomponents: {
-    CreateTearsheetStep,
-  },
   argTypes: {
     description: { control: { type: 'text' } },
     label: { control: { type: 'text' } },

--- a/packages/ibm-products/src/components/EditFullPage/EditFullPage.stories.js
+++ b/packages/ibm-products/src/components/EditFullPage/EditFullPage.stories.js
@@ -41,7 +41,6 @@ export default {
   title: getStoryTitle(EditFullPage.displayName),
   component: EditFullPage,
   tags: ['autodocs'],
-  subcomponents: { CreateFullPageStep },
   parameters: {
     styles,
     layout: 'fullscreen',

--- a/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.stories.js
+++ b/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.stories.js
@@ -12,16 +12,12 @@ import {
 import styles from './_storybook-styles.scss';
 import { EditTearsheet } from './EditTearsheet';
 import DocsPage from './EditTearsheet.docs-page';
-import { EditTearsheetForm } from './EditTearsheetForm';
 import { MultiFormEditTearsheet } from './preview-components/MultiFormEditTearsheet';
 
 export default {
   title: getStoryTitle(EditTearsheet.displayName),
   component: EditTearsheet,
   tags: ['autodocs'],
-  subcomponents: {
-    EditTearsheetForm,
-  },
   argTypes: {
     description: { control: { type: 'text' } },
     label: { control: { type: 'text' } },

--- a/packages/ibm-products/src/components/EmptyStates/EmptyStates.stories.js
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyStates.stories.js
@@ -15,15 +15,7 @@ import {
 } from '../../global/js/utils/story-helper';
 // import mdx from './EmptyState.mdx';
 
-import {
-  EmptyState,
-  ErrorEmptyState,
-  NoDataEmptyState,
-  NoTagsEmptyState,
-  NotFoundEmptyState,
-  NotificationsEmptyState,
-  UnauthorizedEmptyState,
-} from '.';
+import { EmptyState } from '.';
 import { StoryDocsPage } from '../../global/js/utils/StoryDocsPage';
 
 // import styles from './_storybook-styles.scss';
@@ -32,14 +24,6 @@ export default {
   title: getStoryTitle(EmptyState.displayName),
   component: EmptyState,
   tags: ['autodocs'],
-  subcomponents: {
-    ErrorEmptyState,
-    NoDataEmptyState,
-    NoTagsEmptyState,
-    NotFoundEmptyState,
-    NotificationsEmptyState,
-    UnauthorizedEmptyState,
-  },
   parameters: {
     // styles,
     docs: {

--- a/packages/ibm-products/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/ibm-products/src/components/PageHeader/PageHeader.stories.js
@@ -40,7 +40,6 @@ import {
 } from '@carbon/react/icons';
 import cx from 'classnames';
 
-import { ActionBarItem } from '../ActionBar';
 import { PageHeader } from './PageHeader';
 
 import {
@@ -399,7 +398,6 @@ export default {
   title: getStoryTitle(PageHeader.displayName),
   component: PageHeader,
   tags: ['autodocs'],
-  subcomponents: { ActionBarItem },
   parameters: { styles, layout: 'fullscreen' /* docs: { page: mdx } */ },
   decorators: [
     (story, { args }) => (

--- a/packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.js
+++ b/packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.js
@@ -24,7 +24,6 @@ import {
 } from '@carbon/react';
 
 import { Tearsheet, deprecatedProps } from './Tearsheet';
-import { TearsheetNarrow } from '.';
 import {
   actionsOptions,
   actionsLabels,
@@ -45,7 +44,6 @@ export default {
   title: getStoryTitle(Tearsheet.displayName),
   component: Tearsheet,
   tags: ['autodocs'],
-  subcomponents: { TearsheetNarrow },
   parameters: { styles /* docs: { page: mdx } */, layout: 'fullscreen' },
   argTypes: {
     ...getDeprecatedArgTypes(deprecatedProps),

--- a/packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.stories.js
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.stories.js
@@ -13,7 +13,6 @@ import { pkg } from '../../settings';
 
 import { Button, Form, FormGroup, TextInput } from '@carbon/react';
 
-import { Tearsheet } from '.';
 import { TearsheetNarrow, deprecatedProps } from './TearsheetNarrow';
 
 import {
@@ -36,7 +35,6 @@ export default {
   title: getStoryTitle(TearsheetNarrow.displayName),
   component: TearsheetNarrow,
   tags: ['autodocs'],
-  subcomponents: { Tearsheet },
   parameters: { layout: 'fullscreen', styles /* docs: { page: mdx } */ },
   argTypes: {
     ...getDeprecatedArgTypes(deprecatedProps),

--- a/packages/ibm-products/src/components/Toolbar/Toolbar.stories.js
+++ b/packages/ibm-products/src/components/Toolbar/Toolbar.stories.js
@@ -44,9 +44,6 @@ export default {
   title: getStoryTitle(Toolbar.displayName),
   component: Toolbar,
   tags: ['autodocs'],
-
-  subcomponents: { ToolbarGroup, ToolbarButton },
-
   parameters: {
     docs: {
       page: DocsPage,


### PR DESCRIPTION
Contributes to #3667 

Fixes a console warning in Storybook.

#### What did you change?

Removed `subcomponents` property from Storybook settings.

#### How did you test and verify your work?

- [x] Verified error no longer appeared in browser console.
- [ ] Verified by @lee-chase that I didn't break anything.