### PR TITLE
fix(side panel): increase title spacing in side panel without subtitle

### DIFF
--- a/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
+++ b/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
@@ -114,8 +114,12 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
     position: sticky;
     z-index: 4;
     top: 0;
-    padding: $spacing-05 $spacing-05 $spacing-03 $spacing-05;
+    padding: $spacing-05;
     background-color: $layer-01;
+
+    &:has(~ .#{$block-class}__subtitle-text) {
+      padding-bottom: $spacing-03;
+    }
 
     &:has(.#{$block-class}__navigation-back-button) {
       padding-top: $spacing-07;


### PR DESCRIPTION
Contributes to #3966 

Changed padding to spacing-05 when there is no subtitle, if a subtitle is present then padding would be spacing-03

#### What did you change?
`packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss`

```
.#{$block-class}__title-container {
    ...
    padding: $spacing-05;
    ...
    &:has(~ .#{$block-class}__subtitle-text) {
      padding-bottom: $spacing-03;
    }
    ...
```


#### How did you test and verify your work?
Manually tested in Storybook
