### PR TITLE
feat: side panel for create and edit + type check

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
     "@carbon/ibm-products-styles": "^2.18.0",
     "@carbon/layout": "^11.20.1",
     "@carbon/motion": "^11.16.1",
-    "@carbon/react": "^1.44.0",
+    "@carbon/react": "^1.45.0",
     "@carbon/storybook-addon-theme": "^2.0.5",
     "@carbon/themes": "^11.28.0",
     "@carbon/type": "^11.25.1",

--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -2432,6 +2432,12 @@ p.c4p--about-modal__copyright-text:first-child {
   background-color: var(--cds-layer-01, #f4f4f4);
   /* stylelint-disable-next-line max-nesting-depth */
 }
+.c4p--side-panel__container .c4p--side-panel__title-container:has(.c4p--side-panel__navigation-back-button) {
+  padding-top: 2rem;
+}
+.c4p--side-panel__container .c4p--side-panel__title-container:has(.c4p--side-panel__navigation-back-button.cds--btn--md) {
+  padding-top: 2.5rem;
+}
 .c4p--side-panel__container .c4p--side-panel__title-container::before {
   position: absolute;
   bottom: 0;
@@ -2452,7 +2458,10 @@ p.c4p--about-modal__copyright-text:first-child {
   margin-bottom: 0;
 }
 .c4p--side-panel__container .c4p--side-panel__title-container.c4p--side-panel__on-detail-step .c4p--side-panel__collapsed-title-text {
-  top: 3rem;
+  top: 2rem;
+}
+.c4p--side-panel__container .c4p--side-panel__title-container.c4p--side-panel__on-detail-step .c4p--side-panel__navigation-back-button.cds--btn--md ~ .c4p--side-panel__collapsed-title-text {
+  top: 2.5rem;
 }
 .c4p--side-panel__container .c4p--side-panel__title-container.c4p--side-panel__title-container-without-title {
   padding: 0;
@@ -2605,26 +2614,29 @@ p.c4p--about-modal__copyright-text:first-child {
   margin-right: 0.5rem;
 }
 .c4p--side-panel__container .cds--btn.c4p--side-panel__navigation-back-button {
-  position: relative;
+  position: fixed;
   z-index: 5;
-  top: calc(-1 * 0.5rem);
-  left: calc(-1 * 0.5rem);
+  top: 0;
+  left: 0;
 }
 .c4p--side-panel__container .cds--btn.c4p--side-panel__navigation-back-button,
 .c4p--side-panel__container .cds--btn.c4p--side-panel__close-button {
-  min-width: 2rem;
+  display: flex;
+  width: 2rem;
+  height: 2rem;
+  align-items: center;
+  justify-content: center;
   padding: 0;
   color: var(--cds-text-primary, #161616);
 }
-.c4p--side-panel__container .cds--btn.c4p--side-panel__close-button {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin: 0.5rem;
-  margin-bottom: 0;
-}
+.c4p--side-panel__container .cds--btn.c4p--side-panel__navigation-back-button .cds--btn__icon,
 .c4p--side-panel__container .cds--btn.c4p--side-panel__close-button .cds--btn__icon {
   margin: 0;
+}
+.c4p--side-panel__container .cds--btn--md.c4p--side-panel__navigation-back-button,
+.c4p--side-panel__container .cds--btn--md.c4p--side-panel__close-button {
+  width: 2.5rem;
+  height: 2.5rem;
 }
 .c4p--side-panel__container .c4p--side-panel__slug-and-close {
   position: fixed;
@@ -5068,6 +5080,10 @@ th.c4p--datagrid__select-all-toggle-on.button {
   padding: 0.5rem;
   border-top: 1px solid var(--cds-border-subtle-01, #c6c6c6);
   background: var(--cds-layer-01, #f4f4f4);
+}
+
+.c4p--filter-summary .c4p--tag-set.c4p--tag-set.c4p--filter-summary__clear-button-inline {
+  width: auto;
 }
 
 .c4p--datagrid__datagridWrap {

--- a/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
+++ b/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
@@ -115,6 +115,16 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
     padding: $spacing-05 $spacing-05 $spacing-03 $spacing-05;
     background-color: $layer-01;
 
+    &:has(.#{$block-class}__navigation-back-button) {
+      padding-top: $spacing-07;
+    }
+
+    &:has(
+        .#{$block-class}__navigation-back-button.#{c4p-settings.$carbon-prefix}--btn--md
+      ) {
+      padding-top: $spacing-08;
+    }
+
     /* stylelint-disable-next-line max-nesting-depth */
     &::before {
       @include setDividerStyles();
@@ -129,8 +139,15 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
       margin-bottom: 0;
     }
     &.#{$block-class}__on-detail-step .#{$block-class}__collapsed-title-text {
-      top: $spacing-09;
+      top: $spacing-07;
     }
+
+    &.#{$block-class}__on-detail-step
+      .#{$block-class}__navigation-back-button.#{c4p-settings.$carbon-prefix}--btn--md
+      ~ .#{$block-class}__collapsed-title-text {
+      top: $spacing-08;
+    }
+
     &.#{$block-class}__title-container-without-title {
       padding: 0;
     }
@@ -326,29 +343,30 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
   }
 
   .#{c4p-settings.$carbon-prefix}--btn.#{$block-class}__navigation-back-button {
-    position: relative;
+    position: fixed;
     z-index: 5;
-    top: calc(-1 * #{$spacing-03});
-    left: calc(-1 * #{$spacing-03});
+    top: 0;
+    left: 0;
   }
   .#{c4p-settings.$carbon-prefix}--btn.#{$block-class}__navigation-back-button,
   .#{c4p-settings.$carbon-prefix}--btn.#{$block-class}__close-button {
-    min-width: 2rem;
-    padding: 0;
-    color: $text-primary;
-  }
-
-  .#{c4p-settings.$carbon-prefix}--btn.#{$block-class}__close-button {
     display: flex;
+    width: $spacing-07;
+    height: $spacing-07;
     align-items: center;
     justify-content: center;
-    margin: $spacing-03;
-    margin-bottom: 0;
+    padding: 0;
+    color: $text-primary;
+
+    .#{c4p-settings.$carbon-prefix}--btn__icon {
+      margin: 0;
+    }
   }
 
-  .#{c4p-settings.$carbon-prefix}--btn.#{$block-class}__close-button
-    .#{c4p-settings.$carbon-prefix}--btn__icon {
-    margin: 0;
+  .#{c4p-settings.$carbon-prefix}--btn--md.#{$block-class}__navigation-back-button,
+  .#{c4p-settings.$carbon-prefix}--btn--md.#{$block-class}__close-button {
+    width: $spacing-08;
+    height: $spacing-08;
   }
 
   .#{$block-class}__slug-and-close {

--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -90,7 +90,7 @@
     "@carbon/grid": "^11.21.1",
     "@carbon/layout": "^11.20.1",
     "@carbon/motion": "^11.16.1",
-    "@carbon/react": "^1.44.0",
+    "@carbon/react": "^1.45.0",
     "@carbon/themes": "^11.28.0",
     "@carbon/type": "^11.25.1",
     "react": "^16.8.6 || ^17.0.1 || ^18.2.0",

--- a/packages/ibm-products/src/components/CreateSidePanel/CreateSidePanel.js
+++ b/packages/ibm-products/src/components/CreateSidePanel/CreateSidePanel.js
@@ -185,6 +185,12 @@ CreateSidePanel.propTypes = {
    * Specifies which DOM element in the form should be focused.
    */
   selectorPrimaryFocus: PropTypes.node.isRequired,
+
+  /**
+   * Provide a `Slug` component to be rendered inside the `SidePanel` component
+   */
+  slug: PropTypes.node,
+
   /**
    * The subtitle of the CreateSidePanel is optional and serves to provide more information about the modal.
    */

--- a/packages/ibm-products/src/components/CreateSidePanel/CreateSidePanel.js
+++ b/packages/ibm-products/src/components/CreateSidePanel/CreateSidePanel.js
@@ -187,7 +187,7 @@ CreateSidePanel.propTypes = {
   selectorPrimaryFocus: PropTypes.node.isRequired,
 
   /**
-   * Provide a `Slug` component to be rendered inside the `SidePanel` component
+   *  **Experimental:** Provide a `Slug` component to be rendered inside the `SidePanel` component
    */
   slug: PropTypes.node,
 

--- a/packages/ibm-products/src/components/CreateSidePanel/CreateSidePanel.stories.js
+++ b/packages/ibm-products/src/components/CreateSidePanel/CreateSidePanel.stories.js
@@ -17,6 +17,8 @@ import {
   HeaderContainer,
   HeaderName,
   usePrefix,
+  unstable__Slug as Slug,
+  unstable__SlugContent as SlugContent,
 } from '@carbon/react';
 
 import { pkg } from '../../settings';
@@ -34,6 +36,26 @@ import { sidePanelDecorator } from '../../global/decorators/sidePanelDecorator';
 const blockClass = `${pkg.prefix}--create-side-panel`;
 
 const prefix = 'create-side-panel-stories__';
+
+const sampleSlug = (
+  <Slug className="slug-container" size="xs">
+    <SlugContent>
+      <div>
+        <p className="secondary">AI Explained</p>
+        <h1>84%</h1>
+        <p className="secondary bold">Confidence score</p>
+        <p className="secondary">
+          This is not really Lorem Ipsum but the spell checker did not like the
+          previous text with it&apos;s non-words which is why this unwieldy
+          sentence, should one choose to call it that, here.
+        </p>
+        <hr />
+        <p className="secondary">Model type</p>
+        <p className="bold">Foundation model</p>
+      </div>
+    </SlugContent>
+  </Slug>
+);
 
 const defaultStoryProps = {
   title: 'Create partitions',
@@ -69,10 +91,23 @@ export default {
       page: DocsPage,
     },
   },
+  argTypes: {
+    slug: {
+      control: {
+        type: 'select',
+        labels: {
+          0: 'No AI slug',
+          1: 'with AI Slug',
+        },
+        default: 0,
+      },
+      options: [0, 1],
+    },
+  },
   decorators: [sidePanelDecorator(renderUIShellHeader, prefix)],
 };
 
-const DefaultTemplate = ({ ...args }) => {
+const DefaultTemplate = ({ slug, ...args }) => {
   const carbonPrefix = usePrefix();
   const [open, setOpen] = useState(false);
   return (
@@ -91,6 +126,7 @@ const DefaultTemplate = ({ ...args }) => {
         onRequestClose={() => setOpen(false)}
         onRequestSubmit={() => setOpen(false)}
         selectorPrimaryFocus={`.${carbonPrefix}--text-input`}
+        slug={slug && sampleSlug}
       >
         <TextInput
           id="create-side-panel-topic-name-a"
@@ -165,7 +201,7 @@ const DefaultTemplate = ({ ...args }) => {
   );
 };
 
-const TemplateWithFormValidation = ({ ...args }) => {
+const TemplateWithFormValidation = ({ slug, ...args }) => {
   const carbonPrefix = usePrefix();
   const [open, setOpen] = useState(false);
   const [textInput, setTextInput] = useState('');
@@ -187,6 +223,7 @@ const TemplateWithFormValidation = ({ ...args }) => {
         onRequestSubmit={() => setOpen(false)}
         disableSubmit={!textInput.length}
         selectorPrimaryFocus={`.${carbonPrefix}--text-input`}
+        slug={slug && sampleSlug}
       >
         <TextInput
           id="create-side-panel-topic-name-b"
@@ -263,7 +300,7 @@ const TemplateWithFormValidation = ({ ...args }) => {
   );
 };
 
-const TemplateWithMultipleForms = ({ ...args }) => {
+const TemplateWithMultipleForms = ({ slug, ...args }) => {
   const carbonPrefix = usePrefix();
   const [open, setOpen] = useState(false);
   const [textInput, setTextInput] = useState('');
@@ -285,6 +322,7 @@ const TemplateWithMultipleForms = ({ ...args }) => {
         onRequestSubmit={() => setOpen(false)}
         disableSubmit={!textInput.length}
         selectorPrimaryFocus={`.${carbonPrefix}--text-input`}
+        slug={slug && sampleSlug}
       >
         <FormGroup
           className={`${blockClass}__form ${prefix}example-form-group`}

--- a/packages/ibm-products/src/components/EditSidePanel/EditSidePanel.js
+++ b/packages/ibm-products/src/components/EditSidePanel/EditSidePanel.js
@@ -229,7 +229,7 @@ EditSidePanel.propTypes = {
   slideIn: PropTypes.bool,
 
   /**
-   * Provide a `Slug` component to be rendered inside the `SidePanel` component
+   *  **Experimental:** Provide a `Slug` component to be rendered inside the `SidePanel` component
    */
   slug: PropTypes.node,
 

--- a/packages/ibm-products/src/components/EditSidePanel/EditSidePanel.js
+++ b/packages/ibm-products/src/components/EditSidePanel/EditSidePanel.js
@@ -229,6 +229,11 @@ EditSidePanel.propTypes = {
   slideIn: PropTypes.bool,
 
   /**
+   * Provide a `Slug` component to be rendered inside the `SidePanel` component
+   */
+  slug: PropTypes.node,
+
+  /**
    * The subtitle of the CreateSidePanel is optional and serves to provide more information about the modal.
    */
   subtitle: PropTypes.node,

--- a/packages/ibm-products/src/components/EditSidePanel/EditSidePanel.stories.js
+++ b/packages/ibm-products/src/components/EditSidePanel/EditSidePanel.stories.js
@@ -18,6 +18,8 @@ import {
   HeaderContainer,
   HeaderName,
   usePrefix,
+  unstable__Slug as Slug,
+  unstable__SlugContent as SlugContent,
 } from '@carbon/react';
 import { Copy, TrashCan, Settings } from '@carbon/react/icons';
 
@@ -31,6 +33,26 @@ import { EditSidePanel } from '.';
 import styles from './_storybook-styles.scss';
 import { StoryDocsPage } from '../../global/js/utils/StoryDocsPage';
 import { sidePanelDecorator } from '../../global/decorators/sidePanelDecorator';
+
+const sampleSlug = (
+  <Slug className="slug-container" size="xs">
+    <SlugContent>
+      <div>
+        <p className="secondary">AI Explained</p>
+        <h1>84%</h1>
+        <p className="secondary bold">Confidence score</p>
+        <p className="secondary">
+          This is not really Lorem Ipsum but the spell checker did not like the
+          previous text with it&apos;s non-words which is why this unwieldy
+          sentence, should one choose to call it that, here.
+        </p>
+        <hr />
+        <p className="secondary">Model type</p>
+        <p className="bold">Foundation model</p>
+      </div>
+    </SlugContent>
+  </Slug>
+);
 
 const defaultStoryProps = {
   title: 'Edit platform quotas',
@@ -67,6 +89,17 @@ export default {
     formTitle: { control: { type: 'text' } },
     formDescription: { control: { type: 'text' } },
     open: { control: { disable: true } },
+    slug: {
+      control: {
+        type: 'select',
+        labels: {
+          0: 'No AI slug',
+          1: 'with AI Slug',
+        },
+        default: 0,
+      },
+      options: [0, 1],
+    },
   },
   parameters: {
     layout: 'fullscreen',
@@ -83,7 +116,7 @@ export default {
 /**
  * TODO: Declare template(s) for one or more scenarios.
  */
-const Template = (args) => {
+const Template = ({ slug, ...args }) => {
   const carbonPrefix = usePrefix();
   const items = ['Day(s)', 'Month(s)', 'Year(s)'];
   const [open, setOpen] = useState(false);
@@ -106,6 +139,7 @@ const Template = (args) => {
         onRequestSubmit={() => setOpen(false)}
         disableSubmit={!topicValue.length}
         selectorPrimaryFocus={`.${carbonPrefix}--text-input`}
+        slug={slug && sampleSlug}
       >
         <TextInput
           id="create-side-panel-topic-name-a"

--- a/packages/ibm-products/src/components/SidePanel/SidePanel.js
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.js
@@ -570,11 +570,12 @@ export let SidePanel = React.forwardRef(
     ]);
 
     const renderHeader = () => {
+      let slugCloseSize = actions.length && /l/.test(size) ? 'md' : 'sm';
       let normalizedSlug;
       if (slug && slug?.type?.displayName === 'Slug') {
         normalizedSlug = React.cloneElement(slug, {
           // slug size is sm unless actions and size > md
-          size: actions.length && /l/.test(size) ? 'md' : 'sm',
+          size: slugCloseSize,
         });
       }
 
@@ -598,7 +599,7 @@ export let SidePanel = React.forwardRef(
               <Button
                 aria-label={navigationBackIconDescription}
                 kind="ghost"
-                size="sm"
+                size={slugCloseSize}
                 disabled={false}
                 renderIcon={(props) => <ArrowLeft size={20} {...props} />}
                 iconDescription={navigationBackIconDescription}
@@ -617,7 +618,7 @@ export let SidePanel = React.forwardRef(
             <Button
               aria-label={closeIconDescription}
               kind="ghost"
-              size="sm"
+              size={slugCloseSize}
               renderIcon={(props) => <Close size={20} {...props} />}
               iconDescription={closeIconDescription}
               className={`${blockClass}__close-button`}

--- a/packages/ibm-products/src/components/SidePanel/SidePanel.js
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.js
@@ -571,7 +571,7 @@ export let SidePanel = React.forwardRef(
 
     const renderHeader = () => {
       let normalizedSlug;
-      if (slug) {
+      if (slug && slug?.type?.displayName === 'Slug') {
         normalizedSlug = React.cloneElement(slug, {
           // slug size is sm unless actions and size > md
           size: actions.length && /l/.test(size) ? 'md' : 'sm',

--- a/packages/ibm-products/src/components/SidePanel/SidePanel.js
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.js
@@ -570,7 +570,8 @@ export let SidePanel = React.forwardRef(
     ]);
 
     const renderHeader = () => {
-      let slugCloseSize = actions.length && /l/.test(size) ? 'md' : 'sm';
+      let slugCloseSize =
+        actions && actions.length && /l/.test(size) ? 'md' : 'sm';
       let normalizedSlug;
       if (slug && slug?.type?.displayName === 'Slug') {
         normalizedSlug = React.cloneElement(slug, {

--- a/packages/ibm-products/src/components/SidePanel/SidePanel.js
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.js
@@ -958,7 +958,7 @@ SidePanel.propTypes = {
   slideIn: PropTypes.bool,
 
   /**
-   * Provide a `Slug` component to be rendered inside the `SidePanel` component
+   *  **Experimental:** Provide a `Slug` component to be rendered inside the `SidePanel` component
    */
   slug: PropTypes.node,
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2618,7 +2618,7 @@ __metadata:
     "@carbon/ibm-products-styles": ^2.18.0
     "@carbon/layout": ^11.20.1
     "@carbon/motion": ^11.16.1
-    "@carbon/react": ^1.44.0
+    "@carbon/react": ^1.45.0
     "@carbon/storybook-addon-theme": ^2.0.5
     "@carbon/themes": ^11.28.0
     "@carbon/type": ^11.25.1
@@ -2722,7 +2722,7 @@ __metadata:
     "@carbon/grid": ^11.21.1
     "@carbon/layout": ^11.20.1
     "@carbon/motion": ^11.16.1
-    "@carbon/react": ^1.44.0
+    "@carbon/react": ^1.45.0
     "@carbon/themes": ^11.28.0
     "@carbon/type": ^11.25.1
     react: ^16.8.6 || ^17.0.1 || ^18.2.0
@@ -2737,16 +2737,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/icons-react@npm:^11.31.0":
-  version: 11.31.0
-  resolution: "@carbon/icons-react@npm:11.31.0"
+"@carbon/icons-react@npm:^11.32.0":
+  version: 11.32.0
+  resolution: "@carbon/icons-react@npm:11.32.0"
   dependencies:
     "@carbon/icon-helpers": ^10.45.0
     "@carbon/telemetry": 0.1.0
     prop-types: ^15.7.2
   peerDependencies:
     react: ">=16"
-  checksum: 2a42fe082e5067ac166687d05829166962c5c80e25f547677734437e490fb064febb680518f69df4abb5e6ce3ed24acd729b629ba409fe50c605e01a9aae2d52
+  checksum: 2c3a3fa62007cb0cb22a4dbe2f5b1618cc4ea137c58de0c9dd7e18c0b128857662280cee6b0edd4410848f3c820337c3a2ec6697e8790ea49519e286ffd63bf3
   languageName: node
   linkType: hard
 
@@ -2764,15 +2764,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/react@npm:^1.44.0":
-  version: 1.44.0
-  resolution: "@carbon/react@npm:1.44.0"
+"@carbon/react@npm:^1.45.0":
+  version: 1.45.0
+  resolution: "@carbon/react@npm:1.45.0"
   dependencies:
     "@babel/runtime": ^7.18.3
     "@carbon/feature-flags": ^0.16.0
-    "@carbon/icons-react": ^11.31.0
+    "@carbon/icons-react": ^11.32.0
     "@carbon/layout": ^11.20.0
-    "@carbon/styles": ^1.44.0
+    "@carbon/styles": ^1.45.0
     "@carbon/telemetry": 0.1.0
     classnames: 2.3.2
     copy-to-clipboard: ^3.3.1
@@ -2793,7 +2793,7 @@ __metadata:
     react: ^16.8.6 || ^17.0.1 || ^18.2.0
     react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0
     sass: ^1.33.0
-  checksum: ce211e31ff1777857c345970e43a8b6c99ab1fca089fea0872ba0a9a32ff97eebac9f0b0cd6552d0c7d75e68dec149c743fc4f7d18d53c5515faeb72c9062bc5
+  checksum: 15b194893440bc677f630355538fb63c6da8e1eb64f8930558afc7887e7bef67cdb27a42a9ba1fcb9004a86ee6a1cdd37506e8495b7618691b0a679a0fd2d708
   languageName: node
   linkType: hard
 
@@ -2822,9 +2822,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/styles@npm:^1.44.0":
-  version: 1.44.0
-  resolution: "@carbon/styles@npm:1.44.0"
+"@carbon/styles@npm:^1.45.0":
+  version: 1.45.0
+  resolution: "@carbon/styles@npm:1.45.0"
   dependencies:
     "@carbon/colors": ^11.20.0
     "@carbon/feature-flags": ^0.16.0
@@ -2839,7 +2839,7 @@ __metadata:
   peerDependenciesMeta:
     sass:
       optional: true
-  checksum: 1144ae7d1b4dccc70b8a512cddbce1f618024990fd00e03626e69888c90041d9777a2460e1944b556f61846cbe93dccdb063b65e4fc2f50b60bab3625b528a0c
+  checksum: da44d24fc23987b3a03fe8d9ce670dee9560e2291ca4cac7e69b8a676b83b88e8bb56279759d39a1a9611e2f90ee50f25ba8193dc0def5b5243b85df3d7e4a3d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #3752

Updates to the side panel AI expanding it's usage to the patterns.

#### What did you change?
- SidePanel to add a type check to the slug and to mark the prop as `Experimental` as per Carbon/React.
- CreateSidePanel added feature
- EditSidePanel added feature
- Added design updates which included moving the 

#### How did you test and verify your work?

Storybook.