### PR TITLE
docs(Datagrid): include multiselect and slug docs

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Filtering.docs-page.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Filtering.docs-page.js
@@ -309,6 +309,24 @@ const filters = [
       },
     },
   },
+  {
+    type: 'multiSelect',
+    column: 'status',
+    props: {
+      MultiSelect: {
+        items: [
+          { text: 'relationship', id: 'relationship' },
+          { text: 'complicated', id: 'complicated' },
+          { text: 'single', id: 'single' },
+        ],
+        id: 'carbon-multiselect-example',
+        label: 'Status selection',
+        titleText: 'Multiselect title',
+        itemToString: (item) => (item ? item.text : ''),
+        // Add any other Carbon MultiSelect props here
+      },
+    },
+  },
 ];
           `,
         },

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Slug/Slug.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Slug/Slug.stories.js
@@ -42,7 +42,48 @@ export default {
   parameters: {
     styles,
     docs: {
-      page: () => <StoryDocsPage blocks={[]} />,
+      page: () => (
+        <StoryDocsPage
+          blocks={[
+            {
+              description:
+                "A Carbon AI slug can be used within the Datagrid for both column headers and rows. To include a column header AI slug, include a `slug` property within your column definition and include the Slug component as it's own custom component",
+              source: {
+                code: `
+{
+  Header: 'Visits',
+  accessor: 'visits',
+  slug: <ExampleSlug />,
+}
+`,
+              },
+            },
+            {
+              description: 'or used directly from the Slug component itself',
+              source: {
+                code: `
+{
+  Header: 'Visits',
+  accessor: 'visits',
+  slug: (
+    <Slug className="slug-container" autoAlign={false} align="bottom-right">
+      <SlugContent>
+        ...
+        ...
+      </SlugContent>
+    </Slug>
+  ),
+}           
+`,
+              },
+            },
+            {
+              description:
+                'To include a slug on the row level, include a `slug` property in your row data with the same structure as outlined above.',
+            },
+          ]}
+        />
+      ),
     },
     layout: 'fullscreen',
   },


### PR DESCRIPTION
Contributes to https://github.com/carbon-design-system/ibm-products/issues/4431

Adds some missing docs for multi select filter type and AI slug usage in Datagrid.

