### PR TITLE
fix: side panel label scroll

### DIFF
--- a/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
+++ b/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
@@ -199,9 +199,9 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
 
     overflow: hidden;
     padding-right: var(--#{$block-class}--title-padding-right);
+    margin-top: var(--#{$block-class}--title-y-position);
     opacity: var(--#{$block-class}--subtitle-opacity);
     text-overflow: ellipsis;
-    transform: translateY(var(--#{$block-class}--title-y-position));
     white-space: nowrap;
   }
   .#{$block-class}__collapsed-title-text {


### PR DESCRIPTION
With a label added to the side panel scrolling leaves too much below the collapsed title.

https://ibm-products.carbondesignsystem.com/?path=/story/ibm-products-components-side-panel-sidepanel--slide-over&args=size:md;labelText:asdf

Initially
![image](https://github.com/carbon-design-system/ibm-products/assets/15086604/d56b5f3c-ac01-4f86-b697-d579b889db61)

After scroll
![image](https://github.com/carbon-design-system/ibm-products/assets/15086604/951c35f1-e563-489e-b669-fa385a1f483c)

With fix
![image](https://github.com/carbon-design-system/ibm-products/assets/15086604/db614193-3fba-4486-ab32-dcc0195ca6a5)

#### What did you change?
Use of translateY for margin-top

#### How did you test and verify your work?
Storybook