### PR TITLE
fix(DataGrid): customize column prevent disabled drop

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
@@ -54,7 +54,7 @@ const DraggableElement = ({
   );
 
   const style = {
-    transform: CSS.Transform.toString(transform),
+    transform: !disabled ? CSS.Transform.toString(transform): {},
     transition,
   };
 


### PR DESCRIPTION
Contributes to #3624 

This should prevent dropping into the locked column position in the customize column modal.

#### What did you change?


#### How did you test and verify your work?
Storybook