### PR TITLE
fix(Datagrid): review fixes from resizable columns review

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
@@ -143,7 +143,6 @@ export const BasicUsage = () => {
   const datagridState = useDatagrid({
     columns,
     data: rows,
-    multiLineWrapAll: true, // If `multiLineWrap` is required for all columns in data grid
     onColResizeEnd: (currentColumn, allColumns) =>
       console.log(currentColumn, allColumns),
   });

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -69,6 +69,17 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
 
   const [incrementAmount] = useState(2);
 
+  const handleOnMouseDownResize = (event, resizeProps) => {
+    const { onMouseDown } = { ...resizeProps() };
+    // When event.button is 2, that is a right click
+    // and we do not want to resize
+    if (event.button === 2 || event.ctrlKey) {
+      event.target.blur();
+      return;
+    }
+    onMouseDown?.(event);
+  };
+
   return (
     <TableRow
       {...headerGroup.getHeaderGroupProps()}
@@ -114,6 +125,9 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
                 <>
                   <input
                     {...header.getResizerProps()}
+                    onMouseDown={(event) =>
+                      handleOnMouseDownResize(event, header.getResizerProps)
+                    }
                     onKeyDown={(event) => {
                       const { key } = event;
                       if (key === 'ArrowLeft' || key === 'ArrowRight') {

--- a/packages/ibm-products/src/components/Datagrid/useDatagrid.js
+++ b/packages/ibm-products/src/components/Datagrid/useDatagrid.js
@@ -57,9 +57,13 @@ const useDatagrid = (params, ...plugins) => {
   ];
   const clientEndPlugins = params.endPlugins || [];
 
+  const defaultColumn = {
+    minWidth: 50,
+  };
+
   const tableId = useMemo(() => uniqueId('datagrid-table-id'), []);
   const tableState = useTable(
-    { tableId, ...params, stateReducer },
+    { tableId, ...params, stateReducer, defaultColumn },
     ...defaultPlugins,
     ...plugins,
     ...defaultEndPlugins,


### PR DESCRIPTION
Contributes to #2507 

Fixes a few issues that @My-Money29 found during the design review for resizable columns.
-  Column resizing should respect a `min-width` which was only working for keyboard resizing.
- Right clicking on a row would trigger resizing but would continue after mouse up

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
packages/ibm-products/src/components/Datagrid/useDatagrid.js
```
#### How did you test and verify your work?
Storybook