### PR TITLE
chore(Datagrid): use browser locale to avoid confusion in formatting

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
@@ -28,6 +28,7 @@ import { DatagridActions } from '../../utils/DatagridActions';
 import { StatusIcon } from '../../../StatusIcon';
 import { pkg } from '../../../../settings';
 import { handleFilterTagLabelText } from '../../utils/handleFilterTagLabelText';
+import { getDateFormat } from './Panel.stories';
 
 export default {
   title: `${getStoryTitle(Datagrid.displayName)}/Extensions/Flyout`,
@@ -169,16 +170,18 @@ const filters = [
     props: {
       DatePicker: {
         datePickerType: 'range',
+        locale: navigator?.language || 'en',
+        dateFormat: getDateFormat(navigator?.language || 'en'),
       },
       DatePickerInput: {
         start: {
           id: 'date-picker-input-id-start',
-          placeholder: 'mm/dd/yyyy',
+          placeholder: getDateFormat(navigator?.language || 'en', true),
           labelText: 'Joined start date',
         },
         end: {
           id: 'date-picker-input-id-end',
-          placeholder: 'mm/dd/yyyy',
+          placeholder: getDateFormat(navigator?.language || 'en', true),
           labelText: 'Joined end date',
         },
       },

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
@@ -46,7 +46,7 @@ export default {
       },
     },
   },
-  excludeStories: ['FilteringUsage', 'filterProps'],
+  excludeStories: ['FilteringUsage', 'filterProps', 'getDateFormat'],
 };
 
 // This is to show off the View all button in checkboxes

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
@@ -173,6 +173,25 @@ const FilteringTemplateWrapper = ({ ...args }) => {
   return <FilteringUsage defaultGridProps={{ ...args }} />;
 };
 
+// Example usage of mapping locale to flatpickr date format or placeholder value (m/d/Y or mm/dd/yyyy)
+export const getDateFormat = (lang, full) => {
+  const formatObj = new Intl.DateTimeFormat(lang).formatToParts(new Date());
+  return formatObj
+    .map(({ type, value }) => {
+      switch (type) {
+        case 'day':
+          return full ? 'dd' : 'd';
+        case 'month':
+          return full ? 'mm' : 'm';
+        case 'year':
+          return full ? 'yyyy' : 'Y';
+        default:
+          return value;
+      }
+    })
+    .join('');
+};
+
 export const filterProps = {
   variation: 'panel',
   updateMethod: 'batch',
@@ -193,16 +212,18 @@ export const filterProps = {
             props: {
               DatePicker: {
                 datePickerType: 'range',
+                locale: navigator?.language || 'en',
+                dateFormat: getDateFormat(navigator?.language || 'en'),
               },
               DatePickerInput: {
                 start: {
                   id: 'date-picker-input-id-start',
-                  placeholder: 'mm/dd/yyyy',
+                  placeholder: getDateFormat(navigator?.language || 'en', true),
                   labelText: 'Joined start date',
                 },
                 end: {
                   id: 'date-picker-input-id-end',
-                  placeholder: 'mm/dd/yyyy',
+                  placeholder: getDateFormat(navigator?.language || 'en', true),
                   labelText: 'Joined end date',
                 },
               },


### PR DESCRIPTION
Contributes to #3899 

This was something that only required storybook updates, since the `renderDateLabel` property uses `.toLocaleDateString()` to render the filter tags we need to also use a localized date format for the `DatePicker` in the filter panel/flyout (with the use of `navigator?.language`).

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
```
#### How did you test and verify your work?
Storybook (changed my browsers preferred language list to test)