### PR TITLE
fix: side panel and tearsheet fixes

### DIFF
--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -2061,6 +2061,10 @@ p.c4p--about-modal__copyright-text:first-child {
   border-top: 1px solid var(--cds-layer-accent-01, #e0e0e0);
 }
 
+/* One or two values
+  * - width (first value)
+  * - min-width (optional second value)
+*/
 @keyframes hide-feedback {
   0% {
     opacity: 1;
@@ -2294,7 +2298,6 @@ p.c4p--about-modal__copyright-text:first-child {
 
 .c4p--side-panel__container {
   --c4p--side-panel--title-stop: 1rem;
-  --c4p--side-panel--title-animation-progress: 0;
   --c4p--side-panel--scroll-animation-progress: 0;
   --c4p--side-panel--title-padding-right: 2rem;
   --c4p--side-panel--actions-height: 4rem;
@@ -2309,48 +2312,60 @@ p.c4p--about-modal__copyright-text:first-child {
   grid-template-rows: 1fr auto; /* titles and content */
 }
 .c4p--side-panel__container.c4p--side-panel__container--xs {
+  /* any value is single value list */
   width: 16rem;
   max-width: 100%;
 }
 .c4p--side-panel__container.c4p--side-panel__container--xs .c4p--side-panel__header.c4p--side-panel__header--no-title-animation,
 .c4p--side-panel__container.c4p--side-panel__container--xs .c4p--side-panel__header--no-title-animation .c4p--side-panel__subtitle-text {
+  /* any value is single value list */
   width: 16rem;
   max-width: 100%;
 }
 .c4p--side-panel__container.c4p--side-panel__container--sm {
+  /* any value is single value list */
   width: 20rem;
   max-width: 100%;
 }
 .c4p--side-panel__container.c4p--side-panel__container--sm .c4p--side-panel__header.c4p--side-panel__header--no-title-animation,
 .c4p--side-panel__container.c4p--side-panel__container--sm .c4p--side-panel__header--no-title-animation .c4p--side-panel__subtitle-text {
+  /* any value is single value list */
   width: 20rem;
   max-width: 100%;
 }
 .c4p--side-panel__container.c4p--side-panel__container--md {
+  /* any value is single value list */
   width: 30rem;
   max-width: 100%;
 }
 .c4p--side-panel__container.c4p--side-panel__container--md .c4p--side-panel__header.c4p--side-panel__header--no-title-animation,
 .c4p--side-panel__container.c4p--side-panel__container--md .c4p--side-panel__header--no-title-animation .c4p--side-panel__subtitle-text {
+  /* any value is single value list */
   width: 30rem;
   max-width: 100%;
 }
 .c4p--side-panel__container.c4p--side-panel__container--lg {
+  /* any value is single value list */
   width: 40rem;
   max-width: 100%;
 }
 .c4p--side-panel__container.c4p--side-panel__container--lg .c4p--side-panel__header.c4p--side-panel__header--no-title-animation,
 .c4p--side-panel__container.c4p--side-panel__container--lg .c4p--side-panel__header--no-title-animation .c4p--side-panel__subtitle-text {
+  /* any value is single value list */
   width: 40rem;
   max-width: 100%;
 }
 .c4p--side-panel__container.c4p--side-panel__container--2xl {
-  width: 75%;
+  /* any value is single value list */
+  width: 40rem;
+  min-width: 75%;
   max-width: 100%;
 }
 .c4p--side-panel__container.c4p--side-panel__container--2xl .c4p--side-panel__header.c4p--side-panel__header--no-title-animation,
 .c4p--side-panel__container.c4p--side-panel__container--2xl .c4p--side-panel__header--no-title-animation .c4p--side-panel__subtitle-text {
-  width: 75%;
+  /* any value is single value list */
+  width: 40rem;
+  min-width: 75%;
   max-width: 100%;
 }
 .c4p--side-panel__container:not(:has(.c4p--side-panel__animated-scroll-wrapper)), .c4p--side-panel__container.c4p--side-panel__container--has-no-animated-scroll-wrapper {
@@ -2468,7 +2483,7 @@ p.c4p--about-modal__copyright-text:first-child {
 }
 .c4p--side-panel__container .c4p--side-panel__title--no-label .c4p--side-panel__title-text {
   /* stylelint-disable-next-line carbon/layout-token-use */
-  transform: translateY(calc(-1 * 1rem * var(--c4p--side-panel--title-animation-progress)));
+  transform: translateY(calc(-1 * 1rem * var(--c4p--side-panel--scroll-animation-progress)));
 }
 .c4p--side-panel__container .c4p--side-panel__header--no-title-animation .c4p--side-panel__title-text {
   position: static;
@@ -2502,7 +2517,7 @@ p.c4p--about-modal__copyright-text:first-child {
 }
 .c4p--side-panel__container .c4p--side-panel__title--no-label .c4p--side-panel__collapsed-title-text {
   /* stylelint-disable-next-line carbon/layout-token-use */
-  transform: translateY(calc(1rem * (1 - var(--c4p--side-panel--title-animation-progress))));
+  transform: translateY(calc(1rem * (1 - var(--c4p--side-panel--scroll-animation-progress))));
 }
 .c4p--side-panel__container .c4p--side-panel__subtitle-text {
   font-size: var(--cds-body-compact-01-font-size, 0.875rem);
@@ -2532,7 +2547,8 @@ p.c4p--about-modal__copyright-text:first-child {
   padding-top: 0.5rem;
 }
 .c4p--side-panel__container.c4p--side-panel__container--has-slug .c4p--side-panel__inner-content {
-  background-image: linear-gradient(0deg, var(--cds-ai-gradient-start-01, rgba(242, 244, 248, 0.5)) 0%, var(--cds-ai-gradient-end, rgba(255, 255, 255, 0)) 33%, transparent 100%), linear-gradient(0deg, var(--cds-ai-gradient-start-02, rgba(237, 245, 255, 0.5)) 0%, var(--cds-ai-gradient-end, rgba(255, 255, 255, 0)) 33%, transparent 100%);
+  background-image: linear-gradient(0deg, var(--cds-ai-inner-shadow, rgba(69, 137, 255, 0.2)) 0%, 15%, var(--cds-ai-aura-end, rgba(255, 255, 255, 0)) 50%, transparent 100%);
+  border-block-end-color: var(--cds-ai-border-strong, #4589ff);
 }
 .c4p--side-panel__container .c4p--side-panel__inner-content.c4p--side-panel__inner-content--static {
   padding-top: 1rem;
@@ -2605,6 +2621,7 @@ p.c4p--about-modal__copyright-text:first-child {
   height: var(--c4p--side-panel--actions-height);
 }
 .c4p--side-panel__container.c4p--side-panel__container.c4p--side-panel__container--xs .c4p--side-panel__actions-container.c4p--action-set--sm {
+  /* any value is single value list */
   width: 16rem;
   max-width: 100%;
 }
@@ -2662,76 +2679,6 @@ p.c4p--about-modal__copyright-text:first-child {
   padding-right: calc(20% - 1rem);
 }
 
-.c4p--create-side-panel.c4p--side-panel__container--xs .c4p--side-panel__title-text {
-  width: calc(16rem - 1rem);
-  padding-right: calc(16rem * 0.2 - 1rem);
-  margin-bottom: 0.25rem;
-}
-
-.c4p--create-side-panel.c4p--side-panel__container--xs .c4p--side-panel__subtitle-text {
-  width: calc(16rem - 1rem);
-  padding-right: calc(16rem * 0.2 - 1rem);
-  padding-bottom: 1rem;
-  border-bottom: 1px solid var(--cds-layer-accent-01, #e0e0e0);
-  color: var(--cds-text-secondary, #525252);
-}
-
-.c4p--create-side-panel.c4p--side-panel__container--sm .c4p--side-panel__title-text {
-  width: calc(20rem - 1rem);
-  padding-right: calc(20rem * 0.2 - 1rem);
-  margin-bottom: 0.25rem;
-}
-
-.c4p--create-side-panel.c4p--side-panel__container--sm .c4p--side-panel__subtitle-text {
-  width: calc(20rem - 1rem);
-  padding-right: calc(20rem * 0.2 - 1rem);
-  padding-bottom: 1rem;
-  border-bottom: 1px solid var(--cds-layer-accent-01, #e0e0e0);
-  color: var(--cds-text-secondary, #525252);
-}
-
-.c4p--create-side-panel.c4p--side-panel__container--md .c4p--side-panel__title-text {
-  width: calc(30rem - 1rem);
-  padding-right: calc(30rem * 0.2 - 1rem);
-  margin-bottom: 0.25rem;
-}
-
-.c4p--create-side-panel.c4p--side-panel__container--md .c4p--side-panel__subtitle-text {
-  width: calc(30rem - 1rem);
-  padding-right: calc(30rem * 0.2 - 1rem);
-  padding-bottom: 1rem;
-  border-bottom: 1px solid var(--cds-layer-accent-01, #e0e0e0);
-  color: var(--cds-text-secondary, #525252);
-}
-
-.c4p--create-side-panel.c4p--side-panel__container--lg .c4p--side-panel__title-text {
-  width: calc(40rem - 1rem);
-  padding-right: calc(40rem * 0.2 - 1rem);
-  margin-bottom: 0.25rem;
-}
-
-.c4p--create-side-panel.c4p--side-panel__container--lg .c4p--side-panel__subtitle-text {
-  width: calc(40rem - 1rem);
-  padding-right: calc(40rem * 0.2 - 1rem);
-  padding-bottom: 1rem;
-  border-bottom: 1px solid var(--cds-layer-accent-01, #e0e0e0);
-  color: var(--cds-text-secondary, #525252);
-}
-
-.c4p--create-side-panel.c4p--side-panel__container--2xl .c4p--side-panel__title-text {
-  width: calc(75% - 1rem);
-  padding-right: calc(75% * 0.2 - 1rem);
-  margin-bottom: 0.25rem;
-}
-
-.c4p--create-side-panel.c4p--side-panel__container--2xl .c4p--side-panel__subtitle-text {
-  width: calc(75% - 1rem);
-  padding-right: calc(75% * 0.2 - 1rem);
-  padding-bottom: 1rem;
-  border-bottom: 1px solid var(--cds-layer-accent-01, #e0e0e0);
-  color: var(--cds-text-secondary, #525252);
-}
-
 .cds--form.c4p--create-side-panel__form {
   padding-top: 1rem;
 }
@@ -2763,30 +2710,8 @@ p.c4p--about-modal__copyright-text:first-child {
   display: none;
 }
 
-.c4p--create-side-panel__title {
-  font-size: var(--cds-heading-03-font-size, 1.25rem);
-  font-weight: var(--cds-heading-03-font-weight, 400);
-  line-height: var(--cds-heading-03-line-height, 1.4);
-  letter-spacing: var(--cds-heading-03-letter-spacing, 0);
-  margin-bottom: 0.25rem;
-}
-
-.c4p--create-side-panel__subtitle {
-  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
-  font-weight: var(--cds-body-compact-01-font-weight, 400);
-  line-height: var(--cds-body-compact-01-line-height, 1.28572);
-  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
-  margin-bottom: 0.5rem;
+.c4p--create-side-panel .c4p--side-panel__subtitle-text {
   color: var(--cds-text-secondary, #525252);
-}
-
-.c4p--side-panel .c4p--create-side-panel__actions-container {
-  position: absolute;
-  z-index: 4;
-  right: 0;
-  bottom: 0;
-  width: 100%;
-  margin-bottom: 0;
 }
 
 .c4p--tearsheet.c4p--tearsheet {
@@ -3207,6 +3132,7 @@ p.c4p--about-modal__copyright-text:first-child {
   position: sticky;
   z-index: 1;
   left: 0;
+  background-color: var(--cds-layer-01, #f4f4f4);
 }
 .c4p--datagrid__grid-container table.c4p--datagrid__vertical-align-center .c4p--datagrid__cell {
   align-items: center;
@@ -3228,6 +3154,7 @@ p.c4p--about-modal__copyright-text:first-child {
 .c4p--datagrid__grid-container table.c4p--datagrid__vertical-align-center th.cds--table-column-checkbox.c4p--datagrid__checkbox-cell-sticky-left {
   position: sticky;
   left: 0;
+  background-color: var(--cds-layer-01, #f4f4f4);
 }
 .c4p--datagrid__grid-container table.c4p--datagrid__vertical-align-center .c4p--datagrid__checkbox-cell th.cds--table-column-checkbox {
   display: flex;
@@ -3278,6 +3205,15 @@ p.c4p--about-modal__copyright-text:first-child {
   background-color: var(--cds-background, #ffffff);
 }
 
+.c4p--datagrid th.c4p--datagrid__with-slug {
+  background-image: linear-gradient(180deg, var(--cds-ai-inner-shadow, rgba(69, 137, 255, 0.2)) 0%, 15%, var(--cds-ai-aura-end, rgba(255, 255, 255, 0)) 100%, transparent 100%);
+  border-block-end-color: var(--cds-ai-border-strong, #4589ff);
+}
+
+.c4p--datagrid th.c4p--datagrid__with-slug .cds--slug {
+  margin-left: 0.5rem;
+}
+
 .c4p--datagrid__grid-container {
   display: block;
   width: 100%;
@@ -3303,6 +3239,9 @@ p.c4p--about-modal__copyright-text:first-child {
   width: 100%;
   height: 100%;
   overflow-x: auto;
+}
+.c4p--datagrid__grid-container .c4p--datagrid-filter-panel + .c4p--datagrid__table-container-inner .cds--data-table-content {
+  height: fit-content;
 }
 .c4p--datagrid__grid-container table.c4p--datagrid__table-simple {
   display: flex;
@@ -3345,6 +3284,9 @@ p.c4p--about-modal__copyright-text:first-child {
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
   white-space: initial;
+}
+.c4p--datagrid__grid-container .c4p--datagrid__defaultStringRenderer.c4p--datagrid__defaultStringRenderer--slug {
+  width: fit-content;
 }
 .c4p--datagrid__grid-container .c4p--datagrid__expanded-row {
   display: flex;
@@ -3441,7 +3383,7 @@ p.c4p--about-modal__copyright-text:first-child {
 }
 
 .c4p--datagrid__resizableColumn:hover {
-  background-color: var(--cds-background-selected-hover, rgba(141, 141, 141, 0.32));
+  background-color: var(--cds-layer-selected-hover);
 }
 .c4p--datagrid__resizableColumn:hover .c4p--datagrid__resizer {
   border-right: 0.125rem solid var(--cds-border-strong-01, #8d8d8d);
@@ -3988,6 +3930,7 @@ p.c4p--about-modal__copyright-text:first-child {
   display: flex;
   align-items: center;
   border-left: 1px solid var(--cds-layer-active-02, #c6c6c6);
+  background-color: var(--cds-layer-01, #f4f4f4);
 }
 
 .c4p--datagrid__right-sticky-column-header {
@@ -4003,6 +3946,7 @@ p.c4p--about-modal__copyright-text:first-child {
   display: flex;
   align-items: center;
   border-right: 1px solid var(--cds-layer-active-02, #c6c6c6);
+  background-color: var(--cds-layer-01, #f4f4f4);
 }
 
 .c4p--datagrid__left-sticky-column-header {
@@ -5001,14 +4945,32 @@ th.c4p--datagrid__select-all-toggle-on.button {
   width: 100%;
   /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
   height: 3rem;
-  align-items: center;
+  align-items: start;
   padding: 0.5rem;
   border-top: 1px solid var(--cds-border-subtle-01, #c6c6c6);
   background: var(--cds-layer-01, #f4f4f4);
 }
+.c4p--filter-summary.c4p--filter-summary__expanded {
+  height: fit-content;
+}
 
 .c4p--filter-summary .c4p--tag-set.c4p--tag-set.c4p--filter-summary__clear-button-inline {
   width: auto;
+}
+
+.c4p--filter-summary__view-all--wrapper {
+  position: absolute;
+  top: 0.5rem;
+  right: 0;
+}
+
+.c4p--filter-summary__expanded .c4p--filter-summary__clear-all-button.cds--btn {
+  margin-right: 2rem;
+}
+
+.c4p--filter-summary__view-all--wrapper .c4p--filter-summary__view-all--chevron-multiline {
+  transform: rotate(180deg);
+  transition: transform 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
 }
 
 .c4p--datagrid__datagridWrap {
@@ -5047,6 +5009,10 @@ th.c4p--datagrid__select-all-toggle-on.button {
 
 .c4p--datagrid .cds--menu-button__trigger:not(.cds--btn--ghost) {
   min-width: auto;
+}
+
+.c4p--datagrid .cds--pagination {
+  background-color: var(--cds-layer-02, #ffffff);
 }
 
 .c4p--edit-in-place {
@@ -5423,7 +5389,7 @@ th.c4p--datagrid__select-all-toggle-on.button {
 }
 
 .c4p--card .cds--slug {
-  background: linear-gradient(0deg, var(--cds-slug-callout-aura-start, rgba(237, 245, 255, 0.6)) 0%, var(--cds-slug-callout-aura-end, rgba(255, 255, 255, 0)) 50%, transparent 50%), linear-gradient(180deg, var(--cds-slug-callout-gradient-top, rgba(244, 244, 244, 0.85)) 0%, var(--cds-slug-callout-gradient-bottom, rgba(224, 224, 224, 0.85)) 100%) rgba(0, 0, 0, 0.01);
+  background: linear-gradient(to top, var(--cds-ai-aura-start, rgba(69, 137, 255, 0.1)) 0%, var(--cds-ai-aura-end, rgba(255, 255, 255, 0)) 50%) padding-box, linear-gradient(to top, var(--cds-background, #ffffff), var(--cds-background, #ffffff)) padding-box, linear-gradient(to bottom, var(--cds-ai-border-start, #78a9ff), var(--cds-ai-border-end, #d0e2ff)) border-box, linear-gradient(to top, var(--cds-background, #ffffff), var(--cds-background, #ffffff)) border-box;
   position: absolute;
   top: 1rem;
   right: 1rem;
@@ -5452,7 +5418,7 @@ th.c4p--datagrid__select-all-toggle-on.button {
 }
 
 .c4p--card--has-slug {
-  background: linear-gradient(0deg, var(--cds-slug-callout-aura-start, rgba(237, 245, 255, 0.6)) 0%, var(--cds-slug-callout-aura-end, rgba(255, 255, 255, 0)) 50%, transparent 50%), linear-gradient(180deg, var(--cds-slug-callout-gradient-top, rgba(244, 244, 244, 0.85)) 0%, var(--cds-slug-callout-gradient-bottom, rgba(224, 224, 224, 0.85)) 100%) rgba(0, 0, 0, 0.01);
+  background: linear-gradient(to top, var(--cds-ai-aura-start, rgba(69, 137, 255, 0.1)) 0%, var(--cds-ai-aura-end, rgba(255, 255, 255, 0)) 50%) padding-box, linear-gradient(to top, var(--cds-background, #ffffff), var(--cds-background, #ffffff)) padding-box, linear-gradient(to bottom, var(--cds-ai-border-start, #78a9ff), var(--cds-ai-border-end, #d0e2ff)) border-box, linear-gradient(to top, var(--cds-background, #ffffff), var(--cds-background, #ffffff)) border-box;
   border: 1px solid var(--cds-border-tile);
 }
 
@@ -6045,9 +6011,16 @@ button.c4p--add-select__global-filter-toggle--open {
   }
 }
 .c4p--notifications-panel__container {
+  --cds-ai-aura-end: rgba(0, 0, 0, 0);
+  --cds-ai-aura-start: rgba(69, 137, 255, 0.1);
+  --cds-ai-border-end: rgba(166, 200, 255, 0.24);
+  --cds-ai-border-start: #4589ff;
+  --cds-ai-border-strong: #78a9ff;
+  --cds-ai-drop-shadow: rgba(15, 98, 254, 0.32);
   --cds-ai-gradient-end: rgba(38, 38, 38, 0);
   --cds-ai-gradient-start-01: rgba(208, 226, 255, 0.2);
   --cds-ai-gradient-start-02: transparent;
+  --cds-ai-inner-shadow: rgba(69, 137, 255, 0.2);
   --cds-background: #161616;
   --cds-background-active: rgba(141, 141, 141, 0.4);
   --cds-background-brand: #0f62fe;
@@ -6063,11 +6036,11 @@ button.c4p--add-select__global-filter-toggle--open {
   --cds-border-strong-02: #8d8d8d;
   --cds-border-strong-03: #a8a8a8;
   --cds-border-subtle-00: #393939;
-  --cds-border-subtle-01: #393939;
-  --cds-border-subtle-02: #525252;
+  --cds-border-subtle-01: #525252;
+  --cds-border-subtle-02: #6f6f6f;
   --cds-border-subtle-03: #6f6f6f;
-  --cds-border-subtle-selected-01: #525252;
-  --cds-border-subtle-selected-02: #6f6f6f;
+  --cds-border-subtle-selected-01: #6f6f6f;
+  --cds-border-subtle-selected-02: #8d8d8d;
   --cds-border-subtle-selected-03: #8d8d8d;
   --cds-border-tile-01: #525252;
   --cds-border-tile-02: #6f6f6f;
@@ -6129,20 +6102,26 @@ button.c4p--add-select__global-filter-toggle--open {
   --cds-skeleton-element: #393939;
   --cds-slug-background: #c6c6c6;
   --cds-slug-background-hover: #e0e0e0;
-  --cds-slug-callout-aura-end: rgba(22, 22, 22, 0);
+  --cds-slug-callout-aura-end: rgba(0, 0, 0, 0);
   --cds-slug-callout-aura-end-hover-01: rgba(22, 22, 22, 0);
   --cds-slug-callout-aura-end-hover-02: transparent;
   --cds-slug-callout-aura-end-selected: rgba(22, 22, 22, 0);
-  --cds-slug-callout-aura-start: rgba(208, 226, 255, 0.2);
+  --cds-slug-callout-aura-start: rgba(69, 137, 255, 0.1);
   --cds-slug-callout-aura-start-hover-01: rgba(184, 211, 255, 0.3);
   --cds-slug-callout-aura-start-hover-02: transparent;
   --cds-slug-callout-aura-start-selected: rgba(208, 226, 255, 0.2);
+  --cds-slug-callout-caret-bottom: #3d4655;
+  --cds-slug-callout-caret-bottom-background: #213250;
+  --cds-slug-callout-caret-bottom-background-actions: #192436;
+  --cds-slug-callout-caret-center: #3f68af;
   --cds-slug-callout-gradient-bottom: rgba(38, 38, 38, 0.85);
   --cds-slug-callout-gradient-bottom-hover: rgba(71, 71, 71, 0.55);
   --cds-slug-callout-gradient-bottom-selected: rgba(71, 71, 71, 0.85);
   --cds-slug-callout-gradient-top: rgba(22, 22, 22, 0.85);
   --cds-slug-callout-gradient-top-hover: rgba(57, 57, 57, 0.55);
   --cds-slug-callout-gradient-top-selected: rgba(57, 57, 57, 0.85);
+  --cds-slug-callout-shadow-outer-01: rgba(0, 45, 156, 0.25);
+  --cds-slug-callout-shadow-outer-02: rgba(0, 0, 0, 0.65);
   --cds-slug-gradient: #8d8d8d linear-gradient(135deg, #f4f4f4 0%, rgba(255, 255, 255, 0) 100%);
   --cds-slug-gradient-hover: #a8a8a8 linear-gradient(135deg, #ffffff 0%, rgba(255, 255, 255, 0) 100%);
   --cds-slug-hollow-hover: #b5b5b5;
@@ -9847,9 +9826,16 @@ button.c4p--add-select__global-filter-toggle--open {
   despite of which carbon theme the user has.
 */
 .c4p--web-terminal {
+  --cds-ai-aura-end: rgba(0, 0, 0, 0);
+  --cds-ai-aura-start: rgba(69, 137, 255, 0.1);
+  --cds-ai-border-end: rgba(166, 200, 255, 0.24);
+  --cds-ai-border-start: #4589ff;
+  --cds-ai-border-strong: #78a9ff;
+  --cds-ai-drop-shadow: rgba(15, 98, 254, 0.32);
   --cds-ai-gradient-end: rgba(38, 38, 38, 0);
   --cds-ai-gradient-start-01: rgba(208, 226, 255, 0.2);
   --cds-ai-gradient-start-02: transparent;
+  --cds-ai-inner-shadow: rgba(69, 137, 255, 0.2);
   --cds-background: #262626;
   --cds-background-active: rgba(141, 141, 141, 0.4);
   --cds-background-brand: #0f62fe;
@@ -9865,11 +9851,11 @@ button.c4p--add-select__global-filter-toggle--open {
   --cds-border-strong-02: #a8a8a8;
   --cds-border-strong-03: #c6c6c6;
   --cds-border-subtle-00: #525252;
-  --cds-border-subtle-01: #525252;
-  --cds-border-subtle-02: #6f6f6f;
+  --cds-border-subtle-01: #6f6f6f;
+  --cds-border-subtle-02: #8d8d8d;
   --cds-border-subtle-03: #8d8d8d;
-  --cds-border-subtle-selected-01: #6f6f6f;
-  --cds-border-subtle-selected-02: #8d8d8d;
+  --cds-border-subtle-selected-01: #8d8d8d;
+  --cds-border-subtle-selected-02: #a8a8a8;
   --cds-border-subtle-selected-03: #a8a8a8;
   --cds-border-tile-01: #6f6f6f;
   --cds-border-tile-02: #8d8d8d;
@@ -9931,20 +9917,26 @@ button.c4p--add-select__global-filter-toggle--open {
   --cds-skeleton-element: #525252;
   --cds-slug-background: #c6c6c6;
   --cds-slug-background-hover: #e0e0e0;
-  --cds-slug-callout-aura-end: rgba(22, 22, 22, 0);
+  --cds-slug-callout-aura-end: rgba(0, 0, 0, 0);
   --cds-slug-callout-aura-end-hover-01: rgba(22, 22, 22, 0);
   --cds-slug-callout-aura-end-hover-02: transparent;
   --cds-slug-callout-aura-end-selected: rgba(22, 22, 22, 0);
-  --cds-slug-callout-aura-start: rgba(208, 226, 255, 0.2);
+  --cds-slug-callout-aura-start: rgba(69, 137, 255, 0.1);
   --cds-slug-callout-aura-start-hover-01: rgba(184, 211, 255, 0.3);
   --cds-slug-callout-aura-start-hover-02: transparent;
   --cds-slug-callout-aura-start-selected: rgba(208, 226, 255, 0.2);
+  --cds-slug-callout-caret-bottom: #465060;
+  --cds-slug-callout-caret-bottom-background: #2d3f5c;
+  --cds-slug-callout-caret-bottom-background-actions: #253042;
+  --cds-slug-callout-caret-center: #456fb5;
   --cds-slug-callout-gradient-bottom: rgba(38, 38, 38, 0.85);
   --cds-slug-callout-gradient-bottom-hover: rgba(71, 71, 71, 0.55);
   --cds-slug-callout-gradient-bottom-selected: rgba(71, 71, 71, 0.85);
   --cds-slug-callout-gradient-top: rgba(22, 22, 22, 0.85);
   --cds-slug-callout-gradient-top-hover: rgba(57, 57, 57, 0.55);
   --cds-slug-callout-gradient-top-selected: rgba(57, 57, 57, 0.85);
+  --cds-slug-callout-shadow-outer-01: rgba(0, 45, 156, 0.25);
+  --cds-slug-callout-shadow-outer-02: rgba(0, 0, 0, 0.65);
   --cds-slug-gradient: #8d8d8d linear-gradient(135deg, #f4f4f4 0%, rgba(255, 255, 255, 0) 100%);
   --cds-slug-gradient-hover: #a8a8a8 linear-gradient(135deg, #ffffff 0%, rgba(255, 255, 255, 0) 100%);
   --cds-slug-hollow-hover: #b5b5b5;
@@ -10261,9 +10253,16 @@ button.c4p--add-select__global-filter-toggle--open {
 }
 
 .c4p--web-terminal__documentation-overflow {
+  --cds-ai-aura-end: rgba(0, 0, 0, 0);
+  --cds-ai-aura-start: rgba(69, 137, 255, 0.1);
+  --cds-ai-border-end: rgba(166, 200, 255, 0.24);
+  --cds-ai-border-start: #4589ff;
+  --cds-ai-border-strong: #78a9ff;
+  --cds-ai-drop-shadow: rgba(15, 98, 254, 0.32);
   --cds-ai-gradient-end: rgba(38, 38, 38, 0);
   --cds-ai-gradient-start-01: rgba(208, 226, 255, 0.2);
   --cds-ai-gradient-start-02: transparent;
+  --cds-ai-inner-shadow: rgba(69, 137, 255, 0.2);
   --cds-background: #161616;
   --cds-background-active: rgba(141, 141, 141, 0.4);
   --cds-background-brand: #0f62fe;
@@ -10279,11 +10278,11 @@ button.c4p--add-select__global-filter-toggle--open {
   --cds-border-strong-02: #8d8d8d;
   --cds-border-strong-03: #a8a8a8;
   --cds-border-subtle-00: #393939;
-  --cds-border-subtle-01: #393939;
-  --cds-border-subtle-02: #525252;
+  --cds-border-subtle-01: #525252;
+  --cds-border-subtle-02: #6f6f6f;
   --cds-border-subtle-03: #6f6f6f;
-  --cds-border-subtle-selected-01: #525252;
-  --cds-border-subtle-selected-02: #6f6f6f;
+  --cds-border-subtle-selected-01: #6f6f6f;
+  --cds-border-subtle-selected-02: #8d8d8d;
   --cds-border-subtle-selected-03: #8d8d8d;
   --cds-border-tile-01: #525252;
   --cds-border-tile-02: #6f6f6f;
@@ -10345,20 +10344,26 @@ button.c4p--add-select__global-filter-toggle--open {
   --cds-skeleton-element: #393939;
   --cds-slug-background: #c6c6c6;
   --cds-slug-background-hover: #e0e0e0;
-  --cds-slug-callout-aura-end: rgba(22, 22, 22, 0);
+  --cds-slug-callout-aura-end: rgba(0, 0, 0, 0);
   --cds-slug-callout-aura-end-hover-01: rgba(22, 22, 22, 0);
   --cds-slug-callout-aura-end-hover-02: transparent;
   --cds-slug-callout-aura-end-selected: rgba(22, 22, 22, 0);
-  --cds-slug-callout-aura-start: rgba(208, 226, 255, 0.2);
+  --cds-slug-callout-aura-start: rgba(69, 137, 255, 0.1);
   --cds-slug-callout-aura-start-hover-01: rgba(184, 211, 255, 0.3);
   --cds-slug-callout-aura-start-hover-02: transparent;
   --cds-slug-callout-aura-start-selected: rgba(208, 226, 255, 0.2);
+  --cds-slug-callout-caret-bottom: #3d4655;
+  --cds-slug-callout-caret-bottom-background: #213250;
+  --cds-slug-callout-caret-bottom-background-actions: #192436;
+  --cds-slug-callout-caret-center: #3f68af;
   --cds-slug-callout-gradient-bottom: rgba(38, 38, 38, 0.85);
   --cds-slug-callout-gradient-bottom-hover: rgba(71, 71, 71, 0.55);
   --cds-slug-callout-gradient-bottom-selected: rgba(71, 71, 71, 0.85);
   --cds-slug-callout-gradient-top: rgba(22, 22, 22, 0.85);
   --cds-slug-callout-gradient-top-hover: rgba(57, 57, 57, 0.55);
   --cds-slug-callout-gradient-top-selected: rgba(57, 57, 57, 0.85);
+  --cds-slug-callout-shadow-outer-01: rgba(0, 45, 156, 0.25);
+  --cds-slug-callout-shadow-outer-02: rgba(0, 0, 0, 0.65);
   --cds-slug-gradient: #8d8d8d linear-gradient(135deg, #f4f4f4 0%, rgba(255, 255, 255, 0) 100%);
   --cds-slug-gradient-hover: #a8a8a8 linear-gradient(135deg, #ffffff 0%, rgba(255, 255, 255, 0) 100%);
   --cds-slug-hollow-hover: #b5b5b5;

--- a/packages/ibm-products-styles/src/components/CreateSidePanel/_create-side-panel.scss
+++ b/packages/ibm-products-styles/src/components/CreateSidePanel/_create-side-panel.scss
@@ -24,25 +24,6 @@ $side-panel-block-class: #{c4p-settings.$pkg-prefix}--side-panel;
   padding-right: calc(20% - #{$spacing-05});
 }
 
-@each $size, $value in side-panel-vars.$side-panel-sizes {
-  .#{$create-side-panel-block-class}.#{$side-panel-block-class}__container--#{$size}
-    .#{$side-panel-block-class}__title-text {
-    width: calc(#{$value} - #{$spacing-05});
-    // stylelint-disable-next-line carbon/layout-token-use
-    padding-right: calc((#{$value} * 0.2) - #{$spacing-05});
-    margin-bottom: $spacing-02;
-  }
-  .#{$create-side-panel-block-class}.#{$side-panel-block-class}__container--#{$size}
-    .#{$side-panel-block-class}__subtitle-text {
-    width: calc(#{$value} - #{$spacing-05});
-    // stylelint-disable-next-line carbon/layout-token-use
-    padding-right: calc((#{$value} * 0.2) - #{$spacing-05});
-    padding-bottom: $spacing-05;
-    border-bottom: 1px solid $layer-accent-01;
-    color: $text-secondary;
-  }
-}
-
 .#{c4p-settings.$carbon-prefix}--form.#{$create-side-panel-block-class}__form {
   padding-top: $spacing-05;
 }
@@ -70,24 +51,6 @@ $side-panel-block-class: #{c4p-settings.$pkg-prefix}--side-panel;
   display: none;
 }
 
-.#{$create-side-panel-block-class}__title {
-  @include type.type-style('heading-03');
-
-  margin-bottom: $spacing-02;
-}
-
-.#{$create-side-panel-block-class}__subtitle {
-  @include type.type-style('body-compact-01');
-
-  margin-bottom: $spacing-03;
+.#{$create-side-panel-block-class} .#{$side-panel-block-class}__subtitle-text {
   color: $text-secondary;
-}
-.#{$side-panel-block-class}
-  .#{$create-side-panel-block-class}__actions-container {
-  position: absolute;
-  z-index: 4;
-  right: 0;
-  bottom: 0;
-  width: 100%;
-  margin-bottom: 0;
 }

--- a/packages/ibm-products-styles/src/components/EditSidePanel/_edit-side-panel.scss
+++ b/packages/ibm-products-styles/src/components/EditSidePanel/_edit-side-panel.scss
@@ -45,22 +45,4 @@ $side-panel-block-class: #{c4p-settings.$pkg-prefix}--side-panel;
     .#{c4p-settings.$carbon-prefix}--btn.#{$side-panel-block-class}__close-button {
     display: none;
   }
-
-  .#{$side-panel-block-class} .#{$block-class}__actions-container {
-    position: absolute;
-    z-index: 4;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    margin-bottom: 0;
-  }
-
-  .#{$block-class}__actions-container {
-    position: absolute;
-    z-index: 4;
-    right: 0;
-    bottom: 0;
-    width: 100%;
-    margin-bottom: 0;
-  }
 }

--- a/packages/ibm-products/src/components/CreateSidePanel/CreateSidePanel.stories.js
+++ b/packages/ibm-products/src/components/CreateSidePanel/CreateSidePanel.stories.js
@@ -86,6 +86,7 @@ export default {
   component: CreateSidePanel,
   tags: ['autodocs'],
   parameters: {
+    layout: 'fullscreen',
     styles,
     docs: {
       page: DocsPage,

--- a/packages/ibm-products/src/global/js/hooks/useResizeObserver.js
+++ b/packages/ibm-products/src/global/js/hooks/useResizeObserver.js
@@ -42,7 +42,7 @@ export const useResizeObserver = (ref, callback, deps = []) => {
     }
     getInitialSize();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [width, height, ref, ...deps]);
+  }, [width, height, ref.current, ...deps]);
 
   useLayoutEffect(() => {
     if (!ref?.current) {
@@ -80,6 +80,6 @@ export const useResizeObserver = (ref, callback, deps = []) => {
       observer = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ref, ...deps]);
+  }, [ref.current, ...deps]);
   return { width, height };
 };


### PR DESCRIPTION
Fixes #4177 #4176

Tidies up and removes styling differences between core SidePanel and CreateSidePanel/EditSidePanel. Some styling had no effect, other parts were no longer relevant.

Fixed the dependency lists in useResizeObserver.

NOTE: @matthewgallo @Laura-Marshall the only visible difference is the change of subtitle from `$text-secondary` to default. Does the SidePanel pattern need changing, I cannot make a case the CreateSidePanel not following the pattern. 

The SidePanel design does not include setting subtitle text color to $test-secondary. https://www.figma.com/file/Yz74b1hPqqYWwEtmcPqojq/(v10)-Gray-10---IBM-Products?type=design&node-id=8858-390242&mode=design&t=3fDSawd8fVykIuwe-0

#### What did you change?

- subtitle text in create is now default (was $text-secondary)
- Removed styles no longer needed from CreateSidePanel and EditSidePanel

#### How did you test and verify your work?

Storybook