### PR TITLE
fix(Dataspreadsheet): Reduce duplication with isHoldingCommandKey #4188

### DIFF
--- a/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheetBody.js
+++ b/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheetBody.js
@@ -30,6 +30,7 @@ import { handleHeaderCellSelection } from './utils/handleHeaderCellSelection';
 import { getSpreadsheetWidth } from './utils/getSpreadsheetWidth';
 
 import { useSpreadsheetMouseUp } from './hooks';
+import { checkForHoldingKey } from './utils/checkForHoldingKey';
 
 const blockClass = `${pkg.prefix}--data-spreadsheet`;
 
@@ -277,8 +278,8 @@ export const DataSpreadsheetBody = forwardRef(
             `${blockClass}__body--td`
           );
           setValidStartingPoint(isValidSelectionAreaStart);
-          const isHoldingCommandKey = event.metaKey || event.ctrlKey;
-          const isHoldingShiftKey = event.shiftKey;
+          const isHoldingCommandKey = checkForHoldingKey(event, 'cmd');
+          const isHoldingShiftKey = checkForHoldingKey(event, 'shiftKey');
           setContainerHasFocus(true);
           const activeCoordinates = {
             row: cell.row.index,
@@ -407,7 +408,7 @@ export const DataSpreadsheetBody = forwardRef(
     const handleRowHeaderClick = useCallback(
       (index) => {
         return (event) => {
-          const isHoldingCommandKey = event.metaKey || event.ctrlKey;
+          const isHoldingCommandKey = checkForHoldingKey(event, 'cmd');
           handleHeaderCellSelection({
             type: 'row',
             activeCellCoordinates,

--- a/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
+++ b/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
@@ -17,6 +17,7 @@ import { handleHeaderCellSelection } from './utils/handleHeaderCellSelection';
 import { selectAllCells } from './utils/selectAllCells';
 import { getSpreadsheetWidth } from './utils/getSpreadsheetWidth';
 import { useSpreadsheetMouseMove } from './hooks';
+import { checkForHoldingKey } from './utils/checkForHoldingKey';
 
 const blockClass = `${pkg.prefix}--data-spreadsheet`;
 
@@ -63,8 +64,8 @@ export const DataSpreadsheetHeader = forwardRef(
 
     const handleColumnHeaderClick = (index) => {
       return (event) => {
-        const isHoldingCommandKey = event.metaKey || event.ctrlKey;
-        const isHoldingShiftKey = event.shiftKey;
+        const isHoldingCommandKey = checkForHoldingKey(event, 'cmd');
+        const isHoldingShiftKey = checkForHoldingKey(event, 'shiftKey');
         handleHeaderCellSelection({
           type: 'column',
           activeCellCoordinates,

--- a/packages/ibm-products/src/components/DataSpreadsheet/utils/checkForHoldingKey.js
+++ b/packages/ibm-products/src/components/DataSpreadsheet/utils/checkForHoldingKey.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const checkForHoldingKey = (event, key) => {
+  // possible key inputs: altKey,ctrlKey,metaKey,shiftKey
+  if (key == 'cmd') {
+    return event.metaKey || event.ctrlKey;
+  } else {
+    return event[key];
+  }
+};


### PR DESCRIPTION
Contributes to #4188 

Reduce duplication with isHoldingCommandKey

#### What did you change?
Created a util method _checkForHoldingKey_ that will check if the key is holding. 
Method accept 2 arguments, event object and the key.
This method will isolate this logic , so that can be reused.

#### How did you test and verify your work?
Tested locally