### PR TITLE
fix(Datagrid): render expanded component via jsx (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridExpandedRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridExpandedRow.js
@@ -39,7 +39,7 @@ const DatagridExpandedRow =
             height: expandedContentHeight ? expandedContentHeight : null,
           }}
         >
-          {ExpandedRowContentComponent(datagridState)}
+          <ExpandedRowContentComponent {...datagridState} />
         </div>
       </tr>
     );

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
@@ -21,6 +21,7 @@ import { DatagridPagination } from '../../utils/DatagridPagination';
 import { makeData } from '../../utils/makeData';
 import { ARG_TYPES } from '../../utils/getArgTypes';
 import { pkg } from '../../../../settings';
+import { usePrefix } from '../../../../global/js/hooks';
 
 export default {
   title: `${getStoryTitle(Datagrid.displayName)}/Extensions/ExpandableRow`,
@@ -152,56 +153,57 @@ const sharedDatagridProps = {
   expandedContentHeight: 96,
 };
 
-const ExpandedRows = ({ ...args }) => {
-  const expansionRenderer = ({ row, expandedContentAlign }) => {
-    console.log(row);
-    return (
-      <div
-        className="expanded-content"
-        style={{ justifyContent: `${expandedContentAlign}` }}
-      >
-        <div className="expanded-content__child">
-          <h5 className="expanded-content__title">Details</h5>
-          <div className="expanded-content__row">
-            <span>Date created</span>
-            <span>
-              {new Date(2023, 0, 0, 0, 0, 0, 0).toUTCString().slice(0, -4)}
-            </span>
-          </div>
-          <div className="expanded-content__row">
-            <span>User IP address</span>
-            <span>10.123.11/29</span>
-          </div>
-          <div className="expanded-content__row">
-            <span>User IP address</span>
-            <span>10.123.11/29</span>
-          </div>
-          <div className="expanded-content__row">
-            <span>IBM IP address</span>
-            <span>10.123.20/29</span>
-          </div>
-          <div className="expanded-content__row">
-            <span>BGP ASN</span>
-            <span>63888</span>
-          </div>
-          <div className="expanded-content__row">
-            <span>IBM ASN</span>
-            <span>12733</span>
-          </div>
-          <div className="expanded-content__row">
-            <span>Router</span>
-            <span>ZCV-DRK-TZ03</span>
-          </div>
+const ExpansionRenderer = ({ row, expandedContentAlign }) => {
+  console.log(row);
+  const prefix = usePrefix();
+  return (
+    <div
+      className={`expanded-content ${prefix}--test-hook-from-expanded-row-class`}
+      style={{ justifyContent: `${expandedContentAlign}` }}
+    >
+      <div className="expanded-content__child">
+        <h5 className="expanded-content__title">Details</h5>
+        <div className="expanded-content__row">
+          <span>Date created</span>
+          <span>
+            {new Date(2023, 0, 0, 0, 0, 0, 0).toUTCString().slice(0, -4)}
+          </span>
         </div>
-        <div className="expanded-content__child">
-          <h5 className="expanded-content__title">Provision status</h5>
-          <div className="expanded-content__row">
-            <span>Case #0001 created by RJ Smithson on 02/02/2023 9:30</span>
-          </div>
+        <div className="expanded-content__row">
+          <span>User IP address</span>
+          <span>10.123.11/29</span>
+        </div>
+        <div className="expanded-content__row">
+          <span>User IP address</span>
+          <span>10.123.11/29</span>
+        </div>
+        <div className="expanded-content__row">
+          <span>IBM IP address</span>
+          <span>10.123.20/29</span>
+        </div>
+        <div className="expanded-content__row">
+          <span>BGP ASN</span>
+          <span>63888</span>
+        </div>
+        <div className="expanded-content__row">
+          <span>IBM ASN</span>
+          <span>12733</span>
+        </div>
+        <div className="expanded-content__row">
+          <span>Router</span>
+          <span>ZCV-DRK-TZ03</span>
         </div>
       </div>
-    );
-  };
+      <div className="expanded-content__child">
+        <h5 className="expanded-content__title">Provision status</h5>
+        <div className="expanded-content__row">
+          <span>Case #0001 created by RJ Smithson on 02/02/2023 9:30</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+const ExpandedRows = ({ ...args }) => {
   const columns = React.useMemo(() => [...defaultHeader.slice(0, 6)], []);
   const [data] = useState(makeData(10));
   const rows = React.useMemo(() => data, [data]);
@@ -222,7 +224,7 @@ const ExpandedRows = ({ ...args }) => {
       },
       DatagridActions,
       DatagridPagination,
-      ExpandedRowContentComponent: expansionRenderer,
+      ExpandedRowContentComponent: ExpansionRenderer,
       ...args.defaultGridProps,
     },
     useExpandedRow

--- a/packages/ibm-products/src/global/js/hooks/index.js
+++ b/packages/ibm-products/src/global/js/hooks/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,3 +16,4 @@ export { useResetCreateComponent } from './useResetCreateComponent';
 export { useRetrieveStepData } from './useRetrieveStepData';
 export { useValidCreateStepCount } from './useValidCreateStepCount';
 export { useControllableState } from './useControllableState';
+export { usePrefix } from './usePrefix';

--- a/packages/ibm-products/src/global/js/hooks/usePrefix.js
+++ b/packages/ibm-products/src/global/js/hooks/usePrefix.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import pkg from '../package-settings';
+
+export const usePrefix = () => pkg.prefix;


### PR DESCRIPTION
Contributes to #3782 

The way we were rendering the expandable row component was causing a hook error because it was not rendered as `jsx`. After rendering `ExpandedRowContentComponent` as jsx and adding in a test hook (`usePrefix()`) inside of the row expansion renderer component for testing, this error is no longer seen when multiple expandable rows are open.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridExpandedRow.js
packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
```
#### How did you test and verify your work?
Storybook

___

#### Reproduction
To view this error, see [this code sandbox](https://codesandbox.io/s/nervous-wright-hc6fdd?file=/src/Table.js) and attempt to open more than one expandable row