### PR TITLE
fix(Datagrid): address resize end issues (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// @flow
 import React, { useState, useEffect } from 'react';
 import cx from 'classnames';
 import { DataTable } from 'carbon-components-react';
@@ -14,7 +13,6 @@ import { selectionColumnId } from '../common-column-ids';
 import { pkg } from '../../../settings';
 import {
   handleColumnResizeEndEvent,
-  handleColumnResizeStartEvent,
   handleColumnResizingEvent,
 } from './addons/stateReducer';
 import { getNodeTextContent } from '../../../global/js/utils/getNodeTextContent';
@@ -73,46 +71,6 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
 
   const [incrementAmount] = useState(2);
 
-  const getClientXPosition = (event) => {
-    let isTouchEvent = false;
-    if (event.type === 'touchstart') {
-      // Do not respond to multiple touches (e.g. 2 or 3 fingers)
-      if (event.touches && event.touches.length > 1) {
-        return;
-      }
-      isTouchEvent = true;
-    }
-    const clientX = isTouchEvent
-      ? Math.round(event.touches[0].clientX)
-      : event.clientX;
-    const closestHeader = event.target.closest('th');
-    const closestHeaderCoords = closestHeader.getBoundingClientRect();
-    const headerOffset = closestHeaderCoords.left;
-    const offsetValue = clientX - headerOffset;
-    return offsetValue;
-  };
-
-  useEffect(() => {
-    const { isResizing } = datagridState.state;
-    if (isResizing) {
-      const { onColResizeEnd } = datagridState;
-      document.addEventListener('mouseup', () => {
-        handleColumnResizeEndEvent(
-          datagridState.dispatch,
-          onColResizeEnd,
-          isResizing
-        );
-        document.activeElement.blur();
-      });
-    }
-    return () => {
-      document.removeEventListener('mouseup', () =>
-        handleColumnResizeEndEvent(datagridState.dispatch)
-      );
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [datagridState.state.isResizing]);
-
   return (
     <TableRow
       {...headerGroup.getHeaderGroupProps({ role: false })}
@@ -132,7 +90,7 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
           const { minWidth } = header || 50;
           const { visibleColumns, state, dispatch, onColResizeEnd } =
             datagridState;
-          const { columnResizing, isResizing } = state;
+          const { columnResizing } = state;
           const { columnWidths } = columnResizing;
           const originalCol = visibleColumns[index];
           return (
@@ -157,19 +115,6 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
                 <>
                   <input
                     {...header.getResizerProps()}
-                    onMouseMove={(event) => {
-                      if (isResizing) {
-                        const newWidth = getClientXPosition(event);
-                        const originalColMinWidth = originalCol.minWidth || 50;
-                        // Sets a min width for resizing so at least one character from the column header is visible
-                        if (newWidth >= originalColMinWidth) {
-                          handleColumnResizingEvent(dispatch, header, newWidth);
-                        }
-                      }
-                    }}
-                    onMouseDown={() =>
-                      handleColumnResizeStartEvent(dispatch, header.id)
-                    }
                     onKeyDown={(event) => {
                       const { key } = event;
                       if (key === 'ArrowLeft' || key === 'ArrowRight') {
@@ -210,7 +155,8 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
                       handleColumnResizeEndEvent(
                         dispatch,
                         onColResizeEnd,
-                        header.id
+                        header.id,
+                        true
                       )
                     }
                     className={cx(`${blockClass}__col-resizer-range`)}


### PR DESCRIPTION
Contributes to #3737

Fixes a column resize bug in the Datagrid where if you resized a column focusable items outside of the Datagrid seemed to lose focus. There was some extra logic in the resize end action to prevent this behavior.

While working on this issue, I discovered that we don't need to handle all of the custom logic to handle mouse events with resizing, `react-table` will still take care of that even if we want custom control over the key events so that we have keyboard support with resizing columns. Because of this, I was able to remove some code from `DatagridHeaderRow.js`.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
```
#### How did you test and verify your work?
Storybook