### PR TITLE
fix(Checklist): add carbon scss import files

### DIFF
--- a/packages/ibm-products-styles/src/components/Checklist/_carbon-imports.scss
+++ b/packages/ibm-products-styles/src/components/Checklist/_carbon-imports.scss
@@ -1,0 +1,11 @@
+//
+// Copyright IBM Corp. 2020, 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// AboutModal uses the following Carbon components:
+// Button, IconButton
+
+@use '@carbon/react/scss/components/button';

--- a/packages/ibm-products-styles/src/components/Checklist/_checklist.scss
+++ b/packages/ibm-products-styles/src/components/Checklist/_checklist.scss
@@ -7,7 +7,6 @@
 
 // Standard imports.
 @use '@carbon/layout/scss/convert' as *;
-
 @use '@carbon/styles/scss/motion' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;

--- a/packages/ibm-products-styles/src/components/Checklist/_index-with-carbon.scss
+++ b/packages/ibm-products-styles/src/components/Checklist/_index-with-carbon.scss
@@ -1,0 +1,9 @@
+//
+// Copyright IBM Corp. 2022, 2022
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use './carbon-imports';
+@use './about-modal';

--- a/packages/ibm-products-styles/src/components/Checklist/_index-with-carbon.scss
+++ b/packages/ibm-products-styles/src/components/Checklist/_index-with-carbon.scss
@@ -6,4 +6,4 @@
 //
 
 @use './carbon-imports';
-@use './about-modal';
+@use './checklist';


### PR DESCRIPTION
This is a simple update. 

The Novice to Pro Checklist component was in development during the Carbon for IBM Products SCSS global update. This just brings the component inline with the other components.

#### What did you change?

Added Carbon-specific SCSS files

#### How did you test and verify your work?

Built locally and verified no Carbon styles related to checklist.