### PR TITLE
feat: add drag and drop examples/explorations

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -114,6 +114,7 @@
     "rerender",
     "resizer",
     "responsivity",
+    "roledescription",
     "rowgroup",
     "rowheader",
     "rowindex",

--- a/packages/core/story-structure.js
+++ b/packages/core/story-structure.js
@@ -109,6 +109,7 @@ const s = [
               'c/EmptyStateV2',
             ],
           },
+          { n: 'Drag and drop', s: ['c/DragAndDrop'] },
           { n: 'Export', s: ['c/ExportModal'] },
           { n: 'Full-page error', s: ['c/FullPageError'] },
           { n: 'Generating an API key', s: ['c/APIKeyModal'] },

--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -93,6 +93,7 @@
     "@carbon/ibm-products-styles": "^2.27.1",
     "@carbon/telemetry": "^0.1.0",
     "@dnd-kit/core": "^6.0.8",
+    "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@ibm/telemetry-js": "^1.2.0",

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
@@ -53,10 +53,13 @@ const DraggableElement = ({
     </>
   );
 
+  console.log(transform);
+
   const style = {
     transform: !disabled ? CSS.Transform.toString(transform) : {},
     transition,
   };
+  console.log(style);
 
   return (
     <li

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.js
@@ -53,13 +53,10 @@ const DraggableElement = ({
     </>
   );
 
-  console.log(transform);
-
   const style = {
     transform: !disabled ? CSS.Transform.toString(transform) : {},
     transition,
   };
-  console.log(style);
 
   return (
     <li

--- a/packages/ibm-products/src/components/DragAndDrop/DragAndDrop.mdx
+++ b/packages/ibm-products/src/components/DragAndDrop/DragAndDrop.mdx
@@ -15,12 +15,14 @@ import {
 
 The following are drag and drop examples building upon the examples on the [PAL site](https://pages.github.ibm.com/cdai-design/pal/patterns/drag-and-drop/usage). While we are currently not providing these
 as exported components to use directly, they can be used as references for drag and drop interactions. The examples provided use `@dnd-kit`, also used in `@carbon/ibm-products` for customizing the order
-of columns in the Datagrid. We do provide styles for some of the drag states as detailed below.
+of columns in the Datagrid.
 
-| State                  | class                                          |
+{/* We do provide styles for some of the drag states as detailed below. */}
+
+{/* | State                  | class                                          |
 |------------------------|------------------------------------------------|
 | Default draggable item | `${pkg.prefix}__draggable-item`                |
-| Dragging               | `${pkg.prefix}__draggable-item--dragging`      |
+| Dragging               | `${pkg.prefix}__draggable-item--dragging`      | */}
 
 ## Example usage
 

--- a/packages/ibm-products/src/components/DragAndDrop/DragAndDrop.mdx
+++ b/packages/ibm-products/src/components/DragAndDrop/DragAndDrop.mdx
@@ -1,0 +1,37 @@
+import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
+import {
+  getStoryId,
+  CodesandboxLink,
+} from '../../global/js/utils/story-helper';
+
+# DescriptionList
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Example usage](#example-usage)
+- [Component API](#component-api)
+
+## Overview
+
+The following are drag and drop examples building from the examples on the PAL site. While we are currently not providing these
+as exported components to use directly, they can be used as references for drag and drop interactions. We do provide styles for
+some of the drag states as detailed below.
+
+| State                  | class                                          |
+|------------------------|------------------------------------------------|
+| Default draggable item | `${pkg.prefix}__draggable-item`                |
+| Dragging               | `${pkg.prefix}__draggable-item--dragging`      |
+|                        |                                                |
+
+## Example usage
+
+{/* TODO: One example per designed use case. */}
+
+<Canvas>
+  <Story id={getStoryId('DragAndDrop', 'vertical-example')} />
+</Canvas>
+
+<Canvas>
+  <Story id={getStoryId('DragAndDrop', 'horizontal-example')} />
+</Canvas>

--- a/packages/ibm-products/src/components/DragAndDrop/DragAndDrop.mdx
+++ b/packages/ibm-products/src/components/DragAndDrop/DragAndDrop.mdx
@@ -10,28 +10,46 @@ import {
 
 - [Overview](#overview)
 - [Example usage](#example-usage)
-- [Component API](#component-api)
 
 ## Overview
 
-The following are drag and drop examples building from the examples on the PAL site. While we are currently not providing these
-as exported components to use directly, they can be used as references for drag and drop interactions. We do provide styles for
-some of the drag states as detailed below.
+The following are drag and drop examples building upon the examples on the [PAL site](https://pages.github.ibm.com/cdai-design/pal/patterns/drag-and-drop/usage). While we are currently not providing these
+as exported components to use directly, they can be used as references for drag and drop interactions. The examples provided use `@dnd-kit`, also used in `@carbon/ibm-products` for customizing the order
+of columns in the Datagrid. We do provide styles for some of the drag states as detailed below.
 
 | State                  | class                                          |
 |------------------------|------------------------------------------------|
 | Default draggable item | `${pkg.prefix}__draggable-item`                |
 | Dragging               | `${pkg.prefix}__draggable-item--dragging`      |
-|                        |                                                |
 
 ## Example usage
 
-{/* TODO: One example per designed use case. */}
-
+### Vertical list
 <Canvas>
   <Story id={getStoryId('DragAndDrop', 'vertical-example')} />
 </Canvas>
 
+### Horizontal list
 <Canvas>
   <Story id={getStoryId('DragAndDrop', 'horizontal-example')} />
+</Canvas>
+
+### Grid
+<Canvas>
+  <Story id={getStoryId('DragAndDrop', 'grid-example')} />
+</Canvas>
+
+### Grid, restrict drag to window edge
+<Canvas>
+  <Story id={getStoryId('DragAndDrop', 'grid-example-restrict-to-window')} />
+</Canvas>
+
+### Grid, with large item
+<Canvas>
+  <Story id={getStoryId('DragAndDrop', 'grid-example-large-item')} />
+</Canvas>
+
+### Grid, dashboard
+<Canvas>
+  <Story id={getStoryId('DragAndDrop', 'grid-dashboard')} />
 </Canvas>

--- a/packages/ibm-products/src/components/DragAndDrop/DragAndDrop.stories.js
+++ b/packages/ibm-products/src/components/DragAndDrop/DragAndDrop.stories.js
@@ -1,0 +1,208 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React, { useState } from 'react';
+import { action } from '@storybook/addon-actions';
+
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
+import cx from 'classnames';
+
+// Dnd kit imports
+/* ************************ */
+
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  useSortable,
+  SortableContext,
+  verticalListSortingStrategy,
+  arrayMove
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
+
+/* ************************ */
+
+import styles from './_storybook-styles.scss';
+
+// import { ExampleComponent } from '.';
+import { pkg } from '../../settings';
+// import DocsPage from './ExampleComponent.docs-page';
+
+export default {
+  title: getStoryTitle('DragAndDrop'),
+  component: () => {},
+  tags: ['autodocs'],
+  argTypes: {
+    borderColor: { control: 'color' },
+  },
+  parameters: {
+    styles,
+    docs: {
+      // page:  DocsPage, // OPTIONAL: required only to customize default docs page
+    },
+  },
+};
+
+const SortableItem = ({ id, children, assistiveText = 'Text for screen reader' }) => {
+  const {
+    attributes,
+    isDragging,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({
+    id,
+  });
+
+  const style = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+    zIndex: isDragging && 2000000,
+  }
+
+  const draggableClass = `${pkg.prefix}__draggable-item`;
+  return <li
+    className={cx(
+      `${draggableClass}__draggable-handleHolder`,
+      draggableClass, {
+      // [`${draggableClass}__draggable-handleHolder--selected`]: selected,
+      // [`${draggableClass}__draggable-handleHolder--sticky`]: isSticky,
+      [`${draggableClass}__dragging`]: isDragging,
+    })}
+    id={id}
+    ref={setNodeRef}
+    style={style}
+    {...attributes}
+    {...listeners}
+    role='option'
+    aria-selected
+  >
+    <span className={`${draggableClass}__assistive-text`}>
+      {assistiveText}
+    </span>
+    {/* <div
+      className={cx(
+        {
+          // [`${draggableClass}__draggable-handleStyle`]: !disabled,
+        },
+        [`${draggableClass}__draggable-handleHolder-droppable`]
+      )}
+    >
+      {children}
+    </div> */}
+    {children}
+  </li>
+}
+
+const Template = ({ ...args }) => {
+  const [items, setItems] = useState([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  const [activeId, setActiveId] = useState(null);
+  const getIndex = (id) => items.indexOf(id);
+
+  const activeIndex = activeId ? getIndex(activeId) : -1;
+
+  const draggableClass = `${pkg.prefix}__draggable-item`;
+  const pointerSensor = useSensor(PointerSensor, {
+    // Require the mouse to move by 10 pixels before activating
+    activationConstraint: {
+      distance: 4,
+    },
+  });
+
+  const keyboardSensor = useSensor(KeyboardSensor, {
+    coordinateGetter: (event, args) => {
+      const { currentCoordinates } = args;
+
+      let target = event.target;
+
+      while (target && !target.classList.contains(draggableClass)) {
+        target = target.parentNode;
+      }
+
+      const delta = target.offsetHeight;
+
+      switch (event.code) {
+        case 'ArrowRight':
+        case 'ArrowLeft':
+          // ignore right and left
+          return currentCoordinates;
+        case 'ArrowUp':
+          return { ...currentCoordinates, y: currentCoordinates.y - delta };
+        case 'ArrowDown':
+          return { ...currentCoordinates, y: currentCoordinates.y + delta };
+        case 'Space':
+          break;
+      }
+    },
+  });
+
+  const handleDragEnd = ({ over }) => {
+    action('handleDragEnd')();
+    setActiveId(null);
+
+    if (over) {
+      const overIndex = getIndex(over.id);
+      if (activeIndex !== overIndex) {
+        setItems((items) => arrayMove(items, activeIndex, overIndex));
+      }
+    }
+  }
+  // console.log(items);
+
+  const handleDragStart = ({ active }) => {
+    action('handleDragStart')();
+    if (!active) {
+      return;
+    }
+
+    setActiveId(active.id);
+  }
+
+  const handleDragUpdate = () => {
+    action('handleDragUpdate')();
+  }
+
+  const handleDragCancel = () => {
+    setActiveId(null);
+  }
+
+
+  const sensors = useSensors(pointerSensor, keyboardSensor);
+  return (
+    <DndContext
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+      onDragStart={handleDragStart}
+      onDragMove={handleDragUpdate}
+      onDragCancel={handleDragCancel}
+      sensors={sensors}
+      modifiers={[restrictToVerticalAxis]}
+      {...args}
+    >
+    <SortableContext
+      items={items}
+      strategy={verticalListSortingStrategy}
+    >
+      {items.map(i => <SortableItem id={i} key={`${i}__drag_key`}>{i}</SortableItem>)}
+    </SortableContext>
+    </DndContext>
+  );
+};
+
+export const exampleComponent = prepareStory(Template, {
+  args: {},
+});

--- a/packages/ibm-products/src/components/DragAndDrop/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/DragAndDrop/_storybook-styles.scss
@@ -23,7 +23,6 @@ $horizontal-drag-height: 6rem;
   height: 3rem;
   padding: $spacing-03;
   border-bottom: 1px solid $border-subtle;
-  // background-color: paleturquoise;
   background-color: $layer;
   cursor: grab;
   list-style-type: none;
@@ -66,7 +65,7 @@ $horizontal-drag-height: 6rem;
   height: $spacing-09;
   border: 2px dashed $focus;
   /* stylelint-disable-next-line carbon/theme-token-use */
-  background-color: colors.$blue-10; // not good in dark mode
+  background-color: colors.$blue-10;
 }
 
 .#{$drag-class}__list-container {

--- a/packages/ibm-products/src/components/DragAndDrop/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/DragAndDrop/_storybook-styles.scss
@@ -1,0 +1,34 @@
+//
+// Copyright IBM Corp. 2024, 2024
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use 'ALIAS_STORY_STYLE_CONFIG' as c4p-settings;
+@use '@carbon/styles/scss/theme' as *;
+
+// TODO: add any additional styles used by DescriptionList.stories.js
+
+$drag-class: #{c4p-settings.$pkg-prefix}__draggable-item;
+
+.#{$drag-class} {
+  width: 320px;
+  height: 3rem;
+  border-bottom: 1px solid $border-subtle;
+  background-color: paleturquoise;
+  cursor: grab;
+  list-style-type: none;
+}
+
+.#{$drag-class}__dragging {
+  position: relative;
+  z-index: 100000;
+  background-color: pink;
+  cursor: grabbing;
+}
+
+.#{$drag-class}__assistive-text {
+  position: absolute;
+  visibility: hidden;
+}

--- a/packages/ibm-products/src/components/DragAndDrop/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/DragAndDrop/_storybook-styles.scss
@@ -15,7 +15,7 @@
 // TODO: add any additional styles used by DragAndDrop.stories.js
 
 $drag-class: #{c4p-settings.$pkg-prefix}__draggable-item;
-$horizontal-drag-height: 8rem;
+$horizontal-drag-height: 6rem;
 
 .#{$drag-class} {
   position: relative;
@@ -29,7 +29,7 @@ $horizontal-drag-height: 8rem;
   list-style-type: none;
 
   &.#{$drag-class}--horizontal {
-    width: 90px;
+    width: 6rem;
     height: $horizontal-drag-height;
     border-right: 1px solid $border-subtle;
     border-bottom: none;
@@ -44,7 +44,7 @@ $horizontal-drag-height: 8rem;
   @include utilities.focus-outline('outline');
 
   position: relative;
-  z-index: 100000;
+  z-index: 2000000;
   background-color: $layer-hover;
   cursor: grabbing;
 }
@@ -71,6 +71,14 @@ $horizontal-drag-height: 8rem;
 
 .#{$drag-class}__list-container {
   position: relative;
+}
+
+.#{$drag-class}__list-container--grid,
+.#{$drag-class}__draggable-underlay--grid {
+  display: grid;
+  max-width: 800px;
+  grid-gap: var(--grid-gap);
+  grid-template-columns: repeat(var(--col-count), 1fr);
 }
 
 .#{$drag-class}--type {

--- a/packages/ibm-products/src/components/DragAndDrop/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/DragAndDrop/_storybook-styles.scss
@@ -7,28 +7,84 @@
 
 @use 'ALIAS_STORY_STYLE_CONFIG' as c4p-settings;
 @use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/colors';
+@use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/utilities';
 
-// TODO: add any additional styles used by DescriptionList.stories.js
+// TODO: add any additional styles used by DragAndDrop.stories.js
 
 $drag-class: #{c4p-settings.$pkg-prefix}__draggable-item;
+$horizontal-drag-height: 8rem;
 
 .#{$drag-class} {
+  position: relative;
   width: 320px;
   height: 3rem;
+  padding: $spacing-03;
   border-bottom: 1px solid $border-subtle;
-  background-color: paleturquoise;
+  // background-color: paleturquoise;
+  background-color: $layer;
   cursor: grab;
   list-style-type: none;
+
+  &.#{$drag-class}--horizontal {
+    width: 90px;
+    height: $horizontal-drag-height;
+    border-right: 1px solid $border-subtle;
+    border-bottom: none;
+  }
+
+  &.#{$drag-class}:focus {
+    @include utilities.focus-outline('outline');
+  }
 }
 
-.#{$drag-class}__dragging {
+.#{$drag-class}--dragging {
+  @include utilities.focus-outline('outline');
+
   position: relative;
   z-index: 100000;
-  background-color: pink;
+  background-color: $layer-hover;
   cursor: grabbing;
 }
 
 .#{$drag-class}__assistive-text {
   position: absolute;
   visibility: hidden;
+}
+
+.#{$drag-class}__draggable-underlay {
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+
+.#{$drag-class}__draggable-underlay-item {
+  // must match draggable item size
+  width: 100%;
+  height: $spacing-09;
+  border: 2px dashed $focus;
+  /* stylelint-disable-next-line carbon/theme-token-use */
+  background-color: colors.$blue-10; // not good in dark mode
+}
+
+.#{$drag-class}__list-container {
+  position: relative;
+}
+
+.#{$drag-class}--type {
+  @include type.type-style('body-compact-01');
+}
+
+.#{$drag-class}__list-container--horizontal,
+.#{$drag-class}__draggable-underlay--horizontal {
+  display: grid;
+  width: 100%;
+  grid-auto-flow: column;
+}
+
+.#{$drag-class}__draggable-underlay--horizontal
+  .#{$drag-class}__draggable-underlay-item {
+  height: $horizontal-drag-height;
 }

