### PR TITLE
feat(Tearsheet): support aria-label

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/Tearsheet.js
+++ b/packages/ibm-products/src/components/Tearsheet/Tearsheet.js
@@ -133,6 +133,12 @@ Tearsheet.propTypes = {
   ]),
 
   /**
+   * The aria-label for the tearsheet, which is optional.
+   * if it is not passed, the title will be used as the aria-label.
+   */
+  ariaLabel: PropTypes.string,
+
+  /**
    * An optional class or classes to be added to the outermost element.
    */
   className: PropTypes.string,

--- a/packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.js
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.js
@@ -121,6 +121,12 @@ TearsheetNarrow.propTypes = {
   ]),
 
   /**
+   * The aria-label for the tearsheet, which is optional.
+   * if it is not passed, the title will be used as the aria-label.
+   */
+  ariaLabel: PropTypes.string,
+
+  /**
    * An optional class or classes to be added to the outermost element.
    */
   className: PropTypes.string,

--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.js
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.js
@@ -71,6 +71,7 @@ export const TearsheetShell = React.forwardRef(
     {
       // The component props, in alphabetical order (for consistency).
       actions,
+      ariaLabel,
       children,
       className,
       closeIconDescription,
@@ -214,7 +215,7 @@ export const TearsheetShell = React.forwardRef(
             // Pass through any other property values.
             ...rest
           }
-          aria-label={getNodeTextContent(title)}
+          aria-label={ariaLabel || getNodeTextContent(title)}
           className={cx(bc, className, {
             [`${bc}--stacked-${position}-of-${depth}`]:
               // Don't apply this on the initial open of a single tearsheet.


### PR DESCRIPTION
Contributes to #4013


Added an optional 'ariaLabel' prop to Tearsheet/TearsheetNarrow modal components. When the 'ariaLabel' prop is provided, it will be used for the 'aria-label' attribute. If not provided, the 'title' content will be used as the default 'aria-label'.

#### What did you change?
packages/ibm-products/src/components/Tearsheet/Tearsheet.js
packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.js
packages/ibm-products/src/components/Tearsheet/TearsheetShell.js

#### How did you test and verify your work?
storybook controls
