### PR TITLE
fix(Datagrid): re-apply filters during fetching state (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -203,6 +203,7 @@ export const DatagridContent = ({ datagridState, title }) => {
               {...getFilterFlyoutProps()}
               title={filterProps.panelTitle}
               filterSections={filterProps.sections}
+              isFetching={isFetching}
             />
           )}
           <div className={`${blockClass}__table-container-inner`}>

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.js
@@ -181,7 +181,7 @@ const DatagridToolbar = (datagridState) => {
       className={cx([toolbarClass, `${toolbarClass}--${getRowHeight}`])}
     >
       <TableToolbar>
-        {DatagridActions && DatagridActions(datagridState)}
+        {DatagridActions && <DatagridActions {...datagridState} />}
         {DatagridBatchActionsToolbar &&
           DatagridBatchActionsToolbar(datagridState, width, ref)}
       </TableToolbar>
@@ -189,7 +189,7 @@ const DatagridToolbar = (datagridState) => {
   ) : DatagridActions ? (
     <div className={toolbarClass}>
       <TableToolbar>
-        {DatagridActions && DatagridActions(datagridState)}
+        {DatagridActions && <DatagridActions {...datagridState} />}
         {DatagridBatchActions && DatagridBatchActions(datagridState)}
       </TableToolbar>
     </div>

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
@@ -55,6 +55,7 @@ const FilterPanel = ({
   searchLabelText = 'Filter search',
   searchPlaceholder = 'Find filters',
   reactTableFiltersState = [],
+  isFetching = false,
 }) => {
   /** State */
   const [showDividerLine, setShowDividerLine] = useState(false);
@@ -79,6 +80,7 @@ const FilterPanel = ({
     reactTableFiltersState,
     onCancel,
     panelOpen,
+    isFetching,
   });
 
   /** Refs */
@@ -280,6 +282,7 @@ FilterPanel.propTypes = {
   closeIconDescription: PropTypes.string,
   filterPanelMinHeight: PropTypes.number,
   filterSections: PropTypes.array,
+  isFetching: PropTypes.bool,
   onApply: PropTypes.func,
   onCancel: PropTypes.func,
   onPanelClose: PropTypes.func,

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
@@ -37,11 +37,13 @@ const useFilters = ({
   reactTableFiltersState,
   onCancel = () => {},
   panelOpen,
+  isFetching,
 }) => {
   /** State */
   const [filtersState, setFiltersState] = useState(
     getInitialStateFromFilters(filters, variation, reactTableFiltersState)
   );
+  const [fetchingReset, setFetchingReset] = useState(false);
 
   const [filtersObjectArray, setFiltersObjectArray] = useState(
     reactTableFiltersState
@@ -376,6 +378,20 @@ const useFilters = ({
     setAllFilters,
     revertToPreviousFilters,
   ]);
+
+  // Re-applies filters if the Datagrid goes into a fetching state while panel is open
+  // and has had filters changed without applying
+  useEffect(() => {
+    if (isFetching && !fetchingReset) {
+      setFiltersState(JSON.parse(prevFiltersRef.current));
+      setFiltersObjectArray(JSON.parse(prevFiltersRef.current));
+      setAllFilters(JSON.parse(prevFiltersObjectArrayRef.current));
+      setFetchingReset(true);
+    }
+    if (!isFetching) {
+      setFetchingReset(false);
+    }
+  }, [isFetching, reactTableFiltersState, setAllFilters, fetchingReset]);
 
   const cancel = () => {
     // Reverting to previous filters only applies when using batch actions


### PR DESCRIPTION
Contributes to #3945

This fixes an issue with Datagrid filtering where if the Datagrid is refreshed (`isFetching: true`) while the filter panel is open and if some filters have been deselected but not applied, those filters are removed unintentionally.

#### What did you change?
Added `useEffect` in `useFilters` to properly re-apply filters during `isFetching` state.
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
```
#### How did you test and verify your work?
Changed panel story in storybook to include the ability to refresh table