### PR TITLE
fix(Datagrid): ssr fix in `useSelectAllToggle` hook

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useSelectAllToggle.js
+++ b/packages/ibm-products/src/components/Datagrid/useSelectAllToggle.js
@@ -36,7 +36,9 @@ const useSelectAllWithToggleComponent = (hooks) => {
 };
 
 const useAddClassNameToSelectRow = (hooks) => {
-  const [windowSize, setWindowSize] = useState(window.innerWidth);
+  const [windowSize, setWindowSize] = useState(
+    typeof window !== 'undefined' ? window.innerWidth : ''
+  );
   useLayoutEffect(() => {
     function updateSize() {
       setWindowSize(window.innerWidth);


### PR DESCRIPTION
Contributes to #4311 

Fixes a SSR bug caused by the `useSelectAllToggle` hook because there is no check before accessing the `window` object.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/useSelectAllToggle.js
```
#### How did you test and verify your work?
N/A