### PR TITLE
feat: port Guidebanner component w Carousel to v2

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,11 +1,7 @@
 {
   "version": "0.1",
   "language": "en",
-  "dictionaries": [
-    "contributors",
-    "html",
-    "packages"
-  ],
+  "dictionaries": ["contributors", "html", "packages"],
   "dictionaryDefinitions": [
     {
       "name": "contributors",
@@ -89,6 +85,7 @@
     "emptystate",
     "expressivecard",
     "gridcell",
+    "guidebanner",
     "homescreen",
     "inlineedit",
     "listbox",
@@ -111,6 +108,7 @@
     "rowgroup",
     "rowheader",
     "rowindex",
+    "scrollend",
     "sbdocs",
     "semibold",
     "serializers",

--- a/packages/core/story-structure.js
+++ b/packages/core/story-structure.js
@@ -124,6 +124,7 @@ const s = [
           'c/ButtonMenu',
           'c/ButtonSetWithOverflow',
           'c/CancelableTextEdit',
+          'c/Carousel',
           'c/ComboButton',
           'c/ExampleComponent',
           'c/FilterSummary',
@@ -135,7 +136,7 @@ const s = [
       },
       {
         n: 'Novice to pro',
-        s: ['c/Checklist', 'c/InlineTip'],
+        s: ['c/Checklist', 'c/Guidebanner', 'c/InlineTip'],
       },
     ],
   },

--- a/packages/ibm-products-styles/src/components/Carousel/_carbon-imports.scss
+++ b/packages/ibm-products-styles/src/components/Carousel/_carbon-imports.scss
@@ -1,0 +1,6 @@
+//
+// Copyright IBM Corp. 2020, 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//

--- a/packages/ibm-products-styles/src/components/Carousel/_carousel.scss
+++ b/packages/ibm-products-styles/src/components/Carousel/_carousel.scss
@@ -1,94 +1,72 @@
 //
-// Copyright IBM Corp. 2020, 2022
+// Copyright IBM Corp. 2023, 2023
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
 
-@use '@carbon/styles/scss/theme' as *;
-@use '@carbon/styles/scss/spacing' as *;
-@use '@carbon/styles/scss/type';
-@use '@carbon/type/scss/font-family' as *;
-
 // Standard imports.
+@use '@carbon/layout/scss/convert' as *;
+@use '@carbon/react/scss/colors' as *;
+@use '@carbon/styles/scss/motion' as *;
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/themes';
+@use '@carbon/styles/scss/type' as *;
 @use '../../global/styles/project-settings' as c4p-settings;
 
 // The block part of our conventional BEM class names (blockClass__E--M).
-$block-class: #{c4p-settings.$pkg-prefix}--about-modal;
+$block-class: #{c4p-settings.$pkg-prefix}--carousel;
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--modal-container {
-  grid-template-rows: auto auto 1fr auto;
+.#{$block-class} {
+  position: relative;
+
+  /* stylelint-disable-next-line max-nesting-depth */
+  &:focus {
+    outline: none;
+  }
+}
+.#{$block-class}__elements-container {
+  overflow: hidden;
+}
+.#{$block-class}__elements-container--scrolled,
+.#{$block-class}__elements-container--scroll-max {
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  bottom: 0;
+  width: $spacing-07;
+  pointer-events: none;
 }
 
-.#{$block-class} .#{$block-class}__logo {
-  margin: $spacing-05 $spacing-05 $spacing-07 $spacing-05;
+.#{$block-class}__elements-container--scrolled {
+  left: 0;
 }
 
-.#{$block-class} .#{$block-class}__header {
-  padding: 0 20% 0 $spacing-05;
-  margin-bottom: 0;
-  grid-row: auto;
+.#{$block-class}__elements-container--scroll-max {
+  right: 0;
 }
 
-.#{$block-class} .#{$block-class}__title {
-  @include type.type-style('heading-04');
+.#{$block-class}__elements {
+  display: flex;
+  overflow: hidden scroll;
+  -ms-overflow-style: none;
+  scroll-behavior: smooth;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 
-  color: $text-primary;
+  /* stylelint-disable-next-line max-nesting-depth */
+  @media (prefers-reduced-motion) {
+    scroll-behavior: auto;
+  }
 }
 
-.#{$block-class} .#{$block-class}__body {
-  @include type.type-style('body-compact-02');
-
-  overflow: hidden auto;
-  min-height: $spacing-10;
-  padding: 0 20% 0 $spacing-05;
-  margin-bottom: $spacing-06;
-  grid-row: auto;
-}
-
-.#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--modal-content--overflow-indicator {
-  bottom: #{$spacing-06};
-  background-image: linear-gradient(to bottom, #00000000, $layer-01);
-}
-
-.#{$block-class} .#{$block-class}__links-container {
-  @include type.type-style('body-compact-01');
-
-  margin-top: $spacing-06;
-}
-
-.#{$block-class} .#{$block-class}__version {
-  color: $text-secondary;
-}
-
-.#{$block-class} .#{$block-class}__links-container a + a {
-  padding-left: $spacing-03;
-  border-left: 1px solid $border-strong-01;
-  margin-left: $spacing-03;
-}
-
-.#{$block-class} .#{$block-class}__content,
-.#{$block-class} .#{$block-class}__copyright-text {
-  @include type.type-style('label-01');
-
-  margin-top: $spacing-06;
-  margin-bottom: 0;
-  color: $text-secondary;
-}
-
-.#{$block-class} .#{$block-class}__copyright-text {
-  margin-top: $spacing-05;
-}
-
-p.c4p--about-modal__content:first-child,
-p.c4p--about-modal__copyright-text:first-child {
-  margin-top: $spacing-07;
-}
-
-.#{$block-class} .#{$block-class}__footer {
-  display: block;
-  height: auto;
-  padding: $spacing-05;
-  background-color: $layer-02;
+.#{$block-class}__elements::-webkit-scrollbar {
+  display: none;
 }

--- a/packages/ibm-products-styles/src/components/Carousel/_carousel.scss
+++ b/packages/ibm-products-styles/src/components/Carousel/_carousel.scss
@@ -1,0 +1,94 @@
+//
+// Copyright IBM Corp. 2020, 2022
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/type';
+@use '@carbon/type/scss/font-family' as *;
+
+// Standard imports.
+@use '../../global/styles/project-settings' as c4p-settings;
+
+// The block part of our conventional BEM class names (blockClass__E--M).
+$block-class: #{c4p-settings.$pkg-prefix}--about-modal;
+
+.#{$block-class} .#{c4p-settings.$carbon-prefix}--modal-container {
+  grid-template-rows: auto auto 1fr auto;
+}
+
+.#{$block-class} .#{$block-class}__logo {
+  margin: $spacing-05 $spacing-05 $spacing-07 $spacing-05;
+}
+
+.#{$block-class} .#{$block-class}__header {
+  padding: 0 20% 0 $spacing-05;
+  margin-bottom: 0;
+  grid-row: auto;
+}
+
+.#{$block-class} .#{$block-class}__title {
+  @include type.type-style('heading-04');
+
+  color: $text-primary;
+}
+
+.#{$block-class} .#{$block-class}__body {
+  @include type.type-style('body-compact-02');
+
+  overflow: hidden auto;
+  min-height: $spacing-10;
+  padding: 0 20% 0 $spacing-05;
+  margin-bottom: $spacing-06;
+  grid-row: auto;
+}
+
+.#{$block-class}
+  .#{c4p-settings.$carbon-prefix}--modal-content--overflow-indicator {
+  bottom: #{$spacing-06};
+  background-image: linear-gradient(to bottom, #00000000, $layer-01);
+}
+
+.#{$block-class} .#{$block-class}__links-container {
+  @include type.type-style('body-compact-01');
+
+  margin-top: $spacing-06;
+}
+
+.#{$block-class} .#{$block-class}__version {
+  color: $text-secondary;
+}
+
+.#{$block-class} .#{$block-class}__links-container a + a {
+  padding-left: $spacing-03;
+  border-left: 1px solid $border-strong-01;
+  margin-left: $spacing-03;
+}
+
+.#{$block-class} .#{$block-class}__content,
+.#{$block-class} .#{$block-class}__copyright-text {
+  @include type.type-style('label-01');
+
+  margin-top: $spacing-06;
+  margin-bottom: 0;
+  color: $text-secondary;
+}
+
+.#{$block-class} .#{$block-class}__copyright-text {
+  margin-top: $spacing-05;
+}
+
+p.c4p--about-modal__content:first-child,
+p.c4p--about-modal__copyright-text:first-child {
+  margin-top: $spacing-07;
+}
+
+.#{$block-class} .#{$block-class}__footer {
+  display: block;
+  height: auto;
+  padding: $spacing-05;
+  background-color: $layer-02;
+}

