### PR TITLE
fix: update example gallery

### DIFF
--- a/examples/carbon-for-ibm-products/APIKeyModal/README.md
+++ b/examples/carbon-for-ibm-products/APIKeyModal/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. ApiKeyModal, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. ApiKeyModal, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/AboutModal/README.md
+++ b/examples/carbon-for-ibm-products/AboutModal/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. AboutModal, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. AboutModal, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/Cascade/README.md
+++ b/examples/carbon-for-ibm-products/Cascade/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. Cascade, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. Cascade, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/CreateFullPage/README.md
+++ b/examples/carbon-for-ibm-products/CreateFullPage/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. CreateFullPage, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. CreateFullPage, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/CreateModal/README.md
+++ b/examples/carbon-for-ibm-products/CreateModal/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. CreateModal, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. CreateModal, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/CreateSidePanel/README.md
+++ b/examples/carbon-for-ibm-products/CreateSidePanel/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. CreateSidePanel, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. CreateSidePanel, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/CreateTearsheet/README.md
+++ b/examples/carbon-for-ibm-products/CreateTearsheet/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. CreateTearsheet, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. CreateTearsheet, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/CreateTearsheetNarrow/README.md
+++ b/examples/carbon-for-ibm-products/CreateTearsheetNarrow/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. CreateTearsheetNarrow, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. CreateTearsheetNarrow, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/DataSpreadsheet/README.md
+++ b/examples/carbon-for-ibm-products/DataSpreadsheet/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. DataSpreadsheet, 2023, import './config'
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. DataSpreadsheet, 2024, import './config'
 . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 

--- a/examples/carbon-for-ibm-products/Datagrid/README.md
+++ b/examples/carbon-for-ibm-products/Datagrid/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. Datagrid, 2023, import './config'
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. Datagrid, 2024, import './config'
 . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 

--- a/examples/carbon-for-ibm-products/EditInPlace/README.md
+++ b/examples/carbon-for-ibm-products/EditInPlace/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. EditInPlace, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. EditInPlace, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/EmptyStates/README.md
+++ b/examples/carbon-for-ibm-products/EmptyStates/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. EmptyStates, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. EmptyStates, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/ExportModal/README.md
+++ b/examples/carbon-for-ibm-products/ExportModal/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. ExportModal, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. ExportModal, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/ExpressiveCard/README.md
+++ b/examples/carbon-for-ibm-products/ExpressiveCard/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. ExpressiveCard, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. ExpressiveCard, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/HTTPErrors/README.md
+++ b/examples/carbon-for-ibm-products/HTTPErrors/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. HttpErrors, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. HttpErrors, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/ImportModal/README.md
+++ b/examples/carbon-for-ibm-products/ImportModal/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. ImportModal, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. ImportModal, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/NotificationsPanel/README.md
+++ b/examples/carbon-for-ibm-products/NotificationsPanel/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. NotificationsPanel, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. NotificationsPanel, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/OptionsTile/README.md
+++ b/examples/carbon-for-ibm-products/OptionsTile/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. OptionsTile, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. OptionsTile, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/PageHeader/README.md
+++ b/examples/carbon-for-ibm-products/PageHeader/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. PageHeader, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. PageHeader, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/ProductiveCard/README.md
+++ b/examples/carbon-for-ibm-products/ProductiveCard/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. ProductiveCard, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. ProductiveCard, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/RemoveModal/README.md
+++ b/examples/carbon-for-ibm-products/RemoveModal/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. RemoveModal, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. RemoveModal, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/Saving/README.md
+++ b/examples/carbon-for-ibm-products/Saving/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. Saving, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. Saving, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/SidePanel/README.md
+++ b/examples/carbon-for-ibm-products/SidePanel/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. SidePanel, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. SidePanel, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/StatusIcon/README.md
+++ b/examples/carbon-for-ibm-products/StatusIcon/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. StatusIcon, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. StatusIcon, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/TagSet/README.md
+++ b/examples/carbon-for-ibm-products/TagSet/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. TagSet, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. TagSet, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/Tearsheet/README.md
+++ b/examples/carbon-for-ibm-products/Tearsheet/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. Tearsheet, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. Tearsheet, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/UserProfileImage/README.md
+++ b/examples/carbon-for-ibm-products/UserProfileImage/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. UserProfileImage, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. UserProfileImage, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/WebTerminal/README.md
+++ b/examples/carbon-for-ibm-products/WebTerminal/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. WebTerminal, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. WebTerminal, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/prefix-example/README.md
+++ b/examples/carbon-for-ibm-products/prefix-example/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. PrefixExample, 2023, import './config'
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. PrefixExample, 2024, import './config'
 . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 

--- a/examples/carbon-for-ibm-products/react-16-example/README.md
+++ b/examples/carbon-for-ibm-products/react-16-example/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. React_16Example, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. React_16Example, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant

--- a/examples/carbon-for-ibm-products/react-17-example/README.md
+++ b/examples/carbon-for-ibm-products/react-17-example/README.md
@@ -50,7 +50,7 @@ The simplest way to update a template is as follows.
 2. Update it as necessary.
 3. Test that it works.
 4. Remove the folder `scripts/example-gallery-builder/update-example/templates` and rename your folder to this.
-5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. React_17Example, 2023, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
+5. Review the changes made and restore/rectify the template TAGS typically in capitals. These are replaced as part of the build process. E.g. React_17Example, 2024, . For a full set of current tags review the code in `scripts/example-gallery-builder/update-example/index.js`.
 6. Remove the files `gallery.config.json`, `thumbnail.png` and the folder `src/Example`.
 
 ### If a variant


### PR DESCRIPTION
Updates the failing example gallery check so that we can publish a new release without this step failing again. This was all auto generated after running `yarn update-gallery-config`.