### PR TITLE
fix(DataGrid): nested rows on click on child row

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useOnRowClick.js
+++ b/packages/ibm-products/src/components/Datagrid/useOnRowClick.js
@@ -28,9 +28,7 @@ const useOnRowClick = (hooks) => {
               row.classList.remove(`${carbon.prefix}--data-table--selected`);
             });
           }
-          const closestRow = event.target.closest(
-            `.${pkg.prefix}--datagrid__carbon-row`
-          );
+          const closestRow = event.currentTarget.closest('tr');
           closestRow.classList.add(`${carbon.prefix}--data-table--selected`);
 
           if (!withSelectRows) {


### PR DESCRIPTION
Contributes to #3758 

when user clicks on child row, the onRowClick event should be triggered and a corresponding css styling should be applied to that row.

#### What did you change?

Row selection updated to closest row.
`packages/ibm-products/src/components/Datagrid/useOnRowClick.js`

#### How did you test and verify your work?
Storybook.

Add `useOnRowClick` hook in "Nested row story" as the following

```
const SingleLevelNestedRows = ({ ...args }) => {
  const columns = React.useMemo(() => defaultHeader, []);
  const [data] = useState(makeData(10, 2));
  const datagridState = useDatagrid(
    {
      columns,
      data,
      onRowClick: (row, event) => {
        action()(event);
      },
      DatagridActions,
      ...args.defaultGridProps,
    },
    useNestedRows,
    useOnRowClick
  );
  return <Datagrid datagridState={{ ...datagridState }} />;
};
```