### PR TITLE
fix(Datagrid): address ssr bug in nested row hook (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
+++ b/packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 /**
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -24,7 +24,7 @@ const useNestedRowExpander = (hooks) => {
     instance: tempState?.current,
     lastExpandedRowIndex: lastExpandedRowIndex?.current,
     blockClass,
-    activeElement: document.activeElement,
+    activeElement: typeof document !== 'undefined' && document.activeElement,
   });
 
   const visibleColumns = (columns) => {


### PR DESCRIPTION
Contributes to #4203 

Adds `typeof` check before accessing `document.activeElement`, this prevents issues with SSR apps/nextjs.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
```
#### How did you test and verify your work?
Storybook