### PR TITLE
chore: revert ibm-products-styles paths

### DIFF
--- a/packages/core/.storybook/carbon.scss
+++ b/packages/core/.storybook/carbon.scss
@@ -8,4 +8,4 @@
 // a build of carbon css with our required feature flags set
 
 @use '@carbon/styles';
-@use '@carbon/ibm-products-styles/scss/global/styles/project-settings';
+@use '../../ibm-products-styles/src/global/styles/project-settings'

--- a/packages/core/.storybook/index.scss
+++ b/packages/core/.storybook/index.scss
@@ -10,7 +10,7 @@
 // to ensure we are resilient against different CSS loading orders and our
 // styles have the specificity necessary to override Carbon styles when needed.
 @use 'ALIAS_STORY_STYLE_CONFIG' as c4p-settings; // loads config.css or config-dev.scss from ibm-prodcuts/src (see main.js)
-@use '../../ibm-products-styles/scss/index-without-carbon.scss';
+@use '../../ibm-products-styles/src/index-without-carbon.scss';
 
 // Load all Carbon styles now
 @use '../css/carbon';

--- a/packages/core/.storybook/main.js
+++ b/packages/core/.storybook/main.js
@@ -89,8 +89,8 @@ module.exports = {
         alias: {
           ALIAS_STORY_STYLE_CONFIG$: path.resolve(
             configType === 'DEVELOPMENT'
-              ? '../ibm-products-styles/scss/config-dev.scss'
-              : '../ibm-products-styles/scss/config.scss'
+              ? '../ibm-products-styles/src/config-dev.scss'
+              : '../ibm-products-styles/src/config.scss'
           ),
         },
       },

--- a/packages/ibm-products/src/components/ActionBar/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/ActionBar/_storybook-styles.scss
@@ -5,4 +5,5 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@use '@carbon/ibm-products-styles/scss/global/styles/display-box' as *;
+@use '../../../../ibm-products-styles/src/global/styles/display-box' as *;
+// @use '@carbon/ibm-products-styles/scss/global/styles/display-box' as *;

--- a/packages/ibm-products/src/components/ActionSet/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/ActionSet/_storybook-styles.scss
@@ -6,7 +6,8 @@
 //
 
 @use 'ALIAS_STORY_STYLE_CONFIG' as c4p-settings;
-@use '@carbon/ibm-products-styles/scss/global/styles/display-box' as *;
+// @use '@carbon/ibm-products-styles/scss/global/styles/display-box' as *;
+@use '../../../../ibm-products-styles/src/global/styles/display-box' as *;
 
 $block-class: #{c4p-settings.$pkg-prefix}--action-set;
 

--- a/packages/ibm-products/src/components/BreadcrumbWithOverflow/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/BreadcrumbWithOverflow/_storybook-styles.scss
@@ -5,4 +5,5 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@use '@carbon/ibm-products-styles/scss/global/styles/display-box' as *;
+// @use '@carbon/ibm-products-styles/scss/global/styles/display-box' as *;
+@use '../../../../ibm-products-styles/src/global/styles/display-box' as *;

--- a/packages/ibm-products/src/components/ButtonSetWithOverflow/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/ButtonSetWithOverflow/_storybook-styles.scss
@@ -5,4 +5,5 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@use '@carbon/ibm-products-styles/scss/global/styles/display-box' as *;
+// @use '@carbon/ibm-products-styles/scss/global/styles/display-box' as *;
+@use '../../../../ibm-products-styles/src/global/styles/display-box' as *;

--- a/packages/ibm-products/src/components/CreateSidePanel/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/CreateSidePanel/_storybook-styles.scss
@@ -10,7 +10,8 @@
 @use '@carbon/styles/scss/spacing';
 // @use '@carbon/ibm-products-styles/scss/global/decorators/side-panel-decorator'
 //   as *;
-@use '../../../../ibm-products-styles/src/global/decorators/side-panel-decorator' as *;
+@use '../../../../ibm-products-styles/src/global/decorators/side-panel-decorator'
+  as *;
 
 $block-class: #{c4p-settings.$pkg-prefix}--create-side-panel;
 $story-prefix: create-side-panel-stories__;

--- a/packages/ibm-products/src/components/CreateSidePanel/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/CreateSidePanel/_storybook-styles.scss
@@ -8,8 +8,9 @@
 @use 'ALIAS_STORY_STYLE_CONFIG' as c4p-settings;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing';
-@use '@carbon/ibm-products-styles/scss/global/decorators/side-panel-decorator'
-  as *;
+// @use '@carbon/ibm-products-styles/scss/global/decorators/side-panel-decorator'
+//   as *;
+@use '../../../../ibm-products-styles/src/global/decorators/side-panel-decorator' as *;
 
 $block-class: #{c4p-settings.$pkg-prefix}--create-side-panel;
 $story-prefix: create-side-panel-stories__;

