### PR TITLE
fix(Datagrid): fix placement of pagination when used with filter panel

### DIFF
--- a/packages/ibm-products-styles/src/components/Datagrid/_datagrid.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/_datagrid.scss
@@ -80,3 +80,7 @@ $block-class: #{c4p-settings.$pkg-prefix}--datagrid;
   ) {
   min-width: auto;
 }
+
+.#{$block-class} .#{c4p-settings.$carbon-prefix}--pagination {
+  background-color: $layer-02;
+}

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_datagrid.scss
@@ -183,6 +183,12 @@
     overflow-x: auto;
   }
 
+  .#{$block-class}-filter-panel
+    + .#{$block-class}__table-container-inner
+    .#{c4p-settings.$carbon-prefix}--data-table-content {
+    height: fit-content;
+  }
+
   table.#{$block-class}__table-simple {
     display: flex;
     overflow: auto;

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -84,43 +84,46 @@ export const DatagridContent = ({ datagridState, title }) => {
 
   const renderTable = () => {
     return (
-      <Table
-        {...getTableProps()}
-        className={cx(
-          withVirtualScroll ? '' : `${blockClass}__table-simple`,
-          `${blockClass}__vertical-align-${verticalAlign}`,
-          { [`${blockClass}__variable-row-height`]: variableRowHeight },
-          { [`${blockClass}__table-with-inline-edit`]: withInlineEdit },
-          { [`${blockClass}__table-grid-active`]: gridActive },
-          {
-            [`${blockClass}__table-is-resizing`]:
-              typeof columnResizing.isResizingColumn === 'string',
-          },
-          getTableProps()?.className
-        )}
-        role={withInlineEdit ? 'grid' : undefined}
-        tabIndex={withInlineEdit ? 0 : -1}
-        onKeyDown={
-          /* istanbul ignore next */
-          withInlineEdit &&
-          ((event) =>
-            handleGridKeyPress({
-              event,
-              dispatch,
-              instance: datagridState,
-              keysPressedList,
-              state: inlineEditState,
-              usingMac,
-            }))
-        }
-        onFocus={
-          withInlineEdit && (() => handleGridFocus(inlineEditState, dispatch))
-        }
-        title={title}
-      >
-        {!withVirtualScroll && <DatagridHead {...datagridState} />}
-        <DatagridBody {...datagridState} rows={contentRows} />
-      </Table>
+      <>
+        <Table
+          {...getTableProps()}
+          className={cx(
+            withVirtualScroll ? '' : `${blockClass}__table-simple`,
+            `${blockClass}__vertical-align-${verticalAlign}`,
+            { [`${blockClass}__variable-row-height`]: variableRowHeight },
+            { [`${blockClass}__table-with-inline-edit`]: withInlineEdit },
+            { [`${blockClass}__table-grid-active`]: gridActive },
+            {
+              [`${blockClass}__table-is-resizing`]:
+                typeof columnResizing.isResizingColumn === 'string',
+            },
+            getTableProps()?.className
+          )}
+          role={withInlineEdit ? 'grid' : undefined}
+          tabIndex={withInlineEdit ? 0 : -1}
+          onKeyDown={
+            /* istanbul ignore next */
+            withInlineEdit &&
+            ((event) =>
+              handleGridKeyPress({
+                event,
+                dispatch,
+                instance: datagridState,
+                keysPressedList,
+                state: inlineEditState,
+                usingMac,
+              }))
+          }
+          onFocus={
+            withInlineEdit && (() => handleGridFocus(inlineEditState, dispatch))
+          }
+          title={title}
+        >
+          {!withVirtualScroll && <DatagridHead {...datagridState} />}
+          <DatagridBody {...datagridState} rows={contentRows} />
+        </Table>
+        {filterProps?.variation === 'panel' && renderPagination()}
+      </>
     );
   };
 
@@ -165,6 +168,12 @@ export const DatagridContent = ({ datagridState, title }) => {
         overflowType="tag"
       />
     );
+
+  const renderPagination = () => {
+    if (contentRows?.length > 0 && !isFetching && DatagridPagination) {
+      return <DatagridPagination {...datagridState} />;
+    }
+  };
 
   return (
     <>
@@ -215,9 +224,7 @@ export const DatagridContent = ({ datagridState, title }) => {
           </div>
         </div>
       </TableContainer>
-      {contentRows?.length > 0 && !isFetching && DatagridPagination && (
-        <DatagridPagination {...datagridState} />
-      )}
+      {filterProps?.variation !== 'panel' && renderPagination()}
       {CustomizeColumnsTearsheet && (
         <CustomizeColumnsTearsheet instance={datagridState} />
       )}

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
@@ -200,10 +200,12 @@ const FilterPanel = ({
     const actionSetHeight =
       actionSetRef.current?.getBoundingClientRect().height;
 
-    const height = `calc(100vh - ${filterHeadingHeight}px - ${
-      /* istanbul ignore next */
-      showFilterSearch ? filterSearchHeight : 0
-    }px - ${updateMethod === BATCH ? actionSetHeight : 0}px)`;
+    const height = panelOpen
+      ? `calc(100vh - ${filterHeadingHeight}px - ${
+          /* istanbul ignore next */
+          showFilterSearch ? filterSearchHeight : 0
+        }px - ${updateMethod === BATCH ? actionSetHeight : 0}px)`
+      : 0;
 
     return height;
   };


### PR DESCRIPTION
Contributes to #3725 

The pagination component when used in conjunction with the filter panel needed to be rendered with the table and not outside the table and filter panel. Because of the fact that the filter panel when open has a large height, previously the pagination component wasn't visible. It now renders below the last row of the table.

There was also a bug in the panel height when it was not open it was still causing content below the Datagrid to be pushed down the page, this should only occur when the panel is open.

#### What did you change?
```
packages/ibm-products-styles/src/components/Datagrid/_datagrid.scss
packages/ibm-products-styles/src/components/Datagrid/styles/_datagrid.scss
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
```
#### How did you test and verify your work?
Storybook, all tests pass