### PR TITLE
feat(Datagrid): add responsive updates to filter flyout (v1)

### DIFF
--- a/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
@@ -2691,13 +2691,6 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   padding-top: var(--cds-spacing-03, 0.5rem);
 }
 
-/*
-* Licensed Materials - Property of IBM
-* 5724-Q36
-* (c) Copyright IBM Corp. 2022
-* US Government Users Restricted Rights - Use, duplication or disclosure
-* restricted by GSA ADP Schedule Contract with IBM Corp.
-*/
 .c4p--datagrid-filter-flyout__container {
   position: relative;
 }
@@ -2753,7 +2746,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 .c4p--datagrid-filter-flyout__filters {
   display: grid;
   gap: 1rem 2rem;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
 .c4p--datagrid-filter-flyout__trigger--open.bx--btn.bx--btn--icon-only {
@@ -2764,6 +2757,10 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 
 .c4p--datagrid-filter-flyout .bx--fieldset {
   margin-bottom: 0;
+}
+
+.c4p--datagrid-filter-flyout__stacked {
+  grid-template-columns: 1fr;
 }
 
 /*

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
@@ -1,17 +1,20 @@
-// @flow
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Filter16 } from '@carbon/icons-react';
+import React, { useRef, useState, useEffect } from 'react';
 import { Button } from 'carbon-components-react';
+import { Filter16 } from '@carbon/icons-react';
+import { px, breakpoints } from '@carbon/layout';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import React, { useRef, useState, useEffect } from 'react';
-import { useClickOutside } from '../../../../../global/js/hooks';
+import {
+  useClickOutside,
+  useWindowResize,
+} from '../../../../../global/js/hooks';
 import { pkg } from '../../../../../settings';
 import { ActionSet } from '../../../../ActionSet';
 import { BATCH, CLEAR_FILTERS, FLYOUT, INSTANT } from './constants';
@@ -42,6 +45,7 @@ const FilterFlyout = ({
 }) => {
   /** State */
   const [open, setOpen] = useState(false);
+  const [stackedLayout, setStackedLayout] = useState(false);
 
   const {
     filtersState,
@@ -61,8 +65,13 @@ const FilterFlyout = ({
     onCancel,
   });
 
+  const { width } = breakpoints.md;
+  const mdPxWidth = parseInt(width) * 16;
+
   /** Refs */
   const filterFlyoutRef = useRef(null);
+  const flyoutInnerRef = useRef(null);
+  const flyoutFiltersContainerRef = useRef(null);
 
   const [shouldDisableButtons, setShouldDisableButtons] =
     useShouldDisableButtons({
@@ -70,6 +79,43 @@ const FilterFlyout = ({
       filtersState,
       prevFiltersRef,
     });
+
+  const handleResize = (current) => {
+    const filterFlyoutRefPosition =
+      flyoutInnerRef?.current.getBoundingClientRect();
+    const originalFlyoutWidth = parseInt(
+      window.getComputedStyle(flyoutInnerRef?.current).getPropertyValue('width')
+    );
+    // Check to see if left value from flyout getBoundingClientRect is a negative number
+    // If it is, that is the amount we need to subtract from the flyout width
+    if (Math.sign(filterFlyoutRefPosition.left) === -1) {
+      const newFlyoutWidth =
+        originalFlyoutWidth - Math.abs(filterFlyoutRefPosition.left);
+      flyoutInnerRef.current.style.width = px(newFlyoutWidth);
+    }
+    // Check to see if left value from flyout getBoundingClientRect is a positive number or 0
+    // If it is, that is the amount we need to add to the flyout width until we reach the
+    // max-width of the flyout (642)
+    if (
+      (originalFlyoutWidth < 642 &&
+        Math.sign(filterFlyoutRefPosition.left) === 1) ||
+      Math.sign(filterFlyoutRefPosition.left).toString() === '0'
+    ) {
+      const newFlyoutWidth =
+        originalFlyoutWidth + Math.abs(filterFlyoutRefPosition.left);
+      flyoutInnerRef.current.style.width = px(newFlyoutWidth);
+    }
+    // Begin stacking filters at this specific point
+    if (current?.innerWidth <= mdPxWidth + 254) {
+      setStackedLayout(true);
+    } else {
+      setStackedLayout(false);
+    }
+  };
+
+  useWindowResize(({ current }) => {
+    handleResize(current);
+  });
 
   /** Memos */
   const showActionSet = updateMethod === BATCH;
@@ -83,7 +129,13 @@ const FilterFlyout = ({
   const closeFlyout = () => {
     setOpen(false);
     onFlyoutClose();
+    flyoutInnerRef.current.style.width = px(642);
   };
+
+  useEffect(() => {
+    // Initialize flyout width
+    flyoutInnerRef.current.style.width = px(642);
+  }, []);
 
   const apply = () => {
     setAllFilters(filtersObjectArray);
@@ -158,7 +210,7 @@ const FilterFlyout = ({
   );
 
   return (
-    <div className={`${componentClass}__container`}>
+    <div className={`${componentClass}__container`} ref={filterFlyoutRef}>
       <Button
         kind="ghost"
         hasIconOnly
@@ -172,7 +224,7 @@ const FilterFlyout = ({
         disabled={data.length === 0}
       />
       <div
-        ref={filterFlyoutRef}
+        ref={flyoutInnerRef}
         className={cx(componentClass, {
           [`${componentClass}--open`]: open,
           [`${componentClass}--batch`]: showActionSet,
@@ -181,7 +233,14 @@ const FilterFlyout = ({
       >
         <div className={`${componentClass}__inner-container`}>
           <span className={`${componentClass}__title`}>{title}</span>
-          <div className={`${componentClass}__filters`}>{renderFilters()}</div>
+          <div
+            className={cx(`${componentClass}__filters`, {
+              [`${componentClass}__stacked`]: stackedLayout,
+            })}
+            ref={flyoutFiltersContainerRef}
+          >
+            {renderFilters()}
+          </div>
         </div>
         {renderActionSet()}
       </div>

--- a/packages/ibm-products/src/components/Datagrid/styles/addons/_FilterFlyout.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/addons/_FilterFlyout.scss
@@ -1,10 +1,9 @@
-/*
-* Licensed Materials - Property of IBM
-* 5724-Q36
-* (c) Copyright IBM Corp. 2022
-* US Government Users Restricted Rights - Use, duplication or disclosure
-* restricted by GSA ADP Schedule Contract with IBM Corp.
-*/
+//
+// Copyright IBM Corp. 2022, 2024
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
 
 // stylelint-disable carbon/layout-token-use
 
@@ -65,7 +64,7 @@ $action-set-height: rem(64px);
 .#{$block-class}-filter-flyout__filters {
   display: grid;
   gap: rem(16px) rem(32px);
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
 // Carbon overrides
@@ -77,4 +76,8 @@ $action-set-height: rem(64px);
 
 .#{$block-class}-filter-flyout .#{$carbon-prefix}--fieldset {
   margin-bottom: 0;
+}
+
+.#{$block-class}-filter-flyout__stacked {
+  grid-template-columns: 1fr;
 }


### PR DESCRIPTION
Contributes to #2696 

Adds responsive changes to the Filter Flyout so that it renders correctly on smaller viewport widths.

https://github.com/carbon-design-system/ibm-products/assets/10215203/5de28a40-62dc-43bc-82fe-38e669073f97


#### What did you change?
```
packages/ibm-products-styles/src/components/Datagrid/styles/addons/_FilterFlyout.scss
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
```
#### How did you test and verify your work?
Storybook