### PR TITLE
fix(SidePanel): check for element before proceeding, add warning

### DIFF
--- a/packages/ibm-products/src/components/SidePanel/SidePanel.js
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.js
@@ -28,6 +28,7 @@ import { Button } from '@carbon/react';
 import { Close, ArrowLeft } from '@carbon/react/icons';
 import { ActionSet } from '../ActionSet';
 import { overlayVariants, panelVariants } from './motion/variants';
+import pconsole from '../../global/js/utils/pconsole';
 
 const blockClass = `${pkg.prefix}--side-panel`;
 const componentName = 'SidePanel';
@@ -503,7 +504,13 @@ export let SidePanel = React.forwardRef(
     useEffect(() => {
       if (open && slideIn) {
         const pageContentElement = document.querySelector(selectorPageContent);
-        pageContentElement.style.inlineSize = 'auto';
+        if (pageContentElement) {
+          pageContentElement.style.inlineSize = 'auto';
+        } else {
+          pconsole.warn(
+            'SidePanel prop `selectorPageContent` was not provided a selector that matches any element on your page. If an element is not found, the panel will render as a slide over.'
+          );
+        }
         if (placement && placement === 'right' && pageContentElement) {
           pageContentElement.style.marginInlineEnd = 0;
           pageContentElement.style.transition = !reducedMotion.matches


### PR DESCRIPTION
Contributes to #4015

Prevents a type error from being thrown if `selectorPageContent` is passed a selector that does not match any element in the DOM. I also added a warning if we cannot find the `selectorPageContent` element and it is a `slideIn` panel.
<img width="1195" alt="Screenshot 2024-01-10 at 9 40 27 AM" src="https://github.com/carbon-design-system/ibm-products/assets/10215203/24622f6b-c866-4c15-9840-cc675e131443">

#### What did you change?
```
packages/ibm-products/src/components/SidePanel/SidePanel.js
```
#### How did you test and verify your work?
Storybook, temporarily passed in a selector that didn't exist and verified that the panel still renders, just as a slide over instead of slide in.


FYI @lee-chase 