--- a/packages/ibm-products-styles/src/components/Carousel/_carousel.scss
+++ b/packages/ibm-products-styles/src/components/Carousel/_carousel.scss
@@ -49,7 +49,7 @@ $block-class: #{c4p-settings.$pkg-prefix}--carousel;
 
 .#{$block-class}__elements {
   display: flex;
-  overflow: hidden scroll;
+  overflow: scroll;
   -ms-overflow-style: none;
   scroll-behavior: smooth;
   scroll-snap-type: x mandatory;

--- a/packages/ibm-products-styles/src/components/Carousel/_index-with-carbon.scss
+++ b/packages/ibm-products-styles/src/components/Carousel/_index-with-carbon.scss
@@ -1,0 +1,9 @@
+//
+// Copyright IBM Corp. 2022, 2022
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use './carbon-imports';
+@use './carousel';

--- a/packages/ibm-products-styles/src/components/Carousel/_index.scss
+++ b/packages/ibm-products-styles/src/components/Carousel/_index.scss
@@ -1,0 +1,8 @@
+//
+// Copyright IBM Corp. 2020, 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use './carousel';

--- a/packages/ibm-products-styles/src/components/Guidebanner/_carbon-imports.scss
+++ b/packages/ibm-products-styles/src/components/Guidebanner/_carbon-imports.scss
@@ -1,0 +1,6 @@
+//
+// Copyright IBM Corp. 2020, 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//

--- a/packages/ibm-products-styles/src/components/Guidebanner/_guidebanner.scss
+++ b/packages/ibm-products-styles/src/components/Guidebanner/_guidebanner.scss
@@ -1,94 +1,248 @@
 //
-// Copyright IBM Corp. 2020, 2022
+// Copyright IBM Corp. 2023, 2023
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
 
-@use '@carbon/styles/scss/theme' as *;
-@use '@carbon/styles/scss/spacing' as *;
-@use '@carbon/styles/scss/type';
-@use '@carbon/type/scss/font-family' as *;
+/**
+ * The Guidebanner specifically is theme-agnostic, and so we have to 
+ * use color tokens to keep the colors static instead of theme tokens 
+ * that will change depending on the selected theme.
+ * 
+ * Because of this, we are triggering a *large* amount of linting errors.
+ * So, we're adding a few "disable" rules for the file instead of 60 
+ * individual rules.
+ */
+
+/* stylelint-disable carbon/layout-token-use */
+/* stylelint-disable carbon/motion-duration-use */
+/* stylelint-disable carbon/theme-token-use */
+/* stylelint-disable declaration-no-important */
+/* stylelint-disable function-no-unknown */
+/* stylelint-disable max-nesting-depth */
 
 // Standard imports.
+@use '@carbon/layout/scss/convert' as *;
+@use '@carbon/react/scss/colors' as *;
+@use '@carbon/styles/scss/motion' as *;
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/themes';
+@use '@carbon/styles/scss/type' as *;
 @use '../../global/styles/project-settings' as c4p-settings;
 
 // The block part of our conventional BEM class names (blockClass__E--M).
-$block-class: #{c4p-settings.$pkg-prefix}--about-modal;
+$block-class: #{c4p-settings.$pkg-prefix}--guidebanner;
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--modal-container {
-  grid-template-rows: auto auto 1fr auto;
+// Each GuidebannerElement is contained in a CarouselItem.
+$carousel-item: #{c4p-settings.$pkg-prefix}--carousel__item;
+
+@mixin when-collapsed($selector: '&') {
+  .#{c4p-settings.$pkg-prefix}--guidebanner__collapsible-collapsed
+    #{$selector} {
+    @content;
+  }
 }
 
-.#{$block-class} .#{$block-class}__logo {
-  margin: $spacing-05 $spacing-05 $spacing-07 $spacing-05;
+$horizontal-margin: to-rem(52px);
+// Guidebanner-specific colors.
+$purple-1: #9b63ff;
+$purple-2: #7f3ae7;
+$purple-3: #7433e3;
+
+.#{$block-class} {
+  // Due to the Guidebanner's dark background,
+  // apply dark theme by default for all elements:
+  // i.e. light text, icons, tooltips, etc.
+  @include theme(themes.$g100, true);
+
+  position: relative;
+  background: linear-gradient(90deg, $blue-90 0%, $purple-70 100%);
+  background-color: $blue-90;
 }
 
-.#{$block-class} .#{$block-class}__header {
-  padding: 0 20% 0 $spacing-05;
-  margin-bottom: 0;
-  grid-row: auto;
+.#{$block-class}__icon-idea {
+  position: absolute;
+  top: $spacing-05;
+  left: $spacing-05;
+
+  path {
+    fill: $gray-10;
+  }
 }
 
-.#{$block-class} .#{$block-class}__title {
-  @include type.type-style('heading-04');
+.#{$block-class}__title {
+  @include type-style('heading-compact-02');
 
-  color: $text-primary;
+  padding: $spacing-05 to-rem(175px) 0 $horizontal-margin;
+  color: $gray-10;
 }
 
-.#{$block-class} .#{$block-class}__body {
-  @include type.type-style('body-compact-02');
+.#{$block-class}__close-button {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+.#{$block-class}__close-button button {
+  width: $spacing-07;
+  height: $spacing-07;
+  min-height: $spacing-07;
+  padding-top: 6px;
 
-  overflow: hidden auto;
-  min-height: $spacing-10;
-  padding: 0 20% 0 $spacing-05;
-  margin-bottom: $spacing-06;
-  grid-row: auto;
+  &:active,
+  &:hover {
+    background-color: $purple-3;
+  }
+
+  path {
+    fill: $white-0;
+  }
 }
 
-.#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--modal-content--overflow-indicator {
-  bottom: #{$spacing-06};
-  background-image: linear-gradient(to bottom, #00000000, $layer-01);
+// Specify Carousel look and feel.
+.#{$block-class}__carousel {
+  padding: 0 0 $spacing-05 0;
+  color: $gray-10;
+
+  @include when-collapsed() {
+    margin-bottom: 0;
+  }
 }
 
-.#{$block-class} .#{$block-class}__links-container {
-  @include type.type-style('body-compact-01');
+// All carousel elements are 400px wide,
+// except the last one (see below).
+.#{$block-class}__carousel .#{$carousel-item} .#{$block-class}__element {
+  display: flex;
+  width: to-rem(400px); // 25rem
+  max-height: to-rem(512px); // 32rem
+  flex-flow: column;
+  flex-shrink: 0;
+  padding-left: $horizontal-margin;
+  margin: $spacing-05 0 0 0;
+  opacity: 1;
+  scroll-snap-align: start;
+  transition: max-height 50ms motion(exit, productive),
+    margin-top 50ms motion(exit, productive),
+    opacity 300ms motion(exit, productive);
 
-  margin-top: $spacing-06;
+  @include when-collapsed() {
+    max-height: $spacing-03;
+    margin-top: 0;
+    opacity: 0;
+  }
+}
+// The last carousel item is wider, with more padding-right,
+// to provide more space against the right edge of the carousel.
+.#{$block-class}__carousel
+  .#{$carousel-item}:last-child
+  .#{$block-class}__element {
+  width: to-rem(448px); // 28rem
+  padding-right: $horizontal-margin;
 }
 
-.#{$block-class} .#{$block-class}__version {
-  color: $text-secondary;
+.#{$block-class}__carousel .#{$carousel-item} .#{$block-class}__element-title {
+  @include type-style('heading-compact-01');
+
+  margin: $spacing-05 0 0 0;
 }
 
-.#{$block-class} .#{$block-class}__links-container a + a {
-  padding-left: $spacing-03;
-  border-left: 1px solid $border-strong-01;
-  margin-left: $spacing-03;
+.#{$block-class}__carousel .#{$block-class}__element-content {
+  @include type-style('body-01');
+
+  margin-bottom: $spacing-05;
 }
 
-.#{$block-class} .#{$block-class}__content,
-.#{$block-class} .#{$block-class}__copyright-text {
-  @include type.type-style('label-01');
+// Button with crossroads icon
+.#{$block-class}__carousel .#{c4p-settings.$carbon-prefix}--btn--tertiary {
+  border-color: $white-0;
+  color: $white-0;
 
-  margin-top: $spacing-06;
-  margin-bottom: 0;
-  color: $text-secondary;
+  &:active,
+  &:hover {
+    border-color: $white-0;
+    background-color: $white-0;
+    color: $gray-100;
+  }
+
+  // The "render icon" CSS seems to be missing in the latest Carbon button.
+  // Specifically, getting the icon to move to right-hand side of the content area.
+  // Repeating here.
+  svg {
+    position: absolute;
+    right: 1rem;
+    width: 1rem;
+    height: 1rem;
+    flex-shrink: 0;
+  }
 }
 
