### PR TITLE
fix(DataGrid): add support for selectrow and nestedrow V1

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.js
@@ -13,7 +13,12 @@ import {
   getStoryTitle,
   prepareStory,
 } from '../../../../global/js/utils/story-helper';
-import { Datagrid, useDatagrid, useNestedRows } from '../../index';
+import {
+  Datagrid,
+  useDatagrid,
+  useNestedRows,
+  useSelectRows,
+} from '../../index';
 import styles from '../../_storybook-styles.scss';
 import mdx from '../../Datagrid.mdx';
 import { DatagridActions } from '../../utils/DatagridActions';
@@ -233,6 +238,48 @@ export const NestedRowsUsageStory = prepareStory(BasicTemplateWrapper, {
     ...nestedRowsControlProps,
   },
 });
+
+const SelectableNestedRows = ({ ...args }) => {
+  const columns = React.useMemo(() => defaultHeader, []);
+  const [data] = useState(makeData(10, 5, 2, 2));
+  const datagridState = useDatagrid(
+    {
+      columns,
+      data,
+      DatagridActions,
+      ...args.defaultGridProps,
+    },
+    useNestedRows,
+    useSelectRows
+  );
+
+  return <Datagrid datagridState={{ ...datagridState }} />;
+};
+
+const SelectableNestedRowTemplateWrapper = ({ ...args }) => {
+  return <SelectableNestedRows defaultGridProps={{ ...args }} />;
+};
+
+const selectableNestedRowsStoryName = 'With selectable nested rows';
+export const SelectableNestedRowsUsageStory = prepareStory(
+  SelectableNestedRowTemplateWrapper,
+  {
+    storyName: selectableNestedRowsStoryName,
+    argTypes: {
+      gridTitle: ARG_TYPES.gridTitle,
+      gridDescription: ARG_TYPES.gridDescription,
+      useDenseHeader: ARG_TYPES.useDenseHeader,
+      rowSize: ARG_TYPES.rowSize,
+      rowSizes: ARG_TYPES.rowSizes,
+      onRowSizeChange: ARG_TYPES.onRowSizeChange,
+      expanderButtonTitleExpanded: 'Collapse row',
+      expanderButtonTitleCollapsed: 'Expand row',
+    },
+    args: {
+      ...nestedRowsControlProps,
+    },
+  }
+);
 
 const nestedRowsInitialStateStoryName = 'With initially expanded nested rows';
 export const NestedRowsInitialUsageStory = prepareStory(BasicTemplateWrapper, {

--- a/packages/ibm-products/src/components/Datagrid/useSelectRows.js
+++ b/packages/ibm-products/src/components/Datagrid/useSelectRows.js
@@ -122,7 +122,7 @@ const SelectRow = (datagridState) => {
       getRowId,
     });
   };
-  const rowId = `${tableId}-${row.index}`;
+  const rowId = `${tableId}-${row.id}-${row.index}`;
   return (
     <TableSelectRow
       {...cellProps}


### PR DESCRIPTION
Contributes to #3887 

Add support for selected nested rows in the Datagrid.

Note: This PR only covers the selectable nested row part of #3887. The second acceptance criteria in [comment](https://github.com/carbon-design-system/ibm-products/issues/3887#issuecomment-1856319771) "Selecting parent should not select all children by default" is [coming from the React table ](https://github.com/TanStack/table/blob/v7/src/plugin-hooks/useRowSelect.js#L154-L177)and it's hard to override. If there is subRows then child rows get selected when parent row is selected.

#### What did you change?

`rowId` selection changed to a combination of `rowId` and `index` so the nested rows will have unique Id with depth

#### How did you test and verify your work?
Storybook > With selectable nested rows
