### PR TITLE
refactor: added code to check window and document object for nextjs

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSelectAll.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSelectAll.js
@@ -14,13 +14,16 @@ import { handleSelectAllRowData } from './addons/stateReducer';
 const blockClass = `${pkg.prefix}--datagrid`;
 
 const SelectAll = (datagridState) => {
-  const [windowSize, setWindowSize] = useState(window.innerWidth);
+  const [windowSize, setWindowSize] = useState(typeof window !== 'undefined'?window.innerWidth:"");
   useLayoutEffect(() => {
     /* istanbul ignore next */
     function updateSize() {
       setWindowSize(window.innerWidth);
     }
-    window.addEventListener('resize', updateSize);
+    if(typeof window !== 'undefined')
+    {
+      window.addEventListener('resize', updateSize);
+    }
     return () => window.removeEventListener('resize', updateSize);
   }, []);
 

--- a/packages/ibm-products/src/components/Datagrid/useInfiniteScroll.js
+++ b/packages/ibm-products/src/components/Datagrid/useInfiniteScroll.js
@@ -23,7 +23,10 @@ const useInfiniteScroll = (hooks) => {
       tableId,
       loadMoreThreshold,
     } = instance;
-    const tableElement = document.querySelector(`#${tableId}`);
+    let tableElement;
+    if(typeof document !=='undefined'){
+      tableElement = document.querySelector(`#${tableId}`);
+    }
     const totalTableHeight = tableHeight || tableElement?.clientHeight;
 
     const loadMoreThresholdValue =

--- a/packages/ibm-products/src/components/Datagrid/useSelectRows.js
+++ b/packages/ibm-products/src/components/Datagrid/useSelectRows.js
@@ -89,7 +89,7 @@ const SelectRow = (datagridState) => {
     getRowId,
   } = datagridState;
 
-  const [windowSize, setWindowSize] = useState(window.innerWidth);
+  const [windowSize, setWindowSize] = useState((typeof window!=="undefined")?window.innerWidth:"");
   useLayoutEffect(() => {
     function updateSize() {
       setWindowSize(window.innerWidth);


### PR DESCRIPTION
Contributes to #

Due to NextJS compiling at the server-side, there is no access to the window and document objects during compilation. Added conditions to check window and document object.

#### What did you change?
Added conditions to check window and document object.
- /src/components/Datagrid/Datagrid/DatagridSelectAll.js
- /src/components/Datagrid/useInfiniteScroll.js
- /src/components/Datagrid/useSelectRows.js

#### How did you test and verify your work?
I was able to build the code after adding these conditions and also working fine in browser.