--- a/packages/ibm-products/src/components/DragAndDrop/preview-components/GridContainer.js
+++ b/packages/ibm-products/src/components/DragAndDrop/preview-components/GridContainer.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+
+export const GridContainer = ({
+  children,
+  columns,
+  draggableClass,
+  gridGap,
+}) => {
+  return (
+    <ul
+      className={cx(
+        `${draggableClass}__list-container`,
+        `${draggableClass}__list-container--grid`
+      )}
+      style={{
+        '--col-count': columns,
+        '--grid-gap': gridGap,
+      }}
+    >
+      {children}
+    </ul>
+  );
+};
+
+GridContainer.propTypes = {
+  children: PropTypes.node,
+  columns: PropTypes.number,
+  draggableClass: PropTypes.string,
+  gridGap: PropTypes.string,
+  type: PropTypes.string,
+};

--- a/packages/ibm-products/src/components/DragAndDrop/preview-components/Item.js
+++ b/packages/ibm-products/src/components/DragAndDrop/preview-components/Item.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { pkg } from '../../../settings';
+
+export const Item = ({
+  isDragging = false,
+  type,
+  id,
+  setNodeRef = () => {},
+  attributes = {},
+  listeners = {},
+  assistiveText = 'Text for screen reader',
+  children,
+  value,
+  dragOverlay,
+  wrapperStyle,
+  transform,
+  transition,
+}) => {
+  const draggableClass = `${pkg.prefix}__draggable-item`;
+  return (
+    <li
+      className={cx(
+        `${draggableClass}--type`, // Confusing, refactor to typography or something along those lines
+        draggableClass,
+        {
+          [`${draggableClass}--dragging`]: isDragging,
+          [`${draggableClass}--${type}`]: type,
+          [`${draggableClass}--drag-overlay`]: dragOverlay,
+        }
+      )}
+      id={id}
+      ref={setNodeRef}
+      style={{
+        ...wrapperStyle,
+        transform,
+        transition,
+      }}
+      {...attributes}
+      {...listeners}
+      role="option"
+      aria-selected
+    >
+      <span className={`${draggableClass}__assistive-text`}>
+        {assistiveText}
+      </span>
+      {value ? value : children}
+    </li>
+  );
+};
+
+Item.propTypes = {
+  assistiveText: PropTypes.string,
+  attributes: PropTypes.shape({
+    ['aria-describedby']: PropTypes.string,
+    ['aria-disabled']: PropTypes.bool,
+    ['aria-pressed']: PropTypes.oneOfType([PropTypes.bool, undefined]),
+    ['aria-roledescription']: PropTypes.string,
+    ['role']: PropTypes.string,
+    ['tabIndex']: PropTypes.number,
+  }),
+  children: PropTypes.node,
+  dragOverlay: PropTypes.bool,
+  id: PropTypes.string,
+  isDragging: PropTypes.bool,
+  listeners: PropTypes.shape({
+    onPointerDown: PropTypes.func,
+    onKeyDown: PropTypes.func,
+  }),
+  setNodeRef: PropTypes.func,
+  style: PropTypes.object,
+  transform: PropTypes.string,
+  transition: PropTypes.string,
+  type: PropTypes.string,
+  value: PropTypes.node,
+  wrapperStyle: PropTypes.object,
+};

