### PR TITLE
test(Datagrid): increase test coverage for base component

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
@@ -37,6 +37,7 @@ import {
   useColumnOrder,
   useColumnRightAlign,
   useColumnCenterAlign,
+  useEditableCell,
 } from '.';
 
 import {
@@ -57,6 +58,11 @@ const blockClass = `${pkg.prefix}--datagrid`;
 import namor from 'namor';
 
 import userEvent from '@testing-library/user-event';
+import { getInlineEditColumns } from './utils/getInlineEditColumns';
+import {
+  FilteringUsage,
+  filterProps,
+} from './Extensions/Filtering/Panel.stories';
 const { click, hover, unhover } = userEvent.setup({
   // delay: null, // prev version
   advanceTimers: jest.advanceTimersByTime,
@@ -307,6 +313,7 @@ const TenThousandEntries = ({ ...rest } = {}) => {
     {
       columns,
       data,
+      rowSize: 'lg',
     },
     useInfiniteScroll
   );
@@ -928,6 +935,31 @@ describe(componentName, () => {
     ).toEqual(10);
   });
 
+  it('renders a basic table and resizes column', async () => {
+    const user = userEvent.setup({
+      advanceTimers: jest.advanceTimersByTime,
+    });
+    const { keyboard, tab } = user;
+    render(<BasicUsage data-testid={dataTestId} />);
+    await click(screen.getByTestId(dataTestId));
+    await tab();
+    // Input range resizer now has focus
+    await keyboard('[ArrowRight]');
+    const firstColumnHeader = screen.getAllByRole('columnheader')[0];
+    const firstColumnWidth = firstColumnHeader.style.width;
+    expect(parseInt(firstColumnWidth)).toEqual(152);
+    await keyboard('[ArrowRight]');
+    const resizedFirstColumnHeader = screen.getAllByRole('columnheader')[0];
+    const resizedFirstColumnWidth = resizedFirstColumnHeader.style.width;
+    expect(parseInt(resizedFirstColumnWidth)).toEqual(154);
+    await keyboard('[ArrowLeft]');
+    const revertResizedFirstColumnHeader =
+      screen.getAllByRole('columnheader')[0];
+    const revertResizedFirstColumnWidth =
+      revertResizedFirstColumnHeader.style.width;
+    expect(parseInt(revertResizedFirstColumnWidth)).toEqual(152);
+  });
+
   it('renders a Batch Actions Table', async () => {
     render(<BatchActions data-testid={dataTestId}></BatchActions>);
 
@@ -1379,18 +1411,13 @@ describe(componentName, () => {
     const rowExpander = row.querySelector(`button[aria-label="Expand row"]`);
     fireEvent.click(rowExpander);
 
-    expect(
-      screen
-        .getByRole('table')
-        .getElementsByTagName('tbody')[0]
-        .getElementsByClassName('c4p--datagrid__expanded-row')
-    ).toBeDefined();
-    expect(
-      screen
-        .getByRole('table')
-        .getElementsByTagName('tbody')[0]
-        .getElementsByClassName('c4p--datagrid__expanded-row')[0].textContent
-    ).toEqual(`Content for ${rowNumber}`);
+    expect(row.nextElementSibling).toHaveClass(`${blockClass}__expanded-row`);
+    expect(row.nextElementSibling.textContent).toEqual(
+      `Content for ${rowNumber}`
+    );
+
+    fireEvent.mouseOver(row.nextElementSibling);
+    fireEvent.mouseLeave(row.nextElementSibling);
 
     const rowExpanderCollapse = row.querySelector(
       `button[aria-label="Collapse row"]`
@@ -1398,7 +1425,7 @@ describe(componentName, () => {
     fireEvent.click(rowExpanderCollapse);
   }
 
-  it('Expanded Row', async () => {
+  it('Expanded Row', () => {
     render(<ExpandedRow data-testid={dataTestId} />);
     clickRow(1);
     clickRow(4);
@@ -1434,34 +1461,29 @@ describe(componentName, () => {
   });
 
   it('Nested Rows', async () => {
-    render(<NestedRows data-testid={dataTestId}></NestedRows>);
+    render(<NestedRows data-testid={dataTestId} />);
 
-    const row = screen
-      .getByRole('table')
-      .getElementsByTagName('tbody')[0]
-      .getElementsByTagName('tr')[0];
-    const firstRow = row
-      .getElementsByTagName('td')[0]
-      .getElementsByTagName('button')[0];
+    const gridRows = screen.getAllByRole('row');
+    const bodyRows = gridRows.filter(
+      (r) => !r.classList.contains(`${blockClass}__head`)
+    );
+    const firstBodyRow = bodyRows[0];
+    const firstRowExpander = within(firstBodyRow).getByLabelText('Expand row');
+    fireEvent.click(firstRowExpander);
+    expect(firstBodyRow).toHaveClass(`${blockClass}__carbon-row-expanded`);
 
-    fireEvent.click(firstRow);
+    const newAllRows = screen.getAllByRole('row');
+    const newBodyRows = newAllRows.filter(
+      (r) => !r.classList.contains(`${blockClass}__head`)
+    );
+    const nestedRow = newBodyRows[1];
 
-    expect(row.classList[0]).toEqual('c4p--datagrid__carbon-row-expanded');
-
-    const nestedRow = screen
-      .getByRole('table')
-      .getElementsByTagName('tbody')[0]
-      .getElementsByTagName('tr')[1];
-
-    if (nestedRow.className === 'c4p--datagrid__carbon-nested-row') {
-      fireEvent.click(
-        nestedRow
-          .getElementsByTagName('td')[0]
-          .getElementsByTagName('button')[0]
-      );
+    if (nestedRow.className === `${blockClass}__carbon-nested-row`) {
+      const nestedRowExpander = within(nestedRow).getByLabelText('Expand row');
+      fireEvent.click(nestedRowExpander);
     }
 
-    expect(nestedRow.classList[0]).toEqual('c4p--datagrid__carbon-nested-row');
+    expect(nestedRow).toHaveClass(`${blockClass}__carbon-nested-row`);
   });
 
   it('Nested Table', async () => {
@@ -2255,6 +2277,69 @@ describe(componentName, () => {
     );
     expect(within(firstBodyRow).getAllByRole('button').length).toEqual(1); // Previously was 2 but we've hidden the other in this test
   });
+
+  const EditableCellUsage = ({ ...args }) => {
+    const [data, setData] = useState(makeData(3));
+    const columns = React.useMemo(() => getInlineEditColumns(), []);
+    pkg._silenceWarnings(false); // warnings are ordinarily silenced in storybook, add this to test.
+    pkg.feature['Datagrid.useInlineEdit'] = true;
+    pkg._silenceWarnings(true);
+
+    const datagridState = useDatagrid(
+      {
+        columns,
+        data,
+        onDataUpdate: setData,
+        ...args.defaultGridProps,
+      },
+      useEditableCell
+    );
+
+    // Warnings are ordinarily silenced in storybook, add this to test.
+    pkg._silenceWarnings(false);
+    pkg.feature['Datagrid.useEditableCell'] = true;
+    pkg._silenceWarnings(true);
+
+    return <Datagrid datagridState={datagridState} />;
+  };
+  it('should test the basic interactions of the editable cell datagrid', async () => {
+    const { container } = render(<EditableCellUsage />);
+    const tableElement = screen.getByRole('grid');
+    const rowButtons = screen.getAllByRole('button');
+    const firstEditableCell = rowButtons[0];
+
+    await click(firstEditableCell);
+    expect(firstEditableCell).toHaveClass(
+      `${blockClass}__inline-edit-button--active`
+    );
+    await click(container);
+    expect(tableElement).not.toHaveClass(`${blockClass}__table-grid-active`);
+  });
+
+  it('should test basic interactions of filter panel', async () => {
+    render(
+      <FilteringUsage
+        defaultGridProps={{
+          gridTitle: 'Data table title',
+          gridDescription: 'Additional information if needed',
+          useDenseHeader: false,
+          emptyStateTitle: 'No filters match',
+          emptyStateDescription:
+            'Data was not found with the current filters applied. Change filters or clear filters to see other results.',
+          filterProps,
+        }}
+      />
+    );
+    const toolbar = screen.getByLabelText('data table toolbar').parentElement;
+    const panelContainer = toolbar.nextElementSibling;
+    const toolbarButtons = within(toolbar).getAllByRole('button');
+    const filterToggleButton = toolbarButtons[0];
+    // Open filter panel
+    await click(filterToggleButton);
+    expect(panelContainer).toHaveClass(
+      `${blockClass}__table-container--filter-open`
+    );
+  });
 });
 
 const duplicateOnClickFn = jest.fn();
@@ -2312,6 +2397,7 @@ const TestBatch = () => {
       batchActions: true,
       toolbarBatchActions: getBatchActions(),
       DatagridActions,
+      DatagridPagination,
     },
     useSelectRows,
     useSelectAllWithToggle,
@@ -2440,6 +2526,35 @@ describe('batch action testing', () => {
       await click(cancelButton);
       await click(firstCheckbox);
       await click(selectAllButton);
+    });
+
+    it('renders batch action with select all and checks indeterminate behavior', () => {
+      render(<TestBatch />);
+      const bodyElement = screen.getAllByRole('rowgroup')[1];
+      const allRows = screen.getAllByRole('row');
+      // const selectAllCheckbox = within(allRows[0]).getByLabelText('Toggle All Current Page Rows Selected');
+      const selectAllCheckbox = within(allRows[0]).getByLabelText('Select all');
+      click(selectAllCheckbox);
+      const carbonTableToolbar = screen.getByLabelText('data table toolbar');
+      expect(carbonTableToolbar).toBeInTheDocument();
+      const bodyRows = allRows.filter(
+        (r) =>
+          !r.classList.contains('c4p--datagrid__head') &&
+          !r.classList.contains('c4p--datagrid__expanded-row')
+      );
+      const firstBodyRow = bodyRows[0];
+      const firstRowCheckbox = within(firstBodyRow).getByRole('checkbox');
+      click(firstRowCheckbox);
+      // Should remove all checked checkboxes in the body
+      click(selectAllCheckbox);
+      let totalChecked = 0;
+      const allBodyCheckboxes = within(bodyElement).getAllByRole('checkbox');
+      allBodyCheckboxes.forEach((c) => {
+        if (c.checked) {
+          totalChecked = totalChecked + 1;
+        }
+      });
+      expect(totalChecked).toEqual(0);
     });
   });
 });

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -37,7 +37,7 @@ export const DatagridContent = ({ datagridState, title }) => {
   const { filterTags, EventEmitter, panelOpen } = useContext(FilterContext);
   const { activeCellId, gridActive, editId } = inlineEditState;
   const {
-    getTableProps = () => {},
+    getTableProps,
     getFilterFlyoutProps,
     withVirtualScroll,
     DatagridPagination,
@@ -96,22 +96,20 @@ export const DatagridContent = ({ datagridState, title }) => {
         role={withInlineEdit ? 'grid' : undefined}
         tabIndex={withInlineEdit ? 0 : -1}
         onKeyDown={
-          withInlineEdit
-            ? (event) =>
-                handleGridKeyPress({
-                  event,
-                  dispatch,
-                  instance: datagridState,
-                  keysPressedList,
-                  state: inlineEditState,
-                  usingMac,
-                })
-            : null
+          /* istanbul ignore next */
+          withInlineEdit &&
+          ((event) =>
+            handleGridKeyPress({
+              event,
+              dispatch,
+              instance: datagridState,
+              keysPressedList,
+              state: inlineEditState,
+              usingMac,
+            }))
         }
         onFocus={
-          withInlineEdit
-            ? () => handleGridFocus(inlineEditState, dispatch)
-            : null
+          withInlineEdit && (() => handleGridFocus(inlineEditState, dispatch))
         }
         title={title}
       >
@@ -152,6 +150,7 @@ export const DatagridContent = ({ datagridState, title }) => {
     clearSingleFilter(id, setAllFilters, state)
   );
 
+  /* istanbul ignore next */
   const renderFilterSummary = () =>
     state.filters.length > 0 && (
       <FilterSummary

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridExpandedRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridExpandedRow.js
@@ -14,9 +14,10 @@ const blockClass = `${pkg.prefix}--datagrid`;
 const DatagridExpandedRow =
   (ExpandedRowContentComponent) => (datagridState) => {
     const { row } = datagridState;
-    const { expandedContentHeight } = row || {};
+    const { expandedContentHeight } = row;
 
     const toggleParentHoverClass = (event, eventType) => {
+      /* istanbul ignore else */
       if (event?.target?.parentNode?.previousElementSibling) {
         const parentNode = event.target.parentNode.previousElementSibling;
         if (eventType === 'enter') {
@@ -36,7 +37,7 @@ const DatagridExpandedRow =
         <div
           className={`${blockClass}__expanded-row-content`}
           style={{
-            height: expandedContentHeight ? expandedContentHeight : null,
+            height: expandedContentHeight && expandedContentHeight,
           }}
         >
           <ExpandedRowContentComponent {...datagridState} />

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -35,38 +35,36 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
   // to display a vertical line to indicate the column you are resizing
   useEffect(() => {
     const { tableId } = datagridState;
-    if (tableId) {
-      const gridElement = document.querySelector(`#${tableId}`);
-      const tableElement = gridElement.querySelector('table');
-      const headerRowElement = document.querySelector(
-        `#${tableId} .${blockClass}__head`
+    const gridElement = document.querySelector(`#${tableId}`);
+    const tableElement = gridElement.querySelector('table');
+    const headerRowElement = document.querySelector(
+      `#${tableId} .${blockClass}__head`
+    );
+    const hasHorizontalScrollbar =
+      tableElement.scrollWidth > tableElement.clientWidth;
+    const scrollBuffer = hasHorizontalScrollbar ? 18 : 2;
+    const tableToolbar = gridElement.querySelector(
+      `.${blockClass}__table-toolbar`
+    );
+    const tableToolbarHeight = tableToolbar?.offsetHeight || 0;
+    const setCustomValues = ({ rowHeight, gridHeight }) => {
+      headerRowElement.style.setProperty(
+        `--${blockClass}--row-height`,
+        px(rowHeight)
       );
-      const hasHorizontalScrollbar =
-        tableElement.scrollWidth > tableElement.clientWidth;
-      const scrollBuffer = hasHorizontalScrollbar ? 18 : 2;
-      const tableToolbar = gridElement.querySelector(
-        `.${blockClass}__table-toolbar`
+      headerRowElement.style.setProperty(
+        `--${blockClass}--grid-height`,
+        px(gridHeight - scrollBuffer - tableToolbarHeight)
       );
-      const tableToolbarHeight = tableToolbar?.offsetHeight || 0;
-      const setCustomValues = ({ rowHeight = 48, gridHeight }) => {
-        headerRowElement.style.setProperty(
-          `--${blockClass}--row-height`,
-          px(rowHeight)
-        );
-        headerRowElement.style.setProperty(
-          `--${blockClass}--grid-height`,
-          px(gridHeight - scrollBuffer - tableToolbarHeight)
-        );
-        headerRowElement.style.setProperty(
-          `--${blockClass}--header-height`,
-          px(headerRowElement.offsetHeight)
-        );
-      };
-      setCustomValues({
-        gridHeight: gridElement.offsetHeight,
-        rowHeight: headerRowElement.clientHeight,
-      });
-    }
+      headerRowElement.style.setProperty(
+        `--${blockClass}--header-height`,
+        px(headerRowElement.offsetHeight)
+      );
+    };
+    setCustomValues({
+      gridHeight: gridElement.offsetHeight,
+      rowHeight: headerRowElement.clientHeight,
+    });
   }, [datagridState.rowSize, datagridState.tableId, datagridState]);
 
   const [incrementAmount] = useState(2);

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSelectAll.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSelectAll.js
@@ -1,11 +1,10 @@
-/*
- * Licensed Materials - Property of IBM
- * 5724-Q36
- * (c) Copyright IBM Corp. 2023
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
+/**
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
-// @flow
+
 import React, { useLayoutEffect, useState } from 'react';
 import { TableSelectAll } from '@carbon/react';
 import cx from 'classnames';
@@ -16,6 +15,7 @@ const blockClass = `${pkg.prefix}--datagrid`;
 const SelectAll = (datagridState) => {
   const [windowSize, setWindowSize] = useState(window.innerWidth);
   useLayoutEffect(() => {
+    /* istanbul ignore next */
     function updateSize() {
       setWindowSize(window.innerWidth);
     }
@@ -41,6 +41,7 @@ const SelectAll = (datagridState) => {
       <div
         className={cx(`${blockClass}__head-hidden-select-all`, {
           [`${blockClass}__select-all-sticky-left`]:
+            /* istanbul ignore next */
             isFirstColumnStickyLeft && windowSize > 671,
         })}
       />
@@ -50,7 +51,7 @@ const SelectAll = (datagridState) => {
     ? getToggleAllPageRowsSelectedProps
     : getToggleAllRowsSelectedProps;
   const { onChange, ...selectProps } = getProps();
-  const { indeterminate } = selectProps || {};
+  const { indeterminate } = selectProps;
 
   const handleSelectAllChange = (event) => {
     if (indeterminate) {
@@ -68,6 +69,7 @@ const SelectAll = (datagridState) => {
         `${blockClass}__checkbox-cell`,
         {
           [`${blockClass}__checkbox-cell-sticky-left`]:
+            /* istanbul ignore next */
             isFirstColumnStickyLeft && windowSize > 671,
         }
       )}

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
@@ -42,6 +42,7 @@ const DatagridVirtualBody = (datagridState) => {
     gridRef,
   } = datagridState;
 
+  /* istanbul ignore next */
   const handleVirtualGridResize = () => {
     const gridRefElement = gridRef?.current;
     gridRefElement.style.width = gridRefElement?.clientWidth;
@@ -49,6 +50,7 @@ const DatagridVirtualBody = (datagridState) => {
 
   useResizeObserver(gridRef, handleVirtualGridResize);
 
+  /* istanbul ignore next */
   const syncScroll = (event) => {
     const virtualBody = event.target;
     document.querySelector(`.${blockClass}__head-wrap`).scrollLeft =

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
@@ -45,6 +45,7 @@ export default {
       },
     },
   },
+  excludeStories: ['FilteringUsage', 'filterProps'],
 };
 
 // This is to show off the View all button in checkboxes
@@ -89,7 +90,7 @@ const getBatchActions = () => {
   ];
 };
 
-const FilteringUsage = ({ defaultGridProps }) => {
+export const FilteringUsage = ({ defaultGridProps }) => {
   const {
     gridDescription,
     gridTitle,
@@ -204,6 +205,155 @@ const FilteringTemplateWrapper = ({ ...args }) => {
   return <FilteringUsage defaultGridProps={{ ...args }} />;
 };
 
+export const filterProps = {
+  variation: 'panel',
+  updateMethod: 'batch',
+  primaryActionLabel: 'Apply',
+  secondaryActionLabel: 'Cancel',
+  panelIconDescription: `Open filters`,
+  closeIconDescription: 'Close panel',
+  sections: [
+    {
+      categoryTitle: 'Category title',
+      hasAccordion: true,
+      filters: [
+        {
+          filterLabel: 'Joined',
+          filter: {
+            type: 'date',
+            column: 'joined',
+            props: {
+              DatePicker: {
+                datePickerType: 'range',
+              },
+              DatePickerInput: {
+                start: {
+                  id: 'date-picker-input-id-start',
+                  placeholder: 'mm/dd/yyyy',
+                  labelText: 'Joined start date',
+                },
+                end: {
+                  id: 'date-picker-input-id-end',
+                  placeholder: 'mm/dd/yyyy',
+                  labelText: 'Joined end date',
+                },
+              },
+            },
+          },
+        },
+        {
+          filterLabel: 'Status',
+          filter: {
+            type: 'dropdown',
+            column: 'status',
+            props: {
+              Dropdown: {
+                id: 'marital-status-dropdown',
+                ['aria-label']: 'Marital status dropdown',
+                items: ['relationship', 'complicated', 'single'],
+                label: 'Marital status',
+                titleText: 'Marital status',
+              },
+            },
+          },
+        },
+      ],
+    },
+    {
+      categoryTitle: 'Category title',
+      filters: [
+        {
+          filterLabel: 'Role',
+          filter: {
+            type: 'radio',
+            column: 'role',
+            props: {
+              FormGroup: {
+                legendText: 'Role',
+              },
+              RadioButtonGroup: {
+                orientation: 'vertical',
+                legend: 'Role legend',
+                name: 'role-radio-button-group',
+              },
+              RadioButton: [
+                {
+                  id: 'developer',
+                  labelText: 'Developer',
+                  value: 'developer',
+                },
+                {
+                  id: 'designer',
+                  labelText: 'Designer',
+                  value: 'designer',
+                },
+                {
+                  id: 'researcher',
+                  labelText: 'Researcher',
+                  value: 'researcher',
+                },
+              ],
+            },
+          },
+        },
+        {
+          filterLabel: 'Visits',
+          filter: {
+            type: 'number',
+            column: 'visits',
+            props: {
+              NumberInput: {
+                min: 0,
+                id: 'visits-number-input',
+                invalidText: 'A valid value is required',
+                label: 'Visits',
+                placeholder: 'Type a number amount of visits',
+              },
+            },
+          },
+        },
+        {
+          filterLabel: 'Password strength',
+          filter: {
+            type: 'checkbox',
+            column: 'passwordStrength',
+            props: {
+              FormGroup: {
+                legendText: 'Password strength',
+              },
+              Checkbox: [
+                {
+                  id: 'normal',
+                  labelText: 'Normal',
+                  value: 'normal',
+                },
+                {
+                  id: 'minor-warning',
+                  labelText: 'Minor warning',
+                  value: 'minor-warning',
+                },
+                {
+                  id: 'critical',
+                  labelText: 'Critical',
+                  value: 'critical',
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  ],
+  onPanelOpen: action('onPanelOpen'),
+  onPanelClose: action('onPanelClose'),
+  panelTitle: 'Filter',
+  renderDateLabel: (start, end) => {
+    const startDateObj = new Date(start);
+    const endDateObj = new Date(end);
+    return `${startDateObj.toLocaleDateString()} - ${endDateObj.toLocaleDateString()}`;
+  },
+};
+
 export const PanelBatch = prepareStory(FilteringTemplateWrapper, {
   storyName: 'Filter panel with batch update',
   argTypes: {
@@ -219,154 +369,7 @@ export const PanelBatch = prepareStory(FilteringTemplateWrapper, {
     emptyStateTitle: 'No filters match',
     emptyStateDescription:
       'Data was not found with the current filters applied. Change filters or clear filters to see other results.',
-    filterProps: {
-      variation: 'panel',
-      updateMethod: 'batch',
-      primaryActionLabel: 'Apply',
-      secondaryActionLabel: 'Cancel',
-      panelIconDescription: `Open filters`,
-      closeIconDescription: 'Close panel',
-      sections: [
-        {
-          categoryTitle: 'Category title',
-          hasAccordion: true,
-          filters: [
-            {
-              filterLabel: 'Joined',
-              filter: {
-                type: 'date',
-                column: 'joined',
-                props: {
-                  DatePicker: {
-                    datePickerType: 'range',
-                  },
-                  DatePickerInput: {
-                    start: {
-                      id: 'date-picker-input-id-start',
-                      placeholder: 'mm/dd/yyyy',
-                      labelText: 'Joined start date',
-                    },
-                    end: {
-                      id: 'date-picker-input-id-end',
-                      placeholder: 'mm/dd/yyyy',
-                      labelText: 'Joined end date',
-                    },
-                  },
-                },
-              },
-            },
-            {
-              filterLabel: 'Status',
-              filter: {
-                type: 'dropdown',
-                column: 'status',
-                props: {
-                  Dropdown: {
-                    id: 'marital-status-dropdown',
-                    ['aria-label']: 'Marital status dropdown',
-                    items: ['relationship', 'complicated', 'single'],
-                    label: 'Marital status',
-                    titleText: 'Marital status',
-                  },
-                },
-              },
-            },
-          ],
-        },
-        {
-          categoryTitle: 'Category title',
-          filters: [
-            {
-              filterLabel: 'Role',
-              filter: {
-                type: 'radio',
-                column: 'role',
-                props: {
-                  FormGroup: {
-                    legendText: 'Role',
-                  },
-                  RadioButtonGroup: {
-                    orientation: 'vertical',
-                    legend: 'Role legend',
-                    name: 'role-radio-button-group',
-                  },
-                  RadioButton: [
-                    {
-                      id: 'developer',
-                      labelText: 'Developer',
-                      value: 'developer',
-                    },
-                    {
-                      id: 'designer',
-                      labelText: 'Designer',
-                      value: 'designer',
-                    },
-                    {
-                      id: 'researcher',
-                      labelText: 'Researcher',
-                      value: 'researcher',
-                    },
-                  ],
-                },
-              },
-            },
-            {
-              filterLabel: 'Visits',
-              filter: {
-                type: 'number',
-                column: 'visits',
-                props: {
-                  NumberInput: {
-                    min: 0,
-                    id: 'visits-number-input',
-                    invalidText: 'A valid value is required',
-                    label: 'Visits',
-                    placeholder: 'Type a number amount of visits',
-                  },
-                },
-              },
-            },
-            {
-              filterLabel: 'Password strength',
-              filter: {
-                type: 'checkbox',
-                column: 'passwordStrength',
-                props: {
-                  FormGroup: {
-                    legendText: 'Password strength',
-                  },
-                  Checkbox: [
-                    {
-                      id: 'normal',
-                      labelText: 'Normal',
-                      value: 'normal',
-                    },
-                    {
-                      id: 'minor-warning',
-                      labelText: 'Minor warning',
-                      value: 'minor-warning',
-                    },
-                    {
-                      id: 'critical',
-                      labelText: 'Critical',
-                      value: 'critical',
-                    },
-                  ],
-                },
-              },
-            },
-          ],
-        },
-      ],
-      onPanelOpen: action('onPanelOpen'),
-      onPanelClose: action('onPanelClose'),
-      panelTitle: 'Filter',
-      renderDateLabel: (start, end) => {
-        const startDateObj = new Date(start);
-        const endDateObj = new Date(end);
-        return `${startDateObj.toLocaleDateString()} - ${endDateObj.toLocaleDateString()}`;
-      },
-    },
+    filterProps,
   },
 });
 


### PR DESCRIPTION
Increases overall test coverage of the base Datagrid component, added a few `istanbul ignore`s but only for functionality either related to resizing or extensions that are not part of the base component.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid.test.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridExpandedRow.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSelectAll.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
```
#### How did you test and verify your work?
Ran Datagrid tests and confirmed test coverage reaches at least 80% for the following base component files
<img width="1092" alt="image" src="https://github.com/carbon-design-system/ibm-products/assets/10215203/4bf1a6f2-50db-41c3-a60b-90e9d8423ba6">

