### PR TITLE
fix(Datagrid): address duplicate id with radio filters

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
@@ -321,41 +321,49 @@ const useFilters = ({
         filter = renderCheckboxes();
         break;
       case RADIO:
-        filter = (
-          <FormGroup {...components.FormGroup}>
-            <RadioButtonGroup
-              {...components.RadioButtonGroup}
-              valueSelected={
-                filtersState[column]?.value === ''
-                  ? 'Any'
-                  : filtersState[column]?.value
-              }
-              onChange={(selected) => {
-                setFiltersState({
-                  ...filtersState,
-                  [column]: {
+        {
+          const { name } = { ...components.RadioButtonGroup };
+          filter = (
+            <FormGroup {...components.FormGroup}>
+              <RadioButtonGroup
+                {...components.RadioButtonGroup}
+                valueSelected={
+                  filtersState[column]?.value === ''
+                    ? components.DefaultRadioButton?.value ?? 'Any'
+                    : filtersState[column]?.value
+                }
+                onChange={(selected) => {
+                  setFiltersState({
+                    ...filtersState,
+                    [column]: {
+                      value: selected,
+                      type,
+                    },
+                  });
+                  applyFilters({
+                    column,
                     value: selected,
                     type,
-                  },
-                });
-                applyFilters({
-                  column,
-                  value: selected,
-                  type,
-                });
-                components.RadioButtonGroup.onChange?.(selected);
-              }}
-            >
-              <RadioButton id="any" labelText="Any" value="Any" />
-              {components.RadioButton.map((radio) => (
+                  });
+                  components.RadioButtonGroup.onChange?.(selected);
+                }}
+              >
                 <RadioButton
-                  key={radio.id ?? radio.labelText ?? radio.value}
-                  {...radio}
+                  id={components?.DefaultRadioButton?.id ?? `any__${name}`}
+                  labelText={components?.DefaultRadioButton?.labelText ?? 'Any'}
+                  value={components?.DefaultRadioButton?.value ?? 'Any'}
+                  {...components.DefaultRadioButton}
                 />
-              ))}
-            </RadioButtonGroup>
-          </FormGroup>
-        );
+                {components.RadioButton.map((radio) => (
+                  <RadioButton
+                    key={radio.id ?? radio.labelText ?? radio.value}
+                    {...radio}
+                  />
+                ))}
+              </RadioButtonGroup>
+            </FormGroup>
+          );
+        }
         break;
       case DROPDOWN:
         filter = (

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Filtering.docs-page.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Filtering.docs-page.js
@@ -280,6 +280,12 @@ const filters = [
           // Add any other Carbon RadioButton props here
         },
       ],
+      DefaultRadioButton: {
+        id: 'any__unique-id-for-any-radio-button',
+        labelText: 'Any',
+        value: 'Any',
+        // Add any other Carbon RadioButton props here
+      }
     },
   },
   {


### PR DESCRIPTION
Contributes to #3786 

Addresses situation where there can be duplicate `id`s with radio button filters in the Datagrid, stemming from the `Any`/default radio button. There is now a way to pass in values for the default radio button and if nothing is passed in then we handle it internally to ensure there is not a duplicate id for the default radio button.

#### What did you change?
```

packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Filtering.docs-page.js
```
#### How did you test and verify your work?
Storybook, changed `status` filter to type of `radio` just to test