### PR TITLE
fix(Datagrid): resolve useRowIsMouseOver issue V1

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.js
@@ -34,7 +34,7 @@ const DatagridRow = (datagridState) => {
     key,
     tableId,
     withExpandedRows,
-    mouseHover,
+    withMouseHover,
     setMouseOverRowIndex,
   } = datagridState;
 
@@ -95,7 +95,7 @@ const DatagridRow = (datagridState) => {
   };
 
   const handleMouseLeave = (event) => {
-    if (mouseHover) {
+    if (withMouseHover) {
       setMouseOverRowIndex(null);
     }
     const hoverRow = event.target.closest(

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.js
@@ -34,6 +34,8 @@ const DatagridRow = (datagridState) => {
     key,
     tableId,
     withExpandedRows,
+    mouseHover,
+    setMouseOverRowIndex,
   } = datagridState;
 
   const getVisibleNestedRowCount = ({ isExpanded, subRows }) => {
@@ -93,6 +95,9 @@ const DatagridRow = (datagridState) => {
   };
 
   const handleMouseLeave = (event) => {
+    if (mouseHover) {
+      setMouseOverRowIndex(null);
+    }
     const hoverRow = event.target.closest(
       `.${blockClass}__carbon-row-expanded`
     );

--- a/packages/ibm-products/src/components/Datagrid/useRowIsMouseOver.js
+++ b/packages/ibm-products/src/components/Datagrid/useRowIsMouseOver.js
@@ -29,7 +29,11 @@ const useRowIsMouseOver = (hooks) => {
       isMouseOver: row.index === mouseOverRowIndex,
     }));
 
-    Object.assign(instance, { rows: rowsWithMouseOver });
+    Object.assign(instance, {
+      rows: rowsWithMouseOver,
+      mouseHover: true,
+      setMouseOverRowIndex,
+    });
     hooks.getRowProps.push(getRowProps);
   };
 

--- a/packages/ibm-products/src/components/Datagrid/useRowIsMouseOver.js
+++ b/packages/ibm-products/src/components/Datagrid/useRowIsMouseOver.js
@@ -31,7 +31,7 @@ const useRowIsMouseOver = (hooks) => {
 
     Object.assign(instance, {
       rows: rowsWithMouseOver,
-      mouseHover: true,
+      withMouseHover: true,
       setMouseOverRowIndex,
     });
     hooks.getRowProps.push(getRowProps);


### PR DESCRIPTION
Contributes to #3819

{{Fix the issue of Last hovered row stays in the datagrid table when not hovering using useRowIsMouseOver}}

#### What did you change? Added 2 variables in the object of packages/ibm-products/src/components/Datagrid/useRowIsMouseOver.js to track the hovering. Then destructuring it and setting the value of function in packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.js

#### How did you test and verify your work? storybook
