### PR TITLE
fix(Datagrid): use correct motion specs for reduced motion filter panel (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/motion/variants.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/motion/variants.js
@@ -36,33 +36,36 @@ export const innerContainerVariants = {
   hidden: (shouldReduceMotion) => ({
     opacity: 0,
     transition: {
-      duration: shouldReduceMotion ? 0 : DURATIONS.fast01,
+      duration: shouldReduceMotion ? DURATIONS.moderate01 : DURATIONS.fast01,
       ease: shouldReduceMotion ? 0 : EASINGS.productive.exit,
     },
   }),
   visible: (shouldReduceMotion) => ({
     opacity: 1,
     transition: {
-      duration: shouldReduceMotion ? 0 : DURATIONS.fast02,
+      duration: shouldReduceMotion ? DURATIONS.moderate01 : DURATIONS.fast02,
       ease: shouldReduceMotion ? 0 : EASINGS.productive.entrance,
-      when: 'beforeChildren',
+      when: shouldReduceMotion ? null : 'beforeChildren',
     },
   }),
 };
 
 export const actionSetVariants = {
   hidden: (shouldReduceMotion) => ({
-    y: ACTION_SET_HEIGHT,
+    y: shouldReduceMotion ? 0 : ACTION_SET_HEIGHT,
+    opacity: shouldReduceMotion ? 0 : 1,
     transition: {
-      duration: shouldReduceMotion ? 0 : DURATIONS.fast01,
+      duration: shouldReduceMotion ? DURATIONS.moderate01 : DURATIONS.fast01,
       ease: shouldReduceMotion ? 0 : EASINGS.productive.exit,
     },
   }),
   visible: (shouldReduceMotion) => ({
     y: 0,
+    opacity: 1,
     transition: {
-      duration: shouldReduceMotion ? 0 : DURATIONS.fast02,
+      duration: shouldReduceMotion ? DURATIONS.moderate01 : DURATIONS.fast02,
       ease: shouldReduceMotion ? 0 : EASINGS.productive.entrance,
+      delay: shouldReduceMotion ? 0.075 : 0,
     },
   }),
 };


### PR DESCRIPTION
Contributes to #4006 

Updates the motion specs of the reduced motion filter panel in the Datagrid. 

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/motion/variants.js
```
#### How did you test and verify your work?
Storybook, turned on `Reduced motion` in osx settings