### PR TITLE
fix(Datagrid): import filter summary styles from datagrid

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/_datagrid.scss
@@ -19,6 +19,7 @@
 
 // Datagrid uses the following Carbon for IBM Products components:
 // TODO: @import(s) of IBM Products component styles used by Datagrid
+@import '../FilterSummary';
 
 // Define all component styles in a mixin which is then exported using
 // the Carbon import-once mechanism.

--- a/packages/ibm-products/src/components/Datagrid/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/_datagrid.scss
@@ -19,7 +19,7 @@
 
 // Datagrid uses the following Carbon for IBM Products components:
 // TODO: @import(s) of IBM Products component styles used by Datagrid
-@import '../FilterSummary';
+@import '../FilterSummary/filter-summary';
 
 // Define all component styles in a mixin which is then exported using
 // the Carbon import-once mechanism.


### PR DESCRIPTION
Contributes to #3688 

Discovered that the Datagrid does not import the FilterSummary styles, which causes some visual issues since the FilterSummary is an internal component.

Discovered as I was building a [code sandbox](https://codesandbox.io/p/sandbox/datagrid-filter-panel-lj7rn7?file=%2Fsrc%2Findex.scss%3A4%2C39) for Datagrid, filter panel
![image](https://github.com/carbon-design-system/ibm-products/assets/10215203/794ef90f-8679-4d58-b99f-e253aa2f86b4)

_Expected layout_
![image](https://github.com/carbon-design-system/ibm-products/assets/10215203/7fc0085c-db5d-4f6d-92e4-fb6c28cb90b1)



#### What did you change?
Imported FilterSummary styles from Datagrid
#### How did you test and verify your work?
Verified that filter summary styles are now included in the built css