### PR TITLE
feat(Datagrid): update filtering copyright headers, review eslint disable rules, remove filter feature flags

### DIFF
--- a/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_FilterPanel.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_FilterPanel.scss
@@ -1,10 +1,9 @@
-/*
-* Licensed Materials - Property of IBM
-* 5724-Q36
-* (c) Copyright IBM Corp. 2022
-* US Government Users Restricted Rights - Use, duplication or disclosure
-* restricted by GSA ADP Schedule Contract with IBM Corp.
-*/
+//
+// Copyright IBM Corp. 2022, 2024
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
 
 @use '../variables' as *;
 @use '@carbon/styles/scss/theme' as *;

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
@@ -1,10 +1,11 @@
-/* eslint-disable react/prop-types */
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+/* eslint-disable react/prop-types */
 
 import React, { useState, useEffect, forwardRef } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
@@ -200,11 +200,14 @@ const FilterFlyout = ({
   };
 
   /** Effects */
+  // Close flyout when clicking outside
   useClickOutside(filterFlyoutRef, (target) => {
     const hasClickedOnDatePicker = target.closest('.flatpickr-calendar');
     const hasClickedOnDropdown =
       target.className === `${carbonPrefix}--list-box__menu-item__option`;
 
+    // Do not do anything if flyout is closed or if clicking on anything
+    // rendered via a portal
     if (!open || hasClickedOnDatePicker || hasClickedOnDropdown) {
       return;
     }

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
@@ -1,4 +1,3 @@
-// @flow
 /**
  * Copyright IBM Corp. 2022, 2024
  *

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable react/jsx-key */
-
 import { Accordion, AccordionItem, Button, Layer, Search } from '@carbon/react';
 import { BATCH, CLEAR_FILTERS, INSTANT, PANEL } from './constants';
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterProvider.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterProvider.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 import React, { createContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import {

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/OverflowCheckboxes.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/OverflowCheckboxes.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright IBM Corp. 2023, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import { Button, Checkbox, FormGroup } from '@carbon/react';
 import React, { useState } from 'react';
 

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/constants.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/constants.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 /** Constants for update methods can either be batch or instant */
 export const BATCH = 'batch';
 export const INSTANT = 'instant';

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilterContext.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilterContext.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright IBM Corp. 2023, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import { FilterContext } from '../FilterProvider';
 import { useContext } from 'react';
 

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
@@ -1,9 +1,8 @@
-/*
- * Licensed Materials - Property of IBM
- * 5724-Q36
- * (c) Copyright IBM Corp. 2023
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
+/**
+ * Copyright IBM Corp. 2023, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 import {

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useShouldDisableButtons.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useShouldDisableButtons.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 /* eslint-disable jsdoc/check-param-names */
 
 import { useState, useEffect } from 'react';

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useSubscribeToEventEmitter.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useSubscribeToEventEmitter.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 import { useEffect, useContext } from 'react';
 import { FilterContext } from '../FilterProvider';
 

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/index.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/index.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 export { default as FilterFlyout } from './FilterFlyout';
 export { default as FilterPanel } from './FilterPanel';
 export { FilterProvider, FilterContext } from './FilterProvider';

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Filtering.docs-page.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Filtering.docs-page.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright IBM Corp. 2023, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import React from 'react';
 import { StoryDocsPage } from '../../../../global/js/utils/StoryDocsPage';
 

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
@@ -27,7 +27,6 @@ import { makeData } from '../../utils/makeData';
 import { ARG_TYPES } from '../../utils/getArgTypes';
 import { DatagridActions } from '../../utils/DatagridActions';
 import { StatusIcon } from '../../../StatusIcon';
-import { pkg } from '../../../../settings';
 import { handleFilterTagLabelText } from '../../utils/handleFilterTagLabelText';
 import { getDateFormat } from './Panel.stories';
 
@@ -150,12 +149,6 @@ export const FilteringUsage = ({ defaultGridProps }) => {
     useFiltering,
     useColumnCenterAlign
   );
-
-  // Warnings are ordinarily silenced in storybook, add this to test
-  pkg._silenceWarnings(false);
-  // Enable feature flag for `useFiltering` hook
-  pkg.feature['Datagrid.useFiltering'] = true;
-  pkg._silenceWarnings(true);
 
   return <Datagrid datagridState={datagridState} />;
 };
@@ -299,7 +292,6 @@ export const FlyoutBatch = prepareStory(FilteringTemplateWrapper, {
       filters,
       renderLabel: (key, value) => handleFilterTagLabelText(key, value),
     },
-    featureFlags: ['Datagrid.useFiltering'],
   },
 });
 
@@ -329,7 +321,6 @@ export const FlyoutInstant = prepareStory(FilteringTemplateWrapper, {
       filters,
       renderLabel: (key, value) => handleFilterTagLabelText(key, value),
     },
-    featureFlags: ['Datagrid.useFiltering'],
   },
 });
 
