### PR TITLE
fix: Storybook warning "feature Datagrid.useActionsColumn not enabled"

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
@@ -190,6 +190,7 @@ const FilteringUsage = ({ defaultGridProps }) => {
   // Warnings are ordinarily silenced in storybook, add this to test
   pkg._silenceWarnings(false);
   // Enable feature flag for `useFiltering` hook
+  pkg.feature['Datagrid.useActionsColumn'] = true;
   pkg.feature['Datagrid.useFiltering'] = true;
   pkg._silenceWarnings(true);
 


### PR DESCRIPTION
Contributes to #3684 

Fixes a console warning in Storybook.

#### What did you change?

Enabled the feature in the Storybook story.

#### How did you test and verify your work?

- [x] Verified error no longer appeared in browser console. 