-.#{$block-class} .#{$block-class}__copyright-text {
-  margin-top: $spacing-05;
+.#{$block-class}__carousel .#{c4p-settings.$carbon-prefix}--btn--ghost {
+  margin-left: calc(-1 * $spacing-05);
+  color: $blue-30;
+
+  &:active,
+  &:hover {
+    background-color: $purple-2;
+    color: $gray-10;
+  }
 }
 
-p.c4p--about-modal__content:first-child,
-p.c4p--about-modal__copyright-text:first-child {
-  margin-top: $spacing-07;
+.#{$block-class}__carousel .#{$block-class}__element-link {
+  color: $blue-30;
+
+  &:visited {
+    color: $blue-30;
+  }
+
+  &:active,
+  &:hover {
+    color: $blue-20;
+  }
 }
 
-.#{$block-class} .#{$block-class}__footer {
-  display: block;
-  height: auto;
-  padding: $spacing-05;
-  background-color: $layer-02;
+.#{$block-class}__navigation {
+  display: flex;
+  border-top: to-rem(1px) solid $purple-60;
+
+  @include when-collapsed() {
+    border-top: none;
+  }
+}
+.#{$block-class}__navigation .#{$block-class}__toggle-button {
+  margin-left: calc($horizontal-margin - to-rem(18px));
+  color: $blue-30;
+
+  &:active,
+  &:hover {
+    background-color: $purple-3;
+    color: $gray-10;
+  }
+}
+
+// Push navigation buttons to the right
+.#{$block-class}__navigation .#{$block-class}__back-button {
+  margin-left: auto;
+}
+// Hide navigation buttons when collapsed
+.#{$block-class}__navigation .#{$block-class}__back-button,
+.#{$block-class}__navigation .#{$block-class}__next-button {
+  @include when-collapsed() {
+    display: none;
+  }
+}
+.#{$block-class}__navigation .#{$block-class}__back-button button,
+.#{$block-class}__navigation .#{$block-class}__next-button button {
+  &:active,
+  &:hover {
+    background-color: $purple-3;
+  }
+
+  path {
+    fill: $white-0;
+  }
+
+  &[disabled] path {
+    fill: $purple-1;
+  }
 }

--- a/packages/ibm-products-styles/src/components/Guidebanner/_guidebanner.scss
+++ b/packages/ibm-products-styles/src/components/Guidebanner/_guidebanner.scss
@@ -1,0 +1,94 @@
+//
+// Copyright IBM Corp. 2020, 2022
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/type';
+@use '@carbon/type/scss/font-family' as *;
+
+// Standard imports.
+@use '../../global/styles/project-settings' as c4p-settings;
+
+// The block part of our conventional BEM class names (blockClass__E--M).
+$block-class: #{c4p-settings.$pkg-prefix}--about-modal;
+
+.#{$block-class} .#{c4p-settings.$carbon-prefix}--modal-container {
+  grid-template-rows: auto auto 1fr auto;
+}
+
+.#{$block-class} .#{$block-class}__logo {
+  margin: $spacing-05 $spacing-05 $spacing-07 $spacing-05;
+}
+
+.#{$block-class} .#{$block-class}__header {
+  padding: 0 20% 0 $spacing-05;
+  margin-bottom: 0;
+  grid-row: auto;
+}
+
+.#{$block-class} .#{$block-class}__title {
+  @include type.type-style('heading-04');
+
+  color: $text-primary;
+}
+
+.#{$block-class} .#{$block-class}__body {
+  @include type.type-style('body-compact-02');
+
+  overflow: hidden auto;
+  min-height: $spacing-10;
+  padding: 0 20% 0 $spacing-05;
+  margin-bottom: $spacing-06;
+  grid-row: auto;
+}
+
+.#{$block-class}
+  .#{c4p-settings.$carbon-prefix}--modal-content--overflow-indicator {
+  bottom: #{$spacing-06};
+  background-image: linear-gradient(to bottom, #00000000, $layer-01);
+}
+
+.#{$block-class} .#{$block-class}__links-container {
+  @include type.type-style('body-compact-01');
+
+  margin-top: $spacing-06;
+}
+
+.#{$block-class} .#{$block-class}__version {
+  color: $text-secondary;
+}
+
+.#{$block-class} .#{$block-class}__links-container a + a {
+  padding-left: $spacing-03;
+  border-left: 1px solid $border-strong-01;
+  margin-left: $spacing-03;
+}
+
+.#{$block-class} .#{$block-class}__content,
+.#{$block-class} .#{$block-class}__copyright-text {
+  @include type.type-style('label-01');
+
+  margin-top: $spacing-06;
+  margin-bottom: 0;
+  color: $text-secondary;
+}
+
+.#{$block-class} .#{$block-class}__copyright-text {
+  margin-top: $spacing-05;
+}
+
+p.c4p--about-modal__content:first-child,
+p.c4p--about-modal__copyright-text:first-child {
+  margin-top: $spacing-07;
+}
+
+.#{$block-class} .#{$block-class}__footer {
+  display: block;
+  height: auto;
+  padding: $spacing-05;
+  background-color: $layer-02;
+}

--- a/packages/ibm-products-styles/src/components/Guidebanner/_index-with-carbon.scss
+++ b/packages/ibm-products-styles/src/components/Guidebanner/_index-with-carbon.scss
@@ -1,0 +1,9 @@
+//
+// Copyright IBM Corp. 2022, 2022
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use './carbon-imports';
+@use './guidebanner';

--- a/packages/ibm-products-styles/src/components/Guidebanner/_index.scss
+++ b/packages/ibm-products-styles/src/components/Guidebanner/_index.scss
@@ -1,0 +1,8 @@
+//
+// Copyright IBM Corp. 2020, 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use './guidebanner';

--- a/packages/ibm-products-styles/src/components/_index.scss
+++ b/packages/ibm-products-styles/src/components/_index.scss
@@ -50,5 +50,7 @@
 @use './EditTearsheetNarrow';
 @use './EditFullPage';
 @use './EditUpdateCards';
+@use './Carousel';
 @use './Checklist';
+@use './Guidebanner';
 @use './InlineTip';

--- a/packages/ibm-products/src/components/Carousel/Carousel.docs-page.js
+++ b/packages/ibm-products/src/components/Carousel/Carousel.docs-page.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { StoryDocsPage } from '../../global/js/utils/StoryDocsPage';
+
+import * as stories from './Carousel.stories';
+
+const DocsPage = () => (
+  <StoryDocsPage
+    blocks={[
+      {
+        story: stories.carousel,
+      },
+    ]}
+  />
+);
+
+export default DocsPage;

