### PR TITLE
feat(FilterSummary): enable filter summary clear button to be placed inline (v1)

### DIFF
--- a/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
@@ -3443,6 +3443,10 @@ th.c4p--datagrid__select-all-toggle-on.button {
   background: var(--cds-ui-01, #f4f4f4);
 }
 
+.c4p--filter-summary .c4p--tag-set.c4p--tag-set.c4p--filter-summary__clear-button-inline {
+  width: auto;
+}
+
 .c4p--datagrid__datagridWrap {
   display: block;
   width: 100%;

--- a/packages/ibm-products/src/components/FilterSummary/FilterSummary.js
+++ b/packages/ibm-products/src/components/FilterSummary/FilterSummary.js
@@ -35,9 +35,11 @@ let FilterSummary = React.forwardRef(
     }));
 
     const filterSummaryClearButton = useRef();
+    const filterSummaryRef = useRef();
+    const localRef = filterSummaryRef || ref;
     return (
       <div
-        ref={ref}
+        ref={localRef}
         className={cx([blockClass, className])}
         id={filterSummaryId}
       >
@@ -51,7 +53,7 @@ let FilterSummary = React.forwardRef(
           className={cx({
             [`${blockClass}__clear-button-inline`]: clearButtonInline,
           })}
-          containingElementSelector={`#${filterSummaryId}`}
+          containingElementRef={localRef}
           measurementOffset={filterSummaryClearButton?.current?.offsetWidth}
         />
         <Button

--- a/packages/ibm-products/src/components/FilterSummary/FilterSummary.js
+++ b/packages/ibm-products/src/components/FilterSummary/FilterSummary.js
@@ -1,15 +1,16 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 import { Button } from 'carbon-components-react';
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { TagSet } from '../TagSet';
 import { pkg } from '../../settings';
+import uuidv4 from '../../global/js/utils/uuidv4';
 
 const blockClass = `${pkg.prefix}--filter-summary`;
 
@@ -22,17 +23,24 @@ let FilterSummary = React.forwardRef(
       filters = [],
       renderLabel = null,
       overflowType = 'default',
+      clearButtonInline = true,
     },
     ref
   ) => {
+    const filterSummaryId = `${blockClass}__${uuidv4()}`;
     const tagFilters = filters.map(({ key, value, ...rest }) => ({
       ...rest,
       type: 'gray',
       label: renderLabel?.(key, value) ?? `${key}: ${value}`,
     }));
 
+    const filterSummaryClearButton = useRef();
     return (
-      <div ref={ref} className={cx([blockClass, className])}>
+      <div
+        ref={ref}
+        className={cx([blockClass, className])}
+        id={filterSummaryId}
+      >
         <TagSet
           allTagsModalSearchLabel="Search all tags"
           allTagsModalSearchPlaceholderText="Search all tags"
@@ -40,8 +48,18 @@ let FilterSummary = React.forwardRef(
           showAllTagsLabel="View all tags"
           tags={tagFilters}
           overflowType={overflowType}
+          className={cx({
+            [`${blockClass}__clear-button-inline`]: clearButtonInline,
+          })}
+          containingElementSelector={`#${filterSummaryId}`}
+          measurementOffset={filterSummaryClearButton?.current?.offsetWidth}
         />
-        <Button kind="ghost" size="sm" onClick={clearFilters}>
+        <Button
+          kind="ghost"
+          size="sm"
+          onClick={clearFilters}
+          ref={filterSummaryClearButton}
+        >
           {clearFiltersText}
         </Button>
       </div>
@@ -54,6 +72,7 @@ FilterSummary.displayName = componentName;
 
 FilterSummary.propTypes = {
   className: PropTypes.string,
+  clearButtonInline: PropTypes.boolean,
   clearFilters: PropTypes.func.isRequired,
   clearFiltersText: PropTypes.string,
   filters: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/packages/ibm-products/src/components/FilterSummary/_filter-summary.scss
+++ b/packages/ibm-products/src/components/FilterSummary/_filter-summary.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2022
+// Copyright IBM Corp. 2022, 2023
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -16,4 +16,9 @@ $block-class: #{$pkg-prefix}--filter-summary;
   padding: $spacing-03;
   border-top: 1px solid $ui-03;
   background: $ui-01;
+}
+
+.#{$block-class}
+  .#{$pkg-prefix}--tag-set.#{$pkg-prefix}--tag-set.#{$block-class}__clear-button-inline {
+  width: auto;
 }

--- a/packages/ibm-products/src/components/TagSet/TagSet.js
+++ b/packages/ibm-products/src/components/TagSet/TagSet.js
@@ -54,7 +54,7 @@ export let TagSet = React.forwardRef(
       allTagsModalSearchPlaceholderText,
       showAllTagsLabel,
       tags,
-      containingElementSelector,
+      containingElementRef,
       measurementOffset = defaults.measurementOffset,
 
       // Collect any other property values passed in.
@@ -173,9 +173,7 @@ export let TagSet = React.forwardRef(
       let willFit = 0;
 
       if (sizingTags.length > 0) {
-        const optionalContainingElement = document.querySelector(
-          `${containingElementSelector}`
-        );
+        const optionalContainingElement = containingElementRef?.current;
         const measurementOffsetValue =
           typeof measurementOffset === 'number' ? measurementOffset : 0;
         let spaceAvailable = optionalContainingElement
@@ -215,7 +213,7 @@ export let TagSet = React.forwardRef(
       multiline,
       sizingTags,
       tagSetRef,
-      containingElementSelector,
+      containingElementRef,
       measurementOffset,
     ]);
 
@@ -243,7 +241,10 @@ export let TagSet = React.forwardRef(
 
     useResizeObserver(sizingContainerRef, handleSizerTagsResize);
 
-    useResizeObserver(tagSetRef, handleResize);
+    const resizeOption = containingElementRef
+      ? containingElementRef
+      : tagSetRef;
+    useResizeObserver(resizeOption, handleResize);
 
     return (
       <div
@@ -350,9 +351,10 @@ TagSet.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * Optional selector used to measure space available
+   * Optional ref for custom resize container to measure available space
+   * Default will measure the available space of the TagSet container itself.
    */
-  containingElementSelector: PropTypes.string,
+  containingElementRef: PropTypes.object,
   /**
    * maximum visible tags
    */

--- a/packages/ibm-products/src/components/TagSet/TagSet.js
+++ b/packages/ibm-products/src/components/TagSet/TagSet.js
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2023
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -29,6 +29,7 @@ const allTagsModalSearchThreshold = 10;
 const defaults = {
   align: 'start',
   // allTagsModalTarget: document.body,
+  measurementOffset: 0,
   overflowAlign: 'center',
   overflowDirection: 'bottom',
   overflowType: 'default',
@@ -53,6 +54,8 @@ export let TagSet = React.forwardRef(
       allTagsModalSearchPlaceholderText,
       showAllTagsLabel,
       tags,
+      containingElementSelector,
+      measurementOffset = defaults.measurementOffset,
 
       // Collect any other property values passed in.
       ...rest
@@ -170,7 +173,14 @@ export let TagSet = React.forwardRef(
       let willFit = 0;
 
       if (sizingTags.length > 0) {
-        let spaceAvailable = tagSetRef.current.offsetWidth;
+        const optionalContainingElement = document.querySelector(
+          `${containingElementSelector}`
+        );
+        const measurementOffsetValue =
+          typeof measurementOffset === 'number' ? measurementOffset : 0;
+        let spaceAvailable = optionalContainingElement
+          ? optionalContainingElement.offsetWidth - measurementOffsetValue
+          : tagSetRef.current.offsetWidth;
 
         for (let i in sizingTags) {
           const tagWidth = sizingTags[i].offsetWidth;
@@ -200,7 +210,14 @@ export let TagSet = React.forwardRef(
       } else {
         setDisplayCount(maxVisible ? Math.min(willFit, maxVisible) : willFit);
       }
-    }, [maxVisible, multiline, sizingTags, tagSetRef]);
+    }, [
+      maxVisible,
+      multiline,
+      sizingTags,
+      tagSetRef,
+      containingElementSelector,
+      measurementOffset,
+    ]);
 
     useEffect(() => {
       checkFullyVisibleTags();
@@ -333,9 +350,18 @@ TagSet.propTypes = {
    */
   className: PropTypes.string,
   /**
+   * Optional selector used to measure space available
+   */
+  containingElementSelector: PropTypes.string,
+  /**
    * maximum visible tags
    */
   maxVisible: PropTypes.number,
+  /**
+   * Specify offset amount for measure available space, only used when `containingElementSelector`
+   * is also provided
+   */
+  measurementOffset: PropTypes.number,
   /**
    * display tags in multiple lines
    */


### PR DESCRIPTION
Contributes to #3893 

Includes fixes so that the `Clear filters` button can be placed inline next to the filter tags and not spaced at the end of the filter summary component. This required changes/enhancements to the current `TagSet` component in order for it to measure available space from a given element opposed to it's own container element. To account for the width of the `Clear filters` button I also included a new prop, `measurementOffsetValue` otherwise the TagSet only measures based on the width of the entire FilterSummary as opposed to the FilterSummary minus the width of the `ClearFilter` button since that always needs to be visible.

#### What did you change?
```
packages/ibm-products-styles/src/components/FilterSummary/_filter-summary.scss
packages/ibm-products/src/components/FilterSummary/FilterSummary.js
packages/ibm-products/src/components/TagSet/TagSet.js
```
#### How did you test and verify your work?
Storybook

_See interaction below_
<video src='https://github.com/carbon-design-system/ibm-products/assets/10215203/a8a7fad9-d690-435f-8eec-f043de579d4b' width=180/>