### PR TITLE
fix: pass tokens in reusable workflow

### DIFF
--- a/.github/workflows/release-preminor.yml
+++ b/.github/workflows/release-preminor.yml
@@ -8,3 +8,4 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       release-type: '--canary preminor'
+    secrets: inherit

--- a/.github/workflows/release-scheduled.yml
+++ b/.github/workflows/release-scheduled.yml
@@ -8,3 +8,4 @@ on:
 jobs:
   Release:
     uses: ./.github/workflows/release.yml
+    secrets: inherit


### PR DESCRIPTION
Using implicit method[^1] of passing secrets first.

[^1]: [Passing inputs and secrets to a reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow)