### PR TITLE
feat: add custom hook returning library prefix

### DIFF
--- a/packages/ibm-products/src/global/js/hooks/index.js
+++ b/packages/ibm-products/src/global/js/hooks/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,3 +16,4 @@ export { useResetCreateComponent } from './useResetCreateComponent';
 export { useRetrieveStepData } from './useRetrieveStepData';
 export { useValidCreateStepCount } from './useValidCreateStepCount';
 export { useControllableState } from './useControllableState';
+export { usePrefix } from './usePrefix';

--- a/packages/ibm-products/src/global/js/hooks/usePrefix.js
+++ b/packages/ibm-products/src/global/js/hooks/usePrefix.js
@@ -1,10 +1,10 @@
 /**
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2023, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-export { pkg } from './settings';
-export { usePrefix } from './global/js/hooks';
-export * from './components';
+import pkg from '../package-settings';
+
+export const usePrefix = () => pkg.prefix;


### PR DESCRIPTION
Contributes to #3711 

In an effort to align better with Carbon's approach to providing their prefix to consumers, this addition creates a new `usePrefix` hook and exports it for use.

#### What did you change?
```
packages/ibm-products/src/global/js/hooks/index.js
packages/ibm-products/src/global/js/hooks/usePrefix.js
packages/ibm-products/src/index.js
```
#### How did you test and verify your work?
Used the hook internally to check that it returned the expected prefix.