### PR TITLE
fix: unhandling error that caused by extra columns for issue #3455

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
@@ -73,10 +73,10 @@ export const DraggableItemsList = ({
       return;
     }
 
-    const fromVisibleIndex = columns.findIndex((col) =>
+    const fromVisibleIndex = updatedDragCols.findIndex((col) =>
       matchedColsById(col, active)
     );
-    const toVisibleIndex = columns.findIndex((col) =>
+    const toVisibleIndex = updatedDragCols.findIndex((col) =>
       matchedColsById(col, over)
     );
 


### PR DESCRIPTION
Contributes to #3455 

{{Change to use updatedDragCols instead of using the column to get text}}

#### What did you change?
packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js

#### How did you test and verify your work?
Storybook 