### PR TITLE
chore: update chromedriver resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,8 +98,7 @@
   "//resolutions:http-signature": "package 'request' deprecated but still used, asks for http-signature ~1.2.0 which indirectly has vulnerabilities",
   "//resolutions:minimist": "https://security.snyk.io/vuln/SNYK-JS-MINIMIST-2429795 (version <=1.2.5)",
   "resolutions": {
-    "cheerio": "1.0.0-rc.10",
-    "chromedriver": "122.0.1"
+    "cheerio": "1.0.0-rc.10"
   },
   "eslintConfig": {
     "parser": "@babel/eslint-parser",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
   "//resolutions:http-signature": "package 'request' deprecated but still used, asks for http-signature ~1.2.0 which indirectly has vulnerabilities",
   "//resolutions:minimist": "https://security.snyk.io/vuln/SNYK-JS-MINIMIST-2429795 (version <=1.2.5)",
   "resolutions": {
-    "cheerio": "1.0.0-rc.10"
+    "cheerio": "1.0.0-rc.10",
+    "chromedriver": "122.0.1"
   },
   "eslintConfig": {
     "parser": "@babel/eslint-parser",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9232,7 +9232,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromedriver@npm:122.0.1":
+"chromedriver@npm:*":
   version: 122.0.1
   resolution: "chromedriver@npm:122.0.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9232,9 +9232,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromedriver@npm:*":
-  version: 121.0.0
-  resolution: "chromedriver@npm:121.0.0"
+"chromedriver@npm:122.0.1":
+  version: 122.0.1
+  resolution: "chromedriver@npm:122.0.1"
   dependencies:
     "@testim/chrome-version": "npm:^1.1.4"
     axios: "npm:^1.6.5"
@@ -9245,7 +9245,7 @@ __metadata:
     tcp-port-used: "npm:^1.0.2"
   bin:
     chromedriver: bin/chromedriver
-  checksum: 2034325c85a459adb80dbe8156c9db339b28d6101183c769e4ac86d8768983cb9cb3fb8d4bc7b5953a08b4f4b384aed24443b8e7d4c2eab1e7d38f53691d9544
+  checksum: ceb04ff891a042a3bb05954b2489952ce93ab8c4889bfbcda9eb85d2e28a7613436edb31c9694335508a666043931c40938f257af1e9e42485cef5cbeefb6731
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes an issue with changed CDN

`chromedriver` (from `accessibility-checker`) was causing build failures in our CI[^1]. Temporarily added `chromedriver@1.220.1` to resolutions to update version in `yarn.lock`.

#### What did you change?
Add resolution to current latest version in `package.json` to update `yarn.lock`.

#### How did you test and verify your work?
CI checks pass but ... also this _is_ the test.


[^1]: https://github.com/IBMa/equal-access/blob/master/accessibility-checker/package.json#L26