### PR TITLE
feat(TagSet): allow for tag rendering in overflow (v1)

### DIFF
--- a/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
@@ -3275,7 +3275,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   visibility: hidden;
 }
 
-.c4p--tag-set-overflow__tooltip .c4p--tag-set-overflow__tag-item .bx--tag {
+.c4p--tag-set-overflow__tooltip .c4p--tag-set-overflow__tag-item--default .bx--tag {
   border-radius: 0;
 }
 
@@ -3319,12 +3319,18 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   min-width: initial;
   text-align: left;
 }
+.c4p--tag-set-overflow__tooltip.bx--tooltip button {
+  padding-right: 0;
+}
 .c4p--tag-set-overflow__tooltip .c4p--tag-set-overflow__show-all-tags-link {
   display: inline-block;
   margin: var(--cds-spacing-03, 0.5rem) 0 var(--cds-spacing-02, 0.25rem);
 }
-.c4p--tag-set-overflow__tooltip .c4p--tag-set-overflow__tag-item,
-.c4p--tag-set-overflow__tooltip .c4p--tag-set-overflow__tag-item .bx--tag {
+.c4p--tag-set-overflow__tooltip .c4p--tag-set-overflow__tag-item.c4p--tag-set-overflow__tag-item--tag .bx--tag {
+  background-color: var(--cds-inverse-hover-ui, #4c4c4c);
+}
+.c4p--tag-set-overflow__tooltip .c4p--tag-set-overflow__tag-item.c4p--tag-set-overflow__tag-item--default,
+.c4p--tag-set-overflow__tooltip .c4p--tag-set-overflow__tag-item.c4p--tag-set-overflow__tag-item--default .bx--tag {
   font-size: var(--cds-body-short-01-font-size, 0.875rem);
   font-weight: var(--cds-body-short-01-font-weight, 400);
   line-height: var(--cds-body-short-01-line-height, 1.28572);

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -161,6 +161,7 @@ export const DatagridContent = ({ datagridState, title }) => {
         filters={filterTags}
         clearFilters={() => EventEmitter.dispatch(CLEAR_FILTERS)}
         renderLabel={filterProps.renderLabel}
+        overflowType="tag"
       />
     );
 

--- a/packages/ibm-products/src/components/FilterSummary/FilterSummary.js
+++ b/packages/ibm-products/src/components/FilterSummary/FilterSummary.js
@@ -21,6 +21,7 @@ let FilterSummary = React.forwardRef(
       clearFilters = () => {},
       filters = [],
       renderLabel = null,
+      overflowType = 'default',
     },
     ref
   ) => {
@@ -38,6 +39,7 @@ let FilterSummary = React.forwardRef(
           allTagsModalTitle="All tags"
           showAllTagsLabel="View all tags"
           tags={tagFilters}
+          overflowType={overflowType}
         />
         <Button kind="ghost" size="sm" onClick={clearFilters}>
           {clearFiltersText}
@@ -55,6 +57,7 @@ FilterSummary.propTypes = {
   clearFilters: PropTypes.func.isRequired,
   clearFiltersText: PropTypes.string,
   filters: PropTypes.arrayOf(PropTypes.object).isRequired,
+  overflowType: PropTypes.oneOf(['default', 'tag']),
   renderLabel: PropTypes.func,
 };
 

--- a/packages/ibm-products/src/components/TagSet/TagSet.js
+++ b/packages/ibm-products/src/components/TagSet/TagSet.js
@@ -31,6 +31,7 @@ const defaults = {
   // allTagsModalTarget: document.body,
   overflowAlign: 'center',
   overflowDirection: 'bottom',
+  overflowType: 'default',
 };
 
 export let TagSet = React.forwardRef(
@@ -45,6 +46,7 @@ export let TagSet = React.forwardRef(
       multiline,
       overflowAlign = defaults.overflowAlign,
       overflowClassName,
+      overflowType = defaults.overflowType,
       overflowDirection = defaults.overflowDirection,
       allTagsModalTitle,
       allTagsModalSearchLabel,
@@ -140,6 +142,7 @@ export let TagSet = React.forwardRef(
           onShowAllClick={handleShowAllClick}
           overflowTags={newOverflowTags}
           overflowAlign={overflowAlign}
+          overflowType={overflowType}
           overflowDirection={overflowDirection}
           showAllTagsLabel={showAllTagsLabel}
           key="displayed-tag-overflow"
@@ -151,6 +154,7 @@ export let TagSet = React.forwardRef(
     }, [
       displayCount,
       overflowAlign,
+      overflowType,
       overflowClassName,
       overflowDirection,
       showAllTagsLabel,
@@ -348,6 +352,10 @@ TagSet.propTypes = {
    * overflowDirection from the standard tooltip
    */
   overflowDirection: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+  /**
+   * Type of rendering displayed inside of the tag overflow component
+   */
+  overflowType: PropTypes.oneOf(['default', 'tag']),
   /**
    * label for the overflow show all tags link.
    *

--- a/packages/ibm-products/src/components/TagSet/TagSet.stories.js
+++ b/packages/ibm-products/src/components/TagSet/TagSet.stories.js
@@ -246,3 +246,12 @@ export const WithClose = prepareStory(TemplateWithClose, {
     ...overflowAndModalStrings,
   },
 });
+
+export const WithCloseAndOverflowTags = prepareStory(TemplateWithClose, {
+  args: {
+    tags: manyTags,
+    containerWidth: 500,
+    overflowType: 'tag',
+    ...overflowAndModalStrings,
+  },
+});

--- a/packages/ibm-products/src/components/TagSet/TagSet.test.js
+++ b/packages/ibm-products/src/components/TagSet/TagSet.test.js
@@ -126,6 +126,26 @@ describe(TagSet.displayName, () => {
     expect(overflowVisible.length).toEqual(tags10.length);
   });
 
+  it('Renders overflow tags via overflowType prop', async () => {
+    window.innerWidth = tagWidth / 2;
+
+    render(<TagSet tags={tags10} overflowType="tag" />);
+
+    const overflow = screen.getByText('+10');
+    userEvent.click(overflow);
+
+    const overflowVisible = screen.queryAllByText(/Tag [0-9]+/, {
+      // selector need to ignore sizing items
+      selector: `.${blockClassOverflow}__content *`,
+    });
+
+    overflowVisible.forEach((overflowItem) => {
+      expect(overflowItem.closest('li')).not.toHaveClass(
+        `${blockClassOverflow}__tag-item--default`
+      );
+    });
+  });
+
   it('Renders some as visible when space limited', () => {
     const visibleTags = 5;
     window.innerWidth = tagWidth * (visibleTags + 1) + 1; // + 1 for overflow

--- a/packages/ibm-products/src/components/TagSet/TagSetOverflow.js
+++ b/packages/ibm-products/src/components/TagSet/TagSetOverflow.js
@@ -36,6 +36,7 @@ export const TagSetOverflow = React.forwardRef(
       overflowAlign = defaults.overflowAlign,
       overflowDirection = defaults.overflowDirection,
       overflowTags,
+      overflowType,
       showAllTagsLabel,
 
       // Collect any other property values passed in.
@@ -88,11 +89,28 @@ export const TagSetOverflow = React.forwardRef(
                     ? index < allTagsModalSearchThreshold
                     : index <= allTagsModalSearchThreshold
                 )
-                .map((tag, index) => (
-                  <li className={`${blockClass}__tag-item`} key={index}>
-                    {React.cloneElement(tag, { filter: false })}
-                  </li>
-                ))}
+                .map((tag, index) => {
+                  const tagProps = {};
+                  if (overflowType === 'tag') {
+                    tagProps.type = 'high-contrast';
+                  }
+                  if (overflowType === 'default') {
+                    tagProps.filter = false;
+                  }
+                  return (
+                    <li
+                      className={cx(`${blockClass}__tag-item`, {
+                        [`${blockClass}__tag-item--default`]:
+                          overflowType === 'default',
+                        [`${blockClass}__tag-item--tag`]:
+                          overflowType === 'tag',
+                      })}
+                      key={index}
+                    >
+                      {React.cloneElement(tag, tagProps)}
+                    </li>
+                  );
+                })}
             </ul>
             {overflowTags.length > allTagsModalSearchThreshold && (
               <Link
@@ -138,6 +156,10 @@ TagSetOverflow.propTypes = {
    * tags shown in overflow
    */
   overflowTags: PropTypes.arrayOf(PropTypes.object).isRequired,
+  /**
+   * Type of rendering displayed inside of the tag overflow component
+   */
+  overflowType: PropTypes.oneOf(['default', 'tag']),
   /**
    * label for the overflow show all tags link
    */

--- a/packages/ibm-products/src/components/TagSet/_tag-set.scss
+++ b/packages/ibm-products/src/components/TagSet/_tag-set.scss
@@ -70,7 +70,7 @@ $block-class-modal: #{$block-class}-modal;
   }
 
   .#{$block-class-overflow}__tooltip
-    .#{$block-class-overflow}__tag-item
+    .#{$block-class-overflow}__tag-item--default
     .#{$carbon-prefix}--tag {
     border-radius: 0;
   }
@@ -127,13 +127,23 @@ $block-class-modal: #{$block-class}-modal;
       text-align: left;
     }
 
+    &.#{$carbon-prefix}--tooltip button {
+      padding-right: 0;
+    }
+
     .#{$block-class-overflow}__show-all-tags-link {
       display: inline-block;
       margin: $spacing-03 0 $spacing-02; // to match the tags
     }
 
-    .#{$block-class-overflow}__tag-item,
-    .#{$block-class-overflow}__tag-item .#{$carbon-prefix}--tag {
+    .#{$block-class-overflow}__tag-item.#{$block-class-overflow}__tag-item--tag
+      .#{$carbon-prefix}--tag {
+      background-color: $inverse-hover-ui;
+    }
+
+    .#{$block-class-overflow}__tag-item.#{$block-class-overflow}__tag-item--default,
+    .#{$block-class-overflow}__tag-item.#{$block-class-overflow}__tag-item--default
+      .#{$carbon-prefix}--tag {
       @include carbon--type-style('body-short-01');
 
       display: block;


### PR DESCRIPTION
Contributes to #3627

This PR adds the ability to specify a `overflowType` prop on the `TagSet`. This will render the items in the `TagSetOverflow` either as they have been or as actual tag components. This change allows filters to be removed from the `TagSetOverflow` which was previously not possible.

![Screenshot 2023-10-19 at 3 12 55 PM](https://github.com/carbon-design-system/ibm-products/assets/10215203/c33c82c4-eaea-47d4-abcc-f5836e4ebf6a)


#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
packages/ibm-products/src/components/FilterSummary/FilterSummary.js
packages/ibm-products/src/components/TagSet/TagSet.js
packages/ibm-products/src/components/TagSet/TagSet.stories.js
packages/ibm-products/src/components/TagSet/TagSet.test.js
packages/ibm-products/src/components/TagSet/TagSetOverflow.js
packages/ibm-products/src/components/TagSet/_tag-set.scss
```
#### How did you test and verify your work?
