### PR TITLE
chore: reorganize datagrid stories v1

### DIFF
--- a/packages/core/story-structure.js
+++ b/packages/core/story-structure.js
@@ -47,12 +47,10 @@ const s = [
             n: 'Datagrid',
             s: [
               'c/Datagrid',
-              'c/Datagrid/Extensions/Header',
               'c/Datagrid/Extensions/RowHeightSettings',
               'c/Datagrid/Extensions/RowActionButtons',
               'c/Datagrid/Extensions/ExpandableRow',
               'c/Datagrid/Extensions/NestedRows',
-              'c/Datagrid/Extensions/ColumnAlignment',
               'c/Datagrid/Extensions/ClickableRow',
               'c/Datagrid/Extensions/InlineEdit',
               'c/Datagrid/Extensions/ColumnCustomization',

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
@@ -7,7 +7,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { makeData, newPersonWithTwoLines, range } from './utils/makeData';
+import { makeData } from './utils/makeData';
 
 import { getStoryTitle } from '../../global/js/utils/story-helper';
 import { action } from '@storybook/addon-actions';
@@ -20,7 +20,6 @@ import {
   useDatagrid,
   useDisableSelectRows,
   useInfiniteScroll,
-  useRowIsMouseOver,
   useSelectAllWithToggle,
   useSelectRows,
   useSortableColumns,

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
@@ -253,7 +253,7 @@ export const InfiniteScroll = () => {
   );
 };
 
-export const TenThousandEntries = () => {
+export const WithVirtualizedData = () => {
   const [data] = useState(makeData(10000));
   const columns = React.useMemo(() => getColumns(data), []);
   const datagridState = useDatagrid(
@@ -267,7 +267,7 @@ export const TenThousandEntries = () => {
   return <Datagrid datagridState={{ ...datagridState }} />;
 };
 
-export const WithPagination = () => {
+export const Pagination = () => {
   const [data] = useState(makeData(100));
   const columns = React.useMemo(() => getColumns(data), []);
   const datagridState = useDatagrid({

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
@@ -283,37 +283,6 @@ export const WithPagination = () => {
   return <Datagrid datagridState={{ ...datagridState }} />;
 };
 
-export const IsHoverOnRow = () => {
-  const Cell = ({ row }) => {
-    if (row.isMouseOver) {
-      return 'yes hovering!';
-    }
-    return '';
-  };
-  const [data] = useState(makeData(10));
-  const columns = React.useMemo(
-    () => [
-      ...getColumns(data).slice(0, 3),
-      {
-        Header: 'Is hover on row?',
-        id: 'isHoveringColumn',
-        disableSortBy: true,
-        Cell,
-      },
-    ],
-    []
-  );
-  const datagridState = useDatagrid(
-    {
-      columns,
-      data,
-    },
-    useRowIsMouseOver
-  );
-
-  return <Datagrid datagridState={{ ...datagridState }} />;
-};
-
 export const SelectableRow = () => {
   const [data] = useState(makeData(10));
   const columns = React.useMemo(() => getColumns(data), []);
@@ -578,42 +547,6 @@ export const DisableSelectRow = () => {
       endPlugins: [useDisableSelectRows],
       shouldDisableSelectRow: (row) => row.id % 2 === 0,
       disableSelectAll: true,
-    },
-    useSelectRows
-  );
-
-  return <Datagrid datagridState={{ ...datagridState }} />;
-};
-
-const makeDataWithTwoLines = (length) =>
-  range(length).map(() => newPersonWithTwoLines());
-
-export const TopAlignment = () => {
-  const [data] = useState(makeDataWithTwoLines(10));
-  const columns = React.useMemo(() => getColumns(data).slice(0, 3), []);
-  const datagridState = useDatagrid(
-    {
-      columns,
-      data,
-      verticalAlign: 'top',
-      variableRowHeight: true,
-      rowSize: 'xs',
-      rowSizes: [
-        {
-          value: 'xl',
-        },
-        {
-          value: 'lg',
-        },
-        {
-          value: 'md',
-        },
-        {
-          value: 'xs',
-        },
-      ],
-      DatagridActions,
-      DatagridBatchActions,
     },
     useSelectRows
   );

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories/ColumnAlignment/ColumnAlignment.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories/ColumnAlignment/ColumnAlignment.stories.js
@@ -29,7 +29,7 @@ import { makeData } from '../../utils/makeData';
 import { ARG_TYPES } from '../../utils/getArgTypes';
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/ColumnAlignment`,
+  title: `${getStoryTitle(Datagrid.displayName)}`,
   component: Datagrid,
   parameters: {
     styles,
@@ -213,7 +213,7 @@ const columnAlignmentControlProps = {
   gridTitle: sharedDatagridProps.gridTitle,
   gridDescription: sharedDatagridProps.gridDescription,
 };
-const columnAlignmentStoryName = 'With column alignment';
+const columnAlignmentStoryName = 'Column alignment';
 export const ColumnAlignmentStory = prepareStory(BasicTemplateWrapper, {
   storyName: columnAlignmentStoryName,
   argTypes: {

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories/ColumnAlignment/ColumnAlignment.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories/ColumnAlignment/ColumnAlignment.stories.js
@@ -29,7 +29,7 @@ import { makeData } from '../../utils/makeData';
 import { ARG_TYPES } from '../../utils/getArgTypes';
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}`,
+  title: getStoryTitle(Datagrid.displayName),
   component: Datagrid,
   parameters: {
     styles,

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories/Header/Header.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories/Header/Header.stories.js
@@ -22,7 +22,7 @@ import { makeData } from '../../utils/makeData';
 import { ARG_TYPES } from '../../utils/getArgTypes';
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/Header`,
+  title: `${getStoryTitle(Datagrid.displayName)}`,
   component: Datagrid,
   parameters: {
     styles,
@@ -183,7 +183,7 @@ const basicUsageControlProps = {
   gridDescription: sharedDatagridProps.gridDescription,
   useDenseHeader: sharedDatagridProps.useDenseHeader,
 };
-const basicUsageStoryName = 'With header';
+const basicUsageStoryName = 'Header';
 export const HeaderBasicUsageStory = prepareStory(BasicTemplateWrapper, {
   storyName: basicUsageStoryName,
   argTypes: {

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories/Header/Header.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories/Header/Header.stories.js
@@ -22,7 +22,7 @@ import { makeData } from '../../utils/makeData';
 import { ARG_TYPES } from '../../utils/getArgTypes';
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}`,
+  title: getStoryTitle(Datagrid.displayName),
   component: Datagrid,
   parameters: {
     styles,


### PR DESCRIPTION
Contributes to #3863

Initial work in reorganizing Datagrid stories.
For now, moving the `Header` and `Column alignment` stories out from Extensions to align with our current “base” v. “extension” structure.

Will continue to open more PRs for more reorganization in order to keep changes small and somewhat related. (Not prioritizing story order for now.)

#### What did you change?
- Move `Header` and `Column alignment` into main Datagrid section
- Rename stories
  - `With pagination` ➡️ `Pagination`
  - `With column alignment` ➡️ `Column alignment`
- Remove “unofficial” stories like `Is hover on row` and `Top alignment`
  - Functionality _does_ exist but `#notsponsored` since it’s not explicitly discussed in our docs

#### How did you test and verify your work?
Storybook and CI