### PR TITLE
fix(SidePanel): action buttons layout at 2xl (v2)

### DIFF
--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -2313,8 +2313,7 @@ p.c4p--about-modal__copyright-text:first-child {
 }
 .c4p--side-panel__container.c4p--side-panel__container--xs .c4p--side-panel__title-container.c4p--side-panel__title-container--no-title-animation,
 .c4p--side-panel__container.c4p--side-panel__container--xs .c4p--side-panel__subtitle-text.c4p--side-panel__subtitle-text-no-animation,
-.c4p--side-panel__container.c4p--side-panel__container--xs .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation,
-.c4p--side-panel__container.c4p--side-panel__container--xs .c4p--side-panel__actions-container.c4p--action-set--xs {
+.c4p--side-panel__container.c4p--side-panel__container--xs .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation {
   width: 16rem;
   max-width: 100%;
 }
@@ -2324,8 +2323,7 @@ p.c4p--about-modal__copyright-text:first-child {
 }
 .c4p--side-panel__container.c4p--side-panel__container--sm .c4p--side-panel__title-container.c4p--side-panel__title-container--no-title-animation,
 .c4p--side-panel__container.c4p--side-panel__container--sm .c4p--side-panel__subtitle-text.c4p--side-panel__subtitle-text-no-animation,
-.c4p--side-panel__container.c4p--side-panel__container--sm .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation,
-.c4p--side-panel__container.c4p--side-panel__container--sm .c4p--side-panel__actions-container.c4p--action-set--sm {
+.c4p--side-panel__container.c4p--side-panel__container--sm .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation {
   width: 20rem;
   max-width: 100%;
 }
@@ -2335,8 +2333,7 @@ p.c4p--about-modal__copyright-text:first-child {
 }
 .c4p--side-panel__container.c4p--side-panel__container--md .c4p--side-panel__title-container.c4p--side-panel__title-container--no-title-animation,
 .c4p--side-panel__container.c4p--side-panel__container--md .c4p--side-panel__subtitle-text.c4p--side-panel__subtitle-text-no-animation,
-.c4p--side-panel__container.c4p--side-panel__container--md .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation,
-.c4p--side-panel__container.c4p--side-panel__container--md .c4p--side-panel__actions-container.c4p--action-set--md {
+.c4p--side-panel__container.c4p--side-panel__container--md .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation {
   width: 30rem;
   max-width: 100%;
 }
@@ -2346,8 +2343,7 @@ p.c4p--about-modal__copyright-text:first-child {
 }
 .c4p--side-panel__container.c4p--side-panel__container--lg .c4p--side-panel__title-container.c4p--side-panel__title-container--no-title-animation,
 .c4p--side-panel__container.c4p--side-panel__container--lg .c4p--side-panel__subtitle-text.c4p--side-panel__subtitle-text-no-animation,
-.c4p--side-panel__container.c4p--side-panel__container--lg .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation,
-.c4p--side-panel__container.c4p--side-panel__container--lg .c4p--side-panel__actions-container.c4p--action-set--lg {
+.c4p--side-panel__container.c4p--side-panel__container--lg .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation {
   width: 40rem;
   max-width: 100%;
 }
@@ -2357,10 +2353,12 @@ p.c4p--about-modal__copyright-text:first-child {
 }
 .c4p--side-panel__container.c4p--side-panel__container--2xl .c4p--side-panel__title-container.c4p--side-panel__title-container--no-title-animation,
 .c4p--side-panel__container.c4p--side-panel__container--2xl .c4p--side-panel__subtitle-text.c4p--side-panel__subtitle-text-no-animation,
-.c4p--side-panel__container.c4p--side-panel__container--2xl .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation,
-.c4p--side-panel__container.c4p--side-panel__container--2xl .c4p--side-panel__actions-container.c4p--action-set--2xl {
+.c4p--side-panel__container.c4p--side-panel__container--2xl .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation {
   width: 75%;
   max-width: 100%;
+}
+.c4p--side-panel__container .c4p--side-panel__actions-container {
+  width: 100%;
 }
 .c4p--side-panel__container.c4p--side-panel__container-right-placement {
   right: 0;

--- a/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
+++ b/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
@@ -77,11 +77,13 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
       @include setPanelSize($size_value);
       .#{$block-class}__title-container.#{$block-class}__title-container--no-title-animation,
       .#{$block-class}__subtitle-text.#{$block-class}__subtitle-text-no-animation,
-      .#{$block-class}__action-toolbar.#{$block-class}__action-toolbar-no-animation,
-      .#{$block-class}__actions-container.#{$action-set-block-class}--#{$size} {
+      .#{$block-class}__action-toolbar.#{$block-class}__action-toolbar-no-animation {
         @include setPanelSize($size_value);
       }
     }
+  }
+  .#{$block-class}__actions-container {
+    width: 100%;
   }
   &.#{$block-class}__container-right-placement {
     right: 0;


### PR DESCRIPTION
Contributes to #3812 (v1)

Update actions container to be 100% wide at `2xl`.

#### What did you change?

```
packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
```

#### How did you test and verify your work?

- [x] Storybook