### PR TITLE
feat(Datagrid): add reduced motion support to filter panel (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-key */
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,7 +18,7 @@ import { rem } from '@carbon/layout';
 import { pkg } from '../../../../../settings';
 import { BATCH, CLEAR_FILTERS, INSTANT, PANEL } from './constants';
 import cx from 'classnames';
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import {
   panelVariants,
   innerContainerVariants,
@@ -97,6 +97,8 @@ const FilterPanel = ({
       prevFiltersRef,
     });
 
+  const shouldReduceMotion = useReducedMotion();
+
   /** Memos */
   const showActionSet = useMemo(() => updateMethod === BATCH, [updateMethod]);
 
@@ -145,6 +147,7 @@ const FilterPanel = ({
           ]}
           className={`${componentClass}__action-set`}
           ref={actionSetRef}
+          custom={shouldReduceMotion}
           variants={actionSetVariants}
         />
       )
@@ -208,9 +211,10 @@ const FilterPanel = ({
       })}
       initial={false}
       animate={panelOpen ? 'visible' : 'hidden'}
+      custom={shouldReduceMotion}
       variants={panelVariants}
     >
-      <motion.div variants={innerContainerVariants}>
+      <motion.div custom={shouldReduceMotion} variants={innerContainerVariants}>
         <header
           ref={filterHeadingRef}
           className={cx(`${componentClass}__heading`, {

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/motion/variants.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/motion/variants.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright IBM Corp. 2023, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import {
   DURATIONS,
   EASINGS,
@@ -5,57 +12,57 @@ import {
 import { ACTION_SET_HEIGHT, PANEL_WIDTH } from '../constants';
 
 export const panelVariants = {
-  hidden: {
+  hidden: (shouldReduceMotion) => ({
     width: 0,
     overflow: 'hidden',
     transition: {
-      duration: DURATIONS.fast02,
-      ease: EASINGS.productive.exit,
+      duration: shouldReduceMotion ? 0 : DURATIONS.fast02,
+      ease: shouldReduceMotion ? 0 : EASINGS.productive.exit,
       when: 'afterChildren',
     },
-  },
-  visible: {
+  }),
+  visible: (shouldReduceMotion) => ({
     width: PANEL_WIDTH,
     overflow: 'visible',
     transition: {
-      duration: DURATIONS.moderate02,
-      ease: EASINGS.productive.entrance,
+      duration: shouldReduceMotion ? 0 : DURATIONS.moderate02,
+      ease: shouldReduceMotion ? 0 : EASINGS.productive.entrance,
       when: 'beforeChildren',
     },
-  },
+  }),
 };
 
 export const innerContainerVariants = {
-  hidden: {
+  hidden: (shouldReduceMotion) => ({
     opacity: 0,
     transition: {
-      duration: DURATIONS.fast01,
-      ease: EASINGS.productive.exit,
+      duration: shouldReduceMotion ? 0 : DURATIONS.fast01,
+      ease: shouldReduceMotion ? 0 : EASINGS.productive.exit,
     },
-  },
-  visible: {
+  }),
+  visible: (shouldReduceMotion) => ({
     opacity: 1,
     transition: {
-      duration: DURATIONS.fast02,
-      ease: EASINGS.productive.entrance,
+      duration: shouldReduceMotion ? 0 : DURATIONS.fast02,
+      ease: shouldReduceMotion ? 0 : EASINGS.productive.entrance,
       when: 'beforeChildren',
     },
-  },
+  }),
 };
 
 export const actionSetVariants = {
-  hidden: {
+  hidden: (shouldReduceMotion) => ({
     y: ACTION_SET_HEIGHT,
     transition: {
-      duration: DURATIONS.fast01,
-      ease: EASINGS.productive.exit,
+      duration: shouldReduceMotion ? 0 : DURATIONS.fast01,
+      ease: shouldReduceMotion ? 0 : EASINGS.productive.exit,
     },
-  },
-  visible: {
+  }),
+  visible: (shouldReduceMotion) => ({
     y: 0,
     transition: {
-      duration: DURATIONS.fast02,
-      ease: EASINGS.productive.entrance,
+      duration: shouldReduceMotion ? 0 : DURATIONS.fast02,
+      ease: shouldReduceMotion ? 0 : EASINGS.productive.entrance,
     },
-  },
+  }),
 };


### PR DESCRIPTION
Contributes to #2689 

Allows the filter panel in the Datagrid to respond to the user's reduce motion setting.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/motion/variants.js
```
#### How did you test and verify your work?
Storybook, toggled `Reduce motion` in my osx settings to confirm correct behavior