### PR TITLE
fix(Datagrid): semantically hide spacer col

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
@@ -865,6 +865,13 @@ describe(componentName, () => {
     window.ResizeObserver = ResizeObserver;
   });
 
+  it('check total column count', () => {
+    render(<BasicUsage />);
+    expect(screen.getAllByRole('columnheader').length).toEqual(
+      defaultHeader.length
+    );
+  });
+
   it('renders a basic data grid component with devTools attribute', () => {
     render(<BasicUsage data-testid={dataTestId} />);
 

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -143,12 +143,13 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
                   [`${blockClass}__resizableColumn`]: header.getResizerProps,
                   [`${blockClass}__isResizing`]: header.isResizing,
                   [`${blockClass}__sortableColumn`]:
-                    datagridState.isTableSortable,
+                    datagridState.isTableSortable && header.id !== 'spacer',
                   [`${blockClass}__isSorted`]: header.isSorted,
                 },
                 header.getHeaderProps().className
               )}
               key={header.id}
+              aria-hidden={header.id === 'spacer' && 'true'}
               {...getAccessibilityProps(header)}
             >
               {header.render('Header')}


### PR DESCRIPTION
Contributes to #3721 

This PR semantically hides the spacer column used to allow the last visible column to be resized. The spacer column was also getting a class name specifically only for sortable columns, that's been fixed as well.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid.test.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
```
#### How did you test and verify your work?
Storybook and added new test to check we render the expected number of column headers.