### PR TITLE
fix: about modal layout

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
     "@carbon/ibm-products-styles": "^2.28.0",
     "@carbon/layout": "^11.20.1",
     "@carbon/motion": "^11.16.1",
-    "@carbon/react": "^1.51.0",
+    "@carbon/react": "^1.51.1",
     "@carbon/storybook-addon-theme": "^2.0.7",
     "@carbon/themes": "^11.32.0",
     "@carbon/type": "^11.25.1",

--- a/packages/ibm-products-community/package.json
+++ b/packages/ibm-products-community/package.json
@@ -27,7 +27,7 @@
     "@carbon/grid": "^11.21.1",
     "@carbon/layout": "^11.20.1",
     "@carbon/motion": "^11.16.1",
-    "@carbon/react": "^1.51.0",
+    "@carbon/react": "^1.51.1",
     "@carbon/themes": "^11.32.0",
     "@carbon/type": "^11.25.1",
     "react": "^18.2.0",

--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -30,9 +30,13 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   letter-spacing: var(--cds-body-compact-02-letter-spacing, 0);
   overflow: hidden auto;
   min-height: 4rem;
-  padding: 0 20% 0 1rem;
-  margin-bottom: 1.5rem;
   grid-row: auto;
+  padding-block-start: 0;
+  padding-inline: 1rem 20%;
+}
+.c4p--about-modal .c4p--about-modal__body:not(.cds--modal-scroll-content) {
+  margin-bottom: 1.5rem;
+  padding-block-end: 0;
 }
 
 .c4p--about-modal .cds--modal-content--overflow-indicator {
@@ -4326,7 +4330,7 @@ p.c4p--about-modal__copyright-text:first-child {
   position: relative;
   z-index: 0;
   overflow: auto;
-  padding: 0 1rem;
+  padding: 0 1rem 4rem 1rem;
   overscroll-behavior: contain;
 }
 

--- a/packages/ibm-products-styles/src/components/AboutModal/_about-modal.scss
+++ b/packages/ibm-products-styles/src/components/AboutModal/_about-modal.scss
@@ -41,9 +41,14 @@ $block-class: #{c4p-settings.$pkg-prefix}--about-modal;
 
   overflow: hidden auto;
   min-height: $spacing-10;
-  padding: 0 20% 0 $spacing-05;
-  margin-bottom: $spacing-06;
   grid-row: auto;
+  padding-block-start: 0;
+  padding-inline: $spacing-05 20%;
+
+  &:not(.#{c4p-settings.$carbon-prefix}--modal-scroll-content) {
+    margin-bottom: $spacing-06;
+    padding-block-end: 0;
+  }
 }
 
 .#{$block-class}

--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -107,7 +107,7 @@
     "@carbon/grid": "^11.21.1",
     "@carbon/layout": "^11.20.1",
     "@carbon/motion": "^11.16.1",
-    "@carbon/react": "^1.51.0",
+    "@carbon/react": "^1.51.1",
     "@carbon/themes": "^11.32.0",
     "@carbon/type": "^11.25.1",
     "react": "^16.8.6 || ^17.0.1 || ^18.2.0",

