### PR TITLE
test(Datagrid): increase base component test coverage (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
@@ -915,7 +915,7 @@ describe(componentName, () => {
     ).toEqual(10);
   });
 
-  it('renders a basic table and resizes column', async () => {
+  it('renders a basic table and resizes column', () => {
     const { keyboard, tab, click } = userEvent;
     render(<BasicUsage data-testid={dataTestId} />);
     click(screen.getByTestId(dataTestId));
@@ -1468,9 +1468,6 @@ describe(componentName, () => {
     expect(row.nextElementSibling.textContent).toEqual(
       `Content for ${rowNumber}`
     );
-
-    fireEvent.mouseOver(row.nextElementSibling);
-    fireEvent.mouseLeave(row.nextElementSibling);
 
     const rowExpanderCollapse = row.querySelector(
       `button[aria-label="Collapse row"]`

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
@@ -33,6 +33,7 @@ import {
   useColumnOrder,
   useColumnRightAlign,
   useColumnCenterAlign,
+  useEditableCell,
 } from '.';
 
 import {
@@ -49,6 +50,12 @@ import {
   Activity16,
   Add16,
 } from '@carbon/icons-react';
+
+import { getInlineEditColumns } from './utils/getInlineEditColumns';
+import {
+  FilteringUsage,
+  filterProps,
+} from './Extensions/Filtering/Panel.stories';
 
 // import { DatagridActions, DatagridBatchActions, DatagridPagination, } from './Datagrid.stories';
 
@@ -285,6 +292,7 @@ const TenThousandEntries = ({ ...rest }) => {
     {
       columns,
       data,
+      rowSize: 'lg',
     },
     useInfiniteScroll
   );
@@ -907,6 +915,28 @@ describe(componentName, () => {
     ).toEqual(10);
   });
 
+  it('renders a basic table and resizes column', async () => {
+    const { keyboard, tab, click } = userEvent;
+    render(<BasicUsage data-testid={dataTestId} />);
+    click(screen.getByTestId(dataTestId));
+    tab();
+    // Input range resizer now has focus
+    keyboard('[ArrowRight]');
+    const firstColumnHeader = screen.getAllByRole('columnheader')[0];
+    const firstColumnWidth = firstColumnHeader.style.width;
+    expect(parseInt(firstColumnWidth)).toEqual(152);
+    keyboard('[ArrowRight]');
+    const resizedFirstColumnHeader = screen.getAllByRole('columnheader')[0];
+    const resizedFirstColumnWidth = resizedFirstColumnHeader.style.width;
+    expect(parseInt(resizedFirstColumnWidth)).toEqual(154);
+    keyboard('[ArrowLeft]');
+    const revertResizedFirstColumnHeader =
+      screen.getAllByRole('columnheader')[0];
+    const revertResizedFirstColumnWidth =
+      revertResizedFirstColumnHeader.style.width;
+    expect(parseInt(revertResizedFirstColumnWidth)).toEqual(152);
+  });
+
   it('renders a Batch Actions Table', () => {
     render(<BatchActions data-testid={dataTestId}></BatchActions>);
 
@@ -1434,18 +1464,13 @@ describe(componentName, () => {
     const rowExpander = row.querySelector(`button[aria-label="Expand row"]`);
     fireEvent.click(rowExpander);
 
-    expect(
-      screen
-        .getByRole('table')
-        .getElementsByTagName('tbody')[0]
-        .getElementsByClassName('c4p--datagrid__expanded-row')
-    ).toBeDefined();
-    expect(
-      screen
-        .getByRole('table')
-        .getElementsByTagName('tbody')[0]
-        .getElementsByClassName('c4p--datagrid__expanded-row')[0].textContent
-    ).toEqual(`Content for ${rowNumber}`);
+    expect(row.nextElementSibling).toHaveClass(`${blockClass}__expanded-row`);
+    expect(row.nextElementSibling.textContent).toEqual(
+      `Content for ${rowNumber}`
+    );
+
+    fireEvent.mouseOver(row.nextElementSibling);
+    fireEvent.mouseLeave(row.nextElementSibling);
 
     const rowExpanderCollapse = row.querySelector(
       `button[aria-label="Collapse row"]`
@@ -1453,7 +1478,7 @@ describe(componentName, () => {
     fireEvent.click(rowExpanderCollapse);
   }
 
-  it('Expanded Row', () => {
+  it('should render with expandable rows and test by toggling the row open and closed', () => {
     render(<ExpandedRow data-testid={dataTestId} />);
     clickRow(1);
     clickRow(4);
@@ -1479,7 +1504,7 @@ describe(componentName, () => {
   }
 
   it('Hide Select All', () => {
-    render(<HideSelectAll data-testid={dataTestId}></HideSelectAll>);
+    render(<HideSelectAll data-testid={dataTestId} />);
 
     hideSelectAll(2);
 
@@ -1489,33 +1514,29 @@ describe(componentName, () => {
   });
 
   it('Nested Rows', () => {
-    render(<NestedRows data-testid={dataTestId}></NestedRows>);
+    render(<NestedRows data-testid={dataTestId} />);
 
-    const row = screen
-      .getByRole('table')
-      .getElementsByTagName('tbody')[0]
-      .getElementsByTagName('tr')[0];
-    const firstRow = row
-      .getElementsByTagName('td')[0]
-      .getElementsByTagName('button')[0];
+    const gridRows = screen.getAllByRole('row');
+    const bodyRows = gridRows.filter(
+      (r) => !r.classList.contains(`${blockClass}__head`)
+    );
+    const firstBodyRow = bodyRows[0];
+    const firstRowExpander = within(firstBodyRow).getByLabelText('Expand row');
+    fireEvent.click(firstRowExpander);
+    expect(firstBodyRow).toHaveClass(`${blockClass}__carbon-row-expanded`);
 
-    fireEvent.click(firstRow);
-    expect(row.classList[0]).toEqual('c4p--datagrid__carbon-row-expanded');
+    const newAllRows = screen.getAllByRole('row');
+    const newBodyRows = newAllRows.filter(
+      (r) => !r.classList.contains(`${blockClass}__head`)
+    );
+    const nestedRow = newBodyRows[1];
 
-    const nestedRow = screen
-      .getByRole('table')
-      .getElementsByTagName('tbody')[0]
-      .getElementsByTagName('tr')[1];
-
-    if (nestedRow.className === 'c4p--datagrid__carbon-nested-row') {
-      fireEvent.click(
-        nestedRow
-          .getElementsByTagName('td')[0]
-          .getElementsByTagName('button')[0]
-      );
+    if (nestedRow.className === `${blockClass}__carbon-nested-row`) {
+      const nestedRowExpander = within(nestedRow).getByLabelText('Expand row');
+      fireEvent.click(nestedRowExpander);
     }
 
-    expect(nestedRow.classList[0]).toEqual('c4p--datagrid__carbon-nested-row');
+    expect(nestedRow).toHaveClass(`${blockClass}__carbon-nested-row`);
   });
 
   it('Nested Table', () => {
@@ -2500,6 +2521,72 @@ describe(componentName, () => {
     );
     expect(within(firstBodyRow).getAllByRole('button').length).toEqual(1); // Previously was 2 but we've hidden the other in this test
   });
+
+  const EditableCellUsage = ({ ...args }) => {
+    const [data, setData] = useState(makeData(3));
+    const columns = React.useMemo(() => getInlineEditColumns(), []);
+    pkg._silenceWarnings(false); // warnings are ordinarily silenced in storybook, add this to test.
+    pkg.feature['Datagrid.useInlineEdit'] = true;
+    pkg._silenceWarnings(true);
+
+    const datagridState = useDatagrid(
+      {
+        columns,
+        data,
+        onDataUpdate: setData,
+        ...args.defaultGridProps,
+      },
+      useEditableCell
+    );
+
+    // Warnings are ordinarily silenced in storybook, add this to test.
+    pkg._silenceWarnings(false);
+    pkg.feature['Datagrid.useEditableCell'] = true;
+    pkg._silenceWarnings(true);
+
+    return <Datagrid datagridState={datagridState} />;
+  };
+
+  it('should test the basic interactions of the editable cell datagrid', () => {
+    const { click } = userEvent;
+    const { container } = render(<EditableCellUsage />);
+    const tableElement = screen.getByRole('grid');
+    const rowButtons = screen.getAllByRole('button');
+    const firstEditableCell = rowButtons[0];
+
+    click(firstEditableCell);
+    expect(firstEditableCell).toHaveClass(
+      `${blockClass}__inline-edit-button--active`
+    );
+    click(container);
+    expect(tableElement).not.toHaveClass(`${blockClass}__table-grid-active`);
+  });
+
+  it('should test basic interactions of filter panel', async () => {
+    const { click } = userEvent;
+    render(
+      <FilteringUsage
+        defaultGridProps={{
+          gridTitle: 'Data table title',
+          gridDescription: 'Additional information if needed',
+          useDenseHeader: false,
+          emptyStateTitle: 'No filters match',
+          emptyStateDescription:
+            'Data was not found with the current filters applied. Change filters or clear filters to see other results.',
+          filterProps,
+        }}
+      />
+    );
+    const toolbar = screen.getByLabelText('data table toolbar').parentElement;
+    const panelContainer = toolbar.nextElementSibling;
+    const toolbarButtons = within(toolbar).getAllByRole('button');
+    const filterToggleButton = toolbarButtons[0];
+    // Open filter panel
+    click(filterToggleButton);
+    expect(panelContainer).toHaveClass(
+      `${blockClass}__table-container--filter-open`
+    );
+  });
 });
 
 const duplicateOnClickFn = jest.fn();
@@ -2557,9 +2644,9 @@ const TestBatch = () => {
       batchActions: true,
       toolbarBatchActions: getBatchActions(),
       DatagridActions,
+      DatagridPagination,
     },
     useSelectRows,
-    useSelectAllWithToggle,
     useStickyColumn
   );
 
@@ -2619,7 +2706,7 @@ describe('batch action testing', () => {
 
     // Resize observer or mocked widths not working as expected, changes batch action summary element
     // width to 0 which prevents the default batch action behavior from occurring
-    it.skip('renders batch action and checks for the appropriate rendering based on the current mocked widths', async () => {
+    it('renders batch action and checks for the appropriate rendering based on the current mocked widths', async () => {
       const { container } = render(<TestBatch />);
       const { click } = userEvent;
       const firstCheckbox = screen.getAllByLabelText('Toggle Row Selected')[0];
@@ -2640,9 +2727,6 @@ describe('batch action testing', () => {
 
       const menuButton = container.querySelector(`.${pkg.prefix}--button-menu`);
       const cancelButton = screen.getByRole('button', { name: /Cancel/i });
-      const selectAllButton = screen.getByRole('button', {
-        name: /Select all/i,
-      });
       expect(menuButton).toBeInTheDocument();
       click(menuButton);
       const options = Array.from(
@@ -2668,7 +2752,7 @@ describe('batch action testing', () => {
           click(menuButton);
         }
         const displayedMenuElement = document.querySelector(
-          `.${carbon.prefix}--menu`
+          `.${pkg.prefix}--button-menu__options`
         );
         const menuItems = Array.from(displayedMenuElement.children);
 
@@ -2676,7 +2760,8 @@ describe('batch action testing', () => {
           (item) =>
             item.textContent === getBatchActions()[remainingBatchIndex].label
         )[0];
-        click(menuItem);
+        const menuItemButton = menuItem.firstElementChild;
+        click(menuItemButton);
         expect(clickHandlerFn).toHaveBeenCalledTimes(1);
       };
 
@@ -2686,7 +2771,37 @@ describe('batch action testing', () => {
       checkMenuItem(5, deleteOnClickFn, true);
       click(cancelButton);
       click(firstCheckbox);
-      click(selectAllButton);
+    });
+
+    it('renders batch action with select all and checks indeterminate behavior', () => {
+      const { click } = userEvent;
+      render(<TestBatch />);
+      const bodyElement = screen.getAllByRole('rowgroup')[1];
+      const allRows = screen.getAllByRole('row');
+      const selectAllCheckbox = within(allRows[0]).getAllByRole('checkbox')[0];
+      click(selectAllCheckbox);
+      const carbonTableToolbar = screen.getByLabelText('data table toolbar');
+      expect(carbonTableToolbar).toBeInTheDocument();
+      const bodyRows = allRows.filter(
+        (r) =>
+          !r.classList.contains('c4p--datagrid__head') &&
+          !r.classList.contains('c4p--datagrid__expanded-row')
+      );
+      const firstBodyRow = bodyRows[0];
+      const firstRowCheckbox = within(firstBodyRow).getByRole('checkbox');
+      click(firstRowCheckbox);
+
+      // // // Should remove all checked checkboxes in the body
+      const selectAll = screen.getAllByRole('checkbox')[0];
+      click(selectAll);
+      let totalChecked = 0;
+      const allBodyCheckboxes = within(bodyElement).getAllByRole('checkbox');
+      allBodyCheckboxes.forEach((c) => {
+        if (c.checked) {
+          totalChecked = totalChecked + 1;
+        }
+      });
+      expect(totalChecked).toEqual(0);
     });
   });
 });

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -38,7 +38,7 @@ export const DatagridContent = ({ datagridState, title }) => {
   const { filterTags, EventEmitter, panelOpen } = useContext(FilterContext);
   const { activeCellId, gridActive, editId } = inlineEditState;
   const {
-    getTableProps = () => {},
+    getTableProps,
     getFilterFlyoutProps,
     withVirtualScroll,
     DatagridPagination,
@@ -98,22 +98,20 @@ export const DatagridContent = ({ datagridState, title }) => {
         role={withInlineEdit && 'grid'}
         tabIndex={withInlineEdit && 0}
         onKeyDown={
-          withInlineEdit
-            ? (event) =>
-                handleGridKeyPress({
-                  event,
-                  dispatch,
-                  instance: datagridState,
-                  keysPressedList,
-                  state: inlineEditState,
-                  usingMac,
-                })
-            : null
+          /* istanbul ignore next */
+          withInlineEdit &&
+          ((event) =>
+            handleGridKeyPress({
+              event,
+              dispatch,
+              instance: datagridState,
+              keysPressedList,
+              state: inlineEditState,
+              usingMac,
+            }))
         }
         onFocus={
-          withInlineEdit
-            ? () => handleGridFocus(inlineEditState, dispatch)
-            : null
+          withInlineEdit && (() => handleGridFocus(inlineEditState, dispatch))
         }
         title={title}
       >
@@ -154,6 +152,7 @@ export const DatagridContent = ({ datagridState, title }) => {
     clearSingleFilter(id, setAllFilters, state)
   );
 
+  /* istanbul ignore next */
   const renderFilterSummary = () =>
     state.filters.length > 0 && (
       <FilterSummary

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridExpandedRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridExpandedRow.js
@@ -14,9 +14,10 @@ const blockClass = `${pkg.prefix}--datagrid`;
 const DatagridExpandedRow =
   (ExpandedRowContentComponent) => (datagridState) => {
     const { row } = datagridState;
-    const { expandedContentHeight } = row || {};
+    const { expandedContentHeight } = row;
 
     const toggleParentHoverClass = (event, eventType) => {
+      /* istanbul ignore else */
       if (event?.target?.parentNode?.previousElementSibling) {
         const parentNode = event.target.parentNode.previousElementSibling;
         if (eventType === 'enter') {
@@ -36,7 +37,7 @@ const DatagridExpandedRow =
         <div
           className={`${blockClass}__expanded-row-content`}
           style={{
-            height: expandedContentHeight ? expandedContentHeight : null,
+            height: expandedContentHeight && expandedContentHeight,
           }}
         >
           <ExpandedRowContentComponent {...datagridState} />

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -35,38 +35,36 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
   // to display a vertical line to indicate the column you are resizing
   useEffect(() => {
     const { tableId } = datagridState;
-    if (tableId) {
-      const gridElement = document.querySelector(`#${tableId}`);
-      const tableElement = gridElement.querySelector('table');
-      const headerRowElement = document.querySelector(
-        `#${tableId} .${blockClass}__head`
+    const gridElement = document.querySelector(`#${tableId}`);
+    const tableElement = gridElement.querySelector('table');
+    const headerRowElement = document.querySelector(
+      `#${tableId} .${blockClass}__head`
+    );
+    const hasHorizontalScrollbar =
+      tableElement.scrollWidth > tableElement.clientWidth;
+    const scrollBuffer = hasHorizontalScrollbar ? 18 : 2;
+    const tableToolbar = gridElement.querySelector(
+      `.${blockClass}__table-toolbar`
+    );
+    const tableToolbarHeight = tableToolbar?.offsetHeight || 0;
+    const setCustomValues = ({ rowHeight = 48, gridHeight }) => {
+      headerRowElement.style.setProperty(
+        `--${blockClass}--row-height`,
+        px(rowHeight)
       );
-      const hasHorizontalScrollbar =
-        tableElement.scrollWidth > tableElement.clientWidth;
-      const scrollBuffer = hasHorizontalScrollbar ? 18 : 2;
-      const tableToolbar = gridElement.querySelector(
-        `.${blockClass}__table-toolbar`
+      headerRowElement.style.setProperty(
+        `--${blockClass}--grid-height`,
+        px(gridHeight - scrollBuffer - tableToolbarHeight)
       );
-      const tableToolbarHeight = tableToolbar?.offsetHeight || 0;
-      const setCustomValues = ({ rowHeight = 48, gridHeight }) => {
-        headerRowElement.style.setProperty(
-          `--${blockClass}--row-height`,
-          px(rowHeight)
-        );
-        headerRowElement.style.setProperty(
-          `--${blockClass}--grid-height`,
-          px(gridHeight - scrollBuffer - tableToolbarHeight)
-        );
-        headerRowElement.style.setProperty(
-          `--${blockClass}--header-height`,
-          px(headerRowElement.offsetHeight)
-        );
-      };
-      setCustomValues({
-        gridHeight: gridElement.offsetHeight,
-        rowHeight: headerRowElement.clientHeight,
-      });
-    }
+      headerRowElement.style.setProperty(
+        `--${blockClass}--header-height`,
+        px(headerRowElement.offsetHeight)
+      );
+    };
+    setCustomValues({
+      gridHeight: gridElement.offsetHeight,
+      rowHeight: headerRowElement.clientHeight,
+    });
   }, [datagridState.rowSize, datagridState.tableId, datagridState]);
 
   const [incrementAmount] = useState(2);

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSelectAll.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSelectAll.js
@@ -1,11 +1,10 @@
-/*
- * Licensed Materials - Property of IBM
- * 5724-Q36
- * (c) Copyright IBM Corp. 2023
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
+/**
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
-// @flow
+
 import React, { useLayoutEffect, useState } from 'react';
 import { DataTable } from 'carbon-components-react';
 import cx from 'classnames';
@@ -16,6 +15,7 @@ const blockClass = `${pkg.prefix}--datagrid`;
 const SelectAll = (datagridState) => {
   const [windowSize, setWindowSize] = useState(window.innerWidth);
   useLayoutEffect(() => {
+    /* istanbul ignore next */
     function updateSize() {
       setWindowSize(window.innerWidth);
     }
@@ -41,6 +41,7 @@ const SelectAll = (datagridState) => {
       <div
         className={cx(`${blockClass}__head-hidden-select-all`, {
           [`${blockClass}__select-all-sticky-left`]:
+            /* istanbul ignore next */
             isFirstColumnStickyLeft && windowSize > 671,
         })}
       />
@@ -50,7 +51,7 @@ const SelectAll = (datagridState) => {
     ? getToggleAllPageRowsSelectedProps
     : getToggleAllRowsSelectedProps;
   const { onChange, ...selectProps } = getProps();
-  const { indeterminate } = selectProps || {};
+  const { indeterminate } = selectProps;
 
   const handleSelectAllChange = (event) => {
     if (indeterminate) {
@@ -68,6 +69,7 @@ const SelectAll = (datagridState) => {
         `${blockClass}__checkbox-cell`,
         {
           [`${blockClass}__checkbox-cell-sticky-left`]:
+            /* istanbul ignore next */
             isFirstColumnStickyLeft && windowSize > 671,
         }
       )}

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
@@ -44,6 +44,7 @@ const DatagridVirtualBody = (datagridState) => {
     gridRef,
   } = datagridState;
 
+  /* istanbul ignore next */
   const handleVirtualGridResize = () => {
     const gridRefElement = gridRef?.current;
     gridRefElement.style.width = gridRefElement?.clientWidth;
@@ -51,6 +52,7 @@ const DatagridVirtualBody = (datagridState) => {
 
   useResizeObserver(gridRef, handleVirtualGridResize);
 
+  /* istanbul ignore next */
   const syncScroll = (event) => {
     const virtualBody = event.target;
     document.querySelector(`.${blockClass}__head-wrap`).scrollLeft =

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
@@ -34,9 +34,159 @@ export default {
     styles,
     docs: { page: mdx },
   },
+  excludeStories: ['FilteringUsage', 'filterProps'],
 };
 
-const FilteringUsage = ({ defaultGridProps }) => {
+export const filterProps = {
+  variation: 'panel',
+  updateMethod: 'batch',
+  primaryActionLabel: 'Apply',
+  secondaryActionLabel: 'Cancel',
+  panelIconDescription: `Open filters`,
+  closeIconDescription: 'Close panel',
+  sections: [
+    {
+      categoryTitle: 'Category title',
+      hasAccordion: true,
+      filters: [
+        {
+          filterLabel: 'Joined',
+          filter: {
+            type: 'date',
+            column: 'joined',
+            props: {
+              DatePicker: {
+                datePickerType: 'range',
+              },
+              DatePickerInput: {
+                start: {
+                  id: 'date-picker-input-id-start',
+                  placeholder: 'mm/dd/yyyy',
+                  labelText: 'Joined start date',
+                },
+                end: {
+                  id: 'date-picker-input-id-end',
+                  placeholder: 'mm/dd/yyyy',
+                  labelText: 'Joined end date',
+                },
+              },
+            },
+          },
+        },
+        {
+          filterLabel: 'Status',
+          filter: {
+            type: 'dropdown',
+            column: 'status',
+            props: {
+              Dropdown: {
+                id: 'marital-status-dropdown',
+                ariaLabel: 'Marital status dropdown',
+                items: ['relationship', 'complicated', 'single'],
+                label: 'Marital status',
+                titleText: 'Marital status',
+              },
+            },
+          },
+        },
+      ],
+    },
+    {
+      categoryTitle: 'Category title',
+      filters: [
+        {
+          filterLabel: 'Role',
+          filter: {
+            type: 'radio',
+            column: 'role',
+            props: {
+              FormGroup: {
+                legendText: 'Role',
+              },
+              RadioButtonGroup: {
+                orientation: 'vertical',
+                legend: 'Role legend',
+                name: 'role-radio-button-group',
+              },
+              RadioButton: [
+                {
+                  id: 'developer',
+                  labelText: 'Developer',
+                  value: 'developer',
+                },
+                {
+                  id: 'designer',
+                  labelText: 'Designer',
+                  value: 'designer',
+                },
+                {
+                  id: 'researcher',
+                  labelText: 'Researcher',
+                  value: 'researcher',
+                },
+              ],
+            },
+          },
+        },
+        {
+          filterLabel: 'Visits',
+          filter: {
+            type: 'number',
+            column: 'visits',
+            props: {
+              NumberInput: {
+                min: 0,
+                id: 'visits-number-input',
+                invalidText: 'A valid value is required',
+                label: 'Visits',
+                placeholder: 'Type a number amount of visits',
+              },
+            },
+          },
+        },
+        {
+          filterLabel: 'Password strength',
+          filter: {
+            type: 'checkbox',
+            column: 'passwordStrength',
+            props: {
+              FormGroup: {
+                legendText: 'Password strength',
+              },
+              Checkbox: [
+                {
+                  id: 'normal',
+                  labelText: 'Normal',
+                  value: 'normal',
+                },
+                {
+                  id: 'minor-warning',
+                  labelText: 'Minor warning',
+                  value: 'minor-warning',
+                },
+                {
+                  id: 'critical',
+                  labelText: 'Critical',
+                  value: 'critical',
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  ],
+  onPanelOpen: action('onPanelOpen'),
+  onPanelClose: action('onPanelClose'),
+  panelTitle: 'Filter',
+  renderDateLabel: (start, end) => {
+    const startDateObj = new Date(start);
+    const endDateObj = new Date(end);
+    return `${startDateObj.toLocaleDateString()} - ${endDateObj.toLocaleDateString()}`;
+  },
+};
+
+export const FilteringUsage = ({ defaultGridProps }) => {
   const {
     gridDescription,
     gridTitle,
@@ -161,154 +311,7 @@ export const PanelBatch = prepareStory(FilteringTemplateWrapper, {
     emptyStateTitle: 'No filters match',
     emptyStateDescription:
       'Data was not found with the current filters applied. Change filters or clear filters to see other results.',
-    filterProps: {
-      variation: 'panel',
-      updateMethod: 'batch',
-      primaryActionLabel: 'Apply',
-      secondaryActionLabel: 'Cancel',
-      panelIconDescription: `Open filters`,
-      closeIconDescription: 'Close panel',
-      sections: [
-        {
-          categoryTitle: 'Category title',
-          hasAccordion: true,
-          filters: [
-            {
-              filterLabel: 'Joined',
-              filter: {
-                type: 'date',
-                column: 'joined',
-                props: {
-                  DatePicker: {
-                    datePickerType: 'range',
-                  },
-                  DatePickerInput: {
-                    start: {
-                      id: 'date-picker-input-id-start',
-                      placeholder: 'mm/dd/yyyy',
-                      labelText: 'Joined start date',
-                    },
-                    end: {
-                      id: 'date-picker-input-id-end',
-                      placeholder: 'mm/dd/yyyy',
-                      labelText: 'Joined end date',
-                    },
-                  },
-                },
-              },
-            },
-            {
-              filterLabel: 'Status',
-              filter: {
-                type: 'dropdown',
-                column: 'status',
-                props: {
-                  Dropdown: {
-                    id: 'marital-status-dropdown',
-                    ariaLabel: 'Marital status dropdown',
-                    items: ['relationship', 'complicated', 'single'],
-                    label: 'Marital status',
-                    titleText: 'Marital status',
-                  },
-                },
-              },
-            },
-          ],
-        },
-        {
-          categoryTitle: 'Category title',
-          filters: [
-            {
-              filterLabel: 'Role',
-              filter: {
-                type: 'radio',
-                column: 'role',
-                props: {
-                  FormGroup: {
-                    legendText: 'Role',
-                  },
-                  RadioButtonGroup: {
-                    orientation: 'vertical',
-                    legend: 'Role legend',
-                    name: 'role-radio-button-group',
-                  },
-                  RadioButton: [
-                    {
-                      id: 'developer',
-                      labelText: 'Developer',
-                      value: 'developer',
-                    },
-                    {
-                      id: 'designer',
-                      labelText: 'Designer',
-                      value: 'designer',
-                    },
-                    {
-                      id: 'researcher',
-                      labelText: 'Researcher',
-                      value: 'researcher',
-                    },
-                  ],
-                },
-              },
-            },
-            {
-              filterLabel: 'Visits',
-              filter: {
-                type: 'number',
-                column: 'visits',
-                props: {
-                  NumberInput: {
-                    min: 0,
-                    id: 'visits-number-input',
-                    invalidText: 'A valid value is required',
-                    label: 'Visits',
-                    placeholder: 'Type a number amount of visits',
-                  },
-                },
-              },
-            },
-            {
-              filterLabel: 'Password strength',
-              filter: {
-                type: 'checkbox',
-                column: 'passwordStrength',
-                props: {
-                  FormGroup: {
-                    legendText: 'Password strength',
-                  },
-                  Checkbox: [
-                    {
-                      id: 'normal',
-                      labelText: 'Normal',
-                      value: 'normal',
-                    },
-                    {
-                      id: 'minor-warning',
-                      labelText: 'Minor warning',
-                      value: 'minor-warning',
-                    },
-                    {
-                      id: 'critical',
-                      labelText: 'Critical',
-                      value: 'critical',
-                    },
-                  ],
-                },
-              },
-            },
-          ],
-        },
-      ],
-      onPanelOpen: action('onPanelOpen'),
-      onPanelClose: action('onPanelClose'),
-      panelTitle: 'Filter',
-      renderDateLabel: (start, end) => {
-        const startDateObj = new Date(start);
-        const endDateObj = new Date(end);
-        return `${startDateObj.toLocaleDateString()} - ${endDateObj.toLocaleDateString()}`;
-      },
-    },
+    filterProps,
   },
 });
 


### PR DESCRIPTION
Increases overall test coverage of the base Datagrid component, added a few `istanbul ignore`s but only for functionality either related to resizing or extensions that are not part of the base component. I also was able to remove `.skip` from the batch action test, the button menu selector was using a v11 class name which was causing it not to find the menu or menu items.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid.test.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridExpandedRow.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSelectAll.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
```
#### How did you test and verify your work?
Ran Datagrid tests and confirmed test coverage reaches at least 80% for the following base component files
<img width="1092" alt="image" src="https://github.com/carbon-design-system/ibm-products/assets/10215203/4bf1a6f2-50db-41c3-a60b-90e9d8423ba6">

