### PR TITLE
fix(DataGrid): clickable row retain focus after side panel close

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Edit, TrashCan, Add } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
 import {
@@ -356,6 +356,25 @@ const ClickableRowWithPanel = ({ ...args }) => {
   const [data] = useState(makeData(10));
   const [openSidePanel, setOpenSidePanel] = useState(false);
   const [rowData, setRowData] = useState({});
+  const [focusBackElm, setFocusBackElm] = useState();
+  const sidePanelRef = useRef(sidePanelRef);
+  
+  useEffect(()=>{
+      if(openSidePanel){
+        const focusableElements = sidePanelRef.current.querySelectorAll(
+          'button, [href], input, select, [tabindex]:not([tabindex="-1"])'
+        );
+        const lastFocusableElement = focusableElements[focusableElements.length - 2]; //excluding 'Focus sentinel' span
+        const handleFocus = () => {
+          focusBackElm.focus();
+        }
+        lastFocusableElement.addEventListener("blur", handleFocus);
+        return () => {
+          lastFocusableElement.removeEventListener("blur", handleFocus);
+        }
+      }
+  },[openSidePanel]);
+
   const datagridState = useDatagrid(
     {
       columns,
@@ -364,6 +383,7 @@ const ClickableRowWithPanel = ({ ...args }) => {
         action()(event);
         setOpenSidePanel(true);
         setRowData(row);
+        setFocusBackElm(event.currentTarget); // set focus back to the row selected when closing side panel
       },
       DatagridActions,
       batchActions: true,
@@ -388,7 +408,9 @@ const ClickableRowWithPanel = ({ ...args }) => {
         selectorPageContent={true && '.page-content-wrapper'} // Only if SlideIn
         selectorPrimaryFocus="#side-panel-story__view-link"
         open={openSidePanel}
-        onRequestClose={() => setOpenSidePanel(false)}
+        onRequestClose={() => {setOpenSidePanel(false); focusBackElm.focus() }}
+        ref={sidePanelRef}
+        tabIndex="0"
         size={'sm'}
         title={'Title'}
         slideIn


### PR DESCRIPTION
Contributes to #3165 

After opening and dismissing the side panel from row 3, pressing the tab key again will move the focus to the first row of the table. The desired behavior should be moving the focus down to row 4.

While the focus ring appears on the Close button in the side panel, pressing the tab key again doesn't do anything. The desired behavior should be moving the focus in the side panel and then go back to row 2 in the table.

#### What did you change?

Side panel `onRequestClose` setback the focus to the selected row. 
If the Side panel's last focusable element loses focus then the focus goes to the selected row.
`packages/ibm-products/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js`

#### How did you test and verify your work?

Storybook
