### PR TITLE
feat(FilterSummary): enable filter summary clear button to be placed inline

### DIFF
--- a/packages/ibm-products-styles/src/components/FilterSummary/_filter-summary.scss
+++ b/packages/ibm-products-styles/src/components/FilterSummary/_filter-summary.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2022
+// Copyright IBM Corp. 2022, 2023
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -20,4 +20,9 @@ $block-class: #{$pkg-prefix}--filter-summary;
   padding: $spacing-03;
   border-top: 1px solid $border-subtle-01;
   background: $layer-01;
+}
+
+.#{$block-class}
+  .#{$pkg-prefix}--tag-set.#{$pkg-prefix}--tag-set.#{$block-class}__clear-button-inline {
+  width: auto;
 }

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
@@ -95,7 +95,7 @@ const useFilters = ({
   /** Methods */
   // If the user decides to cancel or click outside the flyout, it reverts back to the filters that were
   // there when they opened the flyout
-  const revertToPreviousFilters = () => {
+  const revertToPreviousFilters = useCallback(() => {
     setFiltersState(JSON.parse(prevFiltersRef.current));
     setFiltersObjectArray(JSON.parse(prevFiltersObjectArrayRef.current));
     setAllFilters(JSON.parse(lastAppliedFilters.current));
@@ -109,7 +109,7 @@ const useFilters = ({
     holdingPrevFiltersObjectArrayRef.current = JSON.parse(
       lastAppliedFilters.current
     );
-  };
+  }, [setAllFilters]);
 
   const reset = useCallback(() => {
     // When we reset we want the "initialFilters" to be an empty array
@@ -402,6 +402,7 @@ const useFilters = ({
    */
   useEffect(() => {
     if (!panelOpen && previousState?.panelOpen) {
+      revertToPreviousFilters();
       setAllFilters(holdingLastAppliedFiltersRef.current);
     }
     if (panelOpen && !previousState?.panelOpen) {
@@ -421,6 +422,7 @@ const useFilters = ({
     previousState?.panelOpen,
     reset,
     setAllFilters,
+    revertToPreviousFilters,
   ]);
 
   const cancel = () => {

--- a/packages/ibm-products/src/components/FilterSummary/FilterSummary.js
+++ b/packages/ibm-products/src/components/FilterSummary/FilterSummary.js
@@ -37,9 +37,11 @@ let FilterSummary = React.forwardRef(
     });
 
     const filterSummaryClearButton = useRef();
+    const filterSummaryRef = useRef();
+    const localRef = filterSummaryRef || ref;
     return (
       <div
-        ref={ref}
+        ref={localRef}
         className={cx([blockClass, className])}
         id={filterSummaryId}
       >
@@ -53,7 +55,7 @@ let FilterSummary = React.forwardRef(
           className={cx({
             [`${blockClass}__clear-button-inline`]: clearButtonInline,
           })}
-          containingElementSelector={`#${filterSummaryId}`}
+          containingElementRef={localRef}
           measurementOffset={filterSummaryClearButton?.current?.offsetWidth}
         />
         <Button

--- a/packages/ibm-products/src/components/FilterSummary/FilterSummary.js
+++ b/packages/ibm-products/src/components/FilterSummary/FilterSummary.js
@@ -1,11 +1,11 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 import { Button } from '@carbon/react';
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { TagSet } from '../TagSet';
@@ -22,6 +22,7 @@ let FilterSummary = React.forwardRef(
       filters = [],
       renderLabel = null,
       overflowType = 'default',
+      clearButtonInline = true,
     },
     ref
   ) => {
@@ -33,8 +34,14 @@ let FilterSummary = React.forwardRef(
       };
     });
 
+    const filterSummaryId = `filter-summary-test-id`;
+    const filterSummaryClearButton = useRef();
     return (
-      <div ref={ref} className={cx([blockClass, className])}>
+      <div
+        ref={ref}
+        className={cx([blockClass, className])}
+        id={filterSummaryId}
+      >
         <TagSet
           allTagsModalSearchLabel="Search all tags"
           allTagsModalSearchPlaceholderText="Search all tags"
@@ -42,8 +49,18 @@ let FilterSummary = React.forwardRef(
           showAllTagsLabel="View all tags"
           tags={tagFilters}
           overflowType={overflowType}
+          className={cx({
+            [`${blockClass}__clear-button-inline`]: clearButtonInline,
+          })}
+          containingElementSelector={`#${filterSummaryId}`}
+          measurementOffset={filterSummaryClearButton?.current?.offsetWidth}
         />
-        <Button kind="ghost" size="sm" onClick={clearFilters}>
+        <Button
+          kind="ghost"
+          size="sm"
+          onClick={clearFilters}
+          ref={filterSummaryClearButton}
+        >
           {clearFiltersText}
         </Button>
       </div>
@@ -56,6 +73,7 @@ FilterSummary.displayName = componentName;
 
 FilterSummary.propTypes = {
   className: PropTypes.string,
+  clearButtonInline: PropTypes.bool,
   clearFilters: PropTypes.func.isRequired,
   clearFiltersText: PropTypes.string,
   filters: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/packages/ibm-products/src/components/FilterSummary/FilterSummary.js
+++ b/packages/ibm-products/src/components/FilterSummary/FilterSummary.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { TagSet } from '../TagSet';
 import { pkg } from '../../settings';
+import uuidv4 from '../../global/js/utils/uuidv4';
 
 const blockClass = `${pkg.prefix}--filter-summary`;
 
@@ -26,6 +27,7 @@ let FilterSummary = React.forwardRef(
     },
     ref
   ) => {
+    const filterSummaryId = `${blockClass}__${uuidv4()}`;
     const tagFilters = filters.map(({ key, value, ...rest }) => {
       return {
         ...rest,
@@ -34,7 +36,6 @@ let FilterSummary = React.forwardRef(
       };
     });
 
-    const filterSummaryId = `filter-summary-test-id`;
     const filterSummaryClearButton = useRef();
     return (
       <div

--- a/packages/ibm-products/src/components/TagSet/TagSet.js
+++ b/packages/ibm-products/src/components/TagSet/TagSet.js
@@ -50,7 +50,7 @@ export let TagSet = React.forwardRef(
       allTagsModalSearchPlaceholderText,
       showAllTagsLabel,
       tags,
-      containingElementSelector,
+      containingElementRef,
       measurementOffset = defaults.measurementOffset,
 
       // Collect any other property values passed in.
@@ -156,9 +156,7 @@ export let TagSet = React.forwardRef(
       let willFit = 0;
 
       if (sizingTags.length > 0) {
-        const optionalContainingElement = document.querySelector(
-          `${containingElementSelector}`
-        );
+        const optionalContainingElement = containingElementRef?.current;
         const measurementOffsetValue =
           typeof measurementOffset === 'number' ? measurementOffset : 0;
         let spaceAvailable = optionalContainingElement
@@ -198,8 +196,8 @@ export let TagSet = React.forwardRef(
       multiline,
       sizingTags,
       tagSetRef,
-      containingElementSelector,
       measurementOffset,
+      containingElementRef,
     ]);
 
     useEffect(() => {
@@ -226,7 +224,10 @@ export let TagSet = React.forwardRef(
 
     useResizeObserver(sizingContainerRef, handleSizerTagsResize);
 
-    useResizeObserver(tagSetRef, handleResize);
+    const resizeOption = containingElementRef
+      ? containingElementRef
+      : tagSetRef;
+    useResizeObserver(resizeOption, handleResize);
 
     return (
       <div
@@ -330,9 +331,10 @@ TagSet.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * Optional selector used to measure space available
+   * Optional ref for custom resize container to measure available space
+   * Default will measure the available space of the TagSet container itself.
    */
-  containingElementSelector: PropTypes.string,
+  containingElementRef: PropTypes.object,
   /**
    * maximum visible tags
    */

--- a/packages/ibm-products/src/components/TagSet/TagSet.js
+++ b/packages/ibm-products/src/components/TagSet/TagSet.js
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2022
+// Copyright IBM Corp. 2020, 2023
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -27,6 +27,7 @@ const allTagsModalSearchThreshold = 10;
 // Default values for props
 const defaults = {
   align: 'start',
+  measurementOffset: 0,
   overflowAlign: 'bottom',
   overflowType: 'default',
 };
@@ -49,6 +50,8 @@ export let TagSet = React.forwardRef(
       allTagsModalSearchPlaceholderText,
       showAllTagsLabel,
       tags,
+      containingElementSelector,
+      measurementOffset = defaults.measurementOffset,
 
       // Collect any other property values passed in.
       ...rest
@@ -153,7 +156,15 @@ export let TagSet = React.forwardRef(
       let willFit = 0;
 
       if (sizingTags.length > 0) {
-        let spaceAvailable = tagSetRef.current.offsetWidth;
+        const optionalContainingElement = document.querySelector(
+          `${containingElementSelector}`
+        );
+        const measurementOffsetValue =
+          typeof measurementOffset === 'number' ? measurementOffset : 0;
+        let spaceAvailable =
+          typeof optionalContainingElement === 'object'
+            ? optionalContainingElement.offsetWidth - measurementOffsetValue
+            : tagSetRef.current.offsetWidth;
 
         for (let i in sizingTags) {
           const tagWidth = sizingTags[i]?.offsetWidth || 0;
@@ -183,7 +194,14 @@ export let TagSet = React.forwardRef(
       } else {
         setDisplayCount(maxVisible ? Math.min(willFit, maxVisible) : willFit);
       }
-    }, [maxVisible, multiline, sizingTags, tagSetRef]);
+    }, [
+      maxVisible,
+      multiline,
+      sizingTags,
+      tagSetRef,
+      containingElementSelector,
+      measurementOffset,
+    ]);
 
     useEffect(() => {
       checkFullyVisibleTags();
@@ -313,9 +331,18 @@ TagSet.propTypes = {
    */
   className: PropTypes.string,
   /**
+   * Optional selector used to measure space available
+   */
+  containingElementSelector: PropTypes.string,
+  /**
    * maximum visible tags
    */
   maxVisible: PropTypes.number,
+  /**
+   * Specify offset amount for measure available space, only used when `containingElementSelector`
+   * is also provided
+   */
+  measurementOffset: PropTypes.number,
   /**
    * display tags in multiple lines
    */

--- a/packages/ibm-products/src/components/TagSet/TagSet.js
+++ b/packages/ibm-products/src/components/TagSet/TagSet.js
@@ -161,10 +161,9 @@ export let TagSet = React.forwardRef(
         );
         const measurementOffsetValue =
           typeof measurementOffset === 'number' ? measurementOffset : 0;
-        let spaceAvailable =
-          typeof optionalContainingElement === 'object'
-            ? optionalContainingElement.offsetWidth - measurementOffsetValue
-            : tagSetRef.current.offsetWidth;
+        let spaceAvailable = optionalContainingElement
+          ? optionalContainingElement.offsetWidth - measurementOffsetValue
+          : tagSetRef.current.offsetWidth;
 
         for (let i in sizingTags) {
           const tagWidth = sizingTags[i]?.offsetWidth || 0;


### PR DESCRIPTION
Contributes to #3893 

Includes fixes so that the `Clear filters` button can be placed inline next to the filter tags and not spaced at the end of the filter summary component. This required changes/enhancements to the current `TagSet` component in order for it to measure available space from a given element opposed to it's own container element. To account for the width of the `Clear filters` button I also included a new prop, `measurementOffsetValue` otherwise the TagSet only measures based on the width of the entire FilterSummary as opposed to the FilterSummary minus the width of the `ClearFilter` button since that always needs to be visible.

#### What did you change?
```
packages/ibm-products-styles/src/components/FilterSummary/_filter-summary.scss
packages/ibm-products/src/components/FilterSummary/FilterSummary.js
packages/ibm-products/src/components/TagSet/TagSet.js
```
#### How did you test and verify your work?
Storybook

_See interaction below_
<video src='https://github.com/carbon-design-system/ibm-products/assets/10215203/a8a7fad9-d690-435f-8eec-f043de579d4b' width=180/>



