### PR TITLE
fix(DataGrid): nested rows on click on child row v1

### DIFF
--- a/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
@@ -2140,11 +2140,11 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   transform: translateY(-50%);
 }
 
-.c4p--datagrid .bx--data-table--selected:not(.c4p--datagrid__active-row) {
+.c4p--datagrid .bx--data-table--selected:not(.c4p--datagrid__active-row) td:first-child {
   position: relative;
 }
 
-.c4p--datagrid .bx--data-table--selected:not(.c4p--datagrid__active-row) :first-child:not(.bx--checkbox--inline)::before {
+.c4p--datagrid .bx--data-table--selected:not(.c4p--datagrid__active-row) td:first-child:not(.bx--checkbox--inline)::before {
   position: absolute;
   top: 0;
   left: 0;

--- a/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
@@ -542,7 +542,8 @@
 }
 
 .#{$block-class}
-  .#{$carbon-prefix}--data-table--selected:not(.#{$block-class}__active-row) td:first-child{
+  .#{$carbon-prefix}--data-table--selected:not(.#{$block-class}__active-row)
+  td:first-child {
   position: relative;
 }
 

--- a/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
@@ -542,13 +542,13 @@
 }
 
 .#{$block-class}
-  .#{$carbon-prefix}--data-table--selected:not(.#{$block-class}__active-row) {
+  .#{$carbon-prefix}--data-table--selected:not(.#{$block-class}__active-row) td:first-child{
   position: relative;
 }
 
 .#{$block-class}
   .#{$carbon-prefix}--data-table--selected:not(.#{$block-class}__active-row)
-  :first-child:not(.#{$carbon-prefix}--checkbox--inline)::before {
+  td:first-child:not(.#{$carbon-prefix}--checkbox--inline)::before {
   position: absolute;
   top: 0;
   left: 0;

--- a/packages/ibm-products/src/components/Datagrid/useOnRowClick.js
+++ b/packages/ibm-products/src/components/Datagrid/useOnRowClick.js
@@ -28,9 +28,7 @@ const useOnRowClick = (hooks) => {
               row.classList.remove(`${carbon.prefix}--data-table--selected`);
             });
           }
-          const closestRow = event.target.closest(
-            `.${pkg.prefix}--datagrid__carbon-row`
-          );
+          const closestRow = event.target.closest('tr');
           closestRow.classList.add(`${carbon.prefix}--data-table--selected`);
 
           if (!withSelectRows) {


### PR DESCRIPTION
Contributes to #3758 

when user clicks on child row, the onRowClick event should be triggered and a corresponding css styling should be applied to that row.

#### What did you change?

Row selection updated to closest row.
`packages/ibm-products/src/components/Datagrid/useOnRowClick.js`
`packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss`

#### How did you test and verify your work?
Storybook.

Add `useOnRowClick` hook in "Nested row story" as the following

```
const SingleLevelNestedRows = ({ ...args }) => {
  const columns = React.useMemo(() => defaultHeader, []);
  const [data] = useState(makeData(10, 2));
  const datagridState = useDatagrid(
    {
      columns,
      data,
      onRowClick: (row, event) => {
        action()(event);
      },
      DatagridActions,
      ...args.defaultGridProps,
    },
    useNestedRows,
    useOnRowClick
  );
  return <Datagrid datagridState={{ ...datagridState }} />;
};
```