### PR TITLE
fix(Datagrid): use `getRowId` instead of `index` for tracking `selectedRowData` (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
@@ -559,7 +559,6 @@ export const BatchActions = () => {
       rowActions: getRowActions(),
     },
     useSelectRows,
-    useSelectAllWithToggle,
     useActionsColumn,
     useStickyColumn
   );

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSelectAll.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSelectAll.js
@@ -9,6 +9,7 @@ import React, { useLayoutEffect, useState } from 'react';
 import { DataTable } from 'carbon-components-react';
 import cx from 'classnames';
 import { pkg } from '../../../settings';
+import { handleSelectAllRowData } from './addons/stateReducer';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
@@ -33,6 +34,10 @@ const SelectAll = (datagridState) => {
     radio,
     columns,
     withStickyColumn,
+    dispatch,
+    rows,
+    getRowId,
+    toggleAllRowsSelected,
   } = datagridState;
   const isFirstColumnStickyLeft =
     columns[0]?.sticky === 'left' && withStickyColumn;
@@ -55,10 +60,23 @@ const SelectAll = (datagridState) => {
 
   const handleSelectAllChange = (event) => {
     if (indeterminate) {
+      handleSelectAllRowData({
+        dispatch,
+        rows,
+        getRowId,
+        indeterminate: true,
+      });
+      toggleAllRowsSelected(false);
       return onChange?.({
         target: { checked: false },
       });
     }
+    handleSelectAllRowData({
+      dispatch,
+      rows,
+      getRowId,
+      isChecked: event.target.checked,
+    });
     return onChange?.(event);
   };
 

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.js
@@ -16,6 +16,7 @@ import { useResizeObserver } from '../../../global/js/hooks/useResizeObserver';
 import { ButtonMenu, ButtonMenuItem } from '../../ButtonMenu';
 import { pkg, carbon } from '../../../settings';
 import cx from 'classnames';
+import { handleSelectAllRowData } from './addons/stateReducer';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 const toolbarClass = `${blockClass}__table-toolbar`;
@@ -32,8 +33,11 @@ const DatagridBatchActionsToolbar = (datagridState, width, ref) => {
     toggleAllRowsSelected,
     toolbarBatchActions,
     setGlobalFilter,
+    dispatch,
+    getRowId,
     batchActionMenuButtonLabel,
     translateWithIdBatchActions,
+    rows,
   } = datagridState;
   const batchActionMenuButtonLabelText = batchActionMenuButtonLabel ?? 'More';
   const selectedKeys = Object.keys(selectedRowIds || {});
@@ -101,6 +105,11 @@ const DatagridBatchActionsToolbar = (datagridState, width, ref) => {
                   batchAction.onClick();
                   if (batchAction.type === 'select_all') {
                     toggleAllRowsSelected(true);
+                    handleSelectAllRowData({
+                      dispatch,
+                      rows,
+                      getRowId,
+                    });
                   }
                 }}
               />
@@ -139,6 +148,11 @@ const DatagridBatchActionsToolbar = (datagridState, width, ref) => {
                   batchAction.onClick();
                   if (batchAction.type === 'select_all') {
                     toggleAllRowsSelected(true);
+                    handleSelectAllRowData({
+                      dispatch,
+                      rows,
+                      getRowId,
+                    });
                   }
                 }}
                 iconDescription={batchAction.label}

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -12,6 +12,7 @@ const COLUMN_RESIZING = 'columnResizing';
 const COLUMN_RESIZE_END = 'columnDoneResizing';
 const INIT = 'init';
 const TOGGLE_ROW_SELECTED = 'toggleRowSelected';
+const TOGGLE_ALL_ROWS_SELECTED = 'toggleAllRowsSelected';
 const blockClass = `${pkg.prefix}--datagrid`;
 
 export const handleColumnResizeEndEvent = (
@@ -52,16 +53,51 @@ export const handleColumnResizingEvent = (
   });
 };
 
-export const handleToggleRowSelected = (dispatch, rowData, isChecked) =>
+export const handleToggleRowSelected = ({
+  dispatch,
+  rowData,
+  isChecked,
+  getRowId,
+  selectAll,
+}) =>
   dispatch({
     type: TOGGLE_ROW_SELECTED,
-    payload: { rowData, isChecked },
+    payload: { rowData, isChecked, getRowId, selectAll },
+  });
+
+export const handleSelectAllRowData = ({
+  dispatch,
+  rows,
+  getRowId,
+  indeterminate,
+  isChecked,
+}) =>
+  dispatch({
+    type: TOGGLE_ALL_ROWS_SELECTED,
+    payload: { rows, getRowId, indeterminate, isChecked },
   });
 
 export const stateReducer = (newState, action) => {
   switch (action.type) {
+    case TOGGLE_ALL_ROWS_SELECTED: {
+      const { rows, getRowId, indeterminate, isChecked } = action.payload || {};
+      if (rows) {
+        const newSelectedRowData = {};
+        rows.forEach((row) => {
+          newSelectedRowData[getRowId(row, row.index)] = row;
+        });
+        return {
+          ...newState,
+          selectedRowData:
+            indeterminate || !isChecked ? {} : newSelectedRowData,
+        };
+      }
+      return {
+        ...newState,
+      };
+    }
     case TOGGLE_ROW_SELECTED: {
-      const { rowData, isChecked } = action.payload || {};
+      const { rowData, isChecked, getRowId } = action.payload || {};
       if (!rowData) {
         return;
       }
@@ -70,7 +106,7 @@ export const stateReducer = (newState, action) => {
           ...newState,
           selectedRowData: {
             ...newState.selectedRowData,
-            [rowData.index]: rowData,
+            [getRowId(rowData, rowData.index)]: rowData,
           },
         };
       }

--- a/packages/ibm-products/src/components/Datagrid/useSelectRows.js
+++ b/packages/ibm-products/src/components/Datagrid/useSelectRows.js
@@ -1,11 +1,10 @@
-/*
- * Licensed Materials - Property of IBM
- * 5724-Q36
- * (c) Copyright IBM Corp. 2023
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
+/**
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
-// @flow
+
 import React, { useLayoutEffect, useState } from 'react';
 import cx from 'classnames';
 import { TableSelectRow } from 'carbon-components-react';
@@ -72,6 +71,7 @@ const SelectRow = (datagridState) => {
     columns,
     withStickyColumn,
     dispatch,
+    getRowId,
   } = datagridState;
 
   const [windowSize, setWindowSize] = useState(window.innerWidth);
@@ -98,7 +98,12 @@ const SelectRow = (datagridState) => {
     }
     onChange(event);
     onRowSelect?.(row, event);
-    handleToggleRowSelected(dispatch, row, event.target.checked);
+    handleToggleRowSelected({
+      dispatch,
+      rowData: row,
+      isChecked: event.target.checked,
+      getRowId,
+    });
   };
   const rowId = `${tableId}-${row.index}`;
   return (


### PR DESCRIPTION
Contributes to #3840 

This PR uses `getRowId` to save the selected rows in the react-table state, as opposed to the index for the reasons listed in #3840. The new `selectedRowData` from react-table state also was not yet working when selecting or deselecting all rows. Thanks @K-Markopoulos for the detailed comments on this!

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSelectAll.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
packages/ibm-products/src/components/Datagrid/useSelectRows.js
```
#### How did you test and verify your work?
