### PR TITLE
fix(CreateFullPage): fix back button in full page

### DIFF
--- a/packages/ibm-products/src/global/js/hooks/useCreateComponentStepChange.js
+++ b/packages/ibm-products/src/global/js/hooks/useCreateComponentStepChange.js
@@ -79,10 +79,7 @@ export const useCreateComponentStepChange = ({
       }
     };
     const handlePrevious = async () => {
-      if (componentName === 'CreateFullPage') {
-        return;
-      }
-      setLoadingPrevious(true);
+      setLoadingPrevious?.(true);
       if (typeof onPrevious === 'function') {
         try {
           await onPrevious();


### PR DESCRIPTION
Contributes to #3676 

Fixes the back/previous button in the CreateFullPage component, functionality stopped working after optional handler for back button was added for `CreateTearsheet`.

#### What did you change?
```
packages/ibm-products/src/global/js/hooks/useCreateComponentStepChange.js
```
#### How did you test and verify your work?
Storybook