@@ -370,6 +361,5 @@ export const FlyoutWithInitialFilters = prepareStory(FilteringTemplateWrapper, {
     emptyStateDescription:
       'Data was not found with the current filters applied. Change filters or clear filters to see other results.',
     filterProps,
-    featureFlags: ['Datagrid.useFiltering'],
   },
 });

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
@@ -1,10 +1,11 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+/* eslint-disable react-hooks/exhaustive-deps */
 
 import React, { useState } from 'react';
 import { Tooltip } from '@carbon/react';

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
@@ -28,7 +28,6 @@ import { DocsPage } from './Filtering.docs-page';
 import { StatusIcon } from '../../../StatusIcon';
 import { action } from '@storybook/addon-actions';
 import { makeData } from '../../utils/makeData';
-import { pkg } from '../../../../settings';
 import styles from '../../_storybook-styles.scss';
 
 export default {
@@ -160,12 +159,6 @@ export const FilteringUsage = ({ defaultGridProps }) => {
     useFiltering,
     useColumnCenterAlign
   );
-
-  // Warnings are ordinarily silenced in storybook, add this to test
-  pkg._silenceWarnings(false);
-  // Enable feature flag for `useFiltering` hook
-  pkg.feature['Datagrid.useFiltering'] = true;
-  pkg._silenceWarnings(true);
 
   return <Datagrid datagridState={datagridState} />;
 };
@@ -373,7 +366,6 @@ export const PanelInstant = prepareStory(FilteringTemplateWrapper, {
     filterProps: ARG_TYPES.filterProps,
   },
   args: {
-    featureFlags: ['Datagrid.useFiltering'],
     gridTitle: 'Data table title',
     gridDescription: 'Additional information if needed',
     useDenseHeader: false,
@@ -536,7 +528,6 @@ export const PanelWithInitialFilters = prepareStory(FilteringTemplateWrapper, {
     filterProps: ARG_TYPES.filterProps,
   },
   args: {
-    featureFlags: ['Datagrid.useFiltering'],
     initialState: {
       filters: [
         {
@@ -732,7 +723,6 @@ export const PanelOnlyAccordions = prepareStory(FilteringTemplateWrapper, {
     filterProps: ARG_TYPES.filterProps,
   },
   args: {
-    featureFlags: ['Datagrid.useFiltering'],
     gridTitle: 'Data table title',
     gridDescription: 'Additional information if needed',
     useDenseHeader: false,
@@ -896,7 +886,6 @@ export const PanelNoAccordions = prepareStory(FilteringTemplateWrapper, {
     filterProps: ARG_TYPES.filterProps,
   },
   args: {
-    featureFlags: ['Datagrid.useFiltering'],
     gridTitle: 'Data table title',
     gridDescription: 'Additional information if needed',
     useDenseHeader: false,
@@ -1060,7 +1049,6 @@ export const PanelNoData = prepareStory(FilteringTemplateWrapper, {
     filterProps: ARG_TYPES.filterProps,
   },
   args: {
-    featureFlags: ['Datagrid.useFiltering'],
     data: [],
     gridTitle: 'Data table title',
     gridDescription: 'Additional information if needed',
@@ -1224,7 +1212,6 @@ export const PanelManyCheckboxes = prepareStory(FilteringTemplateWrapper, {
     filterProps: ARG_TYPES.filterProps,
   },
   args: {
-    featureFlags: ['Datagrid.useFiltering'],
     gridTitle: 'Data table title',
     gridDescription: 'Additional information if needed',
     useDenseHeader: false,

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
@@ -1,10 +1,11 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+/* eslint-disable react-hooks/exhaustive-deps */
 
 import React, { useState } from 'react';
 import { Tooltip } from '@carbon/react';

--- a/packages/ibm-products/src/components/Datagrid/useFiltering.js
+++ b/packages/ibm-products/src/components/Datagrid/useFiltering.js
@@ -1,19 +1,15 @@
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useMemo, useEffect } from 'react';
-import { pkg } from '../../settings';
+import { useMemo } from 'react';
 import { FilterFlyout } from './Datagrid/addons/Filtering';
 import { BATCH } from './Datagrid/addons/Filtering/constants';
 
 const useFiltering = (hooks) => {
-  useEffect(() => {
-    pkg.checkReportFeatureEnabled('Datagrid.useFiltering');
-  }, []);
   /* istanbul ignore next */
   const filterTypes = useMemo(
     () => ({

--- a/packages/ibm-products/src/global/js/package-settings.js
+++ b/packages/ibm-products/src/global/js/package-settings.js
@@ -89,7 +89,6 @@ const defaults = {
     'default-portal-target-body': true,
     'Datagrid.useInlineEdit': false,
     'Datagrid.useEditableCell': false,
-    'Datagrid.useFiltering': false,
     'Datagrid.useCustomizeColumns': false,
     'ExampleComponent.secondaryIcon': false,
     'ExampleComponent.useExample': false,


### PR DESCRIPTION
Contributes to #4156 

This PR mostly contains copyright header updates, some files were missing them altogether while some needed to be updated from WKC copyright header to ours. Carbon uses a rollup package (`rollup-plugin-strip-banner`) to enforce copyright header formatting which is included in the [typescript setup](https://github.com/carbon-design-system/ibm-products/pull/4172/files#diff-110b2eef5f7121d5dd4028f07e7ea48a6c7dc4d7861e69fb5e5640773c3a938aR149) PR.

I also removed the filtering feature flags after going through the release review checklist and double checking test coverage.

#### What did you change?
Filtering files, updated copyright headers and added a few comments.

#### How did you test and verify your work?
Storybook