### PR TITLE
feat(Datagrid): add mouseUp event for onColResizeEnd #4235

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -50,6 +50,9 @@ const ResizeHeader = ({
   const mouseDownHandler = (evt) => {
     handleOnMouseDownResize(evt, resizerProps);
   };
+  const mouseUpHandler = () => {
+    handleColumnResizeEndEvent(dispatch, onColResizeEnd, header.id, true);
+  };
   const keyDownHandler = (evt) => {
     const { key } = evt;
     if (key === 'ArrowLeft' || key === 'ArrowRight') {
@@ -80,6 +83,7 @@ const ResizeHeader = ({
       <input
         {...headerProps}
         onMouseDown={mouseDownHandler}
+        onMouseUp={mouseUpHandler}
         onKeyDown={keyDownHandler}
         onKeyUp={keyUpHandler}
         className={`${blockClass}__col-resizer-range`}

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -173,10 +173,8 @@ export const stateReducer = (newState, action) => {
       const currentColumn = {};
       currentColumn[headerId] = newState.columnResizing.columnWidths[headerId];
       const allChangedColumns = newState.columnResizing.columnWidths;
-      const { isResizing } = newState;
-      if (isResizing) {
-        onColResizeEnd?.(currentColumn, allChangedColumns);
-      }
+
+      onColResizeEnd?.(currentColumn, allChangedColumns);
       if (!isKeyEvent) {
         if (typeof isKeyEvent === 'undefined') {
           // Blur resizer input if it has focus and is not from a key event resize


### PR DESCRIPTION
Contributes to #4235 

{{short description}}

#### What did you change?
Add the onColResizeEndto onMouseup event 

#### How did you test and verify your work?
On the storybook 