### PR TITLE
fix(TagSet): address color contrast issue in overflow link button

### DIFF
--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -4326,7 +4326,7 @@ p.c4p--about-modal__copyright-text:first-child {
   position: relative;
   z-index: 0;
   overflow: auto;
-  padding: 0 1rem;
+  padding: 0 1rem 4rem 1rem;
   overscroll-behavior: contain;
 }
 
@@ -8397,6 +8397,7 @@ button.c4p--add-select__global-filter-toggle--open {
 }
 .c4p--tag-set-overflow__tagset-popover .c4p--tag-set-overflow__show-all-tags-link {
   margin-top: 0.5rem;
+  color: var(--cds-link-inverse, #78a9ff);
 }
 .c4p--tag-set-overflow__tagset-popover .c4p--tag-set-overflow__tag-item.c4p--tag-set-overflow__tag-item--tag .cds--tag {
   background-color: var(--cds-background-inverse-hover, #474747);

--- a/packages/ibm-products-styles/src/components/TagSet/_tag-set.scss
+++ b/packages/ibm-products-styles/src/components/TagSet/_tag-set.scss
@@ -146,6 +146,7 @@ $block-class-modal: #{$_block-class}-modal;
 
   .#{$block-class-overflow}__show-all-tags-link {
     margin-top: $spacing-03;
+    color: $link-inverse;
   }
 
   .#{$block-class-overflow}__tag-item.#{$block-class-overflow}__tag-item--tag


### PR DESCRIPTION
Contributes to #4357 

In order to remove the color contrast violation that the accessibility checker was flagging, we have to explicitly set the color on the link/button element. We set the color for the `:visited` state of the link but not on the default state (even though it appears to always default to the `:visited` state which is why visually it looks correct), however, my guess is the accessibility checker is comparing the default state of the link against the background.

#### What did you change?
`_tag-set.scss`
Snapshot update
#### How did you test and verify your work?
Storybook with accessibility checker