### PR TITLE
chore(PageHeader): update subtitle prop type

### DIFF
--- a/packages/ibm-products/src/components/PageHeader/PageHeader.js
+++ b/packages/ibm-products/src/components/PageHeader/PageHeader.js
@@ -1031,7 +1031,7 @@ PageHeader.propTypes = {
    * Sitting just below the title is this optional subtitle that provides additional context to
    * identify the current page.
    */
-  subtitle: PropTypes.string,
+  subtitle: PropTypes.node,
   /**
    * An array of tags to be shown as the final content in the PageHeader.
    *


### PR DESCRIPTION
Contributes to #3575

Changed PageHeader prop `subtitle` from `string` to `node`. This will allow passing in jsx to customize the rendering of the subtitle without any prop type errors.

#### What did you change?
```
packages/ibm-products/src/components/PageHeader/PageHeader.js
```
#### How did you test and verify your work?
Storybook