### PR TITLE
fix(CreateTearsheet & CreateFullPage): Influencer step error indicator extension

### DIFF
--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.docs-page.js
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.docs-page.js
@@ -112,6 +112,20 @@ passing in a title or breadcrumbs to the \`<CreateFullPage />\` component  as sh
           },
         },
         {
+          story: stories.createFullPageWithStepInErrorState,
+          description: `Passing an invalid prop to the step will show up an error icon on the progress indicator step indicating an error state in that step`,
+          source: {
+            code: `<CreateFullPage {...createFullPageProps}>
+  <CreateFullPageStep
+    title="Topic name"
+    invalid={true}
+  >
+    Step content
+  </CreateFullPageStep>
+</CreateFullPage>`,
+          },
+        },
+        {
           title: 'Using custom components',
           description: `It is possible to use custom components that return \`CreateFullPageStep\`s in
 order to help reduce the amount of logic in the component that contains the main

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.stories.js
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.stories.js
@@ -484,6 +484,51 @@ const TemplateWithSections = ({ ...args }) => {
   );
 };
 
+const TemplateWithError = ({ ...args }) => {
+  const [textInput, setTextInput] = useState('');
+  const [isInvalid, setIsInvalid] = useState(true);
+  const [isFirstStepInvalid, setIsFirstStepInvalid] = useState(true);
+
+  return (
+    <CreateFullPage {...args}>
+      <CreateFullPageStep
+        title="Partition"
+        subtitle="One or more partitions make up a topic. A partition is an ordered list
+        of messages."
+        invalid={isFirstStepInvalid}
+        disableSubmit={isFirstStepInvalid}
+      >
+        <Grid>
+          <Column xlg={5} lg={5} md={4} sm={4}>
+            <TextInput
+              id="test-6"
+              invalidText="A valid value is required"
+              labelText="Topic name"
+              placeholder="Enter topic name"
+              onChange={(e) => {
+                setTextInput(e.target.value);
+                setIsInvalid(e.target.value ? false : true);
+                setIsFirstStepInvalid(e.target.value ? false : true);
+              }}
+              onBlur={() => {
+                textInput.length === 0 && setIsInvalid(true);
+              }}
+              invalid={isInvalid}
+            />
+          </Column>
+        </Grid>
+      </CreateFullPageStep>
+      <CreateFullPageStep title="Core Configuration">
+        <Grid>
+          <Column xlg={5} lg={5} md={4} sm={4}>
+            Test step
+          </Column>
+        </Grid>
+      </CreateFullPageStep>
+    </CreateFullPage>
+  );
+};
+
 export const createFullPage = prepareStory(Template, {
   args: {
     ...defaultFullPageProps,
@@ -511,3 +556,12 @@ export const createFullPageWithHeader = prepareStory(Template, {
     maxVisibleBreadcrumbs: 3,
   },
 });
+
+export const createFullPageWithStepInErrorState = prepareStory(
+  TemplateWithError,
+  {
+    args: {
+      ...defaultFullPageProps,
+    },
+  }
+);

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.test.js
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.test.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import { render, screen, waitFor, act } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
 import userEvent from '@testing-library/user-event';
-import { pkg } from '../../settings';
+import { carbon, pkg } from '../../settings';
 import uuidv4 from '../../global/js/utils/uuidv4';
 import {
   expectWarn,
@@ -562,27 +562,24 @@ describe(componentName, () => {
   });
 
   it('renders an error icon if the step invalid prop is set to true', async () => {
-    const { container } = renderCreateFullPage({
+   renderCreateFullPage({
       ...defaultFullPageProps,
     });
-    expect(
-      container.querySelector(`.${blockClass}--progress__warning`)
-    ).not.toBeInTheDocument();
 
     expect(
       screen
         .getByRole('button', { description: 'Title 1' })
-        .querySelector('.cds--progress__warning')
+        .querySelector(`.${carbon.prefix}--progress__warning`)
     ).not.toBeInTheDocument();
     expect(
       screen
         .getByRole('button', { description: 'Title 2' })
-        .querySelector('.cds--progress__warning')
+        .querySelector(`.${carbon.prefix}--progress__warning`)
     ).not.toBeInTheDocument();
     expect(
       screen
         .getByRole('button', { description: 'Title 3' })
-        .querySelector('.cds--progress__warning')
+        .querySelector(`.${carbon.prefix}--progress__warning`)
     ).toBeInTheDocument();
   });
 });

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.test.js
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.test.js
@@ -120,6 +120,7 @@ const renderCreateFullPage = ({
         title="Title 2"
         description="2"
         fieldsetLegendText="2"
+        invalid={false}
       >
         {stepFormField}
       </CreateFullPageStep>
@@ -127,6 +128,7 @@ const renderCreateFullPage = ({
         title="Title 3"
         description="3"
         onNext={rejectOnSubmitNext ? finalStepOnNextRejectFn : finalOnNextFn}
+        invalid
       >
         {stepFormField}
       </CreateFullPageStep>
@@ -557,5 +559,30 @@ describe(componentName, () => {
     });
     const headerSelector = container.querySelector(`.${blockClass}__header`);
     expect(headerSelector).not.toBeInTheDocument();
+  });
+
+  it('renders an error icon if the step invalid prop is set to true', async () => {
+    const { container } = renderCreateFullPage({
+      ...defaultFullPageProps,
+    });
+    expect(
+      container.querySelector(`.${blockClass}--progress__warning`)
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen
+        .getByRole('button', { description: 'Title 1' })
+        .querySelector('.cds--progress__warning')
+    ).not.toBeInTheDocument();
+    expect(
+      screen
+        .getByRole('button', { description: 'Title 2' })
+        .querySelector('.cds--progress__warning')
+    ).not.toBeInTheDocument();
+    expect(
+      screen
+        .getByRole('button', { description: 'Title 3' })
+        .querySelector('.cds--progress__warning')
+    ).toBeInTheDocument();
   });
 });

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPageStep.js
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPageStep.js
@@ -34,6 +34,7 @@ export let CreateFullPageStep = forwardRef(
       disableSubmit,
       includeStep = defaults.includeStep,
       introStep,
+      invalid,
       title,
       hasFieldset,
       fieldsetLegendText,
@@ -54,6 +55,7 @@ export let CreateFullPageStep = forwardRef(
     });
 
     useRetrieveStepData({
+      invalid,
       stepsContext,
       stepNumber,
       introStep,
@@ -196,6 +198,11 @@ CreateFullPageStep.propTypes = {
    * This prop can be used on the first step to mark it as an intro step, which will not render the progress indicator steps
    */
   introStep: PropTypes.bool,
+
+  /**
+   * This optional prop will indicate an error icon on the progress indicator step item
+   */
+  invalid: PropTypes.bool,
 
   /**
    * Optional function to be called on initial mount of a step.

--- a/packages/ibm-products/src/components/CreateInfluencer/CreateInfluencer.js
+++ b/packages/ibm-products/src/components/CreateInfluencer/CreateInfluencer.js
@@ -63,6 +63,7 @@ export let CreateInfluencer = ({ className, currentStep, stepData, title }) => {
                   label={step.title}
                   key={stepIndex}
                   secondaryLabel={step.secondaryLabel}
+                  invalid={step.invalid}
                 />
               );
             })}

--- a/packages/ibm-products/src/components/CreateInfluencer/CreateInfluencer.test.js
+++ b/packages/ibm-products/src/components/CreateInfluencer/CreateInfluencer.test.js
@@ -8,7 +8,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { CreateInfluencer } from '.';
 
-import { pkg } from '../../settings';
+import { carbon, pkg } from '../../settings';
 const blockClass = `${pkg.prefix}--create-influencer`;
 
 const renderComponent = ({ ...rest } = {}) =>
@@ -112,7 +112,7 @@ describe(CreateInfluencer.displayName, () => {
   });
 
   it('renders an error icon if the step invalid prop is set to true', async () => {
-    const { container } = renderComponent({
+    renderComponent({
       stepData: [
         { title: 'Step 1', invalid: true, shouldIncludeStep: true },
         { title: 'Step 2', invalid: false, shouldIncludeStep: true },
@@ -121,24 +121,21 @@ describe(CreateInfluencer.displayName, () => {
       className: 'some-test-class-name',
       currentStep: 1,
     });
-    expect(
-      container.querySelector(`.${blockClass}--progress__warning`)
-    ).not.toBeInTheDocument();
 
     expect(
       screen
         .getByRole('button', { description: 'Step 1' })
-        .querySelector('.cds--progress__warning')
+        .querySelector(`.${carbon.prefix}--progress__warning`)
     ).toBeInTheDocument();
     expect(
       screen
         .getByRole('button', { description: 'Step 2' })
-        .querySelector('.cds--progress__warning')
+        .querySelector(`.${carbon.prefix}--progress__warning`)
     ).not.toBeInTheDocument();
     expect(
       screen
         .getByRole('button', { description: 'Step 3' })
-        .querySelector('.cds--progress__warning')
+        .querySelector(`.${carbon.prefix}--progress__warning`)
     ).not.toBeInTheDocument();
   });
 });

--- a/packages/ibm-products/src/components/CreateInfluencer/CreateInfluencer.test.js
+++ b/packages/ibm-products/src/components/CreateInfluencer/CreateInfluencer.test.js
@@ -110,4 +110,35 @@ describe(CreateInfluencer.displayName, () => {
       container.querySelector(`.${blockClass}__title`)
     ).not.toBeInTheDocument();
   });
+
+  it('renders an error icon if the step invalid prop is set to true', async () => {
+    const { container } = renderComponent({
+      stepData: [
+        { title: 'Step 1', invalid: true, shouldIncludeStep: true },
+        { title: 'Step 2', invalid: false, shouldIncludeStep: true },
+        { title: 'Step 3', shouldIncludeStep: true },
+      ],
+      className: 'some-test-class-name',
+      currentStep: 1,
+    });
+    expect(
+      container.querySelector(`.${blockClass}--progress__warning`)
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen
+        .getByRole('button', { description: 'Step 1' })
+        .querySelector('.cds--progress__warning')
+    ).toBeInTheDocument();
+    expect(
+      screen
+        .getByRole('button', { description: 'Step 2' })
+        .querySelector('.cds--progress__warning')
+    ).not.toBeInTheDocument();
+    expect(
+      screen
+        .getByRole('button', { description: 'Step 3' })
+        .querySelector('.cds--progress__warning')
+    ).not.toBeInTheDocument();
+  });
 });

--- a/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.docs-page.js
+++ b/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.docs-page.js
@@ -108,6 +108,24 @@ const CreateFlow = () => {
 };`,
         },
         {
+          story: stories.withErrorState,
+          title: 'Create tearsheet with step in error state',
+          description:
+            'Passing an invalid prop to the step will show up an error icon on the progress indicator step indicating an error state in that step',
+          source: {
+            code: `<CreateTearsheet {...createTearsheetProps}>
+      <CreateTearsheetStep
+      {...stepProps}
+      invalid={true}
+    >
+      Step in error state
+    </CreateTearsheetStep>
+  </CreateTearsheet>
+  );
+};`,
+          },
+        },
+        {
           title: 'Class names',
           description: `Additionally, to get the preferred styling when including your own children as
 sections, you can utilize the below included class names.

--- a/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.stories.js
+++ b/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.stories.js
@@ -14,6 +14,7 @@ import { CreateTearsheet } from './CreateTearsheet';
 import DocsPage from './CreateTearsheet.docs-page';
 import { MultiStepTearsheet } from './preview-components/MultiStepTearsheet';
 import { MultiStepWithIntro } from './preview-components/MultiStepWithIntro';
+import { MultiStepWithStepInErrorState } from './preview-components/MultiStepWithStepInErrorState';
 
 export default {
   title: getStoryTitle(CreateTearsheet.displayName),
@@ -55,6 +56,13 @@ export const multiStepTearsheet = prepareStory(MultiStepTearsheet, {
 
 export const withIntroStep = prepareStory(MultiStepWithIntro, {
   storyName: 'Create tearsheet with intro step',
+  args: {
+    ...createTearsheetProps,
+  },
+});
+
+export const withErrorState = prepareStory(MultiStepWithStepInErrorState, {
+  storyName: 'Create tearsheet with step in error state',
   args: {
     ...createTearsheetProps,
   },

--- a/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheetStep.js
+++ b/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheetStep.js
@@ -42,6 +42,7 @@ export let CreateTearsheetStep = forwardRef(
       hasFieldset = defaults.hasFieldset,
       includeStep = defaults.includeStep,
       introStep,
+      invalid,
       onMount,
       onNext,
       onPrevious,
@@ -68,6 +69,7 @@ export let CreateTearsheetStep = forwardRef(
       shouldIncludeStep,
       secondaryLabel,
       title,
+      invalid,
     });
 
     // This useEffect reports back the onMount value so that they can be used
@@ -208,6 +210,11 @@ CreateTearsheetStep.propTypes = {
    * This prop can be used on the first step to mark it as an intro step, which will not render the progress indicator steps
    */
   introStep: PropTypes.bool,
+
+  /**
+   * This optional prop will indicate an error icon on the progress indicator step item
+   */
+  invalid: PropTypes.bool,
 
   /**
    * Optional function to be called on initial mount of a step.

--- a/packages/ibm-products/src/components/CreateTearsheet/preview-components/MultiStepWithStepInErrorState.js
+++ b/packages/ibm-products/src/components/CreateTearsheet/preview-components/MultiStepWithStepInErrorState.js
@@ -86,9 +86,7 @@ export const MultiStepWithStepInErrorState = ({
                 value={stepOneTextInputValue}
                 placeholder="Enter topic name"
                 onChange={(event) => {
-                  if (event.target.value.length) {
-                    setStepOneIsInvalid(false);
-                  }
+                  setStepOneIsInvalid(!event.target.value.length);
                   setStepOneTextInputValue(event.target.value);
                 }}
                 invalid={stepOneIsInvalid}

--- a/packages/ibm-products/src/components/CreateTearsheet/preview-components/MultiStepWithStepInErrorState.js
+++ b/packages/ibm-products/src/components/CreateTearsheet/preview-components/MultiStepWithStepInErrorState.js
@@ -1,0 +1,146 @@
+/* eslint-disable react/prop-types */
+/**
+ * Copyright IBM Corp. 2021, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Button, Column, Grid, TextInput, NumberInput } from '@carbon/react';
+import cx from 'classnames';
+import { pkg } from '../../../settings';
+import { CreateTearsheet } from '../CreateTearsheet';
+import { CreateTearsheetStep } from '../CreateTearsheetStep';
+
+const blockClass = `${pkg.prefix}--tearsheet-create-multi-step`;
+
+export const MultiStepWithStepInErrorState = ({
+  backButtonText,
+  cancelButtonText,
+  className,
+  description,
+  influencerWidth,
+  label,
+  nextButtonText,
+  submitButtonText,
+  title,
+}) => {
+  const [simulatedDelay] = useState(750);
+  const [open, setOpen] = useState(false);
+  const [stepOneTextInputValue, setStepOneTextInputValue] = useState('');
+  const [topicDescriptionValue, setTopicDescriptionValue] = useState('');
+  const [stepTwoTextInputValue, setStepTwoTextInputValue] = useState(1);
+  useState('one-day');
+  const [stepOneIsInvalid, setStepOneIsInvalid] = useState(true);
+  const [stepTwoIsInvalid, setStepTwoIsInvalid] = useState(false);
+
+  const clearCreateData = () => {
+    setStepOneTextInputValue('');
+    setTopicDescriptionValue('');
+    setStepTwoTextInputValue(1);
+    setStepOneIsInvalid(true);
+    setStepTwoIsInvalid(true);
+    setOpen(false);
+  };
+
+  return (
+    <div>
+      <style>{`.${blockClass} { opacity: 0 }`};</style>
+      <Button onClick={() => setOpen(!open)}>
+        {open ? 'Close CreateTearsheet' : 'Open CreateTearsheet'}
+      </Button>
+      <CreateTearsheet
+        influencerWidth={influencerWidth}
+        label={label}
+        className={cx(blockClass, className)}
+        submitButtonText={submitButtonText}
+        cancelButtonText={cancelButtonText}
+        backButtonText={backButtonText}
+        nextButtonText={nextButtonText}
+        description={description}
+        title={title}
+        open={open}
+        onClose={clearCreateData}
+        onRequestSubmit={() =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              clearCreateData();
+              resolve();
+            }, simulatedDelay);
+          })
+        }
+      >
+        <CreateTearsheetStep
+          title="Topic name"
+          fieldsetLegendText="Topic information"
+          disableSubmit={stepOneIsInvalid}
+          subtitle="This is the unique name used to recognize your topic"
+          invalid={stepOneIsInvalid}
+        >
+          <Grid>
+            <Column xlg={8} lg={8} md={8} sm={4}>
+              <TextInput
+                labelText="Topic name"
+                id="tearsheet-multi-step-story-text-input-multi-step-1"
+                value={stepOneTextInputValue}
+                placeholder="Enter topic name"
+                onChange={(event) => {
+                  if (event.target.value.length) {
+                    setStepOneIsInvalid(false);
+                  }
+                  setStepOneTextInputValue(event.target.value);
+                }}
+                invalid={stepOneIsInvalid}
+                invalidText="This is a required field"
+                onBlur={() => {}}
+              />
+              <TextInput
+                labelText="Topic description (optional)"
+                id="tearsheet-multi-step-story-text-input-multi-step-1-input-2"
+                value={topicDescriptionValue}
+                placeholder="Enter topic description"
+                onChange={(event) =>
+                  setTopicDescriptionValue(event.target.value)
+                }
+              />
+            </Column>
+          </Grid>
+        </CreateTearsheetStep>
+        <CreateTearsheetStep
+          title="Partitions"
+          disableSubmit={stepTwoIsInvalid}
+          subtitle="One or more partitions make up a topic. A partition is an ordered
+           list of messages."
+          description="Partitions are distributed across the brokers in order to increase
+           the scalability of your topic. You can also use them to distribute
+           messages across the members of a consumer group."
+          fieldsetLegendText="Partition information"
+          invalid={stepTwoIsInvalid}
+        >
+          <Grid>
+            <Column xlg={3} lg={3} md={8} sm={4}>
+              <NumberInput
+                iconDescription="Choose a number"
+                id="carbon-number"
+                min={1}
+                max={100}
+                value={stepTwoTextInputValue}
+                label="Partitions"
+                helperText="1 partition is sufficient for getting started but, production systems often have more."
+                invalidText="Max partitions is 100, min is 1"
+                hideSteppers
+                onChange={(event) => {
+                  event.target.value > 0 && event.target.value <= 100
+                    ? setStepTwoIsInvalid(false)
+                    : setStepTwoIsInvalid(true);
+                  setStepTwoTextInputValue(event.target.value);
+                }}
+              />
+            </Column>
+          </Grid>
+        </CreateTearsheetStep>
+      </CreateTearsheet>
+    </div>
+  );
+};

--- a/packages/ibm-products/src/global/js/hooks/useRetrieveStepData.js
+++ b/packages/ibm-products/src/global/js/hooks/useRetrieveStepData.js
@@ -9,11 +9,12 @@ import { useEffect } from 'react';
 
 /**
  * This useEffect makes sure that every CreateTearsheetStep/CreateFullPageStep reports back it's
- * title, secondaryLabel, introStep, and shouldIncludeStep data so that it can be sent to the CreateInfluencer.
+ * title, secondaryLabel, introStep, invalid and shouldIncludeStep data so that it can be sent to the CreateInfluencer.
  * @param {object} useResetCreateComponent
  * @param {object} useResetCreateComponent.stepsContext
  * @param {number} useResetCreateComponent.stepNumber
  * @param {boolean} useResetCreateComponent.introStep
+ * @param {boolean} useResetCreateComponent.invalid
  * @param {boolean} useResetCreateComponent.shouldIncludeStep
  * @param {string} useResetCreateComponent.secondaryLabel
  * @param {string} useResetCreateComponent.title
@@ -22,6 +23,7 @@ export const useRetrieveStepData = ({
   stepsContext,
   stepNumber,
   introStep,
+  invalid,
   shouldIncludeStep,
   secondaryLabel,
   title,
@@ -33,6 +35,7 @@ export const useRetrieveStepData = ({
           title,
           secondaryLabel,
           introStep,
+          invalid,
           shouldIncludeStep,
         };
         const previousItem = prev[stepNumber - 1];
@@ -40,7 +43,8 @@ export const useRetrieveStepData = ({
           previousItem?.title !== stepItem.title ||
           previousItem?.secondaryLabel !== stepItem.secondaryLabel ||
           previousItem?.introStep !== stepItem.introStep ||
-          previousItem?.shouldIncludeStep !== stepItem.shouldIncludeStep
+          previousItem?.shouldIncludeStep !== stepItem.shouldIncludeStep ||
+          previousItem?.invalid !== stepItem.invalid
         ) {
           const clone = [...prev];
           clone[stepNumber - 1] = stepItem;
@@ -54,6 +58,7 @@ export const useRetrieveStepData = ({
     title,
     secondaryLabel,
     introStep,
+    invalid,
     stepsContext,
     stepNumber,
   ]);


### PR DESCRIPTION
Contributes to #2930

The Carbon ProgressIndicator component already supports the "invalid" prop, although it was unused in both the CreateInfluencer for the CreateFullPage and the CreateTearsheet components. These changes involve incorporating the use of this prop.

#### What did you change?
- I Added the invalid optional prop support to the CreateInfluencer, CreateFullPageStep, CreateTearsheetStep and the useRetrieveStepData hook
- I added storybook examples to show this error state for both the CreateFullPage and the CreateTearsheet
- Added unit-tests

#### How did you test and verify your work?
- I tested my changes on storybook new examples that I added in this PR
- introduced more unit-tests