### PR TITLE
feat(Datagrid): add support for multi select filter type (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterProvider.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterProvider.js
@@ -15,6 +15,7 @@ import {
   CHECKBOX,
   CLEAR_SINGLE_FILTER,
   SAVED_FILTERS,
+  MULTISELECT,
 } from './constants';
 
 export const FilterContext = createContext();
@@ -39,7 +40,7 @@ const EventEmitter = {
 const removeFilterItem = (state, index) => state.splice(index, 1);
 
 const updateFilterState = (state, type, value) => {
-  if (type === CHECKBOX) {
+  if (type === CHECKBOX || type === MULTISELECT) {
     return;
   }
   if (type === DATE) {
@@ -61,7 +62,7 @@ export const clearSingleFilter = ({ key, value }, setAllFilters, state) => {
       const filterValues = f.value;
       const filterType = f.type;
       updateFilterState(tempState, filterType, value);
-      if (filterType === CHECKBOX) {
+      if (filterType === CHECKBOX || filterType === MULTISELECT) {
         /**
           When all checkboxes of a group are all unselected the value still exists in the filtersObjectArray
           This checks if all the checkboxes are selected = false and removes it from the array
@@ -122,14 +123,14 @@ const prepareFiltersForTags = (filters, renderDateLabel) => {
           formatDateRange(startDate, endDate),
         ...sharedFilterProps,
       });
-    } else if (type === CHECKBOX) {
-      value.forEach((checkbox) => {
-        if (checkbox.selected) {
+    } else if (type === CHECKBOX || type === MULTISELECT) {
+      value.forEach((option) => {
+        if (option.selected) {
           tags.push({
             key: id,
-            value: checkbox.value,
+            value: option.value,
             ...sharedFilterProps,
-            onClose: () => handleSingleFilterRemoval(id, checkbox.value),
+            onClose: () => handleSingleFilterRemoval(id, option.value),
           });
         }
       });

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/constants.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/constants.js
@@ -19,6 +19,7 @@ export const NUMBER = 'number';
 export const CHECKBOX = 'checkbox';
 export const RADIO = 'radio';
 export const DROPDOWN = 'dropdown';
+export const MULTISELECT = 'multiSelect';
 
 /** Constants for event emitters */
 export const CLEAR_FILTERS = 'clearFilters';

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/utils.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/utils.js
@@ -10,6 +10,7 @@ import {
   DATE,
   DROPDOWN,
   FLYOUT,
+  MULTISELECT,
   NUMBER,
   PANEL,
   RADIO,
@@ -62,6 +63,15 @@ export const getInitialStateFromFilters = (
     } else if (type === DROPDOWN) {
       initialFilterState[column] = {
         value: '',
+        type,
+      };
+    } else if (type === MULTISELECT) {
+      initialFilterState[column] = {
+        value: props.MultiSelect.items.map((item) => ({
+          id: typeof item === 'string' ? item : item.id,
+          value: typeof item === 'string' ? item : item.text,
+          selected: false,
+        })),
         type,
       };
     }

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
@@ -28,7 +28,7 @@ import { DatagridActions } from '../../utils/DatagridActions';
 import { StatusIcon } from '../../../StatusIcon';
 import { getBatchActions } from '../../Datagrid.stories';
 import { handleFilterTagLabelText } from '../../utils/handleFilterTagLabelText';
-import { getDateFormat } from './Panel.stories';
+import { getDateFormat, multiSelectProps } from './Panel.stories';
 
 export default {
   title: `${getStoryTitle(Datagrid.displayName)}/Extensions/Filtering/Flyout`,
@@ -87,6 +87,7 @@ export const FilteringUsage = ({ defaultGridProps }) => {
     {
       Header: 'Status',
       accessor: 'status',
+      filter: 'multiSelect',
     },
     // Shows the date filter example
     {
@@ -251,15 +252,11 @@ const filters = [
     },
   },
   {
-    type: 'dropdown',
+    type: 'multiSelect',
     column: 'status',
     props: {
-      Dropdown: {
-        id: 'marital-status-dropdown',
-        ariaLabel: 'Marital status dropdown',
-        items: ['relationship', 'complicated', 'single'],
-        label: 'Marital status',
-        titleText: 'Marital status',
+      MultiSelect: {
+        ...multiSelectProps,
       },
     },
   },

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -36,7 +36,12 @@ export default {
     styles,
     docs: { page: mdx },
   },
-  excludeStories: ['FilteringUsage', 'filterProps', 'getDateFormat'],
+  excludeStories: [
+    'FilteringUsage',
+    'filterProps',
+    'getDateFormat',
+    'multiSelectProps',
+  ],
 };
 
 // Example usage of mapping locale to flatpickr date format or placeholder value (m/d/Y or mm/dd/yyyy)
@@ -56,6 +61,28 @@ export const getDateFormat = (lang, full) => {
       }
     })
     .join('');
+};
+
+export const multiSelectProps = {
+  // items: ['relationship', 'complicated', 'single'],
+  items: [
+    { text: 'relationship', id: 'relationship' },
+    { text: 'complicated', id: 'complicated' },
+    { text: 'single', id: 'single' },
+  ],
+  id: 'carbon-multiselect-example',
+  label: 'Status selection',
+  titleText: 'Multiselect title',
+  itemToString: (item) => (item ? item.text : ''),
+  size: 'md',
+  type: 'default',
+  disabled: false,
+  hideLabel: false,
+  invalid: false,
+  warn: false,
+  open: false,
+  clearSelectionDescription: 'Total items selected: ',
+  clearSelectionText: 'To clear selection, press Delete or Backspace,',
 };
 
 export const filterProps = {
@@ -99,15 +126,11 @@ export const filterProps = {
         {
           filterLabel: 'Status',
           filter: {
-            type: 'dropdown',
+            type: 'multiSelect',
             column: 'status',
             props: {
-              Dropdown: {
-                id: 'marital-status-dropdown',
-                ariaLabel: 'Marital status dropdown',
-                items: ['relationship', 'complicated', 'single'],
-                label: 'Marital status',
-                titleText: 'Marital status',
+              MultiSelect: {
+                ...multiSelectProps,
               },
             },
           },
@@ -251,6 +274,7 @@ export const FilteringUsage = ({ defaultGridProps }) => {
     {
       Header: 'Status',
       accessor: 'status',
+      filter: 'multiSelect',
     },
     // Shows the date filter example
     {

--- a/packages/ibm-products/src/components/Datagrid/useFiltering.js
+++ b/packages/ibm-products/src/components/Datagrid/useFiltering.js
@@ -7,13 +7,36 @@
 
 import { useMemo } from 'react';
 import { FilterFlyout } from './Datagrid/addons/Filtering';
-import { BATCH } from './Datagrid/addons/Filtering/constants';
+import {
+  BATCH,
+  CHECKBOX,
+  DATE,
+  MULTISELECT,
+  NUMBER,
+} from './Datagrid/addons/Filtering/constants';
+
+const handleMultiFilter = (rows, id, value) => {
+  // gets all the items that are selected and returns their value
+  const selectedItems = value
+    .filter((item) => item.selected)
+    .map((item) => item.value);
+
+  // if the user removed all checkboxes then display all rows
+  if (selectedItems.length === 0) {
+    return rows;
+  }
+
+  return rows.filter((row) => {
+    const rowValue = row.values[id];
+    return selectedItems.includes(rowValue);
+  });
+};
 
 const useFiltering = (hooks) => {
   /* istanbul ignore next */
   const filterTypes = useMemo(
     () => ({
-      date: (rows, id, [startDate, endDate]) => {
+      [DATE]: (rows, id, [startDate, endDate]) => {
         return rows.filter((row) => {
           const rowValue = row.values[id];
           const startDateObj =
@@ -34,7 +57,7 @@ const useFiltering = (hooks) => {
           }
         });
       },
-      number: (rows, id, value) => {
+      [NUMBER]: (rows, id, value) => {
         if (value === '') {
           return rows;
         }
@@ -45,22 +68,8 @@ const useFiltering = (hooks) => {
           return rowValue === parsedValue;
         });
       },
-      checkbox: (rows, id, value) => {
-        // gets all the items that are selected and returns their value
-        const selectedItems = value
-          .filter((item) => item.selected)
-          .map((item) => item.value);
-
-        // if the user removed all checkboxes then display all rows
-        if (selectedItems.length === 0) {
-          return rows;
-        }
-
-        return rows.filter((row) => {
-          const rowValue = row.values[id];
-          return selectedItems.includes(rowValue);
-        });
-      },
+      [CHECKBOX]: (rows, id, value) => handleMultiFilter(rows, id, value),
+      [MULTISELECT]: (rows, id, value) => handleMultiFilter(rows, id, value),
     }),
     []
   );


### PR DESCRIPTION
Contributes to #4356 

Adds `multiSelect` filter type to Datagrid filtering, which will render the `<MultiSelect />` carbon component as an available option be used in both the filter panel and filter flyout.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterProvider.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/constants.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/utils.js
packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
packages/ibm-products/src/components/Datagrid/useFiltering.js
```
#### How did you test and verify your work?
Storybook