### PR TITLE
feat(ButtonMenu): export button menu item component (v1)

### DIFF
--- a/packages/ibm-products/src/components/index.js
+++ b/packages/ibm-products/src/components/index.js
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2023
+// Copyright IBM Corp. 2020, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -7,7 +7,7 @@
 
 export { AboutModal } from './AboutModal';
 export { APIKeyModal } from './APIKeyModal';
-export { ButtonMenu } from './ButtonMenu';
+export { ButtonMenu, ButtonMenuItem } from './ButtonMenu';
 export { Cascade } from './Cascade';
 export { ComboButton, ComboButtonItem } from './ComboButton';
 export { CreateFullPage, CreateFullPageStep } from './CreateFullPage';

--- a/packages/ibm-products/src/global/js/package-settings.js
+++ b/packages/ibm-products/src/global/js/package-settings.js
@@ -71,6 +71,7 @@ const defaults = {
     EditFullPage: false,
     EditUpdateCards: false,
     ButtonMenu: false,
+    ButtonMenuItem: false,
 
     // Novice to pro components not yet reviewed and released:
     InlineTip: false,


### PR DESCRIPTION
Follow up to #4132, this PR just exports the `ButtonMenuItem` so it can be used with the `ButtonMenu` in v1.

#### What did you change?
Export `ButtonMenuItem`