### PR TITLE
fix(Button menu): button menu accessibility issue - 3519

### DIFF
--- a/packages/ibm-products/src/components/ButtonMenu/ButtonMenu.js
+++ b/packages/ibm-products/src/components/ButtonMenu/ButtonMenu.js
@@ -69,7 +69,7 @@ export let ButtonMenu = React.forwardRef(
         )}
         menuOptionsClass={cx(`${blockClass}__options`, menuOptionsClass)}
         size={size}
-        ariaLabel={menuAriaLabel??label??undefined}
+        ariaLabel={menuAriaLabel ?? label ?? undefined}
         renderIcon={() => (
           <div
             className={cx([
@@ -135,12 +135,12 @@ ButtonMenu.propTypes = {
    */
   label: PropTypes.node,
 
-    /**
-   * Provide the menuAriaLabel prop to be passed to the ButtonMenu component. 
+  /**
+   * Provide the menuAriaLabel prop to be passed to the ButtonMenu component.
    * This optional label should contain or match the visible labels or
-   *  it will automatically take button label 
+   *  it will automatically take button label
    */
-    menuAriaLabel: PropTypes.string,
+  menuAriaLabel: PropTypes.string,
 
   /**
    * class name applied to the overflow options

--- a/packages/ibm-products/src/components/ButtonMenu/ButtonMenu.js
+++ b/packages/ibm-products/src/components/ButtonMenu/ButtonMenu.js
@@ -68,6 +68,7 @@ export let ButtonMenu = React.forwardRef(
         )}
         menuOptionsClass={cx(`${blockClass}__options`, menuOptionsClass)}
         size={size}
+        ariaLabel={label}
         renderIcon={() => (
           <div
             className={cx([

--- a/packages/ibm-products/src/components/ButtonMenu/ButtonMenu.js
+++ b/packages/ibm-products/src/components/ButtonMenu/ButtonMenu.js
@@ -45,6 +45,7 @@ export let ButtonMenu = React.forwardRef(
       iconDescription,
       kind = defaults.kind,
       label,
+      menuAriaLabel,
       menuOptionsClass,
       renderIcon: Icon,
       size = defaults.size,
@@ -68,7 +69,7 @@ export let ButtonMenu = React.forwardRef(
         )}
         menuOptionsClass={cx(`${blockClass}__options`, menuOptionsClass)}
         size={size}
-        ariaLabel={label}
+        ariaLabel={menuAriaLabel??label??undefined}
         renderIcon={() => (
           <div
             className={cx([
@@ -133,6 +134,13 @@ ButtonMenu.propTypes = {
    * The button label for the menu trigger.
    */
   label: PropTypes.node,
+
+    /**
+   * Provide the menuAriaLabel prop to be passed to the ButtonMenu component. 
+   * This optional label should contain or match the visible labels or
+   *  it will automatically take button label 
+   */
+    menuAriaLabel: PropTypes.string,
 
   /**
    * class name applied to the overflow options

--- a/packages/ibm-products/src/components/ButtonMenu/ButtonMenu.js
+++ b/packages/ibm-products/src/components/ButtonMenu/ButtonMenu.js
@@ -15,6 +15,7 @@ import { pkg, carbon } from '../../settings';
 
 // Carbon and package components we use.
 import { Button, OverflowMenu } from 'carbon-components-react';
+import { getNodeTextContent } from '../../global/js/utils/getNodeTextContent';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 const blockClass = `${pkg.prefix}--button-menu`;
@@ -69,7 +70,7 @@ export let ButtonMenu = React.forwardRef(
         )}
         menuOptionsClass={cx(`${blockClass}__options`, menuOptionsClass)}
         size={size}
-        ariaLabel={menuAriaLabel ?? label ?? undefined}
+        ariaLabel={menuAriaLabel ?? getNodeTextContent(label) ?? undefined}
         renderIcon={() => (
           <div
             className={cx([

--- a/packages/ibm-products/src/components/ButtonMenu/ButtonMenu.stories.js
+++ b/packages/ibm-products/src/components/ButtonMenu/ButtonMenu.stories.js
@@ -38,7 +38,7 @@ export default {
 
 const Template = (args) => {
   return (
-    <ButtonMenu label="Primary button" renderIcon={ChevronDown16} {...args}>
+    <ButtonMenu label="Primary button" renderIcon={ChevronDown16} menuAriaLabel="Primary button" {...args}>
       <ButtonMenuItem
         itemText="Option 1"
         onClick={action(`Click on Option 1`)}

--- a/packages/ibm-products/src/components/ButtonMenu/ButtonMenu.stories.js
+++ b/packages/ibm-products/src/components/ButtonMenu/ButtonMenu.stories.js
@@ -38,7 +38,12 @@ export default {
 
 const Template = (args) => {
   return (
-    <ButtonMenu label="Primary button" renderIcon={ChevronDown16} menuAriaLabel="Primary button" {...args}>
+    <ButtonMenu
+      label="Primary button"
+      renderIcon={ChevronDown16}
+      menuAriaLabel="Primary button"
+      {...args}
+    >
       <ButtonMenuItem
         itemText="Option 1"
         onClick={action(`Click on Option 1`)}

--- a/packages/ibm-products/src/components/ButtonMenu/ButtonMenu.test.js
+++ b/packages/ibm-products/src/components/ButtonMenu/ButtonMenu.test.js
@@ -27,11 +27,11 @@ const icon = Add16;
 const iconDescription = `Icon ${uuidv4()}`;
 const itemText = `Option ${uuidv4()}`;
 const label = `Button ${uuidv4()}`;
-const ariaLabel = `aria ${label} label`;
+const menuAriaLabel = `aria ${label} label`;
 
 const renderMenu = (menuProps = {}, itemProps = {}) => {
   const container = render(
-    <ButtonMenu {...{ ariaLabel, label }} {...menuProps}>
+    <ButtonMenu {...{ menuAriaLabel, label }} {...menuProps}>
       <ButtonMenuItem itemText="Option 1" />
       <ButtonMenuItem {...{ itemText }} {...itemProps} />
       <ButtonMenuItem itemText="Option 3" />
@@ -44,7 +44,7 @@ const renderMenu = (menuProps = {}, itemProps = {}) => {
 describe(componentName, () => {
   it('renders a component ButtonMenu', () => {
     renderMenu();
-    expect(screen.getByRole('button', { name: ariaLabel })).toHaveClass(
+    expect(screen.getByRole('button', { name: menuAriaLabel })).toHaveClass(
       blockClass
     );
   });
@@ -62,7 +62,7 @@ describe(componentName, () => {
 
   it('applies className to the containing node', () => {
     renderMenu({ className });
-    expect(screen.getByRole('button', { name: ariaLabel })).toHaveClass(
+    expect(screen.getByRole('button', { name: menuAriaLabel })).toHaveClass(
       className
     );
   });
@@ -70,7 +70,7 @@ describe(componentName, () => {
   it('renders icon and description', () => {
     renderMenu({ iconDescription, renderIcon: icon });
     const svg = screen
-      .getByRole('button', { name: ariaLabel })
+      .getByRole('button', { name: menuAriaLabel })
       .querySelector('svg');
     expect(svg).toHaveClass(`${carbon.prefix}--btn__icon`);
   });


### PR DESCRIPTION
Contributes to #3519 

Follow a11y guideline about "accessible label should contain or match the visible labels) or allow overrides

#### What did you change?
Provide the menuAriaLabel prop to be passed to the Button menu component. This optional label should contain or match the visible labels or it will automatically take button label

#### How did you test and verify your work?
Verified in the storyboard using IBM Equal Access Accessibility Checker.