### PR TITLE
fix: Storybook error 'triggerclassname is not a DOM element'

### DIFF
--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.stories.js
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.stories.js
@@ -26,7 +26,7 @@ import {
   NumberInput,
   InlineNotification,
   Toggle,
-  Tooltip,
+  DefinitionTooltip,
   RadioButtonGroup,
   RadioButton,
   FormGroup,
@@ -148,24 +148,21 @@ const Template = ({ ...args }) => {
                 />
               )}
               <div>
-                <Tooltip
-                  triggerClassName={`${storyClass}__tooltip`}
-                  direction="right"
-                  tabIndex={0}
-                >
-                  <p className={`${storyClass}__error--text`}>
-                    Once toggled on, an inline error notification will appear
-                    upon clicking next. This is an example usage of how to
-                    prevent the next step if some kind of error occurred during
-                    the `onNext` handler.
-                  </p>
-                </Tooltip>
+                <div>
+                  <DefinitionTooltip
+                    className={`${storyClass}__error--text`}
+                    size="sm"
+                    definition={
+                      'Once toggled on, an inline error notification will appear upon clicking next. This is an example usage of how to prevent the next step if some kind of error occurred during the `onNext` handler.'
+                    }
+                  >
+                    Simulate error
+                  </DefinitionTooltip>
+                </div>
                 <Toggle
-                  className={`${storyClass}__error--toggle`}
                   id="simulated-error-toggle"
                   size="sm"
-                  labelText="Simulate error"
-                  onClick={() => setShouldReject((prev) => !prev)}
+                  onToggle={(event) => setShouldReject(event)}
                 />
               </div>
               <Checkbox
@@ -347,23 +344,20 @@ const TemplateWithSections = ({ ...args }) => {
                   />
                 )}
                 <div>
-                  <Tooltip
-                    triggerClassName={`${storyClass}__tooltip`}
-                    direction="right"
-                    tabIndex={0}
-                  >
-                    <p className={`${storyClass}__error--text`}>
-                      Once toggled on, an inline error notification will appear
-                      upon clicking next. This is an example usage of how to
-                      prevent the next step if some kind of error occurred
-                      during the `onNext` handler.
-                    </p>
-                  </Tooltip>
+                  <div>
+                    <DefinitionTooltip
+                      className={`${storyClass}__error--text`}
+                      size="sm"
+                      definition={
+                        'Once toggled on, an inline error notification will appear upon clicking next. This is an example usage of how to prevent the next step if some kind of error occurred during the `onNext` handler.'
+                      }
+                    >
+                      Simulate error
+                    </DefinitionTooltip>
+                  </div>
                   <Toggle
-                    className={`${storyClass}__error--toggle`}
                     id="simulated-error-toggle"
                     size="sm"
-                    labelText="Simulate error"
                     onToggle={(event) => setShouldReject(event)}
                   />
                 </div>


### PR DESCRIPTION
Contributes to #3696 

1. Fixes a console error in Storybook, renamed `triggerClassName` to `className`.
2. Enables broken tooltip, see images below

#### What did you change?

#### How did you test and verify your work?


## Tooltip before (plain text)

<img width="600" src="https://github.com/carbon-design-system/ibm-products/assets/52505287/85d3f3f4-fa2a-4050-b985-766230b28e16" />

## Tooltip before (working as expected)

<img width="600" src="https://github.com/carbon-design-system/ibm-products/assets/52505287/d96bbbf8-d0d0-44c0-9f60-0a15b908355f" />