### PR TITLE
feat: the button bar covers the last filter options for Datagrid filter panel #4337

### DIFF
--- a/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_FilterPanel.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_FilterPanel.scss
@@ -41,7 +41,7 @@
   position: relative;
   z-index: 0;
   overflow: auto;
-  padding: 0 $spacing-05;
+  padding: 0 $spacing-05 $spacing-10 $spacing-05;
   overscroll-behavior: contain;
 }
 


### PR DESCRIPTION

Contributes to #4337

{{short description}}
the button bar covers the last filter options for Datagrid filter panel 

#### What did you change?
Add the bottom padding 
#### How did you test and verify your work?
Check on the storybook
![Screenshot 2024-02-16 at 3 13 20 PM](https://github.com/carbon-design-system/ibm-products/assets/144151347/45d67f10-f123-407d-a3ce-b93bf80dcb07)

