### PR TITLE
chore: fix small issue with new datagrid story structure

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
@@ -32,8 +32,6 @@ import styles from './_storybook-styles.scss';
 import { DatagridActions } from './utils/DatagridActions';
 import { DatagridPagination } from './utils/DatagridPagination';
 import { Wrapper } from './utils/Wrapper';
-import * as HeaderStory from './Datagrid.stories/Header/Header.stories';
-import * as ColumnAlignmentStory from './Datagrid.stories/ColumnAlignment/ColumnAlignment.stories';
 import { DocsPage } from './Datagrid.docs-page';
 
 export default {
@@ -284,9 +282,6 @@ export const Pagination = () => {
 
   return <Datagrid datagridState={{ ...datagridState }} />;
 };
-
-export const Header = HeaderStory.HeaderBasicUsageStory;
-export const ColumnAlignment = ColumnAlignmentStory.ColumnAlignmentStory;
 
 export const SelectableRow = () => {
   const [data] = useState(makeData(10));

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories/ColumnAlignment/ColumnAlignment.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories/ColumnAlignment/ColumnAlignment.stories.js
@@ -10,7 +10,10 @@ import React, { useState } from 'react';
 import { Tooltip } from '@carbon/react';
 import { Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
-import { prepareStory } from '../../../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../../../global/js/utils/story-helper';
 import {
   Datagrid,
   useDatagrid,
@@ -26,6 +29,7 @@ import { ARG_TYPES } from '../../utils/getArgTypes';
 import { StatusIcon } from '../../../StatusIcon';
 
 export default {
+  title: getStoryTitle(Datagrid.displayName),
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories/Header/Header.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories/Header/Header.stories.js
@@ -9,7 +9,10 @@
 import React, { useState } from 'react';
 import { Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
-import { prepareStory } from '../../../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../../../global/js/utils/story-helper';
 import { Datagrid, useDatagrid } from '../../index';
 import styles from '../../_storybook-styles.scss';
 // import mdx from '../../Datagrid.mdx';
@@ -19,6 +22,7 @@ import { makeData } from '../../utils/makeData';
 import { ARG_TYPES } from '../../utils/getArgTypes';
 
 export default {
+  title: getStoryTitle(Datagrid.displayName),
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {


### PR DESCRIPTION
Removes section added to storybook navigation, I'm guessing because the `Header` and `ColumnAlignment` changes removed the `title` from the story default export.

#### What did you change?
Added `title` porperty to story default export for Header and ColumnAlignment
#### How did you test and verify your work?
Storybook

Removes section highlighted below:
![Screenshot 2023-12-06 at 4 13 34 PM](https://github.com/carbon-design-system/ibm-products/assets/10215203/3c06271d-71c3-4604-bc96-8fa989a63de5)
