### PR TITLE
Fix 3699 sb error labeltext of type object

### DIFF
--- a/packages/ibm-products/src/components/CreateFullPage/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/CreateFullPage/_storybook-styles.scss
@@ -58,7 +58,7 @@ $block-class: #{c4p-settings.$pkg-prefix}--create-full-page;
 .#{$story-class}__error--text {
   @include type.type-style('label-01');
 
-  padding-bottom: $spacing-05;
+  margin-bottom: $spacing-05;
 }
 
 .#{$block-class}

--- a/packages/ibm-products/src/components/EditFullPage/EditFullPage.stories.js
+++ b/packages/ibm-products/src/components/EditFullPage/EditFullPage.stories.js
@@ -130,19 +130,20 @@ const Template = ({ ...args }) => {
                 />
               )}
               <div>
+                <div>
+                  <DefinitionTooltip
+                    className={`${storyClass}__error--text`}
+                    size="sm"
+                    definition={
+                      'Once toggled on, an inline error notification will appear upon clicking next. This is an example usage of how to prevent the next step if some kind of error occurred during the `onNext` handler.'
+                    }
+                  >
+                    Simulate error
+                  </DefinitionTooltip>
+                </div>
                 <Toggle
-                  className={`${storyClass}__error--toggle`}
                   id="simulated-error-toggle"
                   size="sm"
-                  labelText={
-                    <DefinitionTooltip
-                      definition={
-                        'Once toggled on, an inline error notification will appear upon clicking next. This is an example usage of how to prevent the next step if some kind of error occurred during the `onNext` handler.'
-                      }
-                    >
-                      Simulate error
-                    </DefinitionTooltip>
-                  }
                   onToggle={(event) => setShouldReject(event)}
                 />
               </div>


### PR DESCRIPTION
Contributes to #3699

Fixes a console error in Storybook.

#### What did you change?

Modified layout so that the toggle's "label" showed it's tooltip without throwing a console error.

#### How did you test and verify your work?

- [x] viewed in Storybook
- [x] Verified error no longer appeared in browser console.

<img width="600" src="https://github.com/carbon-design-system/ibm-products/assets/52505287/d96bbbf8-d0d0-44c0-9f60-0a15b908355f" />