### PR TITLE
fix: GuideBanner and InlineTip - export sub components

### DIFF
--- a/packages/ibm-products/src/components/Guidebanner/Guidebanner.js
+++ b/packages/ibm-products/src/components/Guidebanner/Guidebanner.js
@@ -213,7 +213,7 @@ Guidebanner.propTypes = {
       );
     }
     React.Children.forEach(prop, (child) => {
-      if (child.type.name !== 'GuidebannerElement') {
+      if (child.type.displayName !== 'GuidebannerElement') {
         // If not GuidebannerElement, then show:
         // React component name(child.type?.name) or
         // HTML element name(child.type).

--- a/packages/ibm-products/src/components/Guidebanner/Guidebanner.js
+++ b/packages/ibm-products/src/components/Guidebanner/Guidebanner.js
@@ -219,7 +219,7 @@ Guidebanner.propTypes = {
         // HTML element name(child.type).
         error = new Error(
           `\`Guidebanner\` only accepts children of type \`GuidebannerElement\`, found \`${
-            child.type?.name || child.type
+            child.type?.displayName || child.type?.name || child.type
           }\` instead.`
         );
       }

--- a/packages/ibm-products/src/components/Guidebanner/GuidebannerElement.js
+++ b/packages/ibm-products/src/components/Guidebanner/GuidebannerElement.js
@@ -26,7 +26,7 @@ const componentName = 'GuidebannerElement';
  * The GuidebannerElement is a required child component of the Guidebanner,
  * and acts as a container for a CarouselItem.
  */
-const GuidebannerElement = ({
+export let GuidebannerElement = ({
   button,
   className,
   description,
@@ -45,6 +45,16 @@ const GuidebannerElement = ({
     </div>
   );
 };
+
+// Return a placeholder if not released and not enabled by feature flag
+GuidebannerElement = pkg.checkComponentEnabled(
+  GuidebannerElement,
+  componentName
+);
+
+// The display name of the component, used by React. Note that displayName
+// is used in preference to relying on function.name.
+GuidebannerElement.displayName = componentName;
 
 // The types and DocGen commentary for the component props,
 // in alphabetical order (for consistency).
@@ -73,5 +83,3 @@ GuidebannerElement.propTypes = {
    */
   title: PropTypes.string,
 };
-
-export { GuidebannerElement };

--- a/packages/ibm-products/src/components/Guidebanner/GuidebannerElementButton.js
+++ b/packages/ibm-products/src/components/Guidebanner/GuidebannerElementButton.js
@@ -27,7 +27,12 @@ const componentName = 'GuidebannerElementButton';
 /**
  * One of two buttons styled specifically for the GuidebannerElement.
  */
-const GuidebannerElementButton = ({ children, className, type, ...rest }) => {
+export let GuidebannerElementButton = ({
+  children,
+  className,
+  type,
+  ...rest
+}) => {
   if (type === 'primary') {
     return (
       <Button
@@ -59,6 +64,16 @@ const GuidebannerElementButton = ({ children, className, type, ...rest }) => {
   );
 };
 
+// Return a placeholder if not released and not enabled by feature flag
+GuidebannerElementButton = pkg.checkComponentEnabled(
+  GuidebannerElementButton,
+  componentName
+);
+
+// The display name of the component, used by React. Note that displayName
+// is used in preference to relying on function.name.
+GuidebannerElementButton.displayName = componentName;
+
 // The types and DocGen commentary for the component props,
 // in alphabetical order (for consistency).
 // See https://www.npmjs.com/package/prop-types#usage.
@@ -81,5 +96,3 @@ GuidebannerElementButton.propTypes = {
 
   /* TODO: add types and DocGen for all props. */
 };
-
-export { GuidebannerElementButton };

--- a/packages/ibm-products/src/components/Guidebanner/GuidebannerElementLink.js
+++ b/packages/ibm-products/src/components/Guidebanner/GuidebannerElementLink.js
@@ -26,7 +26,7 @@ const componentName = 'GuidebannerElementLink';
 /**
  * A link styled specifically for the GuidebannerElement.
  */
-const GuidebannerElementLink = ({ children, className, ...rest }) => {
+export let GuidebannerElementLink = ({ children, className, ...rest }) => {
   return (
     <Link
       {...rest}
@@ -40,6 +40,16 @@ const GuidebannerElementLink = ({ children, className, ...rest }) => {
     </Link>
   );
 };
+
+// Return a placeholder if not released and not enabled by feature flag
+GuidebannerElementLink = pkg.checkComponentEnabled(
+  GuidebannerElementLink,
+  componentName
+);
+
+// The display name of the component, used by React. Note that displayName
+// is used in preference to relying on function.name.
+GuidebannerElementLink.displayName = componentName;
 
 // The types and DocGen commentary for the component props,
 // in alphabetical order (for consistency).
@@ -55,5 +65,3 @@ GuidebannerElementLink.propTypes = {
    */
   className: PropTypes.string,
 };
-
-export { GuidebannerElementLink };

--- a/packages/ibm-products/src/components/InlineTip/InlineTipButton.js
+++ b/packages/ibm-products/src/components/InlineTip/InlineTipButton.js
@@ -82,6 +82,13 @@ export let InlineTipButton = React.forwardRef(
   }
 );
 
+// Return a placeholder if not released and not enabled by feature flag
+InlineTipButton = pkg.checkComponentEnabled(InlineTipButton, componentName);
+
+// The display name of the component, used by React. Note that displayName
+// is used in preference to relying on function.name.
+InlineTipButton.displayName = componentName;
+
 // The types and DocGen commentary for the component props,
 // in alphabetical order (for consistency).
 // See https://www.npmjs.com/package/prop-types#usage.

--- a/packages/ibm-products/src/components/InlineTip/InlineTipLink.js
+++ b/packages/ibm-products/src/components/InlineTip/InlineTipLink.js
@@ -82,6 +82,13 @@ export let InlineTipLink = React.forwardRef(
   }
 );
 
+// Return a placeholder if not released and not enabled by feature flag
+InlineTipLink = pkg.checkComponentEnabled(InlineTipLink, componentName);
+
+// The display name of the component, used by React. Note that displayName
+// is used in preference to relying on function.name.
+InlineTipLink.displayName = componentName;
+
 // The types and DocGen commentary for the component props,
 // in alphabetical order (for consistency).
 // See https://www.npmjs.com/package/prop-types#usage.

--- a/packages/ibm-products/src/components/index.js
+++ b/packages/ibm-products/src/components/index.js
@@ -85,7 +85,12 @@ export { EditUpdateCards } from './EditUpdateCards';
 
 export { InlineEdit } from './InlineEdit';
 export { EditInPlace } from './EditInPlace';
-export { Guidebanner } from './Guidebanner';
+export {
+  Guidebanner,
+  GuidebannerElement,
+  GuidebannerElementButton,
+  GuidebannerElementLink,
+} from './Guidebanner';
 export { NonLinearReading } from './NonLinearReading';
 
 export { Coachmark } from './Coachmark';
@@ -96,5 +101,5 @@ export { CoachmarkOverlayElements } from './CoachmarkOverlayElements';
 export { CoachmarkOverlayElement } from './CoachmarkOverlayElement';
 export { CoachmarkStack } from './CoachmarkStack';
 
-export { InlineTip } from './InlineTip';
+export { InlineTip, InlineTipButton, InlineTipLink } from './InlineTip';
 export { Checklist } from './Checklist';

--- a/packages/ibm-products/src/global/js/package-settings.js
+++ b/packages/ibm-products/src/global/js/package-settings.js
@@ -74,7 +74,12 @@ const defaults = {
 
     // Novice to pro components not yet reviewed and released:
     InlineTip: false,
+    InlineTipButton: false,
+    InlineTipLink: false,
     Guidebanner: false,
+    GuidebannerElement: false,
+    GuidebannerElementButton: false,
+    GuidebannerElementLink: false,
     NonLinearReading: false,
     Checklist: false,
     Coachmark: false,


### PR DESCRIPTION
Contributes to #3759

Add `GuideBanner` and `InlineTip` sub components as exportable.

#### What did you change?

```
packages/ibm-products/src/components/Guidebanner/Guidebanner.js
packages/ibm-products/src/components/Guidebanner/GuidebannerElement.js
packages/ibm-products/src/components/Guidebanner/GuidebannerElementButton.js
packages/ibm-products/src/components/Guidebanner/GuidebannerElementLink.js
packages/ibm-products/src/components/InlineTip/InlineTipButton.js
packages/ibm-products/src/components/InlineTip/InlineTipLink.js
packages/ibm-products/src/components/index.js
packages/ibm-products/src/global/js/package-settings.js
```

#### How did you test and verify your work?
