### PR TITLE
fix(Coachmark): remove malformed svg code

### DIFF
--- a/packages/ibm-products/src/components/CoachmarkBeacon/_coachmark-beacon.scss
+++ b/packages/ibm-products/src/components/CoachmarkBeacon/_coachmark-beacon.scss
@@ -46,21 +46,6 @@
       }
     }
 
-    &-ring {
-      .#{$block-class}__center {
-        -webkit-mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' width='80px' height='80px' viewBox='008080'><pathfill='white' stroke='none' d='M0,0m37-2a404001010Zm128a1212011-10Z'/></svg>");
-        mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' width='80px' height='80px' viewBox='008080'><pathfill='white' stroke='none' d='M0,0m37-2a404001010Zm128a1212011-10Z'/></svg>");
-
-        circle {
-          /* stylelint-disable-next-line carbon/motion-easing-use */
-          animation: ring-ripple $beaconAnimationTime infinite;
-          @media (prefers-reduced-motion) {
-            animation: none;
-          }
-        }
-      }
-    }
-
     .#{$block-class}__target {
       // the hit area
       position: absolute;


### PR DESCRIPTION
Contributes to #3728

The CSS class this svg issue belongs to (`...-ring`) seems to have been a work in progress that was never finished being developed. There is no story showcasing this feature, and this class is not referenced anywhere else in the code. 

#### What did you change?

Removing the class entirely.  

#### How did you test and verify your work?

- [x] Verified no broken tests or stories.