### PR TITLE
feat(Datagrid): clear out filter history on reset

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
@@ -133,6 +133,7 @@ const useFilters = ({
     prevFiltersObjectArrayRef.current = JSON.stringify(
       initialFiltersObjectArray
     );
+    lastAppliedFilters.current = JSON.stringify([]);
   }, [filters, setAllFilters, variation]);
 
   const applyFilters = ({ column, value, type }) => {


### PR DESCRIPTION
Contributes to #3947 and #3867

This PR completely resets filtering history when the "Clear filters" button from the `FilterSummary` is used to reset the filters.

#### What did you change?
Emptied out `lastAppliedFilters` ref.
```
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
```
#### How did you test and verify your work?
Storybook

1. I added two checkbox filters from the filter panel
2. Clicked `Clear filters` from `FilterSummary`
3. I selected another filter checkbox but did not click "Apply' and instead click "Cancel"
4. No new filters should be added to filter summary and it should just go back to the initial state