### PR TITLE
fix: add lottie-web to ibm-products package.json

### DIFF
--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -83,6 +83,7 @@
     "framer-motion": "^6.5.1 < 7",
     "immutability-helper": "^3.1.1",
     "lodash": "^4.17.21",
+    "lottie-web": "^5.12.2",
     "react-table": "^7.8.0",
     "react-window": "^1.8.9"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2860,6 +2860,7 @@ __metadata:
     jest-config-ibm-cloud-cognitive: ^1.1.2
     jest-environment-jsdom: ^29.6.2
     lodash: ^4.17.21
+    lottie-web: ^5.12.2
     namor: ^1.1.2
     npm-check-updates: ^16.11.1
     npm-run-all: ^4.1.5


### PR DESCRIPTION
Contributes to #3352 #3897

Based on the v1 fix for this #3354, added the dependency to the `packages/ibm-products` package.json. Root package did not have the dependency included at all with `lottie-web` in the core package only (which is used for Storybook as well).

#### What did you change?

```
packages/ibm-products/package.json
yarn.lock
```

#### How did you test and verify your work?
`lottie-web` is listed under `ibm-products` in yarn.lock