### PR TITLE
fix(Datagrid): match designs, frozen/non frozen action button behavior

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -103,6 +103,7 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
                   [`${blockClass}__sortableColumn`]:
                     datagridState.isTableSortable && header.id !== 'spacer',
                   [`${blockClass}__isSorted`]: header.isSorted,
+                  [`${blockClass}__header-actions-column`]: header.isAction,
                 },
                 header.getHeaderProps().className
               )}
@@ -111,7 +112,7 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
               {...getAccessibilityProps(header)}
             >
               {header.render('Header')}
-              {header.getResizerProps && (
+              {header.getResizerProps && !header.isAction && (
                 <>
                   <input
                     {...header.getResizerProps()}

--- a/packages/ibm-products/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.js
@@ -64,12 +64,12 @@ const defaultHeader = [
   {
     Header: 'Age',
     accessor: 'age',
-    width: 50,
+    width: 90,
   },
   {
     Header: 'Visits',
     accessor: 'visits',
-    width: 60,
+    width: 100,
   },
   {
     Header: 'Someone 1',
@@ -82,34 +82,6 @@ const defaultHeader = [
   {
     Header: 'Someone 3',
     accessor: 'someone3',
-  },
-  {
-    Header: 'Someone 4',
-    accessor: 'someone4',
-  },
-  {
-    Header: 'Someone 5',
-    accessor: 'someone5',
-  },
-  {
-    Header: 'Someone 6',
-    accessor: 'someone6',
-  },
-  {
-    Header: 'Someone 7',
-    accessor: 'someone7',
-  },
-  {
-    Header: 'Someone 8',
-    accessor: 'someone8',
-  },
-  {
-    Header: 'Someone 9',
-    accessor: 'someone9',
-  },
-  {
-    Header: 'Someone 10',
-    accessor: 'someone10',
   },
 ];
 
@@ -283,7 +255,6 @@ const RowActionButtonsBatchActions = ({ ...args }) => {
         Header: '',
         accessor: 'actions',
         sticky: 'right',
-        width: 96,
         isAction: true,
       },
     ],

--- a/packages/ibm-products/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.js
@@ -140,7 +140,7 @@ const RowActionButtons = ({ ...args }) => {
       {
         Header: '',
         accessor: 'actions',
-        sticky: 'right',
+        // sticky: 'right',
         isAction: true,
       },
     ],

--- a/packages/ibm-products/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.js
@@ -140,7 +140,7 @@ const RowActionButtons = ({ ...args }) => {
       {
         Header: '',
         accessor: 'actions',
-        // sticky: 'right',
+        sticky: 'right',
         isAction: true,
       },
     ],

--- a/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
@@ -354,15 +354,19 @@
 .#{$block-class}
   .#{$block-class}__carbon-row
   .#{$block-class}__actions-column-cell-non-sticky
-  .#{$block-class}__actions-column-contents {
-  visibility: hidden;
+  .#{c4p-settings.$carbon-prefix}--btn--icon-only {
+  opacity: 0;
 }
 
 .#{$block-class}
   .#{$block-class}__carbon-row:hover
   .#{$block-class}__actions-column-cell-non-sticky
-  .#{$block-class}__actions-column-contents {
-  visibility: visible;
+  .#{c4p-settings.$carbon-prefix}--btn--icon-only,
+.#{$block-class}
+  .#{$block-class}__carbon-row
+  .#{$block-class}__actions-column-cell-non-sticky
+  .#{c4p-settings.$carbon-prefix}--btn--icon-only:focus {
+  opacity: 1;
 }
 
 .#{$block-class}__head-hidden-select-all {

--- a/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
@@ -365,7 +365,11 @@
 .#{$block-class}
   .#{$block-class}__carbon-row
   .#{$block-class}__actions-column-cell-non-sticky
-  .#{c4p-settings.$carbon-prefix}--btn--icon-only:focus {
+  .#{c4p-settings.$carbon-prefix}--btn--icon-only:focus,
+.#{$block-class}
+  .#{$block-class}__carbon-row
+  .#{$block-class}__actions-column-cell-non-sticky
+  .#{c4p-settings.$carbon-prefix}--btn--icon-only[aria-expanded='true'] {
   opacity: 1;
 }
 

--- a/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
@@ -347,6 +347,24 @@
   }
 }
 