--- a/packages/ibm-products/src/components/Carousel/Carousel.js
+++ b/packages/ibm-products/src/components/Carousel/Carousel.js
@@ -1,0 +1,363 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  // useState,
+} from 'react';
+
+import PropTypes from 'prop-types';
+import { CarouselItem } from './CarouselItem';
+import cx from 'classnames';
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
+import { pkg } from '../../settings';
+
+// The block part of our conventional BEM class names (blockClass__E--M).
+const blockClass = `${pkg.prefix}--carousel`;
+const componentName = 'Carousel';
+
+// Default values for props
+const defaults = {
+  disableArrowScroll: false,
+  onScroll: () => {},
+  onChangeIsScrollable: () => {},
+};
+
+/**
+ * The Carousel acts as a scaffold for other Novice to Pro content.
+ *
+ * This component is not intended for general use.
+ *
+ * Expected scrolling behavior.
+ * 1. Scroll the maximum number of visible items at a time.
+ * 2. The left-most item should always be left-aligned in the viewport.
+ *
+ * Exception.
+ * 1. After scrolling to the last (right-most) item,
+ *      if some of its content remains hidden,
+ *      then nudge it to the right until it is right-aligned.
+ * 2. From the right-aligned position, when scrolling left,
+ *      the left-most item should again be left-aligned.
+ */
+export let Carousel = React.forwardRef(
+  (
+    {
+      children,
+      className,
+      disableArrowScroll = defaults.disableArrowScroll,
+      fadedEdgeColor,
+      onChangeIsScrollable = defaults.onChangeIsScrollable,
+      onScroll = defaults.onScroll,
+      ...rest
+    },
+    ref
+  ) => {
+    const carouselRef = useRef();
+    const scrollRef = useRef();
+    const leftFadedEdgeColor = fadedEdgeColor?.left || fadedEdgeColor;
+    const rightFadedEdgeColor = fadedEdgeColor?.right || fadedEdgeColor;
+
+    // Return the current state of the carousel.
+    const getWidths = useCallback(() => {
+      const ref = scrollRef.current;
+      // carousel items (DOM)
+      const items = ref.querySelectorAll(`.${blockClass}__item`);
+      // viewport's width
+      const clientWidth = ref.clientWidth;
+      // scroll position
+      const scrollLeft = parseInt(ref.scrollLeft, 10);
+      // scrollable width
+      const scrollWidth = ref.scrollWidth;
+
+      let itemWidths = [];
+      items.forEach((item) => itemWidths.push(item.clientWidth));
+
+      return {
+        clientWidth,
+        itemWidths,
+        scrollLeft,
+        scrollWidth,
+      };
+    }, []);
+
+    // Trigger callbacks to report state of the carousel
+    const handleScroll = useCallback(() => {
+      const { clientWidth, scrollLeft, scrollWidth } = getWidths();
+      // The maximum scrollLeft achievable is the scrollable width - the viewport width.
+      const scrollLeftMax = scrollWidth - clientWidth;
+      // if isNaN(scrollLeft / scrollLeftMax), then set to zero
+      const scrollPercent =
+        parseFloat((scrollLeft / scrollLeftMax).toFixed(2)) || 0;
+
+      if (!scrollRef.current) {
+        return;
+      }
+
+      // Callback 1: Does the carousel have enough content to enable scrolling?
+      onChangeIsScrollable(scrollWidth > clientWidth);
+
+      // Callback 2: Return the percentage of current scroll, between 0 and 1.
+      onScroll(scrollPercent);
+    }, [getWidths, onChangeIsScrollable, onScroll]);
+
+    const handleNext = useCallback(() => {
+      const { clientWidth, itemWidths, scrollLeft } = getWidths();
+      let newScrollLeft = 0;
+      const maxScrollLeft = scrollLeft + clientWidth;
+
+      // Cycle through all items, from the beginning.
+      for (let index = 0; index < itemWidths.length - 1; index++) {
+        const itemWidth = itemWidths[index];
+        if (newScrollLeft + itemWidth < maxScrollLeft) {
+          newScrollLeft += itemWidth;
+        } else {
+          break;
+        }
+      }
+
+      console.log(
+        'clientWidth, itemWidths, scrollLeft,',
+        clientWidth,
+        itemWidths,
+        scrollLeft
+      );
+
+      scrollRef.current.scrollLeft = parseInt(newScrollLeft, 10);
+
+      handleScroll();
+    }, [getWidths, handleScroll]);
+
+    const handlePrev = useCallback(() => {
+      const { clientWidth, itemWidths, scrollLeft, scrollWidth } = getWidths();
+      let newScrollLeft = scrollWidth;
+      let maxScrollLeft;
+
+      // Exception; if already scrolled all the way to the left,
+      // then skip this action.
+      if (scrollLeft === 0) {
+        return;
+      }
+
+      if (scrollLeft + clientWidth < scrollWidth) {
+        // Default: the carousel's scroll is not all the way to the right.
+        // The default max scroll is (the current scroll - the viewport's width)
+        maxScrollLeft = scrollLeft - clientWidth;
+      } else {
+        // Exception: if scrolled all the way to the right, then the items are right-aligned with the component.
+        // Set the initial target scroll to (the max scrollable width - the viewport's width)...
+        maxScrollLeft = scrollWidth - clientWidth;
+        // ...and starting from the last item, find the maximum scroll that can be left-aligned.
+        // Cycle through all items, from the end.
+        for (let index = itemWidths.length - 1; index >= 0; index--) {
+          if (scrollLeft - clientWidth + itemWidths[index] < maxScrollLeft) {
+            maxScrollLeft -= itemWidths[index];
+          } else {
+            break;
+          }
+        }
+      }
+
+      // Calculate exact scroll.
+      // Cycle through all items, from the end.
+      for (let index = itemWidths.length - 1; index >= 0; index--) {
+        const itemWidth = itemWidths[index];
+        if (newScrollLeft - itemWidth >= maxScrollLeft) {
+          newScrollLeft -= itemWidth;
+        } else {
+          break;
+        }
+      }
+
+      scrollRef.current.scrollLeft = parseInt(newScrollLeft, 10);
+
+      handleScroll();
+    }, [getWidths, handleScroll]);
+
+    const handleReset = useCallback(() => {
+      scrollRef.current.scrollLeft = 0;
+    }, []);
+
+    // Trigger a callback after first render (and applied CSS).
+    useEffect(() => {
+      // Normally, we can trigger a callback "immediately after first
+      // render", because we will be doing more "logical" work (update
+      // a state, show / hide a feature, etc.), and the final, applied
+      // CSS,can "catch up" asynchronously without breaking anything.
+      setTimeout(() => {
+        // Because we are making calculations based on the final,
+        // applied CSS, we must wait for one more "tick".
+        handleScroll();
+      }, 0);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    // On window.resize, reset carousel to zero.
+    useEffect(() => {
+      const handleWindowResize = () => {
+        scrollRef.current.scrollLeft = 0;
+        handleScroll();
+      };
+
+      window.addEventListener('resize', handleWindowResize);
+      return () => window.removeEventListener('resize', handleWindowResize);
+    }, [handleScroll]);
+
+    // On scrollRef.scrollend, trigger a callback.
+    useEffect(() => {
+      const handleScrollend = () => {
+        handleScroll();
+      };
+
+      const scrollDiv = scrollRef.current;
+      scrollDiv.addEventListener('scrollend', handleScrollend);
+      return () => scrollDiv.removeEventListener('scrollend', handleScrollend);
+    }, [handleScroll]);
+
+    // Disable wheel scrolling
+    useEffect(() => {
+      function handleWheel(event) {
+        // update the scroll position
+        event.stopPropagation();
+        event.preventDefault();
+        event.cancelBubble = false;
+      }
+      const scrollDiv = scrollRef.current;
+      if (scrollDiv) {
+        scrollDiv.addEventListener('wheel', handleWheel, {
+          passive: false,
+        });
+        return () => {
+          scrollDiv.removeEventListener('wheel', handleWheel, {
+            passive: false,
+          });
+        };
+      }
+    }, []);
+
+    // Enable arrow scrolling from within the carousel
+    useEffect(() => {
+      function handleKeydown(event) {
+        const { key } = event;
+
+        if (
+          (key === 'ArrowLeft' || key === 'ArrowRight') &&
+          disableArrowScroll
+        ) {
+          event.stopPropagation();
+          event.preventDefault();
+          event.cancelBubble = false;
+        }
+      }
+
+      const carouselDiv = carouselRef.current;
+      if (carouselDiv) {
+        carouselDiv.addEventListener('keydown', handleKeydown);
+        return () => carouselDiv.removeEventListener('keydown', handleKeydown);
+      }
+    }, [disableArrowScroll]);
+
+    // Enable external function calls
+    useImperativeHandle(
+      ref,
+      () => ({
+        scrollNext() {
+          handleNext();
+        },
+        scrollPrev() {
+          handlePrev();
+        },
+        scrollReset() {
+          handleReset();
+        },
+      }),
+      [handleNext, handlePrev, handleReset]
+    );
+
+    return (
+      <div
+        {...rest}
+        tabIndex={-1}
+        className={cx(blockClass, className)}
+        ref={carouselRef}
+        role="main"
+        {...getDevtoolsProps(componentName)}
+      >
+        <div className={cx(`${blockClass}__elements-container`)}>
+          <div className={`${blockClass}__elements`} ref={scrollRef}>
+            {React.Children.map(children, (child) => {
+              return <CarouselItem>{child}</CarouselItem>;
+            })}
+          </div>
+
+          {leftFadedEdgeColor && (
+            <div
+              className={`${blockClass}__elements-container--scrolled`}
+              style={{
+                background: `linear-gradient(90deg, ${leftFadedEdgeColor}, transparent)`,
+              }}
+            ></div>
+          )}
+
+          {rightFadedEdgeColor && (
+            <div
+              className={`${blockClass}__elements-container--scroll-max`}
+              style={{
+                background: `linear-gradient(270deg, ${rightFadedEdgeColor}, transparent)`,
+              }}
+            ></div>
+          )}
+        </div>
+      </div>
+    );
+  }
+);
+
+Carousel.displayName = componentName;
+
+// The types and DocGen commentary for the component props,
+// in alphabetical order (for consistency).
+// See https://www.npmjs.com/package/prop-types#usage.
+Carousel.propTypes = {
+  /**
+   * Provide the contents of the Carousel.
+   */
+  children: PropTypes.node.isRequired,
+  /**
+   * Provide an optional class to be applied to the containing node.
+   */
+  className: PropTypes.string,
+  /**
+   * Disables the ability of the Carousel to scroll
+   * use a keyboard's left and right arrow keys.
+   */
+  disableArrowScroll: PropTypes.bool,
+  /**
+   * Enables the edges of the component to have faded styling.
+   *
+   * Pass a single string (`$color`) to specify the same color for left and right.
+   *
+   * Or pass an object (`{ left: $color1, right: $color2 }`) to specify different colors.
+   */
+  fadedEdgeColor: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({ left: PropTypes.string, right: PropTypes.string }),
+  ]),
+  /**
+   * An optional callback function that returns `true`
+   * when the carousel has enough content to be scrollable,
+   * and `false` when there is not enough content.
+   */
+  onChangeIsScrollable: PropTypes.func,
+  /**
+   * An optional callback function that returns the scroll position as
+   * a value between 0 and 1.
+   */
+  onScroll: PropTypes.func,
+};

