### PR TITLE
fix: update generate component script

### DIFF
--- a/packages/ibm-products/scripts/generate/templates/DISPLAY_NAME.mdx
+++ b/packages/ibm-products/scripts/generate/templates/DISPLAY_NAME.mdx
@@ -15,11 +15,11 @@ import { DISPLAY_NAME } from '.';
 
 ## Overview
 
-<!-- TODO: Overview. -->
+{/* TODO: Overview. */}
 
 ## Example usage
 
-<!-- TODO: One example per designed use case. -->
+{/* TODO: One example per designed use case. */}
 
 <Canvas>
   <Story id={getStoryId(DISPLAY_NAME.displayName, 'STYLE_NAME')} />
@@ -27,7 +27,7 @@ import { DISPLAY_NAME } from '.';
 
 ## Code sample
 
-<!-- <CodesandboxLink exampleDirectory="DISPLAY_NAME" /> -->
+{/* <CodesandboxLink exampleDirectory="DISPLAY_NAME" /> */}
 
 ## Component API
 

--- a/packages/ibm-products/scripts/generate/templates/_storybook-styles.scss
+++ b/packages/ibm-products/scripts/generate/templates/_storybook-styles.scss
@@ -5,6 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@forward '../../global/styles/project-settings';
+@forward '../../../../ibm-products-styles/src/global/styles/project-settings';
 
 // TODO: add any additional styles used by DISPLAY_NAME.stories.js


### PR DESCRIPTION
Addresses issues caught by @paul-balchin-ibm while using the generate script. Made some mdx fixes and updates path in the genereated `_storybook-styles.scss` file.

#### What did you change?
```
packages/ibm-products/scripts/generate/templates/DISPLAY_NAME.mdx
packages/ibm-products/scripts/generate/templates/_storybook-styles.scss
```
#### How did you test and verify your work?
Ran `yarn generate TestComponent` and verified that storybook successfully included the new component