### PR TITLE
fix(ButtonMenu): export as canary

### DIFF
--- a/packages/ibm-products/carbon.yml
+++ b/packages/ibm-products/carbon.yml
@@ -2,7 +2,8 @@
 library:
   id: ibm-products
   name: IBM Products
-  description: Discover React-based solutions designed for IBM’s product portfolio.
+  description:
+    Discover React-based solutions designed for IBM’s product portfolio.
   externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/
   designKits:
     ibm-products-g10-figma:
@@ -94,7 +95,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-internal-buttonmenu
+        url: https://v1-ibm-products.carbondesignsystem.com/?path=/story/ibm-products-components-button-menu
     tags:
       - input-control
   button-set-with-overflow:

--- a/packages/ibm-products/src/components/index.js
+++ b/packages/ibm-products/src/components/index.js
@@ -7,6 +7,7 @@
 
 export { AboutModal } from './AboutModal';
 export { APIKeyModal } from './APIKeyModal';
+export { ButtonMenu } from './ButtonMenu';
 export { Cascade } from './Cascade';
 export { ComboButton, ComboButtonItem } from './ComboButton';
 export { CreateFullPage, CreateFullPageStep } from './CreateFullPage';


### PR DESCRIPTION
Contributes to #4132

Fixes an issue where we never actually exported ButtonMenu in our v1 when we added it as a canary component. 🙈 

#### What did you change?
Add to index.js and updated `carbon.yml` for good measure

#### How did you test and verify your work?
c4p CI checks pass
