### PR TITLE
refactor: convert ToolbarButton to typescript

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 IBMers should complete steps documented on
-[W3 Developer](https://w3.ibm.com/developer/docs/open-source/contributing/)
+[W3 Developer](https://w3.ibm.com/developer/docs/open-source/oss-contributing/)
 before contributing to open source projects.
 
 Also refer to

--- a/packages/ibm-products/src/components/Toolbar/ToolbarButton.tsx
+++ b/packages/ibm-products/src/components/Toolbar/ToolbarButton.tsx
@@ -24,13 +24,20 @@ interface ToolbarButtonProps extends React.ComponentProps<typeof IconButton> {
   /** Specifies the label for the icon button */
   iconDescription: string;
   /** Specifies the icon to be used by the ToolbarButton component */
-  renderIcon: React.ElementType,
+  renderIcon: React.ElementType;
 }
 
 /** Toolbar buttons are common functions performed as part of a products interface or an open window.  */
 export let ToolbarButton = forwardRef(
   (
-    { caret = false, children, className, renderIcon, iconDescription = '', ...rest }: React.PropsWithChildren<ToolbarButtonProps>,
+    {
+      caret = false,
+      children,
+      className,
+      renderIcon,
+      iconDescription = '',
+      ...rest
+    }: React.PropsWithChildren<ToolbarButtonProps>,
     ref
   ) => {
     const Icon = renderIcon;

--- a/packages/ibm-products/src/components/Toolbar/ToolbarButton.tsx
+++ b/packages/ibm-products/src/components/Toolbar/ToolbarButton.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,10 +16,21 @@ import { blockClass as toolbarClass, ToolbarContext } from './Toolbar';
 
 export const blockClass = `${toolbarClass}__button`;
 
+interface ToolbarButtonProps extends React.ComponentProps<typeof IconButton> {
+  /** Determines whether the caret is rendered */
+  caret?: boolean;
+  /** Provide an optional class to be applied to the containing node */
+  className?: string;
+  /** Specifies the label for the icon button */
+  iconDescription: string;
+  /** Specifies the icon to be used by the ToolbarButton component */
+  renderIcon: React.ElementType,
+}
+
 /** Toolbar buttons are common functions performed as part of a products interface or an open window.  */
 export let ToolbarButton = forwardRef(
   (
-    { caret, children, className, renderIcon, iconDescription = '', ...rest },
+    { caret = false, children, className, renderIcon, iconDescription = '', ...rest }: React.PropsWithChildren<ToolbarButtonProps>,
     ref
   ) => {
     const Icon = renderIcon;


### PR DESCRIPTION
Contributes to #4276 

Converts ToolbarButton component to use typescript, no visual component changes just refactoring.

Small PR to begin contributing with, I'll add more types if this goes well.

#### What did you change?
Converted `ToolbarButton` component to typescript.
Updated contribution docs to include an up to date link.

#### How did you test and verify your work?
Checked storybook and ran unit tests locally.