### PR TITLE
fix: datagrid header review fixes

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -30,6 +30,7 @@ import { useSubscribeToEventEmitter } from './addons/Filtering/hooks';
 import { clearSingleFilter } from './addons/Filtering/FilterProvider';
 
 const blockClass = `${pkg.prefix}--datagrid`;
+const gcClass = `${blockClass}__grid-container`;
 
 export const DatagridContent = ({ datagridState, title }) => {
   const { state: inlineEditState, dispatch } = useContext(InlineEditContext);
@@ -165,20 +166,16 @@ export const DatagridContent = ({ datagridState, title }) => {
   return (
     <>
       <TableContainer
-        className={cx(
-          `${blockClass}__grid-container`,
-          withVirtualScroll || fullHeightDatagrid
-            ? `${blockClass}__full-height`
-            : '',
-          DatagridPagination ? `${blockClass}__with-pagination` : '',
-          useDenseHeader ? `${blockClass}__dense-header` : '',
-          {
-            [`${blockClass}__grid-container-grid-active`]: gridActive,
-            [`${blockClass}__grid-container-inline-edit`]: withInlineEdit,
-            [`${blockClass}__grid-container-grid-active--without-toolbar`]:
-              withInlineEdit && !DatagridActions,
-          }
-        )}
+        className={cx(`${gcClass}`, {
+          [`${gcClass}-active`]: gridActive,
+          [`${gcClass}-active--without-toolbar`]:
+            withInlineEdit && !DatagridActions,
+          [`${gcClass}-inline-edit`]: withInlineEdit,
+          [`${blockClass}__full-height`]:
+            withVirtualScroll || fullHeightDatagrid,
+          [`${blockClass}__with-pagination`]: DatagridPagination,
+          [`${blockClass}__dense-header`]: useDenseHeader,
+        })}
         title={gridTitle}
         description={gridDescription}
       >

--- a/packages/ibm-products/src/components/Datagrid/styles/_useInlineEdit.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_useInlineEdit.scss
@@ -252,7 +252,7 @@ $row-heights: (
 // containers, using default border caused grid area width to be changed and
 // outlines were not present be
 .#{variables.$block-class}
-  .#{variables.$block-class}__grid-container-grid-active::before {
+  .#{variables.$block-class}__grid-container-active::before {
   position: absolute;
   z-index: 2;
   bottom: 0;
@@ -266,7 +266,7 @@ $row-heights: (
 }
 
 .#{variables.$block-class}
-  .#{variables.$block-class}__grid-container-grid-active::after {
+  .#{variables.$block-class}__grid-container-active::after {
   position: absolute;
   z-index: 2;
   right: 0;
@@ -280,7 +280,7 @@ $row-heights: (
 }
 
 .#{variables.$block-class}
-  .#{variables.$block-class}__grid-container-grid-active
+  .#{variables.$block-class}__grid-container-active
   .#{c4p-settings.$carbon-prefix}--data-table-content::before {
   position: absolute;
   z-index: 2;
@@ -293,16 +293,16 @@ $row-heights: (
 }
 
 .#{variables.$block-class}
-  .#{variables.$block-class}__grid-container-grid-active.#{variables.$block-class}__grid-container-grid-active--without-toolbar::before,
+  .#{variables.$block-class}__grid-container-active.#{variables.$block-class}__grid-container-active--without-toolbar::before,
 .#{variables.$block-class}
-  .#{variables.$block-class}__grid-container-grid-active.#{variables.$block-class}__grid-container-grid-active--without-toolbar::after {
+  .#{variables.$block-class}__grid-container-active.#{variables.$block-class}__grid-container-active--without-toolbar::after {
   height: calc(
     100% - 2px - var(--#{variables.$block-class}--grid-header-height)
   );
 }
 
 .#{variables.$block-class}
-  .#{variables.$block-class}__grid-container-grid-active
+  .#{variables.$block-class}__grid-container-active
   .#{variables.$block-class}__table-container {
   outline: 2px solid $link-inverse;
   outline-offset: -2px;


### PR DESCRIPTION
Contributes to #3462 

just does a little classname cleanup. the issue also mentions a small coverage fix required, but i also noticed in storybook that the datagrid inline edit was being deprecated, so i chose to skip it initially because i don't know if the coverage is needed.

<img width="664" alt="Screenshot 2023-11-01 at 4 41 55 PM" src="https://github.com/carbon-design-system/ibm-products/assets/6370760/4f13660d-0d2a-4438-a204-b6440a1c5fa4">

