### PR TITLE
fix(PageHeader): collapsed breadcrumb tab disappears on resize

### DIFF
--- a/packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
+++ b/packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
@@ -361,8 +361,7 @@ $right-section-alt-width: 100% - $left-section-alt-width;
 
   .#{$block-class}__title-row {
     --title-row-margin-top: #{$spacing-01}; /* spacing needed in case of editable title, otherwise top of focus indicator hidden */
-
-    margin-top: var(--title-row-margin-top);
+    
     margin-bottom: 0;
     transform: translateY(
       $spacing-01

--- a/packages/ibm-products/src/components/PageHeader/PageHeaderUtils.js
+++ b/packages/ibm-products/src/components/PageHeader/PageHeaderUtils.js
@@ -85,7 +85,7 @@ export const utilCheckUpdateVerticalSpace = (
 
     // The header offset calculation is either going to work out at 0 if we have no gap between scrolling container
     // top and the measuring ref top, or the difference between. It does not change on scroll or resize.
-    update.headerOffset = offsetMeasuringTop - scrollableContainerTop;
+    update.headerOffset = offsetMeasuringTop === 0 ? offsetMeasuringTop - scrollableContainerTop: 0;
 
     /* istanbul ignore next */
     update.breadcrumbRowHeight = breadcrumbRowEl


### PR DESCRIPTION
Contributes to #3972 

Interact with the page actions in the page header when is collapsed make the breadcrumb tab disappear.

#### What did you change?
`packages/ibm-products/src/components/PageHeader/PageHeaderUtils.js`
`packages/ibm-products-styles/src/components/PageHeader/_page-header.scss`

#### How did you test and verify your work?
Storybook