--- a/packages/ibm-products/src/components/Carousel/Carousel.stories.js
+++ b/packages/ibm-products/src/components/Carousel/Carousel.stories.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
+
+import { Carousel } from '.';
+import styles from './_storybook-styles.scss';
+import DocsPage from './Carousel.docs-page';
+
+export default {
+  title: getStoryTitle(Carousel.displayName),
+  component: Carousel,
+  tags: ['autodocs'],
+  parameters: {
+    styles,
+    docs: {
+      page: DocsPage,
+    },
+  },
+};
+
+const Template = (args) => {
+  return <Carousel {...args} />;
+};
+
+export const carousel = prepareStory(Template, {
+  args: {
+    children: (
+      <>
+        Carousel is a <em>Novice to Pro</em> internal component and is not
+        intended for general use.
+      </>
+    ),
+  },
+});

--- a/packages/ibm-products/src/components/Carousel/Carousel.test.js
+++ b/packages/ibm-products/src/components/Carousel/Carousel.test.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
+
+import { pkg } from '../../settings';
+import uuidv4 from '../../global/js/utils/uuidv4';
+
+import { Carousel } from '.';
+
+const blockClass = `${pkg.prefix}--carousel`;
+const componentName = Carousel.displayName;
+
+// values to use
+const children = `hello, world (${uuidv4()})`;
+const className = `class-${uuidv4()}`;
+const dataTestId = uuidv4();
+
+describe(componentName, () => {
+  // The Carousel component uses IntersectionObserver.
+  beforeEach(() => {
+    window.IntersectionObserver = jest.fn().mockImplementation(() => ({
+      observe: () => null,
+      unobserve: () => null,
+    }));
+  });
+
+  it('renders a component Carousel', () => {
+    render(<Carousel> </Carousel>);
+    expect(screen.getByRole('main')).toHaveClass(blockClass);
+  });
+
+  // Skipping.
+  // jsdom does not support features like ReactRef.current.clientWidth;
+  it.skip('has no accessibility violations', async () => {
+    const { container } = render(<Carousel> </Carousel>);
+    await expect(container).toBeAccessible(componentName);
+    await expect(container).toHaveNoAxeViolations();
+  });
+
+  it(`renders children`, () => {
+    render(<Carousel>{children}</Carousel>);
+    screen.getByText(children);
+  });
+
+  it('applies className to the containing node', () => {
+    render(<Carousel className={className}> </Carousel>);
+    expect(screen.getByRole('main')).toHaveClass(className);
+  });
+
+  it('adds additional props to the containing node', () => {
+    render(<Carousel data-testid={dataTestId}> </Carousel>);
+    screen.getByTestId(dataTestId);
+  });
+
+  // We are using https://react.dev/reference/react/useImperativeHandle
+  // to return only methods specific to the Carousel's functionality:
+  // scrollNext, scrollPrev, scrollToView, and maxScroll.
+  it('forwards a ref to specific callback functions only', () => {
+    const ref = React.createRef();
+    render(<Carousel ref={ref}> </Carousel>);
+    expect(ref.current.scrollNext).toBeDefined();
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    render(<Carousel data-testid={dataTestId}> </Carousel>);
+
+    expect(screen.getByTestId(dataTestId)).toHaveDevtoolsAttribute(
+      componentName
+    );
+  });
+});

