### PR TITLE
fix(DataGrid): customize column prevent disabled drop v1

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
@@ -51,7 +51,7 @@ const DraggableElement = ({
   );
 
   const style = {
-    transform: CSS.Transform.toString(transform),
+    transform: !disabled ? CSS.Transform.toString(transform): {},
     transition,
   };
 

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
@@ -51,7 +51,7 @@ const DraggableElement = ({
   );
 
   const style = {
-    transform: !disabled ? CSS.Transform.toString(transform): {},
+    transform: !disabled ? CSS.Transform.toString(transform) : {},
     transition,
   };
 

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
@@ -55,6 +55,7 @@ const defaultHeader = [
     Header: 'Row Index',
     accessor: (row, i) => i,
     id: 'rowIndex', // id is required when accessor is a function.
+    sticky: 'left',
   },
   {
     Header: 'First Name',


### PR DESCRIPTION
Contributes to #3624 

This should prevent dropping into the locked column position in the customize column modal.

#### What did you change?
 Transform styles are not being updated if the item is in locked condition.
`packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js`

#### How did you test and verify your work?
Storybook