--- a/packages/ibm-products/src/components/AboutModal/AboutModal.stories.js
+++ b/packages/ibm-products/src/components/AboutModal/AboutModal.stories.js
@@ -211,7 +211,9 @@ export const aboutModal = prepareStory(
   {
     storyName: aboutModalStoryName,
     args: {
-      title: 0,
+      title: 2,
+      links: 0,
+      content: 0,
       additionalInfo: 0,
       ...commonArgs,
     },

--- a/packages/ibm-products/src/components/AboutModal/AboutModal.tsx
+++ b/packages/ibm-products/src/components/AboutModal/AboutModal.tsx
@@ -14,7 +14,7 @@ import {
   Theme,
 } from '@carbon/react';
 // Import portions of React that are needed.
-import React, { ReactNode, useEffect, useRef, useState } from 'react';
+import React, { ReactNode, useEffect, useRef } from 'react';
 
 // Other standard imports.
 import PropTypes from 'prop-types';
@@ -22,7 +22,6 @@ import cx from 'classnames';
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { pkg } from '../../settings';
 import { usePortalTarget } from '../../global/js/hooks/usePortalTarget';
-import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 import uuidv4 from '../../global/js/utils/uuidv4';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
@@ -141,20 +140,11 @@ export let AboutModal = React.forwardRef(
     const contentId = uuidv4();
     const renderPortalUse = usePortalTarget(portalTargetIn);
 
-    const handleResize = () => {
-      if (!bodyRef.current?.clientHeight) {
-        return;
-      }
-    };
-
     // We can't add a ref directly to the ModalBody, so track it in a ref
     // as the parent of the current bodyRef element
     useEffect(() => {
       bodyRef.current = contentRef.current?.parentElement;
     }, [bodyRef]);
-
-    // Detect resize of the ModalBody to recalculate whether scrolling is enabled
-    useResizeObserver(bodyRef, handleResize);
 
     return renderPortalUse(
       <ComposedModal

--- a/packages/ibm-products/src/components/AboutModal/AboutModal.tsx
+++ b/packages/ibm-products/src/components/AboutModal/AboutModal.tsx
@@ -136,7 +136,6 @@ export let AboutModal = React.forwardRef(
     }: AboutModalProps,
     ref: React.Ref<HTMLDivElement>
   ) => {
-    const [hasScrollingContent, setHasScrollingContent] = useState(true);
     const bodyRef = useRef<HTMLElement | null | undefined>(null);
     const contentRef = useRef<HTMLDivElement>(null);
     const contentId = uuidv4();
@@ -146,14 +145,6 @@ export let AboutModal = React.forwardRef(
       if (!bodyRef.current?.clientHeight) {
         return;
       }
-      setHasScrollingContent(
-        // if our scroll height exceeds the client height enable scrolling
-        bodyRef.current?.clientHeight <
-          (hasScrollingContent
-            ? // Carbon modal adds 32px bottom margin when scrolling content is enabled
-              bodyRef.current?.scrollHeight - 32
-            : bodyRef.current?.scrollHeight)
-      );
     };
 
     // We can't add a ref directly to the ModalBody, so track it in a ref
@@ -187,10 +178,7 @@ export let AboutModal = React.forwardRef(
           labelClassName={`${blockClass}__title`}
         />
         <ModalBody
-          aria-label={hasScrollingContent ? '' : undefined}
-          aria-labelledby={hasScrollingContent ? contentId : undefined}
           className={`${blockClass}__body`}
-          hasScrollingContent={hasScrollingContent}
         >
           <div
             className={`${blockClass}__body-content`}

--- a/scripts/example-gallery-builder/update-example/templates-react-16/package.json
+++ b/scripts/example-gallery-builder/update-example/templates-react-16/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@carbon/ibm-products": "^2.21.0",
-    "@carbon/react": "^1.51.0",
+    "@carbon/react": "^1.51.1",
     "lodash": "^4.17.21",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",

--- a/scripts/example-gallery-builder/update-example/templates-react-17/package.json
+++ b/scripts/example-gallery-builder/update-example/templates-react-17/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@carbon/ibm-products": "^2.21.0",
-    "@carbon/react": "^1.51.0",
+    "@carbon/react": "^1.51.1",
     "lodash": "^4.17.21",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/scripts/example-gallery-builder/update-example/templates/package.json
+++ b/scripts/example-gallery-builder/update-example/templates/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@carbon/ibm-products": "^2.21.0",
-    "@carbon/react": "^1.51.0",
+    "@carbon/react": "^1.51.1",
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1958,7 +1958,7 @@ __metadata:
     "@carbon/ibm-products-styles": "npm:^2.28.0"
     "@carbon/layout": "npm:^11.20.1"
     "@carbon/motion": "npm:^11.16.1"
-    "@carbon/react": "npm:^1.51.0"
+    "@carbon/react": "npm:^1.51.1"
     "@carbon/storybook-addon-theme": "npm:^2.0.7"
     "@carbon/themes": "npm:^11.32.0"
     "@carbon/type": "npm:^11.25.1"
@@ -2018,7 +2018,7 @@ __metadata:
     "@carbon/grid": ^11.21.1
     "@carbon/layout": ^11.20.1
     "@carbon/motion": ^11.16.1
-    "@carbon/react": ^1.51.0
+    "@carbon/react": ^1.51.1
     "@carbon/themes": ^11.32.0
     "@carbon/type": ^11.25.1
     react: ^18.2.0
@@ -2106,7 +2106,7 @@ __metadata:
     "@carbon/grid": ^11.21.1
     "@carbon/layout": ^11.20.1
     "@carbon/motion": ^11.16.1
-    "@carbon/react": ^1.51.0
+    "@carbon/react": ^1.51.1
     "@carbon/themes": ^11.32.0
     "@carbon/type": ^11.25.1
     react: ^16.8.6 || ^17.0.1 || ^18.2.0
@@ -2148,15 +2148,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/react@npm:^1.51.0":
-  version: 1.51.0
-  resolution: "@carbon/react@npm:1.51.0"
+"@carbon/react@npm:^1.51.1":
+  version: 1.51.1
+  resolution: "@carbon/react@npm:1.51.1"
   dependencies:
     "@babel/runtime": "npm:^7.18.3"
     "@carbon/feature-flags": "npm:^0.16.0"
     "@carbon/icons-react": "npm:^11.36.0"
     "@carbon/layout": "npm:^11.20.0"
-    "@carbon/styles": "npm:^1.51.0"
+    "@carbon/styles": "npm:^1.51.1"
     "@ibm/telemetry-js": "npm:^1.2.0"
     classnames: "npm:2.5.1"
     copy-to-clipboard: "npm:^3.3.1"
@@ -2177,7 +2177,7 @@ __metadata:
     react: ^16.8.6 || ^17.0.1 || ^18.2.0
     react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0
     sass: ^1.33.0
-  checksum: b11073772f8a3b5754d0617400781217da60ba82f48c1efe28f219c7fcac3d14709229f4621355d78949b684529f2a575b169715965873d71bf0b294acb3a37d
+  checksum: c7fc8a0047b8863c91b062496b4f63fa6ee95f8738c8b75690188e7c402ff5e72522e7e681d4f200e81025a8c0b434bf3f1eabc32c2d75b10a8a2694765a0f7e
   languageName: node
   linkType: hard
 
@@ -2206,9 +2206,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/styles@npm:^1.51.0":
-  version: 1.51.0
-  resolution: "@carbon/styles@npm:1.51.0"
+"@carbon/styles@npm:^1.51.1":
+  version: 1.51.1
+  resolution: "@carbon/styles@npm:1.51.1"
   dependencies:
     "@carbon/colors": "npm:^11.20.0"
     "@carbon/feature-flags": "npm:^0.16.0"
@@ -2223,7 +2223,7 @@ __metadata:
   peerDependenciesMeta:
     sass:
       optional: true
-  checksum: 39f9e56f192c1458a8ba11e2c0c0b58fe1b09e7212adfcc00b61fb270578949979c4ce4b8166193a5489ae347a0558855dae27f47ca0a7a09367cda94aa16fc0
+  checksum: a8078f31bf43b52e615b7e732fc6b8043b28fa0a3fabaf4835ea7976f43ac3c191b7b96ea5a829af4ebcf3df564be144497d0bac14cf61c6342b5e061ebc5bed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #4445 and contributes to #4359 

#### What did you change?
- Updates `@carbon/react` to 1.51.1, which fixes custom class on modal body.
- Removes redundant `hasScrollingContent` code
- Fixes about modal spacing with or without scroll gradient
  - Also uses CSS logical properties in about modal body 🤷‍♀️ 
- Sets defaults in about modal story

#### How did you test and verify your work?
Storybook and CI checks