### PR TITLE
fix(SidePanel): action buttons layout at 2xl (v1)

### DIFF
--- a/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
@@ -731,8 +731,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 }
 .c4p--side-panel__container.c4p--side-panel__container--xs .c4p--side-panel__title-container.c4p--side-panel__title-container--no-title-animation,
 .c4p--side-panel__container.c4p--side-panel__container--xs .c4p--side-panel__subtitle-text.c4p--side-panel__subtitle-text-no-animation,
-.c4p--side-panel__container.c4p--side-panel__container--xs .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation,
-.c4p--side-panel__container.c4p--side-panel__container--xs .c4p--side-panel__actions-container.c4p--action-set--xs {
+.c4p--side-panel__container.c4p--side-panel__container--xs .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation {
   width: 16rem;
   max-width: 100%;
 }
@@ -750,8 +749,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 }
 .c4p--side-panel__container.c4p--side-panel__container--sm .c4p--side-panel__title-container.c4p--side-panel__title-container--no-title-animation,
 .c4p--side-panel__container.c4p--side-panel__container--sm .c4p--side-panel__subtitle-text.c4p--side-panel__subtitle-text-no-animation,
-.c4p--side-panel__container.c4p--side-panel__container--sm .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation,
-.c4p--side-panel__container.c4p--side-panel__container--sm .c4p--side-panel__actions-container.c4p--action-set--sm {
+.c4p--side-panel__container.c4p--side-panel__container--sm .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation {
   width: 20rem;
   max-width: 100%;
 }
@@ -769,8 +767,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 }
 .c4p--side-panel__container.c4p--side-panel__container--md .c4p--side-panel__title-container.c4p--side-panel__title-container--no-title-animation,
 .c4p--side-panel__container.c4p--side-panel__container--md .c4p--side-panel__subtitle-text.c4p--side-panel__subtitle-text-no-animation,
-.c4p--side-panel__container.c4p--side-panel__container--md .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation,
-.c4p--side-panel__container.c4p--side-panel__container--md .c4p--side-panel__actions-container.c4p--action-set--md {
+.c4p--side-panel__container.c4p--side-panel__container--md .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation {
   width: 30rem;
   max-width: 100%;
 }
@@ -788,8 +785,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 }
 .c4p--side-panel__container.c4p--side-panel__container--lg .c4p--side-panel__title-container.c4p--side-panel__title-container--no-title-animation,
 .c4p--side-panel__container.c4p--side-panel__container--lg .c4p--side-panel__subtitle-text.c4p--side-panel__subtitle-text-no-animation,
-.c4p--side-panel__container.c4p--side-panel__container--lg .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation,
-.c4p--side-panel__container.c4p--side-panel__container--lg .c4p--side-panel__actions-container.c4p--action-set--lg {
+.c4p--side-panel__container.c4p--side-panel__container--lg .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation {
   width: 40rem;
   max-width: 100%;
 }
@@ -807,8 +803,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 }
 .c4p--side-panel__container.c4p--side-panel__container--max .c4p--side-panel__title-container.c4p--side-panel__title-container--no-title-animation,
 .c4p--side-panel__container.c4p--side-panel__container--max .c4p--side-panel__subtitle-text.c4p--side-panel__subtitle-text-no-animation,
-.c4p--side-panel__container.c4p--side-panel__container--max .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation,
-.c4p--side-panel__container.c4p--side-panel__container--max .c4p--side-panel__actions-container.c4p--action-set--max {
+.c4p--side-panel__container.c4p--side-panel__container--max .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation {
   width: 75%;
   max-width: 100%;
 }
@@ -819,6 +814,9 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 .c4p--side-panel__container.c4p--side-panel__container-left-placement.c4p--side-panel__container--max {
   left: 0;
   border-right: 1px solid var(--cds-decorative-01, #e0e0e0);
+}
+.c4p--side-panel__container .c4p--side-panel__actions-container {
+  width: 100%;
 }
 .c4p--side-panel__container.c4p--side-panel__container-with-action-toolbar.c4p--side-panel__with-condensed-header .c4p--side-panel__title-container::before {
   content: none;

--- a/packages/ibm-products/src/components/SidePanel/_side-panel.scss
+++ b/packages/ibm-products/src/components/SidePanel/_side-panel.scss
@@ -73,8 +73,7 @@ $action-set-block-class: #{$pkg-prefix}--action-set;
         @include setPanelSize($size_value);
         .#{$block-class}__title-container.#{$block-class}__title-container--no-title-animation,
         .#{$block-class}__subtitle-text.#{$block-class}__subtitle-text-no-animation,
-        .#{$block-class}__action-toolbar.#{$block-class}__action-toolbar-no-animation,
-        .#{$block-class}__actions-container.#{$action-set-block-class}--#{$size} {
+        .#{$block-class}__action-toolbar.#{$block-class}__action-toolbar-no-animation {
           @include setPanelSize($size_value);
         }
       }
@@ -86,6 +85,9 @@ $action-set-block-class: #{$pkg-prefix}--action-set;
         left: 0;
         border-right: 1px solid $decorative-01;
       }
+    }
+    .#{$block-class}__actions-container {
+      width: 100%;
     }
     &.#{$block-class}__container-with-action-toolbar.#{$block-class}__with-condensed-header {
       .#{$block-class}__title-container {


### PR DESCRIPTION
Contributes to #3812 (v1)

Update actions container to be 100% wide at `2xl`.

#### What did you change?

```
packages/ibm-products/src/components/SidePanel/_side-panel.scss
```

#### How did you test and verify your work?

- [x] Storybook
