### PR TITLE
fix(Datagrid): keep filters visible when closing panel via filter icon button

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
@@ -95,7 +95,7 @@ const useFilters = ({
   /** Methods */
   // If the user decides to cancel or click outside the flyout, it reverts back to the filters that were
   // there when they opened the flyout
-  const revertToPreviousFilters = () => {
+  const revertToPreviousFilters = useCallback(() => {
     setFiltersState(JSON.parse(prevFiltersRef.current));
     setFiltersObjectArray(JSON.parse(prevFiltersObjectArrayRef.current));
     setAllFilters(JSON.parse(lastAppliedFilters.current));
@@ -109,7 +109,7 @@ const useFilters = ({
     holdingPrevFiltersObjectArrayRef.current = JSON.parse(
       lastAppliedFilters.current
     );
-  };
+  }, [setAllFilters]);
 
   const reset = useCallback(() => {
     // When we reset we want the "initialFilters" to be an empty array
@@ -402,6 +402,7 @@ const useFilters = ({
    */
   useEffect(() => {
     if (!panelOpen && previousState?.panelOpen) {
+      revertToPreviousFilters();
       setAllFilters(holdingLastAppliedFiltersRef.current);
     }
     if (panelOpen && !previousState?.panelOpen) {
@@ -421,6 +422,7 @@ const useFilters = ({
     previousState?.panelOpen,
     reset,
     setAllFilters,
+    revertToPreviousFilters,
   ]);
 
   const cancel = () => {


### PR DESCRIPTION
Contributes to #3801 

There was some logic missing to prevent the filters from being cleared when closing the filter panel via the icon button used to open/close the panel.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
```
#### How did you test and verify your work?
Storybook