### PR TITLE
fix(Datagrid): disable resizing during fetching state

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /**
- * Copyright IBM Corp. 2022, 2024
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -44,6 +44,7 @@ const ResizeHeader = ({
   dispatch,
   onColResizeEnd,
   resizerAriaLabel,
+  isFetching,
 }) => {
   // eslint-disable-next-line no-unused-vars
   const { role, ...headerProps } = resizerProps;
@@ -90,6 +91,7 @@ const ResizeHeader = ({
         type="range"
         defaultValue={originalCol.width}
         aria-label={resizerAriaLabel || 'Resize column'}
+        disabled={isFetching}
       />
       <span className={`${blockClass}__col-resize-indicator`} />
     </>
@@ -97,7 +99,7 @@ const ResizeHeader = ({
 };
 
 const HeaderRow = (datagridState, headRef, headerGroup) => {
-  const { resizerAriaLabel, isTableSortable, rows } = datagridState;
+  const { resizerAriaLabel, isTableSortable, rows, isFetching } = datagridState;
   // Used to measure the height of the table and uses that value
   // to display a vertical line to indicate the column you are resizing
   useEffect(() => {
@@ -223,6 +225,7 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
                     dispatch,
                     onColResizeEnd,
                     resizerAriaLabel,
+                    isFetching,
                   }}
                 />
               )}


### PR DESCRIPTION
Contributes to #4322 

This prevents any resizing from occurring during `isFetching` otherwise this can cause the app to crash, see #4322 for details.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
```
#### How did you test and verify your work?
Storybook