### PR TITLE
chore: fix build setup with canary component sass

### DIFF
--- a/packages/ibm-products-styles/src/components/_Canary/_carbon-imports.scss
+++ b/packages/ibm-products-styles/src/components/_Canary/_carbon-imports.scss
@@ -4,3 +4,4 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
+@use '@carbon/styles/scss/components/code-snippet';

--- a/packages/ibm-products-styles/src/components/_Canary/_index-with-carbon.scss
+++ b/packages/ibm-products-styles/src/components/_Canary/_index-with-carbon.scss
@@ -4,3 +4,5 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
+@use './carbon-imports';
+@use './canary';

--- a/packages/ibm-products-styles/src/components/_Canary/_index.scss
+++ b/packages/ibm-products-styles/src/components/_Canary/_index.scss
@@ -4,3 +4,4 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
+@use './canary';

--- a/packages/ibm-products-styles/src/components/_index-with-carbon.scss
+++ b/packages/ibm-products-styles/src/components/_index-with-carbon.scss
@@ -7,7 +7,7 @@
 
 // Package all scss files here for those that want them all bundled up.
 
-@use './_Canary/canary';
+@use './_Canary/index-with-carbon' as *;
 
 @use './APIKeyModal/index-with-carbon' as *;
 @use './AboutModal/index-with-carbon' as *;

--- a/packages/ibm-products-styles/src/components/_index.scss
+++ b/packages/ibm-products-styles/src/components/_index.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2021
+// Copyright IBM Corp. 2021, 2023
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -7,7 +7,7 @@
 
 // Package all scss files here for those that want them all bundled up.
 
-@use './_Canary/canary';
+@use './_Canary';
 
 @use './APIKeyModal';
 @use './AboutModal';


### PR DESCRIPTION
Contributes to #3949 

Fixes the Canary sass structure so we do not include Carbon styles.

#### What did you change?
```
packages/ibm-products-styles/src/components/_Canary/_canary.scss
packages/ibm-products-styles/src/components/_Canary/_carbon-imports.scss
packages/ibm-products-styles/src/components/_Canary/_index-with-carbon.scss
packages/ibm-products-styles/src/components/_Canary/_index.scss
packages/ibm-products-styles/src/components/_index-with-carbon.scss
packages/ibm-products-styles/src/components/_index.scss
```
#### How did you test and verify your work?
Ran build script from styles package