### PR TITLE
docs(Datagrid): add docs around specifics of batch actions

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.docs-page.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.docs-page.js
@@ -417,6 +417,30 @@ return <Datagrid datagridState={datagridState} />;
         },
       },
       {
+        description: `Batch actions can be included by providing \`batchActions: true\` and \`toolbarBatchActions: CarbonButtonProps[]\` to the \`useDatagrid\` hook. While passing in a \`DatagridBatchActions\` component will also work it does not have some of the same responsive behavior built-in, thus it is not the recommended approach, as compared to using the \`batchActions\` and \`toolbarBatchActions\` properties.`,
+        source: {
+          code: `
+export const SelectableRowWithBatchActions = () => {
+  const [data] = useState(makeData(10));
+  const columns = React.useMemo(() => getColumns(data), []);
+  const datagridState = useDatagrid(
+    {
+      columns,
+      data,
+      DatagridActions,
+      batchActions: true,
+      toolbarBatchActions: getBatchActions(),
+      onRowSelect: (row, event) => console.log(row, event),
+    },
+    useSelectRows
+  );
+
+  return <Datagrid datagridState={datagridState} />;
+};
+`,
+        },
+      },
+      {
         title: 'Sortable columns',
         description: `To add sortable columns to your Datagrid, simply add the \`useSortableColumns\` hook. This will allow each column header to be clickable and sort each column in either ascending or descending order.
 - Include \`useSortableColumns\` hook

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.docs-page.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.docs-page.js
@@ -417,7 +417,7 @@ return <Datagrid datagridState={datagridState} />;
         },
       },
       {
-        description: `Batch actions can be included by providing \`batchActions: true\` and \`toolbarBatchActions: CarbonButtonProps[]\` to the \`useDatagrid\` hook. While passing in a \`DatagridBatchActions\` component will also work it does not have some of the same responsive behavior built-in, thus it is not the recommended approach, as compared to using the \`batchActions\` and \`toolbarBatchActions\` properties.`,
+        description: `Batch actions can be included by providing \`batchActions: true\` and \`toolbarBatchActions: CarbonButtonProps[]\` to the \`useDatagrid\` hook. While passing in a \`DatagridBatchActions\` component will also work, it does not have the same responsive behavior built-in, thus we recommend using the \`batchActions\` and \`toolbarBatchActions\` properties when possible.`,
         source: {
           code: `
 export const SelectableRowWithBatchActions = () => {


### PR DESCRIPTION
Contributes to #3803 

Adds clarifying docs regarding batch actions in Datagrid.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid.docs-page.js
```
#### How did you test and verify your work?
Storybook, Datagrid docs page