### PR TITLE
fix: update story for selectable row

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
@@ -298,6 +298,8 @@ export const SelectableRow = () => {
       emptyStateTitle,
       emptyStateDescription,
       onRowSelect: (row, event) => console.log(row, event),
+      endPlugins: [useDisableSelectRows],
+      shouldDisableSelectRow: (row) => row.id === '0',
     },
     useSelectRows,
     useStickyColumn


### PR DESCRIPTION
Contributes to #4059 

updates the selectable row story to demonstrate the new functionality to select all ignoring disabled rows
