### PR TITLE
feat(Datagrid): add responsive updates to filter flyout

### DIFF
--- a/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_FilterFlyout.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_FilterFlyout.scss
@@ -82,7 +82,7 @@ $action-set-height: to-rem(64px);
   display: grid;
   /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
   gap: to-rem(16px) rem(32px);
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
 // Carbon overrides
@@ -103,4 +103,8 @@ $action-set-height: to-rem(64px);
 .#{variables.$block-class}-filter-flyout
   .#{c4p-settings.$carbon-prefix}--fieldset {
   margin-bottom: 0;
+}
+
+.#{variables.$block-class}-filter-flyout__stacked {
+  grid-template-columns: 1fr;
 }

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_FilterFlyout.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_FilterFlyout.scss
@@ -1,10 +1,9 @@
-/*
-* Licensed Materials - Property of IBM
-* 5724-Q36
-* (c) Copyright IBM Corp. 2022
-* US Government Users Restricted Rights - Use, duplication or disclosure
-* restricted by GSA ADP Schedule Contract with IBM Corp.
-*/
+//
+// Copyright IBM Corp. 2022, 2024
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
 
 // stylelint-disable carbon/layout-token-use
 

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
@@ -1,6 +1,6 @@
 // @flow
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -11,7 +11,10 @@ import { IconButton, usePrefix } from '@carbon/react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useRef, useState, useEffect } from 'react';
-import { useClickOutside } from '../../../../../global/js/hooks';
+import {
+  useClickOutside,
+  useWindowResize,
+} from '../../../../../global/js/hooks';
 import { pkg } from '../../../../../settings';
 import { ActionSet } from '../../../../ActionSet';
 import { BATCH, CLEAR_FILTERS, FLYOUT, INSTANT } from './constants';
@@ -20,6 +23,7 @@ import {
   useFilters,
   useShouldDisableButtons,
 } from './hooks';
+import { px, breakpoints } from '@carbon/layout';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 const componentClass = `${blockClass}-filter-flyout`;
@@ -41,6 +45,7 @@ const FilterFlyout = ({
 }) => {
   /** State */
   const [open, setOpen] = useState(false);
+  const [stackedLayout, setStackedLayout] = useState(false);
 
   const {
     filtersState,
@@ -60,8 +65,13 @@ const FilterFlyout = ({
     onCancel,
   });
 
+  const { width } = breakpoints.md;
+  const mdPxWidth = parseInt(width) * 16;
+
   /** Refs */
   const filterFlyoutRef = useRef(null);
+  const flyoutInnerRef = useRef(null);
+  const flyoutFiltersContainerRef = useRef(null);
 
   /** State from hooks */
   const [shouldDisableButtons, setShouldDisableButtons] =
@@ -70,6 +80,43 @@ const FilterFlyout = ({
       filtersState,
       prevFiltersRef,
     });
+
+  const handleResize = (current) => {
+    const filterFlyoutRefPosition =
+      flyoutInnerRef?.current.getBoundingClientRect();
+    const originalFlyoutWidth = parseInt(
+      window.getComputedStyle(flyoutInnerRef?.current).getPropertyValue('width')
+    );
+    // Check to see if left value from flyout getBoundingClientRect is a negative number
+    // If it is, that is the amount we need to subtract from the flyout width
+    if (Math.sign(filterFlyoutRefPosition.left) === -1) {
+      const newFlyoutWidth =
+        originalFlyoutWidth - Math.abs(filterFlyoutRefPosition.left);
+      flyoutInnerRef.current.style.width = px(newFlyoutWidth);
+    }
+    // Check to see if left value from flyout getBoundingClientRect is a positive number or 0
+    // If it is, that is the amount we need to add to the flyout width until we reach the
+    // max-width of the flyout (642)
+    if (
+      (originalFlyoutWidth < 642 &&
+        Math.sign(filterFlyoutRefPosition.left) === 1) ||
+      Math.sign(filterFlyoutRefPosition.left).toString() === '0'
+    ) {
+      const newFlyoutWidth =
+        originalFlyoutWidth + Math.abs(filterFlyoutRefPosition.left);
+      flyoutInnerRef.current.style.width = px(newFlyoutWidth);
+    }
+    // Begin stacking filters at this specific point
+    if (current?.innerWidth <= mdPxWidth + 254) {
+      setStackedLayout(true);
+    } else {
+      setStackedLayout(false);
+    }
+  };
+
+  useWindowResize(({ current }) => {
+    handleResize(current);
+  });
 
   /** Memos */
   const showActionSet = updateMethod === BATCH;
@@ -84,7 +131,13 @@ const FilterFlyout = ({
   const closeFlyout = () => {
     setOpen(false);
     onFlyoutClose();
+    flyoutInnerRef.current.style.width = px(642);
   };
+
+  useEffect(() => {
+    // Initialize flyout width
+    flyoutInnerRef.current.style.width = px(642);
+  }, []);
 
   const apply = () => {
     setAllFilters(filtersObjectArray);
@@ -177,10 +230,18 @@ const FilterFlyout = ({
           [`${componentClass}--batch`]: showActionSet,
           [`${componentClass}--instant`]: !showActionSet,
         })}
+        ref={flyoutInnerRef}
       >
         <div className={`${componentClass}__inner-container`}>
           <span className={`${componentClass}__title`}>{title}</span>
-          <div className={`${componentClass}__filters`}>{renderFilters()}</div>
+          <div
+            className={cx(`${componentClass}__filters`, {
+              [`${componentClass}__stacked`]: stackedLayout,
+            })}
+            ref={flyoutFiltersContainerRef}
+          >
+            {renderFilters()}
+          </div>
         </div>
         {renderActionSet()}
       </div>


### PR DESCRIPTION
Contributes to #2696 

Adds responsive changes to the Filter Flyout so that it renders correctly on smaller viewport widths.

https://github.com/carbon-design-system/ibm-products/assets/10215203/5de28a40-62dc-43bc-82fe-38e669073f97


#### What did you change?
```
packages/ibm-products-styles/src/components/Datagrid/styles/addons/_FilterFlyout.scss
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
```
#### How did you test and verify your work?
Storybook