--- a/packages/ibm-products/src/components/Carousel/Carousel.test.js
+++ b/packages/ibm-products/src/components/Carousel/Carousel.test.js
@@ -60,7 +60,7 @@ describe(componentName, () => {
 
   // We are using https://react.dev/reference/react/useImperativeHandle
   // to return only methods specific to the Carousel's functionality:
-  // scrollNext, scrollPrev, scrollToView, and maxScroll.
+  // scrollNext, scrollPrev, scrollToReset, and scrollToView.
   it('forwards a ref to specific callback functions only', () => {
     const ref = React.createRef();
     render(<Carousel ref={ref}> </Carousel>);

--- a/packages/ibm-products/src/components/Carousel/CarouselItem.js
+++ b/packages/ibm-products/src/components/Carousel/CarouselItem.js
@@ -6,32 +6,40 @@
  */
 
 import React from 'react';
+
+// Other standard imports.
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { pkg } from '../../settings';
+
+// Carbon and package components we use.
+/* TODO: @import(s) of carbon components and other package components. */
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 const blockClass = `${pkg.prefix}--carousel__item`;
 const componentName = 'CarouselItem';
 
 /**
- * The Carousel acts as a scaffold for other Novice to Pro content.
- *
- * This component is not intended for general use.
+ * TODO: A description of the component.
  */
-export let CarouselItem = ({ children, className, ...rest }) => {
-  return (
-    <div
-      {...rest}
-      className={cx(blockClass, className)}
-      {...getDevtoolsProps(componentName)}
-    >
-      {children}
-    </div>
-  );
-};
+const CarouselItem = React.forwardRef(
+  ({ children, className, ...rest }, ref) => {
+    return (
+      <div
+        {...rest}
+        className={cx(blockClass, className)}
+        {...getDevtoolsProps(componentName)}
+        ref={ref}
+      >
+        {children}
+      </div>
+    );
+  }
+);
 
+CarouselItem.displayName = componentName;
 // The types and DocGen commentary for the component props,
 // in alphabetical order (for consistency).
 // See https://www.npmjs.com/package/prop-types#usage.
@@ -46,3 +54,5 @@ CarouselItem.propTypes = {
    */
   className: PropTypes.string,
 };
+
+export { CarouselItem };

--- a/packages/ibm-products/src/components/Carousel/CarouselItem.js
+++ b/packages/ibm-products/src/components/Carousel/CarouselItem.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
+import { pkg } from '../../settings';
+
+// The block part of our conventional BEM class names (blockClass__E--M).
+const blockClass = `${pkg.prefix}--carousel__item`;
+const componentName = 'CarouselItem';
+
+/**
+ * The Carousel acts as a scaffold for other Novice to Pro content.
+ *
+ * This component is not intended for general use.
+ */
+export let CarouselItem = ({ children, className, ...rest }) => {
+  return (
+    <div
+      {...rest}
+      className={cx(blockClass, className)}
+      {...getDevtoolsProps(componentName)}
+    >
+      {children}
+    </div>
+  );
+};
+
+// The types and DocGen commentary for the component props,
+// in alphabetical order (for consistency).
+// See https://www.npmjs.com/package/prop-types#usage.
+CarouselItem.propTypes = {
+  /**
+   * Provide the contents of the CarouselItem.
+   */
+  children: PropTypes.node.isRequired,
+
+  /**
+   * Provide an optional class to be applied to the containing node.
+   */
+  className: PropTypes.string,
+};

--- a/packages/ibm-products/src/components/Carousel/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/Carousel/_storybook-styles.scss
@@ -1,0 +1,11 @@
+//
+// Copyright IBM Corp. 2023, 2023
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// @import '../../global/styles/project-settings';
+@use '../../../../ibm-products-styles/src/global/styles/project-settings';
+
+// TODO: add any additional styles used by Carousel.stories.js

--- a/packages/ibm-products/src/components/Carousel/index.js
+++ b/packages/ibm-products/src/components/Carousel/index.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export { Carousel } from './Carousel';
+export { CarouselItem } from './CarouselItem';

--- a/packages/ibm-products/src/components/Carousel/utils.js
+++ b/packages/ibm-products/src/components/Carousel/utils.js
@@ -1,0 +1,106 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+
+export const useIntersection = (element, threshold) => {
+  const [isVisible, setState] = useState(false);
+
+  useEffect(() => {
+    const el = element.current;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setState(entry.isIntersecting);
+      },
+      { threshold }
+    );
+
+    el && observer.observe(el);
+
+    return () => observer.unobserve(el);
+  }, [element, threshold]);
+
+  return isVisible;
+};
+
+export const useIsOverflow = (ref) => {
+  const [isScrollable, setIsScrollable] = useState();
+  const [mutationObserver, setMutationObserver] = useState();
+  const [resizeObserver, setResizeObserver] = useState();
+
+  const checkOverflow = useCallback(() => {
+    if (!ref.current) {
+      return;
+    }
+    const hasOverflow = ref.current.scrollWidth > ref.current.clientWidth;
+    setIsScrollable(hasOverflow);
+  }, [ref]);
+
+  useEffect(() => {
+    if (!mutationObserver) {
+      return;
+    }
+
+    return () => {
+      if (mutationObserver) {
+        mutationObserver.disconnect();
+      }
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
+    };
+  });
+
+  useLayoutEffect(() => {
+    const { current } = ref;
+    if (current) {
+      if ('ResizeObserver' in window && !resizeObserver) {
+        setResizeObserver(new ResizeObserver(checkOverflow).observe(current));
+      }
+      if ('MutationObserver' in window && !mutationObserver) {
+        setMutationObserver(
+          new MutationObserver(checkOverflow).observe(current, {
+            attributes: false,
+            childList: true,
+            subtree: false,
+          })
+        );
+      }
+      checkOverflow();
+    }
+  }, [ref, checkOverflow, mutationObserver, resizeObserver]);
+
+  return isScrollable;
+};
+
+export const useWindowEvent = (eventName, callback) => {
+  const savedCallback = useRef(null);
+
+  useEffect(() => {
+    savedCallback.current = callback;
+  });
+
+  useEffect(() => {
+    function handler(event) {
+      if (savedCallback.current) {
+        savedCallback.current(event);
+      }
+    }
+
+    window.addEventListener(eventName, handler);
+
+    return () => {
+      window.removeEventListener(eventName, handler);
+    };
+  }, [eventName]);
+};

--- a/packages/ibm-products/src/components/Guidebanner/Guidebanner.docs-page.js
+++ b/packages/ibm-products/src/components/Guidebanner/Guidebanner.docs-page.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { StoryDocsPage } from '../../global/js/utils/StoryDocsPage';
+
+import * as stories from './Guidebanner.stories';
+
+const DocsPage = () => (
+  <StoryDocsPage
+    blocks={[
+      {
+        story: stories.collapsible,
+      },
+      {
+        story: stories.manyInsights,
+      },
+      {
+        story: stories.fewInsights,
+      },
+    ]}
+  />
+);
+
+export default DocsPage;

--- a/packages/ibm-products/src/components/Guidebanner/Guidebanner.js
+++ b/packages/ibm-products/src/components/Guidebanner/Guidebanner.js
@@ -1,0 +1,255 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Import portions of React that are needed.
+import React, { useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { blue90, purple70 } from '@carbon/colors';
+import { CaretLeft, CaretRight, Close, Idea } from '@carbon/react/icons';
+import { Button, IconButton } from '@carbon/react';
+import { Carousel } from '../Carousel';
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
+import { pkg } from '../../settings';
+
+// The block part of our conventional BEM class names (blockClass__E--M).
+const blockClass = `${pkg.prefix}--guidebanner`;
+const componentName = 'Guidebanner';
+
+const defaults = {
+  collapsible: false,
+  // Labels
+  closeIconDescription: 'Close',
+  collapseButtonLabel: 'Read less',
+  expandButtonLabel: 'Read more',
+  nextIconDescription: 'Next',
+  previousIconDescription: 'Back',
+};
+
+/**
+ * The guide banner sits at the top of a page, or page-level tab,
+ * to introduce foundational concepts related to the page's content.
+ */
+export let Guidebanner = React.forwardRef(
+  (
+    {
+      children,
+      className,
+      collapsible = defaults.collapsible,
+      onClose,
+      // Labels
+      closeIconDescription = defaults.closeIconDescription,
+      collapseButtonLabel = defaults.collapseButtonLabel,
+      expandButtonLabel = defaults.expandButtonLabel,
+      nextIconDescription = defaults.nextIconDescription,
+      previousIconDescription = defaults.previousIconDescription,
+      title,
+      ...rest
+    },
+    ref
+  ) => {
+    const scrollRef = useRef();
+    const toggleRef = useRef();
+    const [scrollPosition, setScrollPosition] = useState(0);
+    const [showNavigation, setShowNavigation] = useState(false);
+    const [isCollapsed, setIsCollapsed] = useState(collapsible ? true : false);
+
+    const handleClickToggle = () => {
+      // scrollRef.current.scrollReset();
+      setIsCollapsed((prevState) => !prevState);
+    };
+
+    return (
+      <div
+        {...rest}
+        aria-expanded={!isCollapsed}
+        className={cx(
+          blockClass,
+          className,
+          [collapsible ? `${blockClass}__collapsible` : null],
+          [isCollapsed ? `${blockClass}__collapsible-collapsed` : null]
+        )}
+        ref={ref}
+        {...getDevtoolsProps(componentName)}
+      >
+        <Idea size={20} className={`${blockClass}__icon-idea`} />
+        <div className={`${blockClass}__title`}>{title}</div>
+        <Carousel
+          className={`${blockClass}__carousel`}
+          // These colors are to match the Carousel's faded edges
+          // against the Guidebanner's gradient background.
+          fadedEdgeColor={{ left: blue90, right: purple70 }}
+          ref={scrollRef}
+          onChangeIsScrollable={(value) => {
+            setShowNavigation(value);
+          }}
+          onScroll={(scrollPercent) => {
+            setScrollPosition(scrollPercent);
+          }}
+        >
+          {children}
+        </Carousel>
+        <div
+          className={cx([
+            collapsible || showNavigation ? `${blockClass}__navigation` : null,
+          ])}
+        >
+          {collapsible && (
+            <Button
+              kind="ghost"
+              size="md"
+              className={`${blockClass}__toggle-button`}
+              onClick={handleClickToggle}
+              ref={toggleRef}
+            >
+              {isCollapsed ? expandButtonLabel : collapseButtonLabel}
+            </Button>
+          )}
+
+          {showNavigation && (
+            <>
+              <span
+                className={cx(`${blockClass}__back-button`, [
+                  scrollPosition === 0
+                    ? `${blockClass}__back-button--disabled`
+                    : null,
+                ])}
+              >
+                <IconButton
+                  align="top"
+                  disabled={scrollPosition === 0}
+                  kind="ghost"
+                  label={previousIconDescription}
+                  onClick={() => {
+                    console.log('scrollRef.current', scrollRef.current);
+                    scrollRef.current.scrollPrev();
+                  }}
+                  size="md"
+                >
+                  <CaretLeft size={16} />
+                </IconButton>
+              </span>
+              <span
+                className={cx(`${blockClass}__next-button`, [
+                  scrollPosition === 1
+                    ? `${blockClass}__next-button--disabled`
+                    : null,
+                ])}
+              >
+                <IconButton
+                  align="top-right"
+                  disabled={scrollPosition === 1}
+                  kind="ghost"
+                  label={nextIconDescription}
+                  onClick={() => {
+                    scrollRef.current.scrollNext();
+                  }}
+                  size="md"
+                >
+                  <CaretRight size={16} />
+                </IconButton>
+              </span>
+            </>
+          )}
+        </div>
+
+        {onClose && (
+          <span className={`${blockClass}__close-button`}>
+            <IconButton
+              align="bottom-right"
+              kind="ghost"
+              label={closeIconDescription}
+              onClick={onClose}
+              size="md"
+            >
+              <Close size={16} />
+            </IconButton>
+          </span>
+        )}
+      </div>
+    );
+  }
+);
+
+// Return a placeholder if not released and not enabled by feature flag
+Guidebanner = pkg.checkComponentEnabled(Guidebanner, componentName);
+
+// The display name of the component, used by React. Note that displayName
+// is used in preference to relying on function.name.
+Guidebanner.displayName = componentName;
+
+// The types and DocGen commentary for the component props,
+// in alphabetical order (for consistency).
+// See https://www.npmjs.com/package/prop-types#usage.
+Guidebanner.propTypes = {
+  /**
+   * Provide the contents of the Guidebanner.
+   * One or more GuidebannerElement components are required.
+   */
+  children: (props, propName) => {
+    let error;
+    const prop = props[propName];
+    if (!prop) {
+      error = new Error(
+        '`Guidebanner` requires one or more children of type `GuidebannerElement`.'
+      );
+    }
+    React.Children.forEach(prop, (child) => {
+      if (child.type.displayName !== 'GuidebannerElement') {
+        // If not GuidebannerElement, then show:
+        // React component name(child.type?.name) or
+        // HTML element name(child.type).
+        error = new Error(
+          `\`Guidebanner\` only accepts children of type \`GuidebannerElement\`, found \`${
+            child.type?.displayName || child.type?.name || child.type
+          }\` instead.`
+        );
+      }
+    });
+    return error;
+  },
+  /**
+   * Provide an optional class to be applied to the containing node.
+   */
+  className: PropTypes.string,
+  /**
+   * Tooltip text and aria label for the Close button icon.
+   */
+  closeIconDescription: PropTypes.string,
+  /**
+   * Text label for the Collapse button.
+   */
+  collapseButtonLabel: PropTypes.string,
+  /**
+   * When true, the Guidebanner will initialize in a collapsed state,
+   * showing the title and the Expand button.
+   *
+   * When expanded, it will show the GuidebannerElement child components and the Collapse button.
+   */
+  collapsible: PropTypes.bool,
+  /**
+   * Text label for the Expand button.
+   */
+  expandButtonLabel: PropTypes.string,
+  /**
+   * Tooltip text and aria label for the Next button icon.
+   */
+  nextIconDescription: PropTypes.string,
+  /**
+   * If defined, a Close button will render in the top-right corner and a
+   * callback function will be triggered when button is clicked.
+   */
+  onClose: PropTypes.func,
+  /**
+   * Tooltip text and aria label for the Back button icon.
+   */
+  previousIconDescription: PropTypes.string,
+  /**
+   * Title text.
+   */
+  title: PropTypes.string.isRequired,
+};

--- a/packages/ibm-products/src/components/Guidebanner/Guidebanner.js
+++ b/packages/ibm-products/src/components/Guidebanner/Guidebanner.js
@@ -59,7 +59,6 @@ export let Guidebanner = React.forwardRef(
     const [isCollapsed, setIsCollapsed] = useState(collapsible ? true : false);
 
     const handleClickToggle = () => {
-      // scrollRef.current.scrollReset();
       setIsCollapsed((prevState) => !prevState);
     };
 
@@ -125,7 +124,6 @@ export let Guidebanner = React.forwardRef(
                   kind="ghost"
                   label={previousIconDescription}
                   onClick={() => {
-                    console.log('scrollRef.current', scrollRef.current);
                     scrollRef.current.scrollPrev();
                   }}
                   size="md"

--- a/packages/ibm-products/src/components/Guidebanner/Guidebanner.stories.js
+++ b/packages/ibm-products/src/components/Guidebanner/Guidebanner.stories.js
@@ -1,0 +1,193 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
+
+import {
+  Guidebanner,
+  GuidebannerElement,
+  GuidebannerElementButton,
+  GuidebannerElementLink,
+} from '.';
+
+import styles from './_storybook-styles.scss';
+import DocsPage from './Guidebanner';
+
+const storyClass = 'guidebanner-stories';
+
+export default {
+  title: getStoryTitle(Guidebanner.displayName),
+  component: Guidebanner,
+  tags: ['autodocs'],
+  parameters: {
+    styles,
+    layout: 'padded',
+    docs: {
+      page: DocsPage,
+    },
+  },
+  argTypes: {
+    children: {
+      table: {
+        disable: true,
+      },
+    },
+    theme: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+};
+
+const defaultProps = {
+  onClose: () => action('onClose()')(),
+  title: 'Page-related heading that can stand on its own',
+};
+
+const DefaultButtonLarge = () => (
+  <GuidebannerElementButton
+    type="primary"
+    onClick={() => {
+      action('GuidebannerElementButton.onClick() (type="primary")')();
+    }}
+  >
+    Show Me
+  </GuidebannerElementButton>
+);
+
+const DefaultButtonSmall = () => (
+  <GuidebannerElementButton
+    onClick={() => {
+      action('GuidebannerElementButton.onClick()')();
+    }}
+  >
+    Click me
+  </GuidebannerElementButton>
+);
+
+const DefaultLink = () => (
+  <GuidebannerElementLink
+    href="https://www.ibm.com"
+    target="_blank"
+    onClick={() => {
+      action('GuidebannerElementLink.onClick()')();
+    }}
+  >
+    Learn more
+  </GuidebannerElementLink>
+);
+
+const Template = ({ children, ...rest }) => {
+  // Normally GuidebannerElement are listed directly as children of Guidebanner,
+  // but as a story we have to wrap the JSX in a React.Fragment.
+  // To feed them here, we point to the list of GuidebannerElements directly.
+  const childArray = children.props.children;
+
+  return (
+    <div className={`${storyClass}__viewport`}>
+      <Guidebanner {...rest}>{childArray}</Guidebanner>
+    </div>
+  );
+};
+
+export const collapsible = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    collapsible: true,
+    children: (
+      <React.Fragment>
+        <GuidebannerElement
+          title="Use-case specific heading"
+          description="Use-case specific content related to the heading that explains the concept or adds context. Use-case specific content related to the heading that explains the concept or adds context."
+          button={<DefaultButtonLarge />}
+        />
+        <GuidebannerElement
+          title="Use-case specific heading"
+          description="Use-case specific content related to the heading that explains the concept or adds context. Use-case specific content related to the heading that explains the concept or adds context. Use-case specific content related to the heading that explains the concept or adds context."
+          button={<DefaultButtonSmall />}
+        />
+        <GuidebannerElement
+          title="Use-case specific heading"
+          description="Use-case specific content related to the heading that explains the concept or adds context."
+          button={<DefaultButtonSmall />}
+        />
+        <GuidebannerElement
+          title="Use-case specific heading"
+          description="Use-case specific content related to the heading that explains the concept or adds context. Use-case specific content related to the heading that explains the concept or adds context."
+          button={<DefaultLink />}
+        />
+        <GuidebannerElement
+          title="Use-case specific heading"
+          description="Use-case specific content related to the heading that explains the concept or adds context."
+          button={<DefaultLink />}
+        />
+      </React.Fragment>
+    ),
+  },
+});
+
+export const manyInsights = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    children: (
+      <React.Fragment>
+        <GuidebannerElement
+          title="Use-case specific heading"
+          description="Use-case specific content related to the heading that explains the concept or adds context. Use-case specific content related to the heading that explains the concept or adds context."
+          button={<DefaultButtonLarge />}
+        />
+        <GuidebannerElement
+          title="Use-case specific heading"
+          description="Use-case specific content related to the heading that explains the concept or adds context. Use-case specific content related to the heading that explains the concept or adds context. Use-case specific content related to the heading that explains the concept or adds context."
+          button={<DefaultButtonSmall />}
+        />
+        <GuidebannerElement
+          title="Use-case specific heading"
+          description="Use-case specific content related to the heading that explains the concept or adds context."
+          button={<DefaultButtonSmall />}
+        />
+        <GuidebannerElement
+          title="Use-case specific heading"
+          description="Use-case specific content related to the heading that explains the concept or adds context. Use-case specific content related to the heading that explains the concept or adds context."
+          button={<DefaultLink />}
+        />
+        <GuidebannerElement
+          title="Use-case specific heading"
+          description="Use-case specific content related to the heading that explains the concept or adds context."
+          button={<DefaultLink />}
+        />
+      </React.Fragment>
+    ),
+  },
+});
+
+export const fewInsights = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    children: (
+      <React.Fragment>
+        <GuidebannerElement
+          title="Use-case specific heading"
+          description="Use-case specific content related to the heading that explains the concept or adds context. Use-case specific content related to the heading that explains the concept or adds context."
+          button={<DefaultButtonLarge />}
+        />
+        <GuidebannerElement
+          title="Use-case specific heading"
+          description="Use-case specific content related to the heading that explains the concept or adds context."
+          button={<DefaultLink />}
+        />
+      </React.Fragment>
+    ),
+  },
+});

