### PR TITLE
fix(Datagrid): disable resizing during fetching state (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -31,7 +31,7 @@ const getAccessibilityProps = (header) => {
 };
 
 const HeaderRow = (datagridState, headRef, headerGroup) => {
-  const { resizerAriaLabel } = datagridState;
+  const { resizerAriaLabel, isFetching } = datagridState;
   // Used to measure the height of the table and uses that value
   // to display a vertical line to indicate the column you are resizing
   useEffect(() => {
@@ -127,6 +127,7 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
                 <>
                   <input
                     {...header.getResizerProps()}
+                    disabled={isFetching}
                     onMouseDown={(event) =>
                       handleOnMouseDownResize(event, header.getResizerProps)
                     }


### PR DESCRIPTION
Contributes to #4322 

This prevents any resizing from occurring during `isFetching` otherwise this can cause the app to crash, see #4322 for details.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
```
#### How did you test and verify your work?
Storybook