### PR TITLE
fix: Storybook error "Failed prop type: req'd titleText is missing from Dropdown"

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.js
+++ b/packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.js
@@ -79,6 +79,7 @@ export default {
           <Dropdown
             id="tss-had"
             label="Choose an option"
+            // titleText="Choose an option"
             items={['option 1', 'option 2', 'option 3', 'option 4']}
           />
         ),


### PR DESCRIPTION
Contributes to #3763 

Eliminate Storybook console error
```
Warning: Failed prop type: The prop `titleText` is marked as required in `Dropdown`, 
but its value is `undefined`.
```
#### What did you change?

```
packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.js
```

#### How did you test and verify your work?
