### PR TITLE
fix(DataGrid): use action column use isdelete prop V1

### DIFF
--- a/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1980,13 +1980,13 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   background-color: var(--cds-layer-accent, #e0e0e0);
 }
 
-.c4p--datagrid .c4p--datagrid__carbon-row .c4p--datagrid__actions-column-cell-non-sticky .bx--overflow-menu {
+.c4p--datagrid .c4p--datagrid__carbon-row .c4p--datagrid__actions-column-cell-non-sticky .bx--btn--icon-only {
   opacity: 0;
 }
 
-.c4p--datagrid .c4p--datagrid__carbon-row:hover .c4p--datagrid__actions-column-cell-non-sticky .bx--overflow-menu,
-.c4p--datagrid .c4p--datagrid__carbon-row .c4p--datagrid__actions-column-cell-non-sticky .bx--overflow-menu:focus,
-.c4p--datagrid .c4p--datagrid__carbon-row .c4p--datagrid__actions-column-cell-non-sticky .bx--overflow-menu[aria-expanded=true] {
+.c4p--datagrid .c4p--datagrid__carbon-row:hover .c4p--datagrid__actions-column-cell-non-sticky .bx--btn--icon-only,
+.c4p--datagrid .c4p--datagrid__carbon-row .c4p--datagrid__actions-column-cell-non-sticky .bx--btn--icon-only:focus,
+.c4p--datagrid .c4p--datagrid__carbon-row .c4p--datagrid__actions-column-cell-non-sticky .bx--btn--icon-only[aria-expanded=true] {
   opacity: 1;
 }
 

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 /**
  * Copyright IBM Corp. 2022, 2023
  *

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 /**
  * Copyright IBM Corp. 2022, 2023
  *
@@ -49,6 +48,7 @@ import {
   Filter16,
   Activity16,
   Add16,
+  Edit16,
 } from '@carbon/icons-react';
 
 import { getInlineEditColumns } from './utils/getInlineEditColumns';
@@ -839,11 +839,13 @@ const ActionsColumnExample = ({
       disabled,
       shouldHideMenuItem,
       shouldDisableMenuItem,
+      renderIcon: Edit16
     },
     {
       id: 'vote',
       itemText: 'Vote',
       onClick: voteActionClickFn,
+      renderIcon: Add16
     },
     {
       id: 'retire',

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
@@ -839,13 +839,13 @@ const ActionsColumnExample = ({
       disabled,
       shouldHideMenuItem,
       shouldDisableMenuItem,
-      renderIcon: Edit16
+      icon: Edit16,
     },
     {
       id: 'vote',
       itemText: 'Vote',
       onClick: voteActionClickFn,
-      renderIcon: Add16
+      icon: Add16,
     },
     {
       id: 'retire',

--- a/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_datagrid.scss
@@ -353,22 +353,22 @@
 .#{$block-class}
   .#{$block-class}__carbon-row
   .#{$block-class}__actions-column-cell-non-sticky
-  .#{$carbon-prefix}--overflow-menu {
+  .#{$carbon-prefix}--btn--icon-only {
   opacity: 0;
 }
 
 .#{$block-class}
   .#{$block-class}__carbon-row:hover
   .#{$block-class}__actions-column-cell-non-sticky
-  .#{$carbon-prefix}--overflow-menu,
+  .#{$carbon-prefix}--btn--icon-only,
 .#{$block-class}
   .#{$block-class}__carbon-row
   .#{$block-class}__actions-column-cell-non-sticky
-  .#{$carbon-prefix}--overflow-menu:focus,
+  .#{$carbon-prefix}--btn--icon-only:focus,
 .#{$block-class}
   .#{$block-class}__carbon-row
   .#{$block-class}__actions-column-cell-non-sticky
-  .#{$carbon-prefix}--overflow-menu[aria-expanded='true'] {
+  .#{$carbon-prefix}--btn--icon-only[aria-expanded='true'] {
   opacity: 1;
 }
 

--- a/packages/ibm-products/src/components/Datagrid/useActionsColumn.js
+++ b/packages/ibm-products/src/components/Datagrid/useActionsColumn.js
@@ -59,7 +59,7 @@ const useActionsColumn = (hooks) => {
                     >
                       {rowActions.map((action, index) => {
                         const preparedActionProps = prepareProps(action, [
-                          'isDelete'
+                          'isDelete',
                         ]);
                         const {
                           id,
@@ -67,7 +67,7 @@ const useActionsColumn = (hooks) => {
                           onClick,
                           shouldHideMenuItem,
                           align,
-                          renderIcon,
+                          icon,
                           ...rest
                         } = preparedActionProps;
                         const hidden =
@@ -92,7 +92,7 @@ const useActionsColumn = (hooks) => {
                               tooltipPosition={align || 'top'}
                               kind="ghost"
                               name={itemText} //for test use
-                              renderIcon={renderIcon}
+                              renderIcon={icon}
                               iconDescription={itemText}
                               className={cx({
                                 [`${blockClass}__disabled-row-action`]:

--- a/packages/ibm-products/src/components/Datagrid/useActionsColumn.js
+++ b/packages/ibm-products/src/components/Datagrid/useActionsColumn.js
@@ -11,8 +11,10 @@ import {
   IconSkeleton,
   OverflowMenu,
   OverflowMenuItem,
+  Button,
 } from 'carbon-components-react';
 import { pkg } from '../../settings';
+import { prepareProps } from '../../global/js/utils/props-helper';
 const blockClass = `${pkg.prefix}--datagrid`;
 
 const useActionsColumn = (hooks) => {
@@ -56,14 +58,18 @@ const useActionsColumn = (hooks) => {
                       style={{ display: 'flex' }}
                     >
                       {rowActions.map((action, index) => {
+                        const preparedActionProps = prepareProps(action, [
+                          'isDelete'
+                        ]);
                         const {
                           id,
                           itemText,
                           onClick,
-                          icon,
                           shouldHideMenuItem,
+                          align,
+                          renderIcon,
                           ...rest
-                        } = action;
+                        } = preparedActionProps;
                         const hidden =
                           typeof shouldHideMenuItem === 'function' &&
                           shouldHideMenuItem(row);
@@ -81,14 +87,13 @@ const useActionsColumn = (hooks) => {
                             )}
                             key={`${itemText}__${index}`}
                           >
-                            <OverflowMenu
+                            <Button
                               {...rest}
-                              renderIcon={icon}
-                              hasIconOnly
-                              light
-                              iconDescription={itemText}
-                              ariaLabel={itemText}
+                              tooltipPosition={align || 'top'}
                               kind="ghost"
+                              name={itemText} //for test use
+                              renderIcon={renderIcon}
+                              iconDescription={itemText}
                               className={cx({
                                 [`${blockClass}__disabled-row-action`]:
                                   getDisabledState(row.index),
@@ -101,6 +106,7 @@ const useActionsColumn = (hooks) => {
                                 e.stopPropagation();
                                 onClick(id, row, e);
                               }}
+                              hasIconOnly
                             />
                           </div>
                         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -10489,17 +10489,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30000844, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001179, caniuse-lite@npm:^1.0.30001449":
-  version: 1.0.30001519
-  resolution: "caniuse-lite@npm:1.0.30001519"
-  checksum: 66085133ede05d947e30b62fed2cbae18e5767afda8b0de38840883e1cfe5846bf1568ddbafd31647544e59112355abedaf9c867ac34541bfc20d69e7a19d94c
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001487":
-  version: 1.0.30001551
-  resolution: "caniuse-lite@npm:1.0.30001551"
-  checksum: ffdee85b1c130cbebf0aa978ba839f3525f8e304855ba9bf0fbefaac8dd8c40051a7e19ac84a7cf4ba026410abcbe6f8b45560b22ee417c52daecaf955108e65
+"caniuse-lite@npm:^1.0.30000844, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001179, caniuse-lite@npm:^1.0.30001449, caniuse-lite@npm:^1.0.30001487":
+  version: 1.0.30001581
+  resolution: "caniuse-lite@npm:1.0.30001581"
+  checksum: ca4e2cd9d0acf5e3c71fa2e7cd65561e4532d32b640145f634c333792074bb63de1239b35abfb6b6d372f97caf26f8d97faac7ba51ef190717ad2d3ae9c0d7a2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Contributes to #3662 

We should use the `prepareProps` utility to remove the `isDelete` prop if there are either 1 or 2 column actions, 

#### What did you change?
`ibm-products/packages/ibm-products/src/components/Datagrid/useActionsColumn.js`
`ibm-products/packages/ibm-products/src/components/Datagrid/Datagrid.test.js`

#### How did you test and verify your work?
Storybook