--- a/packages/ibm-products/src/components/DragAndDrop/preview-components/ListContainer.js
+++ b/packages/ibm-products/src/components/DragAndDrop/preview-components/ListContainer.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+
+export const ListContainer = ({ children, draggableClass, type }) => {
+  return (
+    <ul
+      className={cx(`${draggableClass}__list-container`, {
+        [`${draggableClass}__list-container--horizontal`]:
+          type === 'horizontal',
+      })}
+    >
+      {children}
+    </ul>
+  );
+};
+
+ListContainer.propTypes = {
+  children: PropTypes.node,
+  draggableClass: PropTypes.string,
+  type: PropTypes.string,
+};

--- a/packages/ibm-products/src/components/DragAndDrop/preview-components/Sortable.js
+++ b/packages/ibm-products/src/components/DragAndDrop/preview-components/Sortable.js
@@ -1,0 +1,191 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { px } from '@carbon/layout';
+import { action } from '@storybook/addon-actions';
+import { pkg } from '../../../settings';
+import { SortableItem } from './SortableItem';
+import { ListContainer } from './ListContainer';
+import { Underlay } from './Underlay';
+
+// Dnd kit imports
+/* ************************ */
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import { SortableContext, arrayMove } from '@dnd-kit/sortable';
+/* ************************ */
+
+export const Sortable = ({
+  type,
+  sortableProps,
+  Container = ListContainer,
+  useDragOverlay = true,
+  wrapperStyle,
+  strategy,
+  withGrid,
+  gridGap = px(12),
+  itemCount = 10,
+  includeUnderlay = true,
+  modifiers = [],
+  ...args
+}) => {
+  const [items, setItems] = useState(
+    Array.from({ length: itemCount }, (_, i) => i + 1)
+  );
+  const [activeId, setActiveId] = useState(null);
+  const getIndex = (id) => items.indexOf(id);
+
+  const activeIndex = activeId ? getIndex(activeId) : -1;
+
+  const draggableClass = `${pkg.prefix}__draggable-item`;
+  const pointerSensor = useSensor(PointerSensor, {
+    // Require the mouse to move by 10 pixels before activating
+    activationConstraint: {
+      distance: 4,
+    },
+  });
+
+  const keyboardSensor = useSensor(KeyboardSensor, {
+    coordinateGetter: (event, args) => {
+      const { currentCoordinates } = args;
+
+      let target = event.target;
+
+      while (target && !target.classList.contains(draggableClass)) {
+        target = target.parentNode;
+      }
+
+      const gapValue = withGrid ? parseInt(gridGap) : 0;
+
+      const delta =
+        type !== 'horizontal'
+          ? target.offsetHeight + gapValue
+          : target.offsetWidth + gapValue;
+
+      switch (event.code) {
+        case 'ArrowRight': {
+          if (type === 'horizontal' || withGrid) {
+            return { ...currentCoordinates, x: currentCoordinates.x + delta };
+          }
+          return currentCoordinates;
+        }
+        case 'ArrowLeft': {
+          if (type === 'horizontal' || withGrid) {
+            return { ...currentCoordinates, x: currentCoordinates.x - delta };
+          }
+          // ignore right and left
+          return currentCoordinates;
+        }
+        case 'ArrowUp':
+          if (type === 'horizontal') {
+            return currentCoordinates;
+          }
+          return { ...currentCoordinates, y: currentCoordinates.y - delta };
+        case 'ArrowDown':
+          if (type === 'horizontal') {
+            return currentCoordinates;
+          }
+          return { ...currentCoordinates, y: currentCoordinates.y + delta };
+        case 'Space':
+          break;
+      }
+    },
+  });
+
+  const handleDragEnd = ({ over }) => {
+    action('handleDragEnd')();
+    setActiveId(null);
+
+    if (over) {
+      const overIndex = getIndex(over.id);
+      if (activeIndex !== overIndex) {
+        setItems((items) => arrayMove(items, activeIndex, overIndex));
+      }
+    }
+  };
+
+  const handleDragStart = ({ active }) => {
+    action('handleDragStart')();
+    if (!active) {
+      return;
+    }
+
+    setActiveId(active.id);
+  };
+
+  const handleDragCancel = () => {
+    setActiveId(null);
+  };
+
+  const sensors = useSensors(pointerSensor, keyboardSensor);
+
+  return (
+    <DndContext
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+      onDragStart={handleDragStart}
+      onDragCancel={handleDragCancel}
+      sensors={sensors}
+      modifiers={modifiers}
+      {...args}
+    >
+      <SortableContext items={items} strategy={strategy} {...sortableProps}>
+        <Container
+          draggableClass={draggableClass}
+          type={type}
+          gridGap={withGrid && gridGap}
+        >
+          <Underlay
+            draggableClass={draggableClass}
+            items={items}
+            type={type}
+            wrapperStyle={wrapperStyle}
+            grid={withGrid}
+            activeId={activeId}
+            includeUnderlay={includeUnderlay}
+          />
+          {items.map((i) => (
+            <SortableItem
+              id={i}
+              key={`${i}__drag_key`}
+              type={type}
+              useDragOverlay={useDragOverlay}
+              wrapperStyle={wrapperStyle}
+              index={i}
+            >
+              Item {i}
+            </SortableItem>
+          ))}
+        </Container>
+      </SortableContext>
+    </DndContext>
+  );
+};
+
+Sortable.propTypes = {
+  Container: PropTypes.elementType,
+  adjustScale: PropTypes.bool,
+  gridGap: PropTypes.number,
+  includeUnderlay: PropTypes.bool,
+  itemCount: PropTypes.number,
+  modifiers: PropTypes.arrayOf(PropTypes.func),
+  restrictToParent: PropTypes.bool,
+  sortableProps: PropTypes.object,
+  strategy: PropTypes.func,
+  type: PropTypes.string,
+  useDragOverlay: PropTypes.bool,
+  withGrid: PropTypes.bool,
+  wrapperStyle: PropTypes.func,
+};

