### PR TITLE
fix: storybook static build folder update

### DIFF
--- a/packages/core/.storybook/main.js
+++ b/packages/core/.storybook/main.js
@@ -9,6 +9,7 @@ const { merge } = require('webpack-merge');
 const { dirname, join, resolve } = require('path');
 
 module.exports = {
+  staticDirs: ['../public'],
   addons: [
     getAbsolutePath('@storybook/addon-actions'),
     getAbsolutePath('@storybook/addon-docs'),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "run-s build:carbon build:storybook",
     "build:carbon": "sass --style=expanded --load-path ../ibm-products/node_modules --load-path ../../node_modules --load-path node_modules .storybook/carbon.scss:css/carbon.css",
-    "build:storybook": "yarn dlx cross-env \"NODE_OPTIONS=--max_old_space_size=8192\" && storybook build -s ./public",
+    "build:storybook": "storybook build",
     "clean": "yarn dlx rimraf storybook-static css",
     "start": "run-s build:carbon start:storybook",
     "start:storybook": "storybook dev -s ./public -p 3000",


### PR DESCRIPTION
for #4220

according to the storybook documentation, [usage of the `-s` flag in the build command is deprecated.](https://storybook.js.org/docs/api/cli-options#build). this PR updates the build command to remove some stuff that i don't *think* is necessary, but more importantly removes the flag and establishes the static directory in the `.storybook/main.js` file where the documentation says to put it.

after doing this i was able to run the build locally with success.