### PR TITLE
fix(Datagrid): fix visible scroll bar when resizing with pagination

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -60,6 +60,7 @@ export const DatagridContent = ({ datagridState, title }) => {
     page,
     rows,
   } = datagridState;
+  const { columnResizing } = state;
 
   const contentRows = (DatagridPagination && page) || rows;
   const gridAreaRef = useRef();
@@ -91,6 +92,10 @@ export const DatagridContent = ({ datagridState, title }) => {
           { [`${blockClass}__variable-row-height`]: variableRowHeight },
           { [`${blockClass}__table-with-inline-edit`]: withInlineEdit },
           { [`${blockClass}__table-grid-active`]: gridActive },
+          {
+            [`${blockClass}__table-is-resizing`]:
+              typeof columnResizing.isResizingColumn === 'string',
+          },
           getTableProps()?.className
         )}
         role={withInlineEdit ? 'grid' : undefined}

--- a/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
@@ -321,6 +321,11 @@
   background-color: $background-selected-hover;
 }
 
+.#{$block-class}__grid-container
+  table.#{$block-class}__table-simple.#{c4p-settings.$carbon-prefix}--data-table.#{$block-class}__table-is-resizing {
+  overflow-y: hidden;
+}
+
 .#{$block-class}__resizableColumn {
   &.#{$block-class}__isResizing {
     .#{$block-class}__resizer {


### PR DESCRIPTION
Contributes to #3692 

Fixes an issue where there was a vertical scrollbar when resizing columns if pagination was included. Added `overflow-y: hidden` to the table when resizing.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
```
#### How did you test and verify your work?
Storybook