### PR TITLE
fix: Storybook warning "feature Datagrid.useActionsColumn not enabled" in ColumnCustomization.stories.js

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
@@ -259,6 +259,10 @@ export const ColumnCustomizationUsageStory = prepareStory(
 const ColumnCustomizationWithFixedColumn = ({ ...args }) => {
   const stickyHeaders = defaultHeader.slice(1, 15);
 
+  pkg._silenceWarnings(false);
+  pkg.feature['Datagrid.useActionsColumn'] = true;
+  pkg._silenceWarnings(true);
+
   const columns = React.useMemo(
     () => [
       {


### PR DESCRIPTION
Contributes to #3691

Fixes a console warning in Storybook.

#### What did you change?

Enabled the feature flag in the Storybook story.

#### How did you test and verify your work?

- [x] Verified error no longer appeared in browser console. 