### PR TITLE
fix(FullPageError): responsive behavior for full page errors

### DIFF
--- a/packages/ibm-products-styles/src/components/FullPageError/_full-page-error.scss
+++ b/packages/ibm-products-styles/src/components/FullPageError/_full-page-error.scss
@@ -47,9 +47,9 @@ $block-class: #{c4p-settings.$pkg-prefix}--full-page-error;
 .#{$block-class}__error-svg-container {
   display: flex;
   height: 100%;
-  margin: $spacing-03 $spacing-03 $spacing-11 $spacing-03;
+  padding: $spacing-03 $spacing-03 $spacing-11 $spacing-03;
   @include breakpoint(md) {
-    margin: auto $spacing-03 $spacing-11 $spacing-03;
+    padding: auto $spacing-03 $spacing-11 $spacing-03;
   }
 }
 


### PR DESCRIPTION
Contributes to #4081 

Although this was implemented in previous issues #4211 and #4304 , i would like to utilize this pr to make fine adjustments and for cross browser compatibility.

#### What did you change?
packages/ibm-products-styles/src/components/FullPageError/_full-page-error.scss

#### How did you test and verify your work?
storybook, chrome, firefox, safari.