### PR TITLE
feat(Datagrid): support timestamp date formats in filtering (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useFiltering.js
+++ b/packages/ibm-products/src/components/Datagrid/useFiltering.js
@@ -24,9 +24,11 @@ const useFiltering = (hooks) => {
             typeof startDate === 'object' ? startDate : new Date(startDate);
           const endDateObj =
             typeof endDate === 'object' ? endDate : new Date(endDate);
+          const rowValueDateObj =
+            typeof rowValue === 'object' ? rowValue : new Date(rowValue);
           if (
-            rowValue.getTime() <= endDateObj.getTime() &&
-            rowValue.getTime() >= startDateObj.getTime()
+            rowValueDateObj.getTime() <= endDateObj.getTime() &&
+            rowValueDateObj.getTime() >= startDateObj.getTime()
           ) {
             // In date range
             return true;


### PR DESCRIPTION
Contributes to #3732 

This PR allows for other date formats to be used with filtering in the Datagrid. Prior to this, all date columns which used filtering had to be Date objects. To test this, I temporarily changed the `makeData` file to use `new Intl.DateTimeFormat('en-US').format(date)`.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/useFiltering.js
```
#### How did you test and verify your work?
Storybook, with localized date format