### PR TITLE
feat(Datagrid): add mouseUp event for onColResizeEnd #4235

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -130,6 +130,14 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
                     onMouseDown={(event) =>
                       handleOnMouseDownResize(event, header.getResizerProps)
                     }
+                    onMouseUp={() =>
+                      handleColumnResizeEndEvent(
+                        dispatch,
+                        onColResizeEnd,
+                        header.id,
+                        true
+                      )
+                    }
                     onKeyDown={(event) => {
                       const { key } = event;
                       if (key === 'ArrowLeft' || key === 'ArrowRight') {

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -173,10 +173,9 @@ export const stateReducer = (newState, action) => {
       const currentColumn = {};
       currentColumn[headerId] = newState.columnResizing.columnWidths[headerId];
       const allChangedColumns = newState.columnResizing.columnWidths;
-      const { isResizing } = newState;
-      if (isResizing) {
-        onColResizeEnd?.(currentColumn, allChangedColumns);
-      }
+
+      onColResizeEnd?.(currentColumn, allChangedColumns);
+
       if (!isKeyEvent) {
         if (typeof isKeyEvent === 'undefined') {
           // Blur resizer input if it has focus and is not from a key event resize


### PR DESCRIPTION
Contributes to #

{{short description}}

#### What did you change?
Add the onColResizeEndto onMouseup event

#### How did you test and verify your work?
Checked on the storybook