### PR TITLE
fix: add missing N2P component exports

### DIFF
--- a/config/jest-config-ibm-cloud-cognitive/setup/setupFilesAfterEnv.js
+++ b/config/jest-config-ibm-cloud-cognitive/setup/setupFilesAfterEnv.js
@@ -46,6 +46,17 @@ const oldConsole = {};
 
   global.beforeEach(() => {
     unexpectedConsoleCallStacks.length = 0;
+
+    // We use `lottie-web` to create complex, animated <svg> elements
+    // from json files. As of this update, only InlineTip (importing
+    // SteppedAnimatedMedia) needs to mock a canvas to pass a test.
+
+    // But, other unrelated components like PageHeader and ComboButton
+    // are failing tests and pointing to SteppedAnimatedMedia as the
+    // culprit. We haven't found the source of the issue, but adding
+    // setupJestCanvasMock() here seems to eliminate these errors.
+
+    // For more details, see also the comment in `InlineTip.test.js @ beforeEach()`.
     setupJestCanvasMock();
   });
 

--- a/config/jest-config-ibm-cloud-cognitive/setup/setupFilesAfterEnv.js
+++ b/config/jest-config-ibm-cloud-cognitive/setup/setupFilesAfterEnv.js
@@ -8,6 +8,7 @@
 // `setupFilesAfterEnv` enables running the code immediately after the test framework has been installed in the environment - https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array
 
 import '@testing-library/jest-dom';
+import { setupJestCanvasMock } from 'jest-canvas-mock';
 
 import chalk from 'chalk';
 import util from 'util';
@@ -45,6 +46,7 @@ const oldConsole = {};
 
   global.beforeEach(() => {
     unexpectedConsoleCallStacks.length = 0;
+    setupJestCanvasMock();
   });
 
   global.afterEach(() => {

--- a/packages/ibm-products/src/components/InlineTip/InlineTip.test.js
+++ b/packages/ibm-products/src/components/InlineTip/InlineTip.test.js
@@ -39,7 +39,7 @@ describe(componentName, () => {
     // environment uses `jsdom` instead, and <canvas> is not available.
     // So, we need to use jest-canvas-mock to mock the <canvas>.
 
-    // See also setupFilesAfterEnv.js
+    // See also the comment in `setupFilesAfterEnv.js @ beforeEach()`.
     setupJestCanvasMock();
   });
 

--- a/packages/ibm-products/src/components/InlineTip/InlineTip.test.js
+++ b/packages/ibm-products/src/components/InlineTip/InlineTip.test.js
@@ -32,10 +32,14 @@ const dataTestId = uuidv4();
 
 describe(componentName, () => {
   beforeEach(() => {
-    // We use the lottie package to create animated <svg> elements from json files.
-    // Lottie uses the browser > DOM > <canvas> to do this.
-    // The testing environment uses `jsdom` instead, and <canvas> is not available.
+    // InlineTip imports SteppedAnimatedMedia, which imports the `lottie-web` package.
+    // We use `lottie-web` to create complex, animated <svg> elements from json files.
+
+    // Lottie uses the browser > DOM > <canvas> to do this, but the test
+    // environment uses `jsdom` instead, and <canvas> is not available.
     // So, we need to use jest-canvas-mock to mock the <canvas>.
+
+    // See also setupFilesAfterEnv.js
     setupJestCanvasMock();
   });
 

--- a/packages/ibm-products/src/components/InlineTip/InlineTipButton.js
+++ b/packages/ibm-products/src/components/InlineTip/InlineTipButton.js
@@ -42,6 +42,9 @@ export let InlineTipButton = React.forwardRef(
   }
 );
 
+InlineTipButton = pkg.checkComponentEnabled(InlineTipButton, componentName);
+InlineTipButton.displayName = componentName;
+
 InlineTipButton.propTypes = {
   /**
    * Provide the contents of the InlineTipButton.

--- a/packages/ibm-products/src/components/InlineTip/InlineTipLink.js
+++ b/packages/ibm-products/src/components/InlineTip/InlineTipLink.js
@@ -42,6 +42,9 @@ export let InlineTipLink = React.forwardRef(
   }
 );
 
+InlineTipLink = pkg.checkComponentEnabled(InlineTipLink, componentName);
+InlineTipLink.displayName = componentName;
+
 InlineTipLink.propTypes = {
   /**
    * Provide the contents of the InlineTipLink.

--- a/packages/ibm-products/src/components/index.js
+++ b/packages/ibm-products/src/components/index.js
@@ -82,3 +82,11 @@ export { EditTearsheetNarrow } from './EditTearsheetNarrow';
 export { EditFullPage } from './EditFullPage';
 export { EditUpdateCards } from './EditUpdateCards';
 export { Checklist } from './Checklist';
+export {
+  Guidebanner,
+  GuidebannerElement,
+  GuidebannerElementButton,
+  GuidebannerElementLink,
+} from './Guidebanner';
+export { InlineTip, InlineTipButton, InlineTipLink } from './InlineTip';
+export { NonLinearReading } from './NonLinearReading';

--- a/packages/ibm-products/src/global/js/package-settings.js
+++ b/packages/ibm-products/src/global/js/package-settings.js
@@ -78,6 +78,8 @@ const defaults = {
     GuidebannerElementButton: false,
     GuidebannerElementLink: false,
     InlineTip: false,
+    InlineTipButton: false,
+    InlineTipLink: false,
     NonLinearReading: false,
   },
 


### PR DESCRIPTION
Adds missing N2P components to list of exports

#### What did you change?

```
packages/ibm-products/src/components/index.js
```

