### PR TITLE
fix(Datagrid): changes getRowId parameter to original row data (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -84,7 +84,7 @@ export const stateReducer = (newState, action) => {
       if (rows) {
         const newSelectedRowData = {};
         rows.forEach((row) => {
-          newSelectedRowData[getRowId(row, row.index)] = row;
+          newSelectedRowData[getRowId(row.original, row.index)] = row.original;
         });
         return {
           ...newState,
@@ -106,7 +106,7 @@ export const stateReducer = (newState, action) => {
           ...newState,
           selectedRowData: {
             ...newState.selectedRowData,
-            [getRowId(rowData, rowData.index)]: rowData,
+            [getRowId(rowData.original, rowData.index)]: rowData.original,
           },
         };
       }


### PR DESCRIPTION
Contributes to #4248

Changes the first parameter passed to getRowId to the original property of row.
So now instead of passing the whole row object it will pass just the actual data.

This is for v1.
#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
```

#### How did you test and verify your work?
Storybook & run unit tests