### PR TITLE
fix(Tearsheet): implement focus trapping within tearsheets

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.stories.js
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.stories.js
@@ -194,8 +194,9 @@ const StackedTemplate = ({ actions, ...args }) => {
           title="Tearsheet #1"
           open={open1}
           onClose={() => setOpen1(false)}
+          selectorPrimaryFocus="#main-content"
         >
-          <div className="tearsheet-stories__narrow-content-block">
+          <div tabIndex={-1} id="main-content" className="tearsheet-stories__narrow-content-block">
             Main content 1
           </div>
         </TearsheetNarrow>
@@ -205,8 +206,9 @@ const StackedTemplate = ({ actions, ...args }) => {
           title="Tearsheet #2"
           open={open2}
           onClose={() => setOpen2(false)}
+          selectorPrimaryFocus="#main-content"
         >
-          <div className="tearsheet-stories__narrow-content-block">
+          <div tabIndex={-1} id="main-content" className="tearsheet-stories__narrow-content-block">
             Main content 2
           </div>
         </TearsheetNarrow>
@@ -216,8 +218,9 @@ const StackedTemplate = ({ actions, ...args }) => {
           title="Tearsheet #3"
           open={open3}
           onClose={() => setOpen3(false)}
+          selectorPrimaryFocus="#main-content"
         >
-          <div className="tearsheet-stories__narrow-content-block">
+          <div tabIndex={-1} id="main-content" className="tearsheet-stories__narrow-content-block">
             Main content 3
           </div>
         </TearsheetNarrow>


### PR DESCRIPTION
Contributes to #3499 

This is to fix the focus trap issue in the Tearsheet component

#### What did you change?
Made changes in the file: `packages/ibm-products/src/components/Tearsheet/TearsheetShell.js`.
Implemented a new 'useEffect' to track the 'keydown' event and created a function to handle this event properly.

File: `packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.stories.js`
Resolved another issue by giving a property `selectorPrimaryFocus="#main-content"` to the `<Tearsheet />` component.
Also given attributes `tabIndex={-1}` and `id="main-content"` to main content `div`.

#### How did you test and verify your work?
Storybook
