### PR TITLE
feat: sort icon appear in the Actions column on Datagrid #4339

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useSortableColumns.js
+++ b/packages/ibm-products/src/components/Datagrid/useSortableColumns.js
@@ -91,8 +91,10 @@ const useSortableColumns = (hooks) => {
         );
       };
       const Header = (headerProp) =>
-        column.disableSortBy === true || column.id === 'datagridSelection' ? (
-          column.disableSortBy ? (
+        column.disableSortBy === true ||
+        column.id === 'datagridSelection' ||
+        column.isAction ? (
+          column.disableSortBy || column.isAction ? (
             column.Header
           ) : (
             <SelectAll {...instance} />


### PR DESCRIPTION
Contributes to #4339

{{short description}}
remove the sort icon from action column

#### What did you change?
Add condition to check the header is the action column

#### How did you test and verify your work?
using storybook