### PR TITLE
fix(Datagrid): expandable/nested review fixes, custom hook for keeping expander focus

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.js
@@ -24,7 +24,8 @@ const rowHeights = {
 
 // eslint-disable-next-line react/prop-types
 const DatagridRow = (datagridState) => {
-  const { row, rowSize, withNestedRows, prepareRow, key } = datagridState;
+  const { row, rowSize, withNestedRows, prepareRow, key, tableId } =
+    datagridState;
 
   const getVisibleNestedRowCount = ({ isExpanded, subRows }) => {
     let size = 0;
@@ -67,7 +68,7 @@ const DatagridRow = (datagridState) => {
 
   const focusRemover = () => {
     const elements = document.querySelectorAll(
-      `.${blockClass}__carbon-row-expanded`
+      `#${tableId} .${blockClass}__carbon-row-expanded`
     );
     elements.forEach((el) => {
       el.classList.remove(`${blockClass}__carbon-row-expanded-hover-active`);
@@ -118,6 +119,7 @@ const DatagridRow = (datagridState) => {
         onFocus={hoverHandler}
         onBlur={focusRemover}
         onKeyUp={handleOnKeyUp}
+        data-nested-row-id={row.id}
       >
         {row.cells.map((cell, index) => {
           const cellProps = cell.getCellProps();

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
@@ -183,7 +183,6 @@ const ExpandedRows = ({ ...args }) => {
       DatagridPagination,
       ExpandedRowContentComponent: ExpansionRenderer,
       tags: ['autodocs'],
-      expanderButtonTitleExpanded: 'Testing',
       ...args.defaultGridProps,
     },
     useExpandedRow

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
@@ -19,7 +19,6 @@ import { DatagridActions } from '../../utils/DatagridActions';
 import { DatagridPagination } from '../../utils/DatagridPagination';
 import { makeData } from '../../utils/makeData';
 import { ARG_TYPES } from '../../utils/getArgTypes';
-import { pkg } from '../../../../settings';
 import { DocsPage } from './ExpandableRow.docs-page';
 import { usePrefix } from '../../../../global/js/hooks';
 
@@ -184,16 +183,11 @@ const ExpandedRows = ({ ...args }) => {
       DatagridPagination,
       ExpandedRowContentComponent: ExpansionRenderer,
       tags: ['autodocs'],
+      expanderButtonTitleExpanded: 'Testing',
       ...args.defaultGridProps,
     },
     useExpandedRow
   );
-
-  // Warnings are ordinarily silenced in storybook, add this to test.
-  pkg._silenceWarnings(false);
-  // Enable feature flag for `useExpandedRow` hook
-  pkg.feature['Datagrid.useExpandedRow'] = true;
-  pkg._silenceWarnings(true);
 
   return <Datagrid datagridState={datagridState} />;
 };
@@ -222,6 +216,5 @@ export const ExpandableRowStory = prepareStory(BasicTemplateWrapper, {
   },
   args: {
     ...expandableRowControlProps,
-    featureFlags: ['Datagrid.useExpandedRow'],
   },
 });

--- a/packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.js
@@ -15,11 +15,9 @@ import {
 } from '../../../../global/js/utils/story-helper';
 import { Datagrid, useDatagrid, useNestedRows } from '../../index';
 import styles from '../../_storybook-styles.scss';
-// import mdx from '../../Datagrid.mdx';
 import { DatagridActions } from '../../utils/DatagridActions';
 import { makeData } from '../../utils/makeData';
 import { ARG_TYPES } from '../../utils/getArgTypes';
-import { pkg } from '../../../../settings';
 import { StoryDocsPage } from '../../../../global/js/utils/StoryDocsPage';
 
 export default {
@@ -196,12 +194,6 @@ const NestedRows = ({ ...args }) => {
     useNestedRows
   );
 
-  // Warnings are ordinarily silenced in storybook, add this to test
-  pkg._silenceWarnings(false);
-  // Enable feature flag for `useNestedRows` hook
-  pkg.feature['Datagrid.useNestedRows'] = true;
-  pkg._silenceWarnings(true);
-
   return <Datagrid datagridState={{ ...datagridState }} />;
 };
 
@@ -232,6 +224,5 @@ export const NestedRowsUsageStory = prepareStory(BasicTemplateWrapper, {
   },
   args: {
     ...nestedRowsControlProps,
-    featureFlags: ['Datagrid.useNestedRows'],
   },
 });

--- a/packages/ibm-products/src/components/Datagrid/useExpandedRow.js
+++ b/packages/ibm-products/src/components/Datagrid/useExpandedRow.js
@@ -5,16 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useEffect, useState } from 'react';
-import { pkg } from '../../settings';
+import { useState } from 'react';
 import DatagridExpandedRow from './Datagrid/DatagridExpandedRow';
 import useRowExpander from './useRowExpander';
 
 const useExpandedRow = (hooks) => {
-  useEffect(() => {
-    pkg.checkReportFeatureEnabled('Datagrid.useExpandedRow');
-  }, []);
-
   useRowExpander(hooks);
   const useInstance = (instance) => {
     const { rows, expandedContentHeight, ExpandedRowContentComponent } =

--- a/packages/ibm-products/src/components/Datagrid/useFocusRowExpander.js
+++ b/packages/ibm-products/src/components/Datagrid/useFocusRowExpander.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useEffect } from 'react';
+
+// Focuses the row expander after a nested/expandable row state change.
+// We have to add this workaround because react-table is re-rendering the entire row
+// which removes the focus from the expander and interrupts the keyboard navigation
+// flow.
+export const useFocusRowExpander = ({
+  instance,
+  lastExpandedRowIndex,
+  blockClass,
+}) => {
+  useEffect(() => {
+    const tableId = instance?.tableId;
+    const rowElements = document.querySelectorAll(`#${tableId} tbody tr`);
+    if (lastExpandedRowIndex) {
+      const rowElementsArray = Array.from(rowElements);
+      const activeRow = rowElementsArray.filter((r) => {
+        if (r.getAttribute('data-nested-row-id') === lastExpandedRowIndex) {
+          return r;
+        }
+        return null;
+      });
+      if (activeRow.length) {
+        const rowExpander = activeRow[0].querySelector(
+          `.${blockClass}__row-expander`
+        );
+        rowExpander.focus();
+      }
+    }
+  }, [
+    instance?.tableId,
+    instance?.expandedRows,
+    lastExpandedRowIndex,
+    blockClass,
+  ]);
+};

--- a/packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
+++ b/packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
@@ -10,14 +10,23 @@ import React, { useRef } from 'react';
 import { ChevronRight } from '@carbon/react/icons';
 import cx from 'classnames';
 import { pkg, carbon } from '../../settings';
+import { useFocusRowExpander } from './useFocusRowExpander';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
 const useNestedRowExpander = (hooks) => {
   const tempState = useRef();
+  const lastExpandedRowIndex = useRef();
   const useInstance = (instance) => {
     tempState.current = instance;
   };
+
+  useFocusRowExpander({
+    instance: tempState?.current,
+    lastExpandedRowIndex: lastExpandedRowIndex?.current,
+    blockClass,
+  });
+
   const visibleColumns = (columns) => {
     const expanderColumn = {
       id: 'expander',
@@ -28,6 +37,7 @@ const useNestedRowExpander = (hooks) => {
             // Prevents `onRowClick` from being called if `useOnRowClick` is included
             event.stopPropagation();
             row.toggleRowExpanded();
+            lastExpandedRowIndex.current = row.id;
           },
         };
         const {

--- a/packages/ibm-products/src/components/Datagrid/useNestedRows.js
+++ b/packages/ibm-products/src/components/Datagrid/useNestedRows.js
@@ -5,18 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useEffect } from 'react';
-import { pkg } from '../../settings';
 import cx from 'classnames';
+import { pkg } from '../../settings';
 import useNestedRowExpander from './useNestedRowExpander';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
 const useNestedRows = (hooks) => {
-  useEffect(() => {
-    pkg.checkReportFeatureEnabled('Datagrid.useNestedRows');
-  }, []);
-
   useNestedRowExpander(hooks);
   const marginLeft = 24;
 

--- a/packages/ibm-products/src/components/Datagrid/useRowExpander.js
+++ b/packages/ibm-products/src/components/Datagrid/useRowExpander.js
@@ -10,14 +10,23 @@ import React, { useRef } from 'react';
 import { ChevronDown, ChevronUp } from '@carbon/react/icons';
 import { pkg, carbon } from '../../settings';
 import cx from 'classnames';
+import { useFocusRowExpander } from './useFocusRowExpander';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
 const useRowExpander = (hooks) => {
   const tempState = useRef();
+  const lastExpandedRowIndex = useRef();
   const useInstance = (instance) => {
     tempState.current = instance;
   };
+
+  useFocusRowExpander({
+    instance: tempState?.current,
+    lastExpandedRowIndex: lastExpandedRowIndex?.current,
+    blockClass,
+  });
+
   const visibleColumns = (columns) => {
     const expanderColumn = {
       id: 'expander',
@@ -28,6 +37,7 @@ const useRowExpander = (hooks) => {
             // Prevents `onRowClick` from being called if `useOnRowClick` is included
             event.stopPropagation();
             row.toggleRowExpanded();
+            lastExpandedRowIndex.current = row.id;
           },
         };
         const {

--- a/packages/ibm-products/src/global/js/package-settings.js
+++ b/packages/ibm-products/src/global/js/package-settings.js
@@ -81,8 +81,6 @@ const defaults = {
     'default-portal-target-body': true,
     'Datagrid.useInlineEdit': false,
     'Datagrid.useEditableCell': false,
-    'Datagrid.useExpandedRow': false,
-    'Datagrid.useNestedRows': false,
     'Datagrid.useFiltering': false,
     'Datagrid.useCustomizeColumns': false,
     'ExampleComponent.secondaryIcon': false,


### PR DESCRIPTION
Contributes to #3821 

Some updates after reviewing nested/expandable rows, also addressed an issue where the row expanders were losing focus, thus breaking the keyboard accessibility while navigating.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.js
packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.js
packages/ibm-products/src/components/Datagrid/useExpandedRow.js
packages/ibm-products/src/components/Datagrid/useFocusRowExpander.js
packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
packages/ibm-products/src/components/Datagrid/useNestedRows.js
packages/ibm-products/src/components/Datagrid/useRowExpander.js
packages/ibm-products/src/global/js/package-settings.js
```
#### How did you test and verify your work?
Storybook