### PR TITLE
fix(DataGrid): column customisation not unselect locked columns V1

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
@@ -46,7 +46,7 @@ const Columns = ({
     },
     [columns, setColumnsObject]
   );
-
+  const filteredStickyColumn = columns?.filter((item) => !item.sticky);
   return (
     <div
       className={`${blockClass}__customize-columns-column-list`}
@@ -89,7 +89,7 @@ const Columns = ({
             }
             onChange={() => {
               onSelectColumn(
-                columns,
+                filteredStickyColumn,
                 getVisibleColumnsCount() !== columns.length
               );
             }}

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
@@ -69,7 +69,7 @@ const CustomizeColumnsTearsheet = ({
   const onCheckboxCheck = (col, value) => {
     const changedDefinitions = columnObjects.map((definition) => {
       if (
-        (Array.isArray(col) && col.indexOf(definition) != null) ||
+        (Array.isArray(col) && col.indexOf(definition) != -1) ||
         definition.id === col.id
       ) {
         return { ...definition, isVisible: value };

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
@@ -55,6 +55,7 @@ const defaultHeader = [
     Header: 'Row Index',
     accessor: (row, i) => i,
     id: 'rowIndex', // id is required when accessor is a function.
+    sticky: 'left'
   },
   {
     Header: 'First Name',

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
@@ -55,7 +55,7 @@ const defaultHeader = [
     Header: 'Row Index',
     accessor: (row, i) => i,
     id: 'rowIndex', // id is required when accessor is a function.
-    sticky: 'left'
+    sticky: 'left',
   },
   {
     Header: 'First Name',


### PR DESCRIPTION
Contributes to #4091 

In the datagrid component, when customizing the columns in the modal the compulsory columns can be deselected by the Select all button.

#### What did you change?
Filtered the locked column when select all works.

#### How did you test and verify your work?
Storybook