--- a/packages/ibm-products/src/components/DragAndDrop/preview-components/SortableItem.js
+++ b/packages/ibm-products/src/components/DragAndDrop/preview-components/SortableItem.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Item } from './Item';
+
+export const SortableItem = ({
+  id,
+  children,
+  assistiveText = 'Text for screen reader',
+  type,
+  useDragOverlay,
+  wrapperStyle,
+  index,
+}) => {
+  const {
+    active,
+    attributes,
+    isDragging,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({
+    id,
+  });
+
+  return (
+    <Item
+      isDragging={isDragging}
+      attributes={attributes}
+      type={type}
+      setNodeRef={setNodeRef}
+      transform={CSS.Translate.toString(transform)}
+      transition={transition}
+      listeners={listeners}
+      assistiveText={assistiveText}
+      dragOverlay={!useDragOverlay && isDragging}
+      wrapperStyle={wrapperStyle?.({ index, isDragging, active, id })}
+    >
+      {children}
+    </Item>
+  );
+};
+
+SortableItem.propTypes = {
+  assistiveText: PropTypes.string,
+  children: PropTypes.node,
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  index: PropTypes.number,
+  type: PropTypes.string,
+  useDragOverlay: PropTypes.bool,
+  wrapperStyle: PropTypes.func,
+};

--- a/packages/ibm-products/src/components/DragAndDrop/preview-components/Underlay.js
+++ b/packages/ibm-products/src/components/DragAndDrop/preview-components/Underlay.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+
+export const Underlay = ({
+  draggableClass,
+  type,
+  items,
+  wrapperStyle,
+  grid,
+  activeId,
+  includeUnderlay,
+}) => {
+  if (!includeUnderlay) {
+    return;
+  }
+  return (
+    <div
+      className={cx(`${draggableClass}__draggable-underlay`, {
+        [`${draggableClass}__draggable-underlay--horizontal`]:
+          type === 'horizontal',
+        [`${draggableClass}__draggable-underlay--grid`]: grid,
+      })}
+      aria-hidden="true"
+      key={`draggable-underlay`}
+    >
+      {items.map((i) => (
+        <div
+          className={`${draggableClass}__draggable-underlay-item`}
+          key={`${i}__key`}
+          style={{
+            ...wrapperStyle?.({
+              index: i,
+              isDragging: false,
+              active: null,
+              id: i,
+              activeId,
+            }),
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+Underlay.propTypes = {
+  activeId: PropTypes.number,
+  draggableClass: PropTypes.string,
+  grid: PropTypes.bool,
+  includeUnderlay: PropTypes.bool,
+  items: PropTypes.array,
+  type: PropTypes.string,
+  wrapperStyle: PropTypes.func,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2068,6 +2068,7 @@ __metadata:
     "@carbon/ibm-products-styles": "npm:^2.27.1"
     "@carbon/telemetry": "npm:^0.1.0"
     "@dnd-kit/core": "npm:^6.0.8"
+    "@dnd-kit/modifiers": "npm:^7.0.0"
     "@dnd-kit/sortable": "npm:^8.0.0"
     "@dnd-kit/utilities": "npm:^3.2.2"
     "@ibm/telemetry-js": "npm:^1.2.0"
@@ -2978,6 +2979,19 @@ __metadata:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
   checksum: cf9e99763fbd9220cb6fdde2950c19fdf6248391234f5ee835601814124445fd8a6e4b3f5bc35543c802d359db8cc47f07d87046577adc41952ae981a03fbda0
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/modifiers@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@dnd-kit/modifiers@npm:7.0.0"
+  dependencies:
+    "@dnd-kit/utilities": "npm:^3.2.2"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@dnd-kit/core": ^6.1.0
+    react: ">=16.8.0"
+  checksum: 9ee0b7b86c23c15f6820d76ec398724597abc9d9e31cf58836e7f0b9935e33f9136a60ee9600eb27818447623f07786d4fed3f1d685d9cc6d860d8f6c5354ae3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Contributes to #2042 

First bit of drag and drop examples added to storybook, this will not be something (as of right now) we'll provide components for. Instead, teams can use these examples to guide their own implementation of drag and drop.

#### What did you change?
Created story files in `packages/ibm-products/src/components/DragAndDrop`
#### How did you test and verify your work?
Storybook