### PR TITLE
chore: fixes 3890

### DIFF
--- a/packages/ibm-products/src/components/SidePanel/SidePanel.js
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.js
@@ -494,18 +494,19 @@ export let SidePanel = React.forwardRef(
     useEffect(() => {
       if (open && slideIn) {
         const pageContentElement = document.querySelector(selectorPageContent);
+        pageContentElement.style.inlineSize = 'auto';
         if (placement && placement === 'right' && pageContentElement) {
-          pageContentElement.style.marginRight = 0;
+          pageContentElement.style.marginInlineEnd = 0;
           pageContentElement.style.transition = !reducedMotion.matches
-            ? `margin-right ${moderate02}`
+            ? `margin-inline-end ${moderate02}`
             : null;
           pageContentElement.style.marginRight = SIDE_PANEL_SIZES[size];
         } else if (pageContentElement) {
           pageContentElement.style.marginLeft = 0;
           pageContentElement.style.transition = !reducedMotion.matches
-            ? `margin-left ${moderate02}`
+            ? `margin-inline-start ${moderate02}`
             : null;
-          pageContentElement.style.marginLeft = SIDE_PANEL_SIZES[size];
+          pageContentElement.style.marginInlineStart = SIDE_PANEL_SIZES[size];
         }
       }
     }, [


### PR DESCRIPTION
Fixes #3890 3890

Content margin for SlideIn version of SidePanel both left and right.

NOTE: The use of `inline-size` and `margin-inline` by Carbon causes the original version to fail.