### PR TITLE
fix(Datagrid): add safety checks for saved filters logic

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
@@ -479,9 +479,11 @@ const useFilters = ({
         });
         return updatedFilters[0];
       };
-      setFiltersObjectArray(savedFilters);
-      const filterStateCopy = cleanFilters(filtersState);
-      setFiltersState(filterStateCopy);
+      if (savedFilters && savedFilters.length) {
+        setFiltersObjectArray(savedFilters);
+        const filterStateCopy = cleanFilters(filtersState) ?? [];
+        setFiltersState(filterStateCopy);
+      }
     }
     if (!isFetching) {
       setFetchingReset(false);


### PR DESCRIPTION
Contributes to #4441 

Fixes an issue in some new logic added to Datagrid that reverts to the saved filter list when refreshing.

#### What did you change?
`useFilter.js`

#### How did you test and verify your work?
Temporarily added fetching state to filter panel story, was able to reproduce the issue and fix.