### PR TITLE
feat(SidePanel): initial reduced motion work for side panel opacity

### DIFF
--- a/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
+++ b/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
@@ -353,7 +353,7 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
   }
 
   .#{$block-class}__slug-and-close {
-    position: fixed;
+    position: absolute;
     z-index: 10; /* must be higher than title container border bottom */
     top: 0;
     right: 0;

--- a/packages/ibm-products/src/components/SidePanel/SidePanel.js
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,7 +7,7 @@
 
 // Import portions of React that are needed.
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 
 // Other standard imports.
 import PropTypes from 'prop-types';
@@ -100,6 +100,8 @@ export let SidePanel = React.forwardRef(
     const previousState = usePreviousValue({ size, open });
     const [scrollAnimationDistance, setScrollAnimationDistance] = useState(-1);
     const [doAnimateTitle, setDoAnimateTitle] = useState(true);
+
+    const shouldReduceMotion = useReducedMotion();
 
     useEffect(() => {
       setDoAnimateTitle(animateTitle);
@@ -603,7 +605,7 @@ export let SidePanel = React.forwardRef(
               initial="hidden"
               animate="visible"
               exit="exit"
-              custom={placement}
+              custom={{ placement, shouldReduceMotion }}
             >
               <span
                 ref={startTrapRef}

--- a/packages/ibm-products/src/components/SidePanel/SidePanel.js
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.js
@@ -27,7 +27,11 @@ import { usePreviousValue } from '../../global/js/hooks';
 import { Button } from '@carbon/react';
 import { Close, ArrowLeft } from '@carbon/react/icons';
 import { ActionSet } from '../ActionSet';
-import { overlayVariants, panelVariants } from './motion/variants';
+import {
+  overlayVariants,
+  panelVariants,
+  actionSetVariants,
+} from './motion/variants';
 import pconsole from '../../global/js/utils/pconsole';
 
 const blockClass = `${pkg.prefix}--side-panel`;
@@ -44,6 +48,8 @@ const defaults = {
   placement: 'right',
   size: 'md',
 };
+
+const MotionActionSet = motion(ActionSet);
 
 /**
  * Side panels keep users in-context of a page while performing tasks like navigating, editing, viewing details, or configuring something new.
@@ -638,10 +644,12 @@ export let SidePanel = React.forwardRef(
               )}
 
               {/* footer */}
-              <ActionSet
+              <MotionActionSet
                 actions={actions}
                 className={primaryActionContainerClassNames}
                 size={size === 'xs' ? 'sm' : size}
+                custom={shouldReduceMotion}
+                variants={actionSetVariants}
               />
 
               <span

--- a/packages/ibm-products/src/components/SidePanel/motion/variants.js
+++ b/packages/ibm-products/src/components/SidePanel/motion/variants.js
@@ -59,3 +59,21 @@ export const panelVariants = {
     opacity: shouldReduceMotion && 0,
   }),
 };
+
+export const actionSetVariants = {
+  hidden: (shouldReduceMotion) => ({
+    opacity: shouldReduceMotion ? 0 : 1,
+    transition: {
+      duration: shouldReduceMotion ? DURATIONS.moderate01 : DURATIONS.fast01,
+      ease: shouldReduceMotion ? 0 : EASINGS.productive.exit,
+    },
+  }),
+  visible: (shouldReduceMotion) => ({
+    opacity: 1,
+    transition: {
+      duration: shouldReduceMotion ? DURATIONS.moderate01 : DURATIONS.fast02,
+      ease: shouldReduceMotion ? 0 : EASINGS.productive.entrance,
+      delay: shouldReduceMotion ? 0.075 : 0,
+    },
+  }),
+};

--- a/packages/ibm-products/src/components/SidePanel/motion/variants.js
+++ b/packages/ibm-products/src/components/SidePanel/motion/variants.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -24,21 +24,38 @@ export const overlayVariants = {
 };
 
 export const panelVariants = {
-  visible: {
+  visible: ({ shouldReduceMotion }) => ({
     x: 0,
     transition: {
       duration: DURATIONS.moderate02,
       ease: EASINGS.productive.standard,
     },
-  },
-  hidden: (placement) => ({
-    x: placement === 'right' ? '100%' : -320,
+    opacity: shouldReduceMotion && 1,
   }),
-  exit: (placement) => ({
-    x: placement === 'right' ? '100%' : -320,
+  hidden: ({ placement, shouldReduceMotion }) => ({
+    x:
+      placement === 'right'
+        ? shouldReduceMotion
+          ? 0
+          : '100%'
+        : shouldReduceMotion
+        ? 0
+        : -320,
+    opacity: shouldReduceMotion && 0,
+  }),
+  exit: ({ placement, shouldReduceMotion }) => ({
+    x:
+      placement === 'right'
+        ? shouldReduceMotion
+          ? 0
+          : '100%'
+        : shouldReduceMotion
+        ? 0
+        : -320,
     transition: {
       duration: DURATIONS.moderate01,
       ease: EASINGS.productive.exit,
     },
+    opacity: shouldReduceMotion && 0,
   }),
 };


### PR DESCRIPTION
Contributes to #3998 

Includes reduced motion support for the `SidePanel`, similar to the FilterPanel this update only uses opacity when the panel is opened or closed. Along, with opacity transition and delay for the action set when reduced motion is enabled.

#### What did you change?
```
packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
packages/ibm-products/src/components/SidePanel/SidePanel.js
packages/ibm-products/src/components/SidePanel/motion/variants.js
```
#### How did you test and verify your work?
Storybook