### PR TITLE
fix(Datagrid): add missing borders to frozen header cells

### DIFF
--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -4051,6 +4051,11 @@ p.c4p--about-modal__copyright-text:first-child {
   position: sticky !important;
   z-index: 1;
   left: 0;
+  border-right: 1px solid var(--cds-layer-active-02, #c6c6c6);
+}
+
+.c4p--datagrid__right-sticky-column-header {
+  border-left: 1px solid var(--cds-layer-active-02, #c6c6c6);
 }
 
 .c4p--datagrid__left-sticky-column-cell.c4p--datagrid__left-sticky-column-cell--with-extra-select-column,

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_useStickyColumn.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_useStickyColumn.scss
@@ -41,6 +41,11 @@
   position: sticky !important;
   z-index: 1;
   left: 0;
+  border-right: 1px solid $layer-active-02;
+}
+
+.#{variables.$block-class}__right-sticky-column-header {
+  border-left: 1px solid $layer-active-02;
 }
 
 .#{variables.$block-class}__left-sticky-column-cell.#{variables.$block-class}__left-sticky-column-cell--with-extra-select-column,


### PR DESCRIPTION
Contributes to #4452 

The frozen column variant of the Datagrid had header cells that were missing borders if they were frozen. I've included them if it is a header cell that is sticky/frozen, see screenshot below:
![image](https://github.com/carbon-design-system/ibm-products/assets/10215203/f337421f-aacf-48d4-bd9c-23815ee0741c)


#### What did you change?
```
packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
packages/ibm-products-styles/src/components/Datagrid/styles/_useStickyColumn.scss
```
#### How did you test and verify your work?
Storybook