### PR TITLE
fix(EditTearsheet): Correctly assign action handlers to associated buttons

### DIFF
--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.test.js
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.test.js
@@ -562,7 +562,7 @@ describe(componentName, () => {
   });
 
   it('renders an error icon if the step invalid prop is set to true', async () => {
-   renderCreateFullPage({
+    renderCreateFullPage({
       ...defaultFullPageProps,
     });
 

--- a/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.js
+++ b/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.js
@@ -102,16 +102,18 @@ export let EditTearsheet = forwardRef(
         {...rest}
         {...getDevtoolsProps(componentName)}
         actions={[
-          {
-            label: submitButtonText,
-            onClick: onHandleModalClick,
-            kind: 'primary',
-          },
-          {
-            label: cancelButtonText,
-            onClick: onHandleModalClick,
-            kind: 'secondary',
-          },
+            {
+                key: 'create-action-button-submit',
+                label: submitButtonText,
+                onClick: onHandleModalClick,
+                kind: 'primary',
+            },
+            {
+                key: 'create-action-button-cancel',
+                label: cancelButtonText,
+                onClick: onClose,
+                kind: 'ghost',
+            }
         ]}
         className={cx(blockClass, className)}
         description={description}

--- a/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.js
+++ b/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.js
@@ -50,7 +50,7 @@ export let EditTearsheet = forwardRef(
       submitButtonText,
       title,
       verticalPosition = defaults.verticalPosition,
-      onHandleModalClick,
+      onRequestSubmit,
       onFormChange,
       sideNavAriaLabel = defaults.sideNavAriaLabel,
 
@@ -105,7 +105,7 @@ export let EditTearsheet = forwardRef(
             {
                 key: 'create-action-button-submit',
                 label: submitButtonText,
-                onClick: onHandleModalClick,
+                onClick: onRequestSubmit,
                 kind: 'primary',
             },
             {
@@ -206,10 +206,10 @@ EditTearsheet.propTypes = {
    */
   onFormChange: PropTypes.func,
 
-  /**
-   * Specifies whether the tearsheet is currently open.
-   */
-  onHandleModalClick: PropTypes.func,
+    /**
+     * Specify a handler for submitting the tearsheet.
+     */
+  onRequestSubmit: PropTypes.func.isRequired,
 
   /**
    * Specifies whether the tearsheet is currently open.

--- a/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.js
+++ b/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.js
@@ -103,13 +103,13 @@ export let EditTearsheet = forwardRef(
         {...getDevtoolsProps(componentName)}
         actions={[
             {
-                key: 'create-action-button-submit',
+                key: 'edit-action-button-submit',
                 label: submitButtonText,
                 onClick: onRequestSubmit,
                 kind: 'primary',
             },
             {
-                key: 'create-action-button-cancel',
+                key: 'edit-action-button-cancel',
                 label: cancelButtonText,
                 onClick: onClose,
                 kind: 'ghost',

--- a/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.js
+++ b/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.js
@@ -102,18 +102,18 @@ export let EditTearsheet = forwardRef(
         {...rest}
         {...getDevtoolsProps(componentName)}
         actions={[
-            {
-                key: 'edit-action-button-submit',
-                label: submitButtonText,
-                onClick: onRequestSubmit,
-                kind: 'primary',
-            },
-            {
-                key: 'edit-action-button-cancel',
-                label: cancelButtonText,
-                onClick: onClose,
-                kind: 'ghost',
-            }
+          {
+            key: 'edit-action-button-submit',
+            label: submitButtonText,
+            onClick: onRequestSubmit,
+            kind: 'primary',
+          },
+          {
+            key: 'edit-action-button-cancel',
+            label: cancelButtonText,
+            onClick: onClose,
+            kind: 'ghost',
+          },
         ]}
         className={cx(blockClass, className)}
         description={description}
@@ -206,9 +206,9 @@ EditTearsheet.propTypes = {
    */
   onFormChange: PropTypes.func,
 
-    /**
-     * Specify a handler for submitting the tearsheet.
-     */
+  /**
+   * Specify a handler for submitting the tearsheet.
+   */
   onRequestSubmit: PropTypes.func.isRequired,
 
   /**

--- a/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.test.js
+++ b/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.test.js
@@ -184,6 +184,24 @@ describe(componentName, () => {
     expect(editTearsheet).not.toHaveClass('is-visible');
   });
 
+  it('calls the submit handler when the primary button is clicked', async () => {
+    render(
+      <EditTearsheet
+        {...{ ...defaultProps }}
+        onClose={onCloseReturnsTrue}
+        onRequestSubmit={onRequestSubmitFn}
+        open
+      />
+    );
+
+    const editTearsheet = document.querySelector(`.${carbon.prefix}--modal`);
+    expect(editTearsheet).toHaveClass('is-visible');
+    const submitButton = screen.getByText('Save');
+
+    await act(() => click(submitButton));
+    expect(onRequestSubmitFn).toHaveBeenCalledTimes(1);
+  });
+
   it('applies className to the root node', async () => {
     renderEditTearsheet({ className });
     const editTearsheet = document.querySelector(`.${carbon.prefix}--modal`);

--- a/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.test.js
+++ b/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.test.js
@@ -36,6 +36,7 @@ const form1Subtitle = uuidv4();
 
 const onCloseFn = jest.fn();
 const onCloseReturnsTrue = jest.fn(() => true);
+const onRequestSubmitFn = jest.fn();
 const ref = React.createRef();
 
 const defaultProps = {
@@ -47,13 +48,14 @@ const defaultProps = {
   label: '',
   influencerWidth: 'narrow',
   onClose: onCloseFn,
+  onRequestSubmit: onRequestSubmitFn,
   open: true,
   ref,
 };
 
 const renderEditTearsheet = ({ ...rest } = {}) =>
   render(
-    <EditTearsheet {...rest}>
+    <EditTearsheet onRequestSubmit={onRequestSubmitFn} {...rest}>
       <EditTearsheetForm
         title={form1Title}
         fieldsetLegendText={form1Title}
@@ -80,7 +82,7 @@ const renderEditTearsheet = ({ ...rest } = {}) =>
 
 const renderEmptyEditTearsheet = ({ ...rest } = {}) =>
   render(
-    <EditTearsheet {...rest}>
+    <EditTearsheet onRequestSubmit={onRequestSubmitFn} {...rest}>
       <p>Child element that persists across all forms</p>
     </EditTearsheet>
   );
@@ -151,7 +153,12 @@ describe(componentName, () => {
   });
 
   it('adds additional props to the containing node', async () => {
-    render(<EditTearsheet data-testid={dataTestId}> </EditTearsheet>);
+    render(
+      <EditTearsheet
+        data-testid={dataTestId}
+        onRequestSubmit={onRequestSubmitFn}
+      ></EditTearsheet>
+    );
     screen.getByTestId(dataTestId);
   });
 
@@ -166,6 +173,7 @@ describe(componentName, () => {
       <EditTearsheet
         {...{ ...defaultProps }}
         onClose={onCloseReturnsTrue}
+        onRequestSubmit={onRequestSubmitFn}
         open
       />
     );

--- a/packages/ibm-products/src/components/EditTearsheet/preview-components/MultiFormEditTearsheet.js
+++ b/packages/ibm-products/src/components/EditTearsheet/preview-components/MultiFormEditTearsheet.js
@@ -61,8 +61,14 @@ export const MultiFormEditTearsheet = ({
     setOpen(false);
   };
 
-  const handleModalClick = () => {
-    setOpen(!open);
+  const onClose = () => {
+    clearCreateData();
+    action('onClose')();
+  }
+
+  const onSubmit = () => {
+    setOpen(false);
+    action('onSubmit')();
   };
 
   const handleFormChange = () => {
@@ -72,7 +78,7 @@ export const MultiFormEditTearsheet = ({
   return (
     <div>
       <style>{`.${blockClass} { opacity: 0 }`};</style>
-      <Button onClick={handleModalClick}>
+      <Button onClick={() => setOpen(!open)}>
         {open ? 'Close EditTearsheet' : 'Open EditTearsheet'}
       </Button>
       <EditTearsheet
@@ -84,8 +90,8 @@ export const MultiFormEditTearsheet = ({
         description={description}
         title={title}
         open={open}
-        onHandleModalClick={handleModalClick}
-        onClose={clearCreateData}
+        onRequestSubmit={onSubmit}
+        onClose={onClose}
         onFormChange={handleFormChange}
       >
         <EditTearsheetForm

--- a/packages/ibm-products/src/components/EditTearsheet/preview-components/MultiFormEditTearsheet.js
+++ b/packages/ibm-products/src/components/EditTearsheet/preview-components/MultiFormEditTearsheet.js
@@ -64,7 +64,7 @@ export const MultiFormEditTearsheet = ({
   const onClose = () => {
     clearCreateData();
     action('onClose')();
-  }
+  };
 
   const onSubmit = () => {
     setOpen(false);


### PR DESCRIPTION
Contributes to #3744

# Intent

Assign the correct handlers to each of their respective buttons.

# Background

Currently, the 2 action buttons on the `EditTearsheet` component refer to the same event handler property. This prohibits the user from distinguishing behavior _and_ closing the modal.

#### What did you change?

- Distinguished event handler assignment
- Changed 'Cancel' button from type secondary to ghost
- Renamed and repurposed `onHandleModalClick` to `onRequestSubmit`
- Updated prop description
- Updated storybook
   - Changed references
   - Added actions to handlers
   - Added handlers definitions

#### How did you test and verify your work?

https://github.com/carbon-design-system/ibm-products/assets/12387334/69bed889-bd83-44ca-aa98-7867c4ee5900

_Observe how action buttons are now associate with the correct handlers._
