### PR TITLE
chore(CreateTearsheet): pass props to story

### DIFF
--- a/packages/ibm-products/src/components/CreateTearsheet/preview-components/MultiStepTearsheet.js
+++ b/packages/ibm-products/src/components/CreateTearsheet/preview-components/MultiStepTearsheet.js
@@ -56,6 +56,7 @@ export const MultiStepTearsheet = ({
   nextButtonText,
   submitButtonText,
   title,
+  ...rest
 }) => {
   const [simulatedDelay] = useState(750);
   const [open, setOpen] = useState(false);
@@ -112,6 +113,7 @@ export const MultiStepTearsheet = ({
           })
         }
         firstFocusElement={firstFocusElement}
+        {...rest}
       >
         <CreateTearsheetStep
           onNext={() => {


### PR DESCRIPTION
Closes to #3865

Tiny fix ... would have let it slide but was reading and investigated so figured better to commit the fix since it took me long enough to remember that we had the preview components for Create ... 🙈 
Fixes an issue where changing `verticalPosition` in Create Tearsheet stories didn’t actually do anything. 🤔 

#### What did you change?
💤 

#### How did you test and verify your work?
Storybook and CI