--- a/packages/ibm-products/src/components/Guidebanner/Guidebanner.test.js
+++ b/packages/ibm-products/src/components/Guidebanner/Guidebanner.test.js
@@ -1,0 +1,95 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
+
+import { pkg } from '../../settings';
+import uuidv4 from '../../global/js/utils/uuidv4';
+
+import { Guidebanner, GuidebannerElement } from '.';
+
+const blockClass = `${pkg.prefix}--guidebanner`;
+const componentName = Guidebanner.displayName;
+
+// values to use
+// const children = `hello, world (${uuidv4()})`;
+const className = `class-${uuidv4()}`;
+const dataTestId = uuidv4();
+
+const defaultProps = {
+  title: 'Guidebanner title',
+};
+const guidebannerElementDefaultProps = {
+  description: 'GuidebannerElement description',
+};
+
+const renderComponent = (customProps = {}) => {
+  // The Guidebanner must have at least one GuidebannerElement as a child.
+  return render(
+    <Guidebanner {...defaultProps} {...customProps}>
+      <GuidebannerElement description="GuidebannerElement description"></GuidebannerElement>
+    </Guidebanner>
+  );
+};
+
+describe(componentName, () => {
+  // The Carousel component uses IntersectionObserver.
+  beforeEach(() => {
+    window.IntersectionObserver = jest.fn().mockImplementation(() => ({
+      observe: () => null,
+      unobserve: () => null,
+    }));
+  });
+
+  it('renders a component Guidebanner', () => {
+    const { container } = renderComponent();
+    const guidebanner = container.getElementsByClassName(blockClass);
+
+    expect(guidebanner.length).toBe(1);
+  });
+
+  it.skip('has no accessibility violations', async () => {
+    const { container } = renderComponent();
+
+    await expect(container).toBeAccessible(componentName);
+    await expect(container).toHaveNoAxeViolations();
+  });
+
+  it(`renders children`, () => {
+    renderComponent();
+
+    screen.getByText(guidebannerElementDefaultProps.description);
+  });
+
+  it('applies className to the containing node', () => {
+    const { container } = renderComponent({ className });
+    const guidebanner = container.getElementsByClassName(blockClass)[0];
+
+    expect(guidebanner).toHaveClass(className);
+  });
+
+  it('adds additional props to the containing node', () => {
+    renderComponent({ 'data-testid': dataTestId });
+
+    screen.getByTestId(dataTestId);
+  });
+
+  it('forwards a ref to an appropriate node', () => {
+    const ref = React.createRef();
+    renderComponent({ ref });
+
+    expect(ref.current).toHaveClass(blockClass);
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    renderComponent({ 'data-testid': dataTestId });
+    expect(screen.getByTestId(dataTestId)).toHaveDevtoolsAttribute(
+      componentName
+    );
+  });
+});

