### PR TITLE
fix(Datagrid): stop propagation of row expander click event

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
+++ b/packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
@@ -24,8 +24,9 @@ const useNestedRowExpander = (hooks) => {
       Cell: ({ row }) => {
         const expanderButtonProps = {
           ...row.getToggleRowExpandedProps(),
-          onClick: (e) => {
-            e.stopPropagation(); // avoid triggering onRowClick
+          onClick: (event) => {
+            // Prevents `onRowClick` from being called if `useOnRowClick` is included
+            event.stopPropagation();
             row.toggleRowExpanded();
           },
         };

--- a/packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
+++ b/packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
@@ -22,6 +22,13 @@ const useNestedRowExpander = (hooks) => {
     const expanderColumn = {
       id: 'expander',
       Cell: ({ row }) => {
+        const expanderButtonProps = {
+          ...row.getToggleRowExpandedProps(),
+          onClick: (e) => {
+            e.stopPropagation(); // avoid triggering onRowClick
+            row.toggleRowExpanded();
+          },
+        };
         const {
           expanderButtonTitleExpanded = 'Collapse row',
           expanderButtonTitleCollapsed = 'Expand row',
@@ -39,7 +46,7 @@ const useNestedRowExpander = (hooks) => {
                 `${carbon.prefix}--btn`,
                 `${carbon.prefix}--btn--ghost`
               )}
-              {...row.getToggleRowExpandedProps()}
+              {...expanderButtonProps}
               title={expanderTitle}
             >
               <ChevronRight

--- a/packages/ibm-products/src/components/Datagrid/useRowExpander.js
+++ b/packages/ibm-products/src/components/Datagrid/useRowExpander.js
@@ -22,6 +22,13 @@ const useRowExpander = (hooks) => {
     const expanderColumn = {
       id: 'expander',
       Cell: ({ row }) => {
+        const expanderButtonProps = {
+          ...row.getToggleRowExpandedProps(),
+          onClick: (e) => {
+            e.stopPropagation(); // avoid triggering onRowClick
+            row.toggleRowExpanded();
+          },
+        };
         const {
           expanderButtonTitleExpanded = 'Collapse row',
           expanderButtonTitleCollapsed = 'Expand row',
@@ -39,7 +46,7 @@ const useRowExpander = (hooks) => {
                 `${carbon.prefix}--btn`,
                 `${carbon.prefix}--btn--ghost`
               )}
-              {...row.getToggleRowExpandedProps()}
+              {...expanderButtonProps}
               title={expanderTitle}
             >
               {row.isExpanded ? (

--- a/packages/ibm-products/src/components/Datagrid/useRowExpander.js
+++ b/packages/ibm-products/src/components/Datagrid/useRowExpander.js
@@ -24,8 +24,9 @@ const useRowExpander = (hooks) => {
       Cell: ({ row }) => {
         const expanderButtonProps = {
           ...row.getToggleRowExpandedProps(),
-          onClick: (e) => {
-            e.stopPropagation(); // avoid triggering onRowClick
+          onClick: (event) => {
+            // Prevents `onRowClick` from being called if `useOnRowClick` is included
+            event.stopPropagation();
             row.toggleRowExpanded();
           },
         };


### PR DESCRIPTION
Contributes to #3749 

Click event from row expanders was bubbling up, causing the `onRowClick` to be called unexpectedly. Thanks @dsav-eng for the detailed issue!

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
packages/ibm-products/src/components/Datagrid/useRowExpander.js
```
#### How did you test and verify your work?
Storybook, temporarily added `useOnRowClick` to both `useNestedRows` and `useExpandableRows` and confirmed the expander click does not trigger the `onRowClick`.