### PR TITLE
fix(Datagrid): always force row expander to be first column (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
@@ -13,7 +13,13 @@ import {
   getStoryTitle,
   prepareStory,
 } from '../../../../global/js/utils/story-helper';
-import { Datagrid, useDatagrid, useExpandedRow } from '../../index';
+import {
+  Datagrid,
+  useDatagrid,
+  useExpandedRow,
+  useSelectRows,
+} from '../../index';
+import { getBatchActions } from '../../Datagrid.stories';
 import styles from '../../_storybook-styles.scss';
 import mdx from '../../Datagrid.mdx';
 import { DatagridActions } from '../../utils/DatagridActions';
@@ -225,8 +231,11 @@ const ExpandedRows = ({ ...args }) => {
       DatagridActions,
       DatagridPagination,
       ExpandedRowContentComponent: ExpansionRenderer,
+      batchActions: true,
+      toolbarBatchActions: getBatchActions(),
       ...args.defaultGridProps,
     },
+    useSelectRows,
     useExpandedRow
   );
 

--- a/packages/ibm-products/src/components/Datagrid/useSelectRows.js
+++ b/packages/ibm-products/src/components/Datagrid/useSelectRows.js
@@ -29,14 +29,29 @@ const useSelectRows = (hooks) => {
       withSelectRows: true,
     });
   });
-  hooks.visibleColumns.push((columns) => [
-    {
-      id: selectionColumnId,
-      Header: (gridState) => <SelectAll {...gridState} />,
-      Cell: (gridState) => <SelectRow {...gridState} />,
-    },
-    ...columns,
-  ]);
+  hooks.visibleColumns.push((columns) => {
+    // Ensures that the first column is the row expander in the
+    // case of selected rows and expandable rows being used together
+    const newColOrder = [...columns];
+    const expanderColumnIndex = newColOrder.findIndex(
+      (col) => col.id === 'expander'
+    );
+    const expanderCol =
+      expanderColumnIndex > -1
+        ? newColOrder.splice(expanderColumnIndex, 1)
+        : [];
+    return [
+      ...(expanderColumnIndex > -1 && expanderCol && expanderCol.length
+        ? expanderCol
+        : []),
+      {
+        id: selectionColumnId,
+        Header: (gridState) => <SelectAll {...gridState} />,
+        Cell: (gridState) => <SelectRow {...gridState} />,
+      },
+      ...newColOrder,
+    ];
+  });
 };
 
 const useHighlightSelection = (hooks) => {


### PR DESCRIPTION
Contributes to #3808 

Previously, the row expander in some cases could be rendered after the row checkbox which is incorrect. With this change, the row expander will always be rendered first.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
packages/ibm-products/src/components/Datagrid/useSelectRows.js
```
#### How did you test and verify your work?
Storybook