### PR TITLE
docs(Datagrid): add story with single level of nesting 

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.js
@@ -151,6 +151,65 @@ const sharedDatagridProps = {
   ],
 };
 
+const nestedRowsControlProps = {
+  gridTitle: sharedDatagridProps.gridTitle,
+  gridDescription: sharedDatagridProps.gridDescription,
+  useDenseHeader: sharedDatagridProps.useDenseHeader,
+  rowSize: sharedDatagridProps.rowSize,
+  rowSizes: sharedDatagridProps.rowSizes,
+  onRowSizeChange: sharedDatagridProps.onRowSizeChange,
+  expanderButtonTitleExpanded: 'Collapse row',
+  expanderButtonTitleCollapsed: 'Expand row',
+};
+
+const SingleLevelNestedRows = ({ ...args }) => {
+  const columns = React.useMemo(() => defaultHeader, []);
+  const [data] = useState(makeData(10, 2));
+  const datagridState = useDatagrid(
+    {
+      columns,
+      data,
+      DatagridActions,
+      ...args.defaultGridProps,
+    },
+    useNestedRows
+  );
+
+  // Warnings are ordinarily silenced in storybook, add this to test
+  pkg._silenceWarnings(false);
+  // Enable feature flag for `useNestedRows` hook
+  pkg.feature['Datagrid.useNestedRows'] = true;
+  pkg._silenceWarnings(true);
+
+  return <Datagrid datagridState={{ ...datagridState }} />;
+};
+
+const SingleLevelNestedRowsWrapper = ({ ...args }) => {
+  return <SingleLevelNestedRows defaultGridProps={{ ...args }} />;
+};
+
+const singleNestedRowsStoryName = 'With single-level nested rows';
+export const SingleLevelNestedRowsUsageStory = prepareStory(
+  SingleLevelNestedRowsWrapper,
+  {
+    storyName: singleNestedRowsStoryName,
+    argTypes: {
+      gridTitle: ARG_TYPES.gridTitle,
+      gridDescription: ARG_TYPES.gridDescription,
+      useDenseHeader: ARG_TYPES.useDenseHeader,
+      rowSize: ARG_TYPES.rowSize,
+      rowSizes: ARG_TYPES.rowSizes,
+      onRowSizeChange: ARG_TYPES.onRowSizeChange,
+      expanderButtonTitleExpanded: 'Collapse row',
+      expanderButtonTitleCollapsed: 'Expand row',
+    },
+    args: {
+      ...nestedRowsControlProps,
+      featureFlags: ['Datagrid.useNestedRows'],
+    },
+  }
+);
+
 const NestedRows = ({ ...args }) => {
   const columns = React.useMemo(() => defaultHeader, []);
   const [data] = useState(makeData(10, 5, 2, 2));
@@ -178,16 +237,6 @@ const BasicTemplateWrapper = ({ ...args }) => {
   return <NestedRows defaultGridProps={{ ...args }} />;
 };
 
-const nestedRowsControlProps = {
-  gridTitle: sharedDatagridProps.gridTitle,
-  gridDescription: sharedDatagridProps.gridDescription,
-  useDenseHeader: sharedDatagridProps.useDenseHeader,
-  rowSize: sharedDatagridProps.rowSize,
-  rowSizes: sharedDatagridProps.rowSizes,
-  onRowSizeChange: sharedDatagridProps.onRowSizeChange,
-  expanderButtonTitleExpanded: 'Collapse row',
-  expanderButtonTitleCollapsed: 'Expand row',
-};
 const nestedRowsStoryName = 'With nested rows';
 export const NestedRowsUsageStory = prepareStory(BasicTemplateWrapper, {
   storyName: nestedRowsStoryName,

--- a/packages/ibm-products/src/components/Datagrid/styles/_useNestedRows.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_useNestedRows.scss
@@ -36,7 +36,7 @@
 
 .#{$block-class}
   tr.#{$block-class}__carbon-nested-row
-  + :not(tr.#{$block-class}__carbon-nested-row)::before {
+  + :not(tr.#{$block-class}__carbon-nested-row)::after {
   position: absolute;
   /* stylelint-disable-next-line carbon/layout-token-use */
   top: -1px;


### PR DESCRIPTION
Contributes to #3563 

Add a story under the nested rows extension with only one level of nesting.
Also fix a bug where row indicator would not appear due to overridden pseudo element.

#### What did you change?
Added story and minor CSS fix

#### How did you test and verify your work?
Storybook and CI