### PR TITLE
fix: Storybook warning "feature Datagrid.useActionsColumn not enabled" in Datagrid.stories.js

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
@@ -485,6 +485,11 @@ const getBatchActions = () => {
 
 export const BatchActions = () => {
   const [data] = useState(makeData(10));
+
+  pkg._silenceWarnings(false); // warnings are ordinarily silenced in storybook, add this to test.
+  pkg.feature['Datagrid.useActionsColumn'] = true;
+  pkg._silenceWarnings(true);
+
   const columns = React.useMemo(
     () => [
       ...getColumns(data),
@@ -593,6 +598,11 @@ export const TopAlignment = () => {
 
 export const FrozenColumns = () => {
   const [data] = useState(makeData(10));
+
+  pkg._silenceWarnings(false); // warnings are ordinarily silenced in storybook, add this to test.
+  pkg.feature['Datagrid.useActionsColumn'] = true;
+  pkg._silenceWarnings(true);
+
   const columns = React.useMemo(
     () => [
       ...getColumns(data),


### PR DESCRIPTION
Contributes to #3691

Fixes a console warning in Storybook.

#### What did you change?

Enabled the feature flag in the Storybook story.

#### How did you test and verify your work?

- [x] Verified error no longer appeared in browser console. 