### PR TITLE
fix: manually bump styles package version

### DIFF
--- a/packages/ibm-products-styles/package.json
+++ b/packages/ibm-products-styles/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ibm-products-styles",
   "description": "Carbon for IBM Products styles",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "license": "Apache-2.0",
   "installConfig": {
     "hoistingLimits": "none"


### PR DESCRIPTION
The version between our core package and the styles package became out of sync, I think because the styles package failed during the prerelease action. I manually published the new version `2.17.0` to npm, adding this change here so that `lerna publish` will keep them synced for further releases.

#### What did you change?
```
packages/ibm-products-styles/package.json
```
#### How did you test and verify your work?
Verified on npm that the new version was published succussfully