### PR TITLE
fix(Tearsheet): stop trying to focus closed tearsheets

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.js
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.js
@@ -128,6 +128,7 @@ export const TearsheetShell = React.forwardRef(
     handleStackChange.checkFocus = function () {
       // if we are now the topmost tearsheet, ensure we have focus
       if (
+        open &&
         position === depth &&
         modalRef.current &&
         !modalRef.current.contains(document.activeElement)


### PR DESCRIPTION
Fixes #3988.

#### What did you change?

Modified checkFocus() so it doesn't try to focus tearsheets that are closed.

#### How did you test and verify your work?

Ran existing storybook test and also ran with my own app.

@dcwarwick maybe you can check and merge this?