### PR TITLE
feat(Datagrid): selectable rows return all row data selected via react-table `state`

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -11,6 +11,7 @@ const COLUMN_RESIZE_START = 'columnStartResizing';
 const COLUMN_RESIZING = 'columnResizing';
 const COLUMN_RESIZE_END = 'columnDoneResizing';
 const INIT = 'init';
+const TOGGLE_ROW_SELECTED = 'toggleRowSelected';
 const blockClass = `${pkg.prefix}--datagrid`;
 
 export const handleColumnResizeEndEvent = (
@@ -51,8 +52,27 @@ export const handleColumnResizingEvent = (
   });
 };
 
+export const handleToggleRowSelected = (dispatch, rowData) =>
+  dispatch({
+    type: TOGGLE_ROW_SELECTED,
+    payload: { rowData },
+  });
+
 export const stateReducer = (newState, action) => {
   switch (action.type) {
+    case TOGGLE_ROW_SELECTED: {
+      const { rowData } = action.payload || {};
+      if (!rowData) {
+        return;
+      }
+      return {
+        ...newState,
+        selectedRowData: {
+          ...newState.selectedRowData,
+          [rowData.index]: rowData,
+        },
+      };
+    }
     case INIT: {
       return {
         ...newState,

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -52,25 +52,42 @@ export const handleColumnResizingEvent = (
   });
 };
 
-export const handleToggleRowSelected = (dispatch, rowData) =>
+export const handleToggleRowSelected = (dispatch, rowData, isChecked) =>
   dispatch({
     type: TOGGLE_ROW_SELECTED,
-    payload: { rowData },
+    payload: { rowData, isChecked },
   });
 
 export const stateReducer = (newState, action) => {
   switch (action.type) {
     case TOGGLE_ROW_SELECTED: {
-      const { rowData } = action.payload || {};
+      const { rowData, isChecked } = action.payload || {};
       if (!rowData) {
         return;
       }
+      if (isChecked) {
+        return {
+          ...newState,
+          selectedRowData: {
+            ...newState.selectedRowData,
+            [rowData.index]: rowData,
+          },
+        };
+      }
+      if (rowData && !isChecked) {
+        const newData = { ...newState.selectedRowData };
+        const dataWithRemovedRow = Object.fromEntries(
+          Object.entries(newData).filter(([key]) => {
+            return parseInt(key) !== parseInt(rowData.index);
+          })
+        );
+        return {
+          ...newState,
+          selectedRowData: dataWithRemovedRow,
+        };
+      }
       return {
         ...newState,
-        selectedRowData: {
-          ...newState.selectedRowData,
-          [rowData.index]: rowData,
-        },
       };
     }
     case INIT: {

--- a/packages/ibm-products/src/components/Datagrid/useSelectRows.js
+++ b/packages/ibm-products/src/components/Datagrid/useSelectRows.js
@@ -12,6 +12,7 @@ import { TableSelectRow } from '@carbon/react';
 import { SelectAll } from './Datagrid/DatagridSelectAll';
 import { selectionColumnId } from './common-column-ids';
 import { pkg, carbon } from '../../settings';
+import { handleToggleRowSelected } from './Datagrid/addons/stateReducer';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 const checkboxClass = `${pkg.prefix}--datagrid__checkbox-cell`;
@@ -70,6 +71,7 @@ const SelectRow = (datagridState) => {
     onRowSelect,
     columns,
     withStickyColumn,
+    dispatch,
   } = datagridState;
 
   const [windowSize, setWindowSize] = useState(window.innerWidth);
@@ -91,6 +93,7 @@ const SelectRow = (datagridState) => {
     }
     onChange(e);
     onRowSelect?.(row, e);
+    handleToggleRowSelected(dispatch, row);
   };
 
   const selectDisabled = isFetching || row.getRowProps().disabled;

--- a/packages/ibm-products/src/components/Datagrid/useSelectRows.js
+++ b/packages/ibm-products/src/components/Datagrid/useSelectRows.js
@@ -83,17 +83,17 @@ const SelectRow = (datagridState) => {
     return () => window.removeEventListener('resize', updateSize);
   }, []);
 
-  const onSelectHandler = (e) => {
-    e.stopPropagation(); // avoid triggering onRowClick
+  const onSelectHandler = (event) => {
+    event.stopPropagation(); // avoid triggering onRowClick
     if (radio) {
       toggleAllRowsSelected(false);
       if (onRadioSelect) {
         onRadioSelect(row);
       }
     }
-    onChange(e);
-    onRowSelect?.(row, e);
-    handleToggleRowSelected(dispatch, row);
+    onChange(event);
+    onRowSelect?.(row, event);
+    handleToggleRowSelected(dispatch, row, event.target.checked);
   };
 
   const selectDisabled = isFetching || row.getRowProps().disabled;


### PR DESCRIPTION
Contributes to #3818 

This enhancement adds `selectedRowData` to the state data returned from the datagrid state via the state reducer we have. We are able to do this by tapping into react table's reducer.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
packages/ibm-products/src/components/Datagrid/useSelectRows.js
```
#### How did you test and verify your work?
Verified that the new property `selectedRowData` is returning expected values, accessed from `datagridState.state.selectedRowData`. Matches the same data structure as `datagridState.state.selectedRowIds`.