### PR TITLE
fix(Datagrid): properly render expandable row component via jsx

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridExpandedRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridExpandedRow.js
@@ -39,7 +39,7 @@ const DatagridExpandedRow =
             height: expandedContentHeight ? expandedContentHeight : null,
           }}
         >
-          {ExpandedRowContentComponent(datagridState)}
+          <ExpandedRowContentComponent {...datagridState} />
         </div>
       </tr>
     );

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
@@ -21,6 +21,7 @@ import { makeData } from '../../utils/makeData';
 import { ARG_TYPES } from '../../utils/getArgTypes';
 import { pkg } from '../../../../settings';
 import { DocsPage } from './ExpandableRow.docs-page';
+import { usePrefix } from '../../../../global/js/hooks';
 
 export default {
   title: `${getStoryTitle(Datagrid.displayName)}/Extensions/ExpandableRow`,
@@ -157,11 +158,16 @@ const sharedDatagridProps = {
   expanderButtonTitleCollapsed: 'Expand row',
 };
 
+const ExpansionRenderer = ({ row }) => {
+  const prefix = usePrefix();
+  return (
+    <div className={`${prefix}__test-class-with-prefix-hook`}>
+      Content for row index: {row.id}
+    </div>
+  );
+};
+
 const ExpandedRows = ({ ...args }) => {
-  const expansionRenderer = ({ row }) => {
-    console.log(row);
-    return <div>Content for row index: {row.id}</div>;
-  };
   const columns = React.useMemo(() => [...defaultHeader], []);
   const [data] = useState(makeData(10));
   const rows = React.useMemo(() => data, [data]);
@@ -176,7 +182,7 @@ const ExpandedRows = ({ ...args }) => {
       },
       DatagridActions,
       DatagridPagination,
-      ExpandedRowContentComponent: expansionRenderer,
+      ExpandedRowContentComponent: ExpansionRenderer,
       tags: ['autodocs'],
       ...args.defaultGridProps,
     },


### PR DESCRIPTION
Contributes to #3782 

The way we were rendering the expandable row component was causing a hook error because it was not rendered as `jsx`. After rendering `ExpandedRowContentComponent` as jsx and adding in a test hook (`usePrefix()`) inside of the row expansion renderer component for testing, this error is no longer seen when multiple expandable rows are open.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridExpandedRow.js
packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
```
#### How did you test and verify your work?
Storybook

___

#### Reproduction
To view this error, see [this code sandbox](https://codesandbox.io/s/nervous-wright-hc6fdd?file=/src/Table.js) and attempt to open more than one expandable row