### PR TITLE
fix(Datagrid): fixes selectedRowData updating on cancel/unselecting

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.js
@@ -123,12 +123,6 @@ const DatagridBatchActionsToolbar = (datagridState, width, ref) => {
   };
 
   const onCancelHandler = () => {
-    handleSelectAllRowData({
-      dispatch,
-      rows: [],
-      getRowId,
-      isChecked: false
-    });
     toggleAllRowsSelected(false);
     setGlobalFilter(null);
   };

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.js
@@ -123,6 +123,12 @@ const DatagridBatchActionsToolbar = (datagridState, width, ref) => {
   };
 
   const onCancelHandler = () => {
+    handleSelectAllRowData({
+      dispatch,
+      rows: [],
+      getRowId,
+      isChecked: false
+    });
     toggleAllRowsSelected(false);
     setGlobalFilter(null);
   };

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -114,7 +114,7 @@ export const stateReducer = (newState, action) => {
         const newData = { ...newState.selectedRowData };
         const dataWithRemovedRow = Object.fromEntries(
           Object.entries(newData).filter(([key]) => {
-            return parseInt(key) !== parseInt(getRowId(rowData.original, rowData.index));
+            return parseInt(key) !== parseInt(rowData.index);
           })
         );
         return {

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -114,7 +114,7 @@ export const stateReducer = (newState, action) => {
         const newData = { ...newState.selectedRowData };
         const dataWithRemovedRow = Object.fromEntries(
           Object.entries(newData).filter(([key]) => {
-            return parseInt(key) !== parseInt(rowData.index);
+            return parseInt(key) !== parseInt(getRowId(rowData.original, rowData.index));
           })
         );
         return {


### PR DESCRIPTION
Contributes to https://github.com/carbon-design-system/ibm-products/issues/4248

- Fixes unselecting a single row -> `selectedRowData` did not update correctly when unselecting a row and when the id of the row doesn't correspond to the index
- Fixes cancel action not triggering the removal of the selected row(s) from  `selectedRowData`

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
```
#### How did you test and verify your work?
Storybook and run unit tests
