### PR TITLE
fix: create tearsheet reset bug

### DIFF
--- a/packages/ibm-products/src/global/js/hooks/useCreateComponentStepChange.js
+++ b/packages/ibm-products/src/global/js/hooks/useCreateComponentStepChange.js
@@ -63,7 +63,7 @@ export const useCreateComponentStepChange = ({
   useEffect(() => {
     const onUnmount = () => {
       if (componentName !== 'CreateFullPage') {
-        setCurrentStep(0);
+        setCurrentStep(1);
       }
       setIsSubmitting(false);
       onClose();


### PR DESCRIPTION
Contributes to #3413

fixes small bug where when a user passes in an `onClose` function that doesn't close the tearsheet the content inside the tearsheet was disappearing.
