### PR TITLE
fix(Datagrid): fix placement of pagination when used with filter panel (v1)

### DIFF
--- a/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1833,6 +1833,9 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   height: 100%;
   overflow-x: auto;
 }
+.c4p--datagrid__grid-container .c4p--datagrid-filter-panel + .c4p--datagrid__table-container-inner .bx--data-table-content {
+  height: fit-content;
+}
 .c4p--datagrid__grid-container table.c4p--datagrid__table-simple {
   display: flex;
   overflow: auto;
@@ -3464,6 +3467,11 @@ th.c4p--datagrid__select-all-toggle-on.button {
 .bx--overflow-menu-options > .c4p--datagrid__row-size-dropdown {
   left: var(--cds-spacing-01, 0.125rem);
   width: 112px;
+}
+
+.c4p--datagrid .bx--pagination,
+.c4p--datagrid .bx--pagination .bx--select-input {
+  background-color: var(--cds-ui-02, #ffffff);
 }
 
 .c4p--empty-state {

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -86,43 +86,46 @@ export const DatagridContent = ({ datagridState, title }) => {
 
   const renderTable = () => {
     return (
-      <Table
-        {...getTableProps()}
-        className={cx(
-          withVirtualScroll ? '' : `${blockClass}__table-simple`,
-          `${blockClass}__vertical-align-${verticalAlign}`,
-          { [`${blockClass}__variable-row-height`]: variableRowHeight },
-          { [`${blockClass}__table-with-inline-edit`]: withInlineEdit },
-          { [`${blockClass}__table-grid-active`]: gridActive },
-          {
-            [`${blockClass}__table-is-resizing`]:
-              typeof columnResizing.isResizingColumn === 'string',
-          },
-          getTableProps()?.className
-        )}
-        role={withInlineEdit && 'grid'}
-        tabIndex={withInlineEdit && 0}
-        onKeyDown={
-          /* istanbul ignore next */
-          withInlineEdit &&
-          ((event) =>
-            handleGridKeyPress({
-              event,
-              dispatch,
-              instance: datagridState,
-              keysPressedList,
-              state: inlineEditState,
-              usingMac,
-            }))
-        }
-        onFocus={
-          withInlineEdit && (() => handleGridFocus(inlineEditState, dispatch))
-        }
-        title={title}
-      >
-        {!withVirtualScroll && <DatagridHead {...datagridState} />}
-        <DatagridBody {...datagridState} rows={contentRows} />
-      </Table>
+      <>
+        <Table
+          {...getTableProps()}
+          className={cx(
+            withVirtualScroll ? '' : `${blockClass}__table-simple`,
+            `${blockClass}__vertical-align-${verticalAlign}`,
+            { [`${blockClass}__variable-row-height`]: variableRowHeight },
+            { [`${blockClass}__table-with-inline-edit`]: withInlineEdit },
+            { [`${blockClass}__table-grid-active`]: gridActive },
+            {
+              [`${blockClass}__table-is-resizing`]:
+                typeof columnResizing.isResizingColumn === 'string',
+            },
+            getTableProps()?.className
+          )}
+          role={withInlineEdit && 'grid'}
+          tabIndex={withInlineEdit && 0}
+          onKeyDown={
+            /* istanbul ignore next */
+            withInlineEdit &&
+            ((event) =>
+              handleGridKeyPress({
+                event,
+                dispatch,
+                instance: datagridState,
+                keysPressedList,
+                state: inlineEditState,
+                usingMac,
+              }))
+          }
+          onFocus={
+            withInlineEdit && (() => handleGridFocus(inlineEditState, dispatch))
+          }
+          title={title}
+        >
+          {!withVirtualScroll && <DatagridHead {...datagridState} />}
+          <DatagridBody {...datagridState} rows={contentRows} />
+        </Table>
+        {filterProps?.variation === 'panel' && renderPagination()}
+      </>
     );
   };
 
@@ -168,6 +171,12 @@ export const DatagridContent = ({ datagridState, title }) => {
         overflowType="tag"
       />
     );
+
+  const renderPagination = () => {
+    if (contentRows?.length > 0 && !isFetching && DatagridPagination) {
+      return <DatagridPagination {...datagridState} />;
+    }
+  };
 
   return (
     <>
@@ -223,9 +232,7 @@ export const DatagridContent = ({ datagridState, title }) => {
           </div>
         </div>
       </TableContainer>
-      {contentRows?.length > 0 && !isFetching && DatagridPagination && (
-        <DatagridPagination {...datagridState} />
-      )}
+      {filterProps?.variation !== 'panel' && renderPagination()}
       {CustomizeColumnsTearsheet && (
         <CustomizeColumnsTearsheet instance={datagridState} />
       )}

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
@@ -194,9 +194,12 @@ const FilterPanel = ({
     const actionSetHeight =
       actionSetRef.current?.getBoundingClientRect().height;
 
-    const height = `calc(100vh - ${filterHeadingHeight}px - ${
-      showFilterSearch ? filterSearchHeight : 0
-    }px - ${updateMethod === BATCH ? actionSetHeight : 0}px)`;
+    const height = panelOpen
+      ? `calc(100vh - ${filterHeadingHeight}px - ${
+          /* istanbul ignore next */
+          showFilterSearch ? filterSearchHeight : 0
+        }px - ${updateMethod === BATCH ? actionSetHeight : 0}px)`
+      : 0;
 
     return height;
   };

--- a/packages/ibm-products/src/components/Datagrid/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/_datagrid.scss
@@ -50,9 +50,17 @@
     }
   }
 
-  .bx--overflow-menu-options > .c4p--datagrid__row-size-dropdown {
+  .#{$carbon-prefix}--overflow-menu-options
+    > .c4p--datagrid__row-size-dropdown {
     left: $spacing-01;
     width: 112px;
+  }
+
+  .#{$block-class} .#{$carbon-prefix}--pagination,
+  .#{$block-class}
+    .#{$carbon-prefix}--pagination
+    .#{$carbon-prefix}--select-input {
+    background-color: $ui-02;
   }
 }
 

--- a/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
@@ -182,6 +182,12 @@
     overflow-x: auto;
   }
 
+  .#{$block-class}-filter-panel
+    + .#{$block-class}__table-container-inner
+    .#{$carbon-prefix}--data-table-content {
+    height: fit-content;
+  }
+
   table.#{$block-class}__table-simple {
     display: flex;
     overflow: auto;


### PR DESCRIPTION
Contributes to #3725 

The pagination component when used in conjunction with the filter panel needed to be rendered with the table and not outside the table and filter panel. Because of the fact that the filter panel when open has a large height, previously the pagination component wasn't visible. It now renders below the last row of the table.

There was also a bug in the panel height when it was not open it was still causing content below the Datagrid to be pushed down the page, this should only occur when the panel is open.

#### What did you change?
```
packages/ibm-products-styles/src/components/Datagrid/_datagrid.scss
packages/ibm-products-styles/src/components/Datagrid/styles/_datagrid.scss
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
```
#### How did you test and verify your work?
Storybook, all tests pass