### PR TITLE
fix(TagSet): remove `.only` from tag set tests

### DIFF
--- a/packages/ibm-products/src/components/TagSet/TagSet.test.js
+++ b/packages/ibm-products/src/components/TagSet/TagSet.test.js
@@ -125,7 +125,7 @@ describe(TagSet.displayName, () => {
     expect(overflowVisible.length).toEqual(tags10.length);
   });
 
-  it.only('Renders overflow tags via overflowType prop', async () => {
+  it('Renders overflow tags via overflowType prop', async () => {
     window.innerWidth = tagWidth / 2;
 
     render(<TagSet tags={tags10} overflowType="tag" />);


### PR DESCRIPTION
Noticed that a `.only` was left in the TagSet tests after https://github.com/carbon-design-system/ibm-products/pull/3646 was merged.