### PR TITLE
fix(Datagrid): import filter summary styles from datagrid

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/_datagrid.scss
@@ -24,6 +24,7 @@
 // Datagrid uses the following Carbon for IBM Products components:
 // TODO: @use(s) of IBM Products component styles used by Datagrid
 @use '../ButtonMenu';
+@use '../FilterSummary';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 $block-class: #{c4p-settings.$pkg-prefix}--datagrid;

--- a/packages/ibm-products/src/components/_index.scss
+++ b/packages/ibm-products/src/components/_index.scss
@@ -23,7 +23,7 @@
 @use './EmptyStates';
 @use './ExportModal';
 @use './ExpressiveCard';
-@use './FilterSummary/index';
+@use './FilterSummary';
 @use './HTTPErrors';
 @use './ImportModal';
 @use './MultiAddSelect';


### PR DESCRIPTION
Contributes to #3688 

Discovered that the Datagrid does not import the FilterSummary styles, which causes some visual issues since the FilterSummary is an internal component.

Discovered as I was building a [code sandbox](https://codesandbox.io/p/sandbox/datagrid-filter-panel-lj7rn7?file=%2Fsrc%2Findex.scss%3A4%2C39) for Datagrid, filter panel
![image](https://github.com/carbon-design-system/ibm-products/assets/10215203/794ef90f-8679-4d58-b99f-e253aa2f86b4)

_Expected layout_
![image](https://github.com/carbon-design-system/ibm-products/assets/10215203/7fc0085c-db5d-4f6d-92e4-fb6c28cb90b1)



#### What did you change?
Imported FilterSummary styles from Datagrid
#### How did you test and verify your work?
Verified that filter summary styles are now included in the built css