### PR TITLE
fix(Datagrid): restrict drag to y axis and parent element

### DIFF
--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -93,6 +93,7 @@
     "@carbon/ibm-products-styles": "^2.28.0",
     "@carbon/telemetry": "^0.1.0",
     "@dnd-kit/core": "^6.0.8",
+    "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@ibm/telemetry-js": "^1.2.0",

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
@@ -11,6 +11,7 @@ import { Checkbox } from '@carbon/react';
 import { isColumnVisible } from './common';
 import DraggableElement from '../../DraggableElement';
 import { pkg } from '../../../../../settings';
+import { getNodeTextContent } from '../../../../../global/js/utils/getNodeTextContent';
 
 import {
   DndContext,
@@ -24,7 +25,10 @@ import {
   SortableContext,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import { getNodeTextContent } from '../../../../../global/js/utils/getNodeTextContent';
+import {
+  restrictToParentElement,
+  restrictToVerticalAxis,
+} from '@dnd-kit/modifiers';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 const matchedColsById = (col1, col2) => col1 && col2 && col1.id === col2.id;
@@ -181,6 +185,7 @@ export const DraggableItemsList = ({
       onDragStart={handleDragStart}
       onDragMove={handleDragUpdate}
       sensors={sensors}
+      modifiers={[restrictToParentElement, restrictToVerticalAxis]}
     >
       <>
         <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -2068,6 +2068,7 @@ __metadata:
     "@carbon/ibm-products-styles": "npm:^2.28.0"
     "@carbon/telemetry": "npm:^0.1.0"
     "@dnd-kit/core": "npm:^6.0.8"
+    "@dnd-kit/modifiers": "npm:^7.0.0"
     "@dnd-kit/sortable": "npm:^8.0.0"
     "@dnd-kit/utilities": "npm:^3.2.2"
     "@ibm/telemetry-js": "npm:^1.2.0"
@@ -2978,6 +2979,19 @@ __metadata:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
   checksum: cf9e99763fbd9220cb6fdde2950c19fdf6248391234f5ee835601814124445fd8a6e4b3f5bc35543c802d359db8cc47f07d87046577adc41952ae981a03fbda0
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/modifiers@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@dnd-kit/modifiers@npm:7.0.0"
+  dependencies:
+    "@dnd-kit/utilities": "npm:^3.2.2"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@dnd-kit/core": ^6.1.0
+    react: ">=16.8.0"
+  checksum: 9ee0b7b86c23c15f6820d76ec398724597abc9d9e31cf58836e7f0b9935e33f9136a60ee9600eb27818447623f07786d4fed3f1d685d9cc6d860d8f6c5354ae3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Contributes to #3833 

This restricts the drag when reordering columns to the y axis only and also prevents it from being dragged outside of the parent element.

fyi @My-Money29 

#### What did you change?
```
packages/ibm-products/package.json
packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
yarn.lock
```
#### How did you test and verify your work?
Storybook