### PR TITLE
chore(Datagrid): fix alignment of icon only columns to match guidance

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Extensions/ColumnAlignment/ColumnAlignment.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ColumnAlignment/ColumnAlignment.stories.js
@@ -7,6 +7,7 @@
  */
 
 import React, { useState } from 'react';
+import { Tooltip } from '@carbon/react';
 import { Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
 import {
@@ -72,7 +73,7 @@ const defaultHeader = [
   {
     Header: 'Password strength',
     accessor: 'passwordStrength',
-    width: 100,
+    width: 160,
     centerAlignedColumn: true,
     Cell: ({ cell: { value } }) => {
       const iconProps = {
@@ -83,16 +84,11 @@ const defaultHeader = [
       };
 
       return (
-        <span
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-          }}
-        >
-          <StatusIcon {...iconProps} />
-          {iconProps.iconDescription}
-        </span>
+        <Tooltip label={iconProps.iconDescription}>
+          <button type="button" className="sb--tooltip-trigger">
+            <StatusIcon {...iconProps} />
+          </button>
+        </Tooltip>
       );
     },
   },

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
@@ -7,13 +7,19 @@
  */
 
 import React, { useState } from 'react';
+import { Tooltip } from '@carbon/react';
 import { Add } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,
   prepareStory,
 } from '../../../../global/js/utils/story-helper';
-import { Datagrid, useDatagrid, useFiltering } from '../../index';
+import {
+  Datagrid,
+  useDatagrid,
+  useFiltering,
+  useColumnCenterAlign,
+} from '../../index';
 import styles from '../../_storybook-styles.scss';
 import { DocsPage } from './Filtering.docs-page';
 import { makeData } from '../../utils/makeData';
@@ -125,6 +131,8 @@ const FilteringUsage = ({ defaultGridProps }) => {
       Header: 'Password strength',
       accessor: 'passwordStrength',
       filter: 'checkbox',
+      centerAlignedColumn: true,
+      width: 160,
       Cell: ({ cell: { value } }) => {
         const iconProps = {
           size: 'sm',
@@ -134,16 +142,11 @@ const FilteringUsage = ({ defaultGridProps }) => {
         };
 
         return (
-          <span
-            style={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}
-          >
-            <StatusIcon {...iconProps} />
-            {iconProps.iconDescription}
-          </span>
+          <Tooltip label={iconProps.iconDescription}>
+            <button type="button" className="sb--tooltip-trigger">
+              <StatusIcon {...iconProps} />
+            </button>
+          </Tooltip>
         );
       },
     },
@@ -172,7 +175,8 @@ const FilteringUsage = ({ defaultGridProps }) => {
       emptyStateTitle,
       emptyStateDescription,
     },
-    useFiltering
+    useFiltering,
+    useColumnCenterAlign
   );
 
   // Warnings are ordinarily silenced in storybook, add this to test

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
@@ -6,8 +6,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Datagrid, useDatagrid, useFiltering } from '../../index';
 import React, { useState } from 'react';
+import { Tooltip } from '@carbon/react';
+import {
+  Datagrid,
+  useDatagrid,
+  useFiltering,
+  useColumnCenterAlign,
+} from '../../index';
 import {
   getStoryTitle,
   prepareStory,
@@ -137,6 +143,8 @@ const FilteringUsage = ({ defaultGridProps }) => {
       Header: 'Password strength',
       accessor: 'passwordStrength',
       filter: 'checkbox',
+      width: 160,
+      centerAlignedColumn: true,
       Cell: ({ cell: { value } }) => {
         const iconProps = {
           size: 'sm',
@@ -144,18 +152,12 @@ const FilteringUsage = ({ defaultGridProps }) => {
           kind: value,
           iconDescription: value,
         };
-
         return (
-          <span
-            style={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}
-          >
-            <StatusIcon {...iconProps} />
-            {iconProps.iconDescription}
-          </span>
+          <Tooltip label={iconProps.iconDescription}>
+            <button type="button" className="sb--tooltip-trigger">
+              <StatusIcon {...iconProps} />
+            </button>
+          </Tooltip>
         );
       },
     },
@@ -184,7 +186,8 @@ const FilteringUsage = ({ defaultGridProps }) => {
       emptyStateTitle,
       emptyStateDescription,
     },
-    useFiltering
+    useFiltering,
+    useColumnCenterAlign
   );
 
   // Warnings are ordinarily silenced in storybook, add this to test

--- a/packages/ibm-products/src/components/Datagrid/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/Datagrid/_storybook-styles.scss
@@ -8,6 +8,7 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/components/tooltip';
 
 @use 'ALIAS_STORY_STYLE_CONFIG' as c4p-settings;
 
@@ -140,4 +141,17 @@ div[data-story-title*='#{$story-anchor}']
   > div:first-child {
   overflow: auto;
   width: 100%;
+}
+
+.sb--tooltip-trigger {
+  display: flex;
+  box-sizing: border-box;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  margin: 0;
+  background: none;
+  cursor: pointer;
+  text-align: start;
 }


### PR DESCRIPTION
Contributes to #3467 

Updates storybook usage examples to match design guidance for icon only columns, they should be center aligned. I also added a tooltip to the status icons so that there is still a way to know what the label associated with the status icon is.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Extensions/ColumnAlignment/ColumnAlignment.stories.js
packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
packages/ibm-products/src/components/Datagrid/_storybook-styles.scss
```
#### How did you test and verify your work?
Storybook