### PR TITLE
feat(Datagrid): selectable rows return all row data selected via react-table `state` (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -11,6 +11,7 @@ const COLUMN_RESIZE_START = 'columnStartResizing';
 const COLUMN_RESIZING = 'columnResizing';
 const COLUMN_RESIZE_END = 'columnDoneResizing';
 const INIT = 'init';
+const TOGGLE_ROW_SELECTED = 'toggleRowSelected';
 const blockClass = `${pkg.prefix}--datagrid`;
 
 export const handleColumnResizeEndEvent = (
@@ -51,8 +52,44 @@ export const handleColumnResizingEvent = (
   });
 };
 
+export const handleToggleRowSelected = (dispatch, rowData, isChecked) =>
+  dispatch({
+    type: TOGGLE_ROW_SELECTED,
+    payload: { rowData, isChecked },
+  });
+
 export const stateReducer = (newState, action) => {
   switch (action.type) {
+    case TOGGLE_ROW_SELECTED: {
+      const { rowData, isChecked } = action.payload || {};
+      if (!rowData) {
+        return;
+      }
+      if (isChecked) {
+        return {
+          ...newState,
+          selectedRowData: {
+            ...newState.selectedRowData,
+            [rowData.index]: rowData,
+          },
+        };
+      }
+      if (rowData && !isChecked) {
+        const newData = { ...newState.selectedRowData };
+        const dataWithRemovedRow = Object.fromEntries(
+          Object.entries(newData).filter(([key]) => {
+            return parseInt(key) !== parseInt(rowData.index);
+          })
+        );
+        return {
+          ...newState,
+          selectedRowData: dataWithRemovedRow,
+        };
+      }
+      return {
+        ...newState,
+      };
+    }
     case INIT: {
       return {
         ...newState,

--- a/packages/ibm-products/src/components/Datagrid/useSelectRows.js
+++ b/packages/ibm-products/src/components/Datagrid/useSelectRows.js
@@ -12,6 +12,7 @@ import { TableSelectRow } from 'carbon-components-react';
 import { SelectAll } from './Datagrid/DatagridSelectAll';
 import { selectionColumnId } from './common-column-ids';
 import { pkg, carbon } from '../../settings';
+import { handleToggleRowSelected } from './Datagrid/addons/stateReducer';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 const checkboxClass = `${blockClass}__checkbox-cell`;
@@ -70,6 +71,7 @@ const SelectRow = (datagridState) => {
     onRowSelect,
     columns,
     withStickyColumn,
+    dispatch,
   } = datagridState;
 
   const [windowSize, setWindowSize] = useState(window.innerWidth);
@@ -86,16 +88,17 @@ const SelectRow = (datagridState) => {
   const cellProps = cell.getCellProps();
   const isFirstColumnStickyLeft =
     columns[0]?.sticky === 'left' && withStickyColumn;
-  const onSelectHandler = (e) => {
-    e.stopPropagation(); // avoid triggering onRowClick
+  const onSelectHandler = (event) => {
+    event.stopPropagation(); // avoid triggering onRowClick
     if (radio) {
       toggleAllRowsSelected(false);
       if (onRadioSelect) {
         onRadioSelect(row);
       }
     }
-    onChange(e);
-    onRowSelect?.(row, e);
+    onChange(event);
+    onRowSelect?.(row, event);
+    handleToggleRowSelected(dispatch, row, event.target.checked);
   };
   const rowId = `${tableId}-${row.index}`;
   return (


### PR DESCRIPTION
Contributes to #3818 

This enhancement adds `selectedRowData` to the state data returned from the datagrid state via the state reducer we have. We are able to do this by tapping into react table's reducer.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
packages/ibm-products/src/components/Datagrid/useSelectRows.js
```
#### How did you test and verify your work?
Verified that the new property `selectedRowData` is returning expected values, accessed from `datagridState.state.selectedRowData`.