### PR TITLE
fix: side panel scrolled height

### DIFF
--- a/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
@@ -2427,7 +2427,6 @@ p.c4p--about-modal__copyright-text:first-child {
   position: sticky;
   z-index: 4;
   top: 0;
-  height: calc(var(--c4p--side-panel--title-container-height) - var(--c4p--side-panel--label-text-height));
   padding: 1rem 1rem 0.5rem 1rem;
   background-color: var(--cds-layer-01, #f4f4f4);
   /* stylelint-disable-next-line max-nesting-depth */
@@ -2488,6 +2487,7 @@ p.c4p--about-modal__copyright-text:first-child {
   -webkit-line-clamp: 2;
   position: inherit;
   z-index: 4;
+  margin-bottom: calc(-1 * var(--c4p--side-panel--label-text-height));
   background-color: var(--cds-layer-01, #f4f4f4);
   opacity: var(--c4p--side-panel--subtitle-opacity);
   transform: translateY(var(--c4p--side-panel--title-y-position));

--- a/packages/ibm-products/src/components/SidePanel/_side-panel.scss
+++ b/packages/ibm-products/src/components/SidePanel/_side-panel.scss
@@ -110,10 +110,6 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
     position: sticky;
     z-index: 4;
     top: 0;
-    height: calc(
-      var(--#{$block-class}--title-container-height) -
-        var(--#{$block-class}--label-text-height)
-    );
     padding: $spacing-05 $spacing-05 $spacing-03 $spacing-05;
     background-color: $layer-01;
 
@@ -169,6 +165,7 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
 
     position: inherit;
     z-index: 4;
+    margin-bottom: calc(-1 * var(--#{$block-class}--label-text-height));
     background-color: $layer-01;
     opacity: var(--#{$block-class}--subtitle-opacity);
     transform: translateY(var(--#{$block-class}--title-y-position));


### PR DESCRIPTION
Closes to #3817

Changes how the height of the side panel title is calculated

#### What did you change?

Stopped changing the container height, instead adding negative margin to the title-text.

#### How did you test and verify your work?

Storybook following steps in issue.