### PR TITLE
fix(Datagrid): top align cell content for extra large row height

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/styles/addons/_RowSizeDropdown.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/addons/_RowSizeDropdown.scss
@@ -44,6 +44,7 @@
   justify-content: center;
 }
 
+// Top align cell content for xl row size
 .#{variables.$block-class}
   table.#{c4p-settings.$carbon-prefix}--data-table--xl.#{variables.$block-class}__vertical-align-center
   td,
@@ -59,7 +60,7 @@
   }
 }
 
-// Top align cell content for xl row size
+// Top align header content for xl row size
 .#{variables.$block-class}
   table.#{c4p-settings.$carbon-prefix}--data-table--xl.#{variables.$block-class}__vertical-align-center
   th,
@@ -71,6 +72,7 @@
   }
 }
 
+// Top align checkbox row header for xl row size
 .#{variables.$block-class}
   table.#{c4p-settings.$carbon-prefix}--data-table--xl.#{variables.$block-class}__vertical-align-center
   .#{variables.$block-class}__checkbox-cell

--- a/packages/ibm-products/src/components/Datagrid/styles/addons/_RowSizeDropdown.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/addons/_RowSizeDropdown.scss
@@ -43,3 +43,38 @@
   height: $spacing-09;
   justify-content: center;
 }
+
+.#{variables.$block-class}
+  table.#{c4p-settings.$carbon-prefix}--data-table--xl.#{variables.$block-class}__vertical-align-center
+  td,
+.#{variables.$block-class}
+  table.#{c4p-settings.$carbon-prefix}--data-table--xl.#{variables.$block-class}__vertical-align-top
+  td {
+  align-items: flex-start;
+  padding-top: $spacing-05;
+  padding-bottom: $spacing-05;
+
+  &.#{variables.$block-class}__actions-column-cell {
+    padding-left: $spacing-03;
+  }
+}
+
+// Top align cell content for xl row size
+.#{variables.$block-class}
+  table.#{c4p-settings.$carbon-prefix}--data-table--xl.#{variables.$block-class}__vertical-align-center
+  th,
+.#{variables.$block-class}
+  table.#{c4p-settings.$carbon-prefix}--data-table--xl.#{variables.$block-class}__vertical-align-top
+  th {
+  .#{c4p-settings.$carbon-prefix}--table-header-label {
+    align-items: flex-start;
+  }
+}
+
+.#{variables.$block-class}
+  table.#{c4p-settings.$carbon-prefix}--data-table--xl.#{variables.$block-class}__vertical-align-center
+  .#{variables.$block-class}__checkbox-cell
+  th.cds--table-column-checkbox {
+  align-items: flex-start;
+  padding-top: $spacing-04;
+}


### PR DESCRIPTION
Contributes to #3508 

This PR will top align cell content when row size is extra large.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/styles/addons/_RowSizeDropdown.scss
```
#### How did you test and verify your work?
Storybook