### PR TITLE
fix(Datagrid): correct number of items displayed when viewing all checkbox filters

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -195,6 +195,7 @@ export const DatagridContent = ({ datagridState, title }) => {
               {...getFilterFlyoutProps()}
               title={filterProps.panelTitle}
               filterSections={filterProps.sections}
+              autoHideFilters={filterProps.autoHideFilters}
             />
           )}
           <div className={`${blockClass}__table-container-inner`}>

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
@@ -52,6 +52,7 @@ const FilterPanel = ({
   searchLabelText = 'Filter search',
   searchPlaceholder = 'Find filters',
   reactTableFiltersState = [],
+  autoHideFilters = false,
 }) => {
   /** State */
   const [showDividerLine, setShowDividerLine] = useState(false);
@@ -76,6 +77,7 @@ const FilterPanel = ({
     reactTableFiltersState,
     onCancel,
     panelOpen,
+    autoHideFilters,
   });
 
   /** Refs */
@@ -273,6 +275,7 @@ const FilterPanel = ({
 };
 
 FilterPanel.propTypes = {
+  autoHideFilters: PropTypes.bool,
   closeIconDescription: PropTypes.string,
   filterPanelMinHeight: PropTypes.number,
   filterSections: PropTypes.array,

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/OverflowCheckboxes.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/OverflowCheckboxes.js
@@ -19,7 +19,7 @@ const OverflowCheckboxes = ({
   const firstFiveItems = filtersState[column].value.slice(0, 5);
   const restOfTheItems = filtersState[column].value.slice(
     5,
-    filtersState[column].value.length - 1
+    filtersState[column].value.length
   );
 
   const renderCheckbox = (option) => (

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
@@ -70,6 +70,7 @@ const useFilters = ({
   reactTableFiltersState,
   onCancel = () => {},
   panelOpen,
+  autoHideFilters,
 }) => {
   /** State */
   const [filtersState, setFiltersState] = useState(
@@ -227,7 +228,11 @@ const useFilters = ({
     }
 
     const renderCheckboxes = () => {
-      if (variation === PANEL && filtersState[column].value.length > 10) {
+      if (
+        variation === PANEL &&
+        filtersState[column].value.length > 10 &&
+        !autoHideFilters
+      ) {
         return (
           <OverflowCheckboxes
             components={components}

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
@@ -1230,6 +1230,7 @@ export const PanelManyCheckboxes = prepareStory(FilteringTemplateWrapper, {
     emptyStateDescription:
       'Data was not found with the current filters applied. Change filters or clear filters to see other results.',
     filterProps: {
+      autoHideFilters: true,
       variation: 'panel',
       updateMethod: 'instant',
       primaryActionLabel: 'Apply',

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
@@ -1230,7 +1230,6 @@ export const PanelManyCheckboxes = prepareStory(FilteringTemplateWrapper, {
     emptyStateDescription:
       'Data was not found with the current filters applied. Change filters or clear filters to see other results.',
     filterProps: {
-      autoHideFilters: true,
       variation: 'panel',
       updateMethod: 'instant',
       primaryActionLabel: 'Apply',


### PR DESCRIPTION
Contributes to #3724 

Fixes the number of items displayed when viewing all checkbox filters. Also added `autoHideFilters` to filterProps which provides a way to opt out of the view all/view less checkbox filter functionality.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/OverflowCheckboxes.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
```
#### How did you test and verify your work?
Storybook