### PR TITLE
feat(Datagrid): add `renderLabel` support to v1 filtering

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -160,6 +160,7 @@ export const DatagridContent = ({ datagridState, title }) => {
         className={`${blockClass}__filter-summary`}
         filters={filterTags}
         clearFilters={() => EventEmitter.dispatch(CLEAR_FILTERS)}
+        renderLabel={filterProps.renderLabel}
       />
     );
 


### PR DESCRIPTION
Contributes to #3680 

Adds support for a custom `renderLabel` function in the filterProps that can be used to customizing the rendering/display of the filter tags from the `FilterSummary` component.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
```
#### How did you test and verify your work?
Storybook