+.#{$block-class}__header-actions-column:hover {
+  background-color: $layer-accent;
+}
+
+.#{$block-class}
+  .#{$block-class}__carbon-row
+  .#{$block-class}__actions-column-cell-non-sticky
+  .#{$block-class}__actions-column-contents {
+  visibility: hidden;
+}
+
+.#{$block-class}
+  .#{$block-class}__carbon-row:hover
+  .#{$block-class}__actions-column-cell-non-sticky
+  .#{$block-class}__actions-column-contents {
+  visibility: visible;
+}
+
 .#{$block-class}__head-hidden-select-all {
   padding-right: $spacing-09;
   &.#{$block-class}__select-all-sticky-left {

--- a/packages/ibm-products/src/components/Datagrid/useActionsColumn.js
+++ b/packages/ibm-products/src/components/Datagrid/useActionsColumn.js
@@ -38,6 +38,7 @@ const useActionsColumn = (hooks) => {
         const { cell } = cellData;
         const { row, column } = cell;
         if (column.isAction) {
+          const isColumnSticky = !!column.sticky;
           return [
             props,
             {
@@ -48,7 +49,8 @@ const useActionsColumn = (hooks) => {
                       className={`${blockClass}__actions-column-loading`}
                     />
                   )}
-                  {!isFetching && rowActions.length <= 2 && (
+                  {/* Icon buttons */}
+                  {!isFetching && rowActions.length <= 2 && !isColumnSticky && (
                     <div
                       className={`${blockClass}_actions-column`}
                       style={{ display: 'flex' }}
@@ -104,7 +106,8 @@ const useActionsColumn = (hooks) => {
                       })}
                     </div>
                   )}
-                  {!isFetching && rowActions.length > 2 && (
+                  {/* Overflow menu */}
+                  {!isFetching && (rowActions.length > 2 || isColumnSticky) && (
                     <div>
                       <OverflowMenu
                         align="left"
@@ -155,9 +158,11 @@ const useActionsColumn = (hooks) => {
               className: cx({
                 [`${blockClass}__actions-column-cell`]: true,
                 [`${blockClass}__cell`]: true,
+                [`${blockClass}__actions-column-cell-non-sticky`]:
+                  !isColumnSticky,
               }),
               style: {
-                width: rowActions.length > 2 ? 48 : 96,
+                width: rowActions.length > 2 || isColumnSticky ? 48 : 96,
               },
             },
           ];
@@ -173,12 +178,13 @@ const useActionsColumn = (hooks) => {
       const addHeaderWidth = (props, cellData) => {
         const { column } = cellData;
         if (column.isAction) {
+          const isColumnSticky = !!column.sticky;
           return [
             props,
             {
               style: {
                 ...props.style,
-                width: rowActions.length > 2 ? 48 : 96, // set header width based on action length
+                width: rowActions.length > 2 || isColumnSticky ? 48 : 96, // set header width based on action length
               },
             },
           ];


### PR DESCRIPTION
Contributes to #3557

This PR fixes some behavior in the row action buttons (ie `useActionButtons`). According to the design guidance, if the action column is frozen/sticky, the row action buttons will _always_ display in an overflow menu. If the action column is not frozen/sticky then it should display as icon buttons for 1 or 2 actions, anything greater than 2 will be displayed in an overflow menu. Lastly, if a row is not frozen, the actions should only show on row hover/focus of icon buttons.

I also fixed an issue where the action column included the column resizer but should not have and removed the background color change on hover of the action column header.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
packages/ibm-products/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.js
packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
packages/ibm-products/src/components/Datagrid/useActionsColumn.js
```
#### How did you test and verify your work?
Storybook