### PR TITLE
fix(Datagrid): invalid selectDisabled prop

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useDisableSelectRows.js
+++ b/packages/ibm-products/src/components/Datagrid/useDisableSelectRows.js
@@ -13,7 +13,7 @@ const useDisableSelectRows = (hooks) => {
   const getRowProps = (props, { row, instance }) => [
     props,
     {
-      selectDisabled:
+      disabled:
         instance.shouldDisableSelectRow && instance.shouldDisableSelectRow(row),
     },
   ];

--- a/packages/ibm-products/src/components/Datagrid/useSelectRows.js
+++ b/packages/ibm-products/src/components/Datagrid/useSelectRows.js
@@ -100,7 +100,7 @@ const SelectRow = (datagridState) => {
     return () => window.removeEventListener('resize', updateSize);
   }, []);
 
-  const selectDisabled = isFetching || row.getRowProps().selectDisabled;
+  const selectDisabled = isFetching || row.getRowProps().disabled;
   const { onChange, title, ...selectProps } = row.getToggleRowSelectedProps();
   const cellProps = cell.getCellProps();
   const isFirstColumnStickyLeft =


### PR DESCRIPTION
Contributes to #4198

Fixes a console warning in Storybook.

See also #3666 for more details when this was fixed in `v2`.

#### What did you change?

`getRowProps()`: renamed property `selectDisabled` to `disabled`.

```
packages/ibm-products/src/components/Datagrid/useDisableSelectRows.js
packages/ibm-products/src/components/Datagrid/useSelectRows.js
```

#### How did you test and verify your work?

- [x] Verified error no longer appeared in Storybook's browser console.