### PR TITLE
fix(Datagrid): destructure key to fix eslint unique key error (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRefBody.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRefBody.js
@@ -27,7 +27,8 @@ const DatagridRefBody = (datagridState) => {
     >
       {rows.map((row) => {
         prepareRow(row);
-        return row.RowRenderer({ ...datagridState, row });
+        const { key } = row.getRowProps();
+        return row.RowRenderer({ ...datagridState, row, key });
       })}
     </tbody>
   );

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.js
@@ -27,7 +27,7 @@ const rowHeights = {
 
 // eslint-disable-next-line react/prop-types
 const DatagridRow = (datagridState) => {
-  const { row, rowSize, withNestedRows, prepareRow } = datagridState;
+  const { row, rowSize, withNestedRows, prepareRow, key } = datagridState;
 
   const getVisibleNestedRowCount = ({ isExpanded, subRows }) => {
     let size = 0;
@@ -111,7 +111,7 @@ const DatagridRow = (datagridState) => {
   });
 
   return (
-    <>
+    <React.Fragment key={key}>
       <TableRow
         className={rowClassNames}
         {...row.getRowProps({ role: false })}
@@ -150,7 +150,7 @@ const DatagridRow = (datagridState) => {
         })}
       </TableRow>
       {renderExpandedRow()}
-    </>
+    </React.Fragment>
   );
 };
 

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSimpleBody.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSimpleBody.js
@@ -26,7 +26,8 @@ const DatagridSimpleBody = (datagridState) => {
     >
       {rows.map((row) => {
         prepareRow(row);
-        return row.RowRenderer({ ...datagridState, row });
+        const { key } = row.getRowProps();
+        return row.RowRenderer({ ...datagridState, row, key });
       })}
     </TableBody>
   );

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
@@ -107,13 +107,14 @@ const DatagridVirtualBody = (datagridState) => {
           {({ index, style }) => {
             const row = visibleRows[index];
             prepareRow(row);
+            const { key } = row.getRowProps();
             return (
               <div
                 style={{
                   ...style,
                 }}
               >
-                {row.RowRenderer({ ...datagridState, row })}
+                {row.RowRenderer({ ...datagridState, row, key })}
               </div>
             );
           }}


### PR DESCRIPTION
Contributes to #3679

I _think_ this finally solves the unique key prop console errors we've been seeing in Datagrid. Found [this discussion](https://github.com/TanStack/table/discussions/2647) helpful, with others stating that destructing the key from `row.getRowProps()` fixes the issue.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRefBody.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSimpleBody.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
```
#### How did you test and verify your work?
Storybook