### PR TITLE
fix(Datagrid): adhere to min width in column definition if one exists

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -159,8 +159,9 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
                     onMouseMove={(event) => {
                       if (isResizing) {
                         const newWidth = getClientXPosition(event);
+                        const originalColMinWidth = originalCol.minWidth || 50;
                         // Sets a min width for resizing so at least one character from the column header is visible
-                        if (newWidth >= 50) {
+                        if (newWidth >= originalColMinWidth) {
                           handleColumnResizingEvent(dispatch, header, newWidth);
                         }
                       }
@@ -171,11 +172,12 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
                     onKeyDown={(event) => {
                       const { key } = event;
                       if (key === 'ArrowLeft' || key === 'ArrowRight') {
+                        const originalColMinWidth = originalCol.minWidth || 90;
                         const currentColumnWidth =
                           columnWidths[header.id] ||
                           (datagridState.isTableSortable &&
-                          originalCol.width < 90
-                            ? 90
+                          originalCol.width < originalColMinWidth
+                            ? originalColMinWidth
                             : originalCol.width);
                         if (key === 'ArrowLeft') {
                           if (

--- a/packages/ibm-products/src/components/Datagrid/useSortableColumns.js
+++ b/packages/ibm-products/src/components/Datagrid/useSortableColumns.js
@@ -124,7 +124,12 @@ const useSortableColumns = (hooks) => {
       return {
         ...column,
         Header,
-        minWidth: column.disableSortBy === true ? 0 : 90,
+        minWidth:
+          column.disableSortBy === true
+            ? 0
+            : column.minWidth
+            ? column.minWidth
+            : 90,
       };
     });
     return instance.customizeColumnsProps?.isTearsheetOpen


### PR DESCRIPTION
Contributes to #3704 

Sortable columns were not adhering to the `minWidth` property in the column definitions while resizing. This PR checks if there is a `minWidth` before defaulting to a min width of 90 for sortable columns so that the sorting icons have room to still display.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
packages/ibm-products/src/components/Datagrid/useSortableColumns.js
```
#### How did you test and verify your work?
Storybook