### PR TITLE
fix(sidePanel): adjust title spacing when there is no subtitle v1

### DIFF
--- a/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
@@ -839,8 +839,11 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   z-index: 4;
   top: 0;
   height: calc(var(--c4p--side-panel--title-container-height) - var(--c4p--side-panel--label-text-height));
-  padding: var(--cds-spacing-05, 1rem) var(--cds-spacing-05, 1rem) var(--cds-spacing-03, 0.5rem) var(--cds-spacing-05, 1rem);
+  padding: var(--cds-spacing-05, 1rem);
   background-color: var(--cds-ui-01, #f4f4f4);
+}
+.c4p--side-panel__container .c4p--side-panel__title-container:has(~ .c4p--side-panel__subtitle-text) {
+  padding-bottom: var(--cds-spacing-03, 0.5rem);
 }
 .c4p--side-panel__container .c4p--side-panel__title-container::before {
   position: absolute;

--- a/packages/ibm-products/src/components/SidePanel/_side-panel.scss
+++ b/packages/ibm-products/src/components/SidePanel/_side-panel.scss
@@ -112,8 +112,12 @@ $action-set-block-class: #{$pkg-prefix}--action-set;
         var(--#{$block-class}--title-container-height) -
           var(--#{$block-class}--label-text-height)
       );
-      padding: $spacing-05 $spacing-05 $spacing-03 $spacing-05;
+      padding: $spacing-05;
       background-color: $ui-01;
+
+      &:has(~ .#{$block-class}__subtitle-text) {
+        padding-bottom: $spacing-03;
+      }
 
       &::before {
         @include setDividerStyles();


### PR DESCRIPTION
Contributes to #3966 

This is to change padding to spacing-05 when there is no subtitle, if a subtitle is present then padding would be spacing-03

#### What did you change?
`packages/ibm-products/src/components/SidePanel/_side-panel.scss`

```
    .#{$block-class}__title-container {
      padding: $spacing-05;

      &:has(~ .#{$block-class}__subtitle-text) {
        padding-bottom: $spacing-03;
      }
```

#### How did you test and verify your work?
Storybook
