### PR TITLE
fix: Storybook error "multiForm is not a valid prop for a DOM element"

### DIFF
--- a/packages/ibm-products/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.stories.js
+++ b/packages/ibm-products/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.stories.js
@@ -299,6 +299,5 @@ export const withMultipleForms = prepareStory(WithValidationTemplate, {
   storyName: withMultipleFormsStoryName,
   args: {
     ...defaultStoryProps,
-    multiForm: true,
   },
 });

--- a/packages/ibm-products/src/components/EditTearsheetNarrow/EditTearsheetNarrow.stories.js
+++ b/packages/ibm-products/src/components/EditTearsheetNarrow/EditTearsheetNarrow.stories.js
@@ -291,6 +291,5 @@ export const withMultipleForms = prepareStory(WithValidationTemplate, {
   storyName: withMultipleFormsStoryName,
   args: {
     ...defaultStoryProps,
-    multiForm: true,
   },
 });


### PR DESCRIPTION
Contributes to #3697 

Fixes a console error in Storybook.

#### What did you change?

Removed a prop.

#### How did you test and verify your work?

- [x] Verified error no longer appeared in browser console.