### PR TITLE
chore(Datagrid): fix alignment of icon only columns to match guidance

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Extensions/ColumnAlignment/ColumnAlignment.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ColumnAlignment/ColumnAlignment.stories.js
@@ -7,6 +7,7 @@
  */
 
 import React, { useState } from 'react';
+import { TooltipIcon } from 'carbon-components-react';
 import { Edit16, TrashCan16 } from '@carbon/icons-react';
 import { action } from '@storybook/addon-actions';
 import {
@@ -70,7 +71,7 @@ const defaultHeader = [
   {
     Header: 'Password strength',
     accessor: 'passwordStrength',
-    width: 100,
+    width: 160,
     centerAlignedColumn: true,
     Cell: ({ cell: { value } }) => {
       const iconProps = {
@@ -81,16 +82,12 @@ const defaultHeader = [
       };
 
       return (
-        <span
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-          }}
-        >
-          <StatusIcon {...iconProps} />
-          {iconProps.iconDescription}
-        </span>
+        <TooltipIcon
+          tooltipText={iconProps.iconDescription}
+          onClick={action('onClick')}
+          renderIcon={() => <StatusIcon {...iconProps} />}
+          direction="top"
+        />
       );
     },
   },

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
@@ -7,12 +7,18 @@
  */
 
 import React, { useState } from 'react';
+import { TooltipIcon } from 'carbon-components-react';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,
   prepareStory,
 } from '../../../../global/js/utils/story-helper';
-import { Datagrid, useDatagrid, useFiltering } from '../../index';
+import {
+  Datagrid,
+  useDatagrid,
+  useFiltering,
+  useColumnCenterAlign,
+} from '../../index';
 import styles from '../../_storybook-styles.scss';
 import mdx from '../../Datagrid.mdx';
 import { makeData } from '../../utils/makeData';
@@ -90,7 +96,9 @@ const FilteringUsage = ({ defaultGridProps }) => {
     {
       Header: 'Password strength',
       accessor: 'passwordStrength',
+      width: 160,
       filter: 'checkbox',
+      centerAlignedColumn: true,
       Cell: ({ cell: { value } }) => {
         const iconProps = {
           size: 'sm',
@@ -100,16 +108,12 @@ const FilteringUsage = ({ defaultGridProps }) => {
         };
 
         return (
-          <span
-            style={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}
-          >
-            <StatusIcon {...iconProps} />
-            {iconProps.iconDescription}
-          </span>
+          <TooltipIcon
+            tooltipText={iconProps.iconDescription}
+            onClick={action('onClick')}
+            renderIcon={() => <StatusIcon {...iconProps} />}
+            direction="top"
+          />
         );
       },
     },
@@ -144,7 +148,8 @@ const FilteringUsage = ({ defaultGridProps }) => {
       emptyStateTitle,
       emptyStateDescription,
     },
-    useFiltering
+    useFiltering,
+    useColumnCenterAlign
   );
 
   return <Datagrid datagridState={datagridState} />;

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
@@ -7,12 +7,18 @@
  */
 
 import React, { useState } from 'react';
+import { TooltipIcon } from 'carbon-components-react';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,
   prepareStory,
 } from '../../../../global/js/utils/story-helper';
-import { Datagrid, useDatagrid, useFiltering } from '../../index';
+import {
+  Datagrid,
+  useDatagrid,
+  useFiltering,
+  useColumnCenterAlign,
+} from '../../index';
 import styles from '../../_storybook-styles.scss';
 import mdx from '../../Datagrid.mdx';
 import { makeData } from '../../utils/makeData';
@@ -83,6 +89,8 @@ const FilteringUsage = ({ defaultGridProps }) => {
     {
       Header: 'Password strength',
       accessor: 'passwordStrength',
+      width: 160,
+      centerAlignedColumn: true,
       filter: 'checkbox',
       Cell: ({ cell: { value } }) => {
         const iconProps = {
@@ -93,16 +101,12 @@ const FilteringUsage = ({ defaultGridProps }) => {
         };
 
         return (
-          <span
-            style={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}
-          >
-            <StatusIcon {...iconProps} />
-            {iconProps.iconDescription}
-          </span>
+          <TooltipIcon
+            tooltipText={iconProps.iconDescription}
+            onClick={action('onClick')}
+            renderIcon={() => <StatusIcon {...iconProps} />}
+            direction="top"
+          />
         );
       },
     },
@@ -131,7 +135,8 @@ const FilteringUsage = ({ defaultGridProps }) => {
       emptyStateTitle,
       emptyStateDescription,
     },
-    useFiltering
+    useFiltering,
+    useColumnCenterAlign
   );
 
   return <Datagrid datagridState={datagridState} />;

--- a/packages/ibm-products/src/components/Datagrid/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/Datagrid/_storybook-styles.scss
@@ -147,3 +147,18 @@ $block-class: #{$pkg-prefix}--datagrid;
     width: 100vw;
   }
 }
+
+.#{$carbon-prefix}--tooltip__trigger:hover
+  .#{$pkg-prefix}--status-icon--light.#{$pkg-prefix}--status-icon--light-minor-warning {
+  fill: $support-03;
+}
+
+.#{$carbon-prefix}--tooltip__trigger:hover
+  .#{$pkg-prefix}--status-icon--light.#{$pkg-prefix}--status-icon--light-normal {
+  fill: $support-02;
+}
+
+.#{$carbon-prefix}--tooltip__trigger:hover
+  .#{$pkg-prefix}--status-icon--light.#{$pkg-prefix}--status-icon--light-critical {
+  fill: $support-01;
+}


### PR DESCRIPTION
Contributes to #3467 

Updates storybook usage examples to match design guidance for icon only columns, they should be center aligned. I also added a tooltip to the status icons so that there is still a way to know what the label associated with the status icon is.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Extensions/ColumnAlignment/ColumnAlignment.stories.js
packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
packages/ibm-products/src/components/Datagrid/_storybook-styles.scss
```
#### How did you test and verify your work?
Storybook