--- a/packages/ibm-products/src/components/Guidebanner/GuidebannerElement.js
+++ b/packages/ibm-products/src/components/Guidebanner/GuidebannerElement.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Import portions of React that are needed.
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
+import { pkg } from '../../settings';
+
+// The block part of our conventional BEM class names (blockClass__E--M).
+const blockClass = `${pkg.prefix}--guidebanner__element`;
+const componentName = 'GuidebannerElement';
+
+/**
+ * The GuidebannerElement is a required child component of the Guidebanner,
+ * and acts as a container for a CarouselItem.
+ */
+export let GuidebannerElement = ({
+  button,
+  className,
+  description,
+  title,
+  ...rest
+}) => {
+  return (
+    <div
+      {...rest}
+      className={cx(blockClass, className)}
+      {...getDevtoolsProps(componentName)}
+    >
+      {title && <h2 className={`${blockClass}-title`}>{title}</h2>}
+      {description && <p className={`${blockClass}-content`}>{description}</p>}
+      {button && <div className={`${blockClass}-buttons`}>{button}</div>}
+    </div>
+  );
+};
+
+// Return a placeholder if not released and not enabled by feature flag
+GuidebannerElement = pkg.checkComponentEnabled(
+  GuidebannerElement,
+  componentName
+);
+
+// The display name of the component, used by React. Note that displayName
+// is used in preference to relying on function.name.
+GuidebannerElement.displayName = componentName;
+
+// The types and DocGen commentary for the component props,
+// in alphabetical order (for consistency).
+// See https://www.npmjs.com/package/prop-types#usage.
+GuidebannerElement.propTypes = {
+  /**
+   * An optional button can be rendered below the description.
+   * This can be a link, button, Coachmark button, etc.
+   */
+  button: PropTypes.node,
+
+  /**
+   * Provide an optional class to be applied to the containing node.
+   */
+  className: PropTypes.string,
+
+  /**
+   * The description of the element.
+   */
+
+  description: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
+    .isRequired,
+
+  /**
+   * The title of the element.
+   */
+  title: PropTypes.string,
+};

--- a/packages/ibm-products/src/components/Guidebanner/GuidebannerElementButton.js
+++ b/packages/ibm-products/src/components/Guidebanner/GuidebannerElementButton.js
@@ -1,0 +1,92 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Import portions of React that are needed.
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { Button } from '@carbon/react';
+import { Crossroads } from '@carbon/react/icons';
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
+import { pkg } from '../../settings';
+
+// The block part of our conventional BEM class names (blockClass__E--M).
+const blockClass = `${pkg.prefix}--guidebanner__element-button`;
+const componentName = 'GuidebannerElementButton';
+
+/**
+ * One of two buttons styled specifically for the GuidebannerElement.
+ */
+export let GuidebannerElementButton = ({
+  children,
+  className,
+  type,
+  ...rest
+}) => {
+  if (type === 'primary') {
+    return (
+      <Button
+        {...rest}
+        className={cx(blockClass, className)}
+        iconDescription={'Crossroads'}
+        kind="tertiary"
+        renderIcon={() => <Crossroads size={16} />}
+        role="button"
+        size="md"
+        {...getDevtoolsProps(componentName)}
+      >
+        {children}
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      {...rest}
+      className={cx(blockClass, className)}
+      kind="ghost"
+      role="button"
+      size="md"
+      {...getDevtoolsProps(componentName)}
+    >
+      {children}
+    </Button>
+  );
+};
+
+// Return a placeholder if not released and not enabled by feature flag
+GuidebannerElementButton = pkg.checkComponentEnabled(
+  GuidebannerElementButton,
+  componentName
+);
+
+// The display name of the component, used by React. Note that displayName
+// is used in preference to relying on function.name.
+GuidebannerElementButton.displayName = componentName;
+
+// The types and DocGen commentary for the component props,
+// in alphabetical order (for consistency).
+// See https://www.npmjs.com/package/prop-types#usage.
+GuidebannerElementButton.propTypes = {
+  /**
+   * Provide the contents of the GuidebannerElementButton.
+   */
+  children: PropTypes.node.isRequired,
+
+  /**
+   * Provide an optional class to be applied to the containing node.
+   */
+  className: PropTypes.string,
+
+  /**
+   * If type is "primary", then return a tertiary button with the "crossroads" icon,
+   * else return a ghost button.
+   */
+  type: PropTypes.string,
+
+  /* TODO: add types and DocGen for all props. */
+};

--- a/packages/ibm-products/src/components/Guidebanner/GuidebannerElementLink.js
+++ b/packages/ibm-products/src/components/Guidebanner/GuidebannerElementLink.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Import portions of React that are needed.
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { Link } from '@carbon/react';
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
+import { pkg } from '../../settings';
+
+// The block part of our conventional BEM class names (blockClass__E--M).
+const blockClass = `${pkg.prefix}--guidebanner__element-link`;
+const componentName = 'GuidebannerElementLink';
+
+/**
+ * A link styled specifically for the GuidebannerElement.
+ */
+export let GuidebannerElementLink = ({ children, className, ...rest }) => {
+  return (
+    <Link
+      {...rest}
+      className={cx(blockClass, className)}
+      kind="ghost"
+      role="link"
+      size="md"
+      {...getDevtoolsProps(componentName)}
+    >
+      {children}
+    </Link>
+  );
+};
+
+// Return a placeholder if not released and not enabled by feature flag
+GuidebannerElementLink = pkg.checkComponentEnabled(
+  GuidebannerElementLink,
+  componentName
+);
+
+// The display name of the component, used by React. Note that displayName
+// is used in preference to relying on function.name.
+GuidebannerElementLink.displayName = componentName;
+
+// The types and DocGen commentary for the component props,
+// in alphabetical order (for consistency).
+// See https://www.npmjs.com/package/prop-types#usage.
+GuidebannerElementLink.propTypes = {
+  /**
+   * Provide the contents of the GuidebannerElementLink.
+   */
+  children: PropTypes.node.isRequired,
+
+  /**
+   * Provide an optional class to be applied to the containing node.
+   */
+  className: PropTypes.string,
+};

--- a/packages/ibm-products/src/components/Guidebanner/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/Guidebanner/_storybook-styles.scss
@@ -1,0 +1,17 @@
+//
+// Copyright IBM Corp. 2023, 2023
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+#storybook-root {
+  overflow-x: hidden;
+}
+
+// The layout has been changed from middle/center to top/left, because
+// the component can expand, and it looks weird when expanding vertically
+// from the middle of the page instead of "dropping down" from above.
+// Margin provides spacing from the edge of the viewport.
+.non-linear-reading-stories__viewport {
+  margin: 0;
+}

--- a/packages/ibm-products/src/components/Guidebanner/index.js
+++ b/packages/ibm-products/src/components/Guidebanner/index.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export { Guidebanner } from './Guidebanner';
+export { GuidebannerElement } from './GuidebannerElement';
+export { GuidebannerElementButton } from './GuidebannerElementButton';
+export { GuidebannerElementLink } from './GuidebannerElementLink';

--- a/packages/ibm-products/src/global/js/package-settings.js
+++ b/packages/ibm-products/src/global/js/package-settings.js
@@ -73,6 +73,10 @@ const defaults = {
 
     // Novice to pro components not yet reviewed and released:
     Checklist: false,
+    Guidebanner: false,
+    GuidebannerElement: false,
+    GuidebannerElementButton: false,
+    GuidebannerElementLink: false,
     InlineTip: false,
   },
 


### PR DESCRIPTION
Contributes to #3599

Guide banners are used to give a bird’s eye view of information users need to know before diving into the page’s workflow.

#### What did you change?

This is a new component.

`Carousel` has been added as an "internal" component. This is a common component used by other Novice to Pro components.

#### How did you test and verify your work?

- [x] Migrated from Carbon v10
- [x] Storybook review
- [x] Design reviewers: Cameron Calder, @sdignum, Bridget Ndege.