### PR TITLE
fix(CreateTearsheet): fix step height to fill available space

### DIFF
--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -3166,6 +3166,10 @@ p.c4p--about-modal__copyright-text:first-child {
   overflow-x: hidden;
 }
 
+.c4p--tearsheet-create .c4p--tearsheet-create__content .cds--form {
+  height: inherit;
+}
+
 .c4p--tearsheet-create .c4p--tearsheet-create__content .cds--grid {
   padding: 0;
   margin: 0;

--- a/packages/ibm-products-styles/src/components/CreateTearsheet/_create-tearsheet.scss
+++ b/packages/ibm-products-styles/src/components/CreateTearsheet/_create-tearsheet.scss
@@ -89,6 +89,12 @@ $tearsheet-fieldset-class: #{c4p-settings.$pkg-prefix}--tearsheet-create__step--
 
 .#{$create-tearsheet-block-class}
   .#{$create-tearsheet-block-class}__content
+  .#{c4p-settings.$carbon-prefix}--form {
+  height: inherit;
+}
+
+.#{$create-tearsheet-block-class}
+  .#{$create-tearsheet-block-class}__content
   .#{c4p-settings.$carbon-prefix}--grid {
   padding: 0;
   margin: 0;


### PR DESCRIPTION
Contributes to #3857 

This change allows the height of create tearsheet steps to fill the available space.

#### What did you change?
```
packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
packages/ibm-products-styles/src/components/CreateTearsheet/_create-tearsheet.scss
```
#### How did you test and verify your work?
Storybook