--- a/packages/ibm-products/src/components/EditFullPage/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/EditFullPage/_storybook-styles.scss
@@ -5,6 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@use '@carbon/ibm-products-styles/scss/global/styles/project-settings';
+// @use '@carbon/ibm-products-styles/scss/global/styles/project-settings';
+@use '../../../../ibm-products-styles/src/global/styles/project-settings';
 
 // TODO: add any additional styles used by EditFullPage.stories.js

--- a/packages/ibm-products/src/components/EditInPlace/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/EditInPlace/_storybook-styles.scss
@@ -4,7 +4,8 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-@use '@carbon/ibm-products-styles/scss/global/styles/display-box';
+// @use '@carbon/ibm-products-styles/scss/global/styles/display-box';
+@use '../../../../ibm-products-styles/src/global/styles/display-box';
 
 $block-class: 'edit-in-place-example';
 

--- a/packages/ibm-products/src/components/EditSidePanel/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/EditSidePanel/_storybook-styles.scss
@@ -10,7 +10,8 @@
 @use '@carbon/styles/scss/spacing' as *;
 // @use '@carbon/ibm-products-styles/scss/global/decorators/side-panel-decorator'
 //   as *;
-@use '../../../../ibm-products-styles/src/global/decorators/side-panel-decorator' as *;
+@use '../../../../ibm-products-styles/src/global/decorators/side-panel-decorator'
+  as *;
 
 $block-class: #{c4p-settings.$pkg-prefix}--edit-side-panel;
 $story-prefix: edit-side-panel-stories__;

--- a/packages/ibm-products/src/components/EditSidePanel/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/EditSidePanel/_storybook-styles.scss
@@ -8,8 +8,9 @@
 @use 'ALIAS_STORY_STYLE_CONFIG' as c4p-settings;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
-@use '@carbon/ibm-products-styles/scss/global/decorators/side-panel-decorator'
-  as *;
+// @use '@carbon/ibm-products-styles/scss/global/decorators/side-panel-decorator'
+//   as *;
+@use '../../../../ibm-products-styles/src/global/decorators/side-panel-decorator' as *;
 
 $block-class: #{c4p-settings.$pkg-prefix}--edit-side-panel;
 $story-prefix: edit-side-panel-stories__;

--- a/packages/ibm-products/src/components/FilterSummary/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/FilterSummary/_storybook-styles.scss
@@ -4,7 +4,9 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-@use '@carbon/ibm-products-styles/scss/global/styles/display-box' as *;
+
+// @use '@carbon/ibm-products-styles/scss/global/styles/display-box' as *;
+@use '../../../../ibm-products-styles/src/global/styles/display-box' as *;
 
 #root {
   width: 100%;

--- a/packages/ibm-products/src/components/InlineTip/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/InlineTip/_storybook-styles.scss
@@ -6,7 +6,8 @@
 //
 
 @use '@carbon/styles/scss/spacing' as *;
-@use '@carbon/ibm-products-styles/scss/global/styles/project-settings';
+// @use '@carbon/ibm-products-styles/scss/global/styles/project-settings';
+@use '../../../../ibm-products-styles/src/global/styles/project-settings';
 
 .storybook--inline-tip-wide {
   max-width: 784px;

--- a/packages/ibm-products/src/components/SidePanel/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/SidePanel/_storybook-styles.scss
@@ -11,7 +11,8 @@
 @use '@carbon/styles/scss/type';
 // @use '@carbon/ibm-products-styles/scss/global/decorators/side-panel-decorator'
 //   as *;
-@use '../../../../ibm-products-styles/src/global/decorators/side-panel-decorator' as *;
+@use '../../../../ibm-products-styles/src/global/decorators/side-panel-decorator'
+  as *;
 
 $story-prefix: side-panel-stories__;
 

--- a/packages/ibm-products/src/components/SidePanel/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/SidePanel/_storybook-styles.scss
@@ -9,8 +9,9 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/themes/scss/themes';
 @use '@carbon/styles/scss/type';
-@use '@carbon/ibm-products-styles/scss/global/decorators/side-panel-decorator'
-  as *;
+// @use '@carbon/ibm-products-styles/scss/global/decorators/side-panel-decorator'
+//   as *;
+@use '../../../../ibm-products-styles/src/global/decorators/side-panel-decorator' as *;
 
 $story-prefix: side-panel-stories__;
 

--- a/packages/ibm-products/src/components/TagSet/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/TagSet/_storybook-styles.scss
@@ -5,4 +5,5 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@use '@carbon/ibm-products-styles/scss/global/styles/display-box' as *;
+// @use '@carbon/ibm-products-styles/scss/global/styles/display-box' as *;
+@use '../../../../ibm-products-styles/src/global/styles/display-box' as *;


### PR DESCRIPTION
Replaces `@carbon/ibm-products-styles` until package is actually published.
This should fix our broken builds. Once published, we can replace the URLs again.