### PR TITLE
test(Datagrid): always set a locale to prevent date format changes in `renderDateLabel` test (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
@@ -2704,7 +2704,10 @@ describe(componentName, () => {
               {
                 id: 'joined',
                 type: 'date',
-                value: [new Date('01/01/2022'), todayDate],
+                value: [
+                  new Date('01/01/2022').toLocaleDateString('en-US'),
+                  todayDate.toLocaleDateString('en-US'),
+                ],
               },
             ],
           },


### PR DESCRIPTION
Issue brought up via slack, the way the test to check the `renderDateLabel` was written could be incorrectly formatted given different locales, I explicitly set it now (ie `.toLocaleDateString('en-US')`) which will prevent this from happening moving forward.
 
#### What did you change?
`Datagrid.test.js`
#### How did you test and verify your work?
Verified that all tests still pass

fyi @lee-chase 