### PR TITLE
fix(Tearsheet): prevent stacking visual cue with different sizes

### DIFF
--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -2771,19 +2771,19 @@ p.c4p--about-modal__copyright-text:first-child {
 .c4p--tearsheet.c4p--tearsheet.c4p--tearsheet .c4p--tearsheet__container {
   transition: transform 240ms cubic-bezier(0, 0, 0.3, 1), max-height 240ms cubic-bezier(0, 0, 0.3, 1);
 }
-.c4p--tearsheet.c4p--tearsheet--stacked-1-of-2 .c4p--tearsheet__container, .c4p--tearsheet.c4p--tearsheet--stacked-2-of-3 .c4p--tearsheet__container {
+.c4p--tearsheet.c4p--tearsheet--stacked-1-of-2 .c4p--tearsheet__container:not(.c4p--tearsheet__container--mixed-size-stacking), .c4p--tearsheet.c4p--tearsheet--stacked-2-of-3 .c4p--tearsheet__container:not(.c4p--tearsheet__container--mixed-size-stacking) {
   max-height: calc(100% - 3rem + 1rem);
 }
-.c4p--tearsheet.c4p--tearsheet--stacked-1-of-3 .c4p--tearsheet__container {
+.c4p--tearsheet.c4p--tearsheet--stacked-1-of-3 .c4p--tearsheet__container:not(.c4p--tearsheet__container--mixed-size-stacking) {
   max-height: calc(100% - 3rem + 2 * 1rem);
 }
 .c4p--tearsheet .c4p--tearsheet__container--lower {
   max-height: calc(100% - (3rem + 2.5rem));
 }
-.c4p--tearsheet.c4p--tearsheet--stacked-1-of-2 .c4p--tearsheet__container--lower, .c4p--tearsheet.c4p--tearsheet--stacked-2-of-3 .c4p--tearsheet__container--lower {
+.c4p--tearsheet.c4p--tearsheet--stacked-1-of-2 .c4p--tearsheet__container--lower:not(.c4p--tearsheet__container--mixed-size-stacking), .c4p--tearsheet.c4p--tearsheet--stacked-2-of-3 .c4p--tearsheet__container--lower:not(.c4p--tearsheet__container--mixed-size-stacking) {
   max-height: calc(100% - (3rem + 2.5rem) + 1rem);
 }
-.c4p--tearsheet.c4p--tearsheet--stacked-1-of-3 .c4p--tearsheet__container--lower {
+.c4p--tearsheet.c4p--tearsheet--stacked-1-of-3 .c4p--tearsheet__container--lower:not(.c4p--tearsheet__container--mixed-size-stacking) {
   max-height: calc(100% - (3rem + 2.5rem) + 2 * 1rem);
 }
 .c4p--tearsheet.c4p--tearsheet--wide .c4p--tearsheet__container {
@@ -3163,7 +3163,6 @@ p.c4p--about-modal__copyright-text:first-child {
   position: sticky;
   z-index: 1;
   left: 0;
-  background-color: var(--cds-layer-01, #f4f4f4);
 }
 .c4p--datagrid__grid-container table.c4p--datagrid__vertical-align-center .c4p--datagrid__cell {
   align-items: center;
@@ -3185,7 +3184,6 @@ p.c4p--about-modal__copyright-text:first-child {
 .c4p--datagrid__grid-container table.c4p--datagrid__vertical-align-center th.cds--table-column-checkbox.c4p--datagrid__checkbox-cell-sticky-left {
   position: sticky;
   left: 0;
-  background-color: var(--cds-layer-01, #f4f4f4);
 }
 .c4p--datagrid__grid-container table.c4p--datagrid__vertical-align-center .c4p--datagrid__checkbox-cell th.cds--table-column-checkbox {
   display: flex;
@@ -3365,6 +3363,18 @@ p.c4p--about-modal__copyright-text:first-child {
   /* stylelint-disable-next-line declaration-no-important */
   color: var(--cds-link-primary-hover, #0043ce) !important;
 }
+.c4p--datagrid__grid-container .c4p--datagrid__carbon-row td {
+  /* stylelint-disable-next-line declaration-no-important */
+  background-color: var(--cds-layer-01, #f4f4f4);
+}
+.c4p--datagrid__grid-container .c4p--datagrid__carbon-row:hover td {
+  /* stylelint-disable-next-line declaration-no-important */
+  background-color: var(--cds-layer-hover-01, #e8e8e8);
+}
+.c4p--datagrid__grid-container .cds--data-table--selected td {
+  /* stylelint-disable-next-line declaration-no-important */
+  background-color: var(--cds-layer-selected-01, #e0e0e0);
+}
 .c4p--datagrid__grid-container .cds--select-input {
   -webkit-appearance: none;
 }
@@ -3444,9 +3454,6 @@ p.c4p--about-modal__copyright-text:first-child {
   background-color: var(--cds-background-selected-hover, rgba(141, 141, 141, 0.32));
 }
 
-.c4p--datagrid__resizableColumn:hover {
-  background-color: var(--cds-layer-selected-hover);
-}
 .c4p--datagrid__resizableColumn:hover .c4p--datagrid__resizer {
   border-right: 0.125rem solid var(--cds-border-strong-01, #8d8d8d);
   background-color: var(--cds-background-selected-hover, rgba(141, 141, 141, 0.32));
@@ -4031,7 +4038,6 @@ p.c4p--about-modal__copyright-text:first-child {
   display: flex;
   align-items: center;
   border-left: 1px solid var(--cds-layer-active-02, #c6c6c6);
-  background-color: var(--cds-layer-01, #f4f4f4);
 }
 
 .c4p--datagrid__right-sticky-column-header {
@@ -4047,7 +4053,6 @@ p.c4p--about-modal__copyright-text:first-child {
   display: flex;
   align-items: center;
   border-right: 1px solid var(--cds-layer-active-02, #c6c6c6);
-  background-color: var(--cds-layer-01, #f4f4f4);
 }
 
 .c4p--datagrid__left-sticky-column-header {

--- a/packages/ibm-products-styles/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/ibm-products-styles/src/components/Tearsheet/_tearsheet.scss
@@ -131,12 +131,21 @@ $motion-duration: $duration-moderate-02;
       max-height $motion-duration motion(entrance, expressive);
   }
 
-  &.#{$block-class}--stacked-1-of-2 .#{$block-class}__container,
-  &.#{$block-class}--stacked-2-of-3 .#{$block-class}__container {
+  &.#{$block-class}--stacked-1-of-2
+    .#{$block-class}__container:not(
+      .#{$block-class}__container--mixed-size-stacking
+    ),
+  &.#{$block-class}--stacked-2-of-3
+    .#{$block-class}__container:not(
+      .#{$block-class}__container--mixed-size-stacking
+    ) {
     max-height: calc(100% - #{$spacing-09} + #{$spacing-05});
   }
 
-  &.#{$block-class}--stacked-1-of-3 .#{$block-class}__container {
+  &.#{$block-class}--stacked-1-of-3
+    .#{$block-class}__container:not(
+      .#{$block-class}__container--mixed-size-stacking
+    ) {
     max-height: calc(100% - #{$spacing-09} + (2 * #{$spacing-05}));
   }
 
@@ -144,12 +153,21 @@ $motion-duration: $duration-moderate-02;
     max-height: calc(100% - (#{$spacing-09} + #{$spacing-08}));
   }
 
-  &.#{$block-class}--stacked-1-of-2 .#{$block-class}__container--lower,
-  &.#{$block-class}--stacked-2-of-3 .#{$block-class}__container--lower {
+  &.#{$block-class}--stacked-1-of-2
+    .#{$block-class}__container--lower:not(
+      .#{$block-class}__container--mixed-size-stacking
+    ),
+  &.#{$block-class}--stacked-2-of-3
+    .#{$block-class}__container--lower:not(
+      .#{$block-class}__container--mixed-size-stacking
+    ) {
     max-height: calc(100% - (#{$spacing-09} + #{$spacing-08}) + #{$spacing-05});
   }
 
-  &.#{$block-class}--stacked-1-of-3 .#{$block-class}__container--lower {
+  &.#{$block-class}--stacked-1-of-3
+    .#{$block-class}__container--lower:not(
+      .#{$block-class}__container--mixed-size-stacking
+    ) {
     max-height: calc(
       100% - (#{$spacing-09} + #{$spacing-08}) + (2 * #{$spacing-05})
     );

--- a/packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.js
+++ b/packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.js
@@ -39,6 +39,7 @@ import {
 } from '../../global/js/utils/story-helper';
 
 import styles from './_storybook-styles.scss';
+import { TearsheetNarrow } from './TearsheetNarrow';
 
 // import mdx from './Tearsheet.mdx';
 
@@ -236,7 +237,7 @@ const Template = ({ actions, slug, ...args }) => {
 };
 
 // eslint-disable-next-line react/prop-types
-const StackedTemplate = ({ actions, slug, ...args }) => {
+const StackedTemplate = ({ mixedSizes, actions, slug, ...args }) => {
   const [open1, setOpen1] = useState(false);
   const [open2, setOpen2] = useState(false);
   const [open3, setOpen3] = useState(false);
@@ -284,6 +285,8 @@ const StackedTemplate = ({ actions, slug, ...args }) => {
     return action;
   });
 
+  const VariableSizeTearsheet = mixedSizes ? TearsheetNarrow : Tearsheet;
+
   return (
     <>
       <style>{`.${pkg.prefix}--tearsheet { opacity: 0 }`};</style>
@@ -303,9 +306,11 @@ const StackedTemplate = ({ actions, slug, ...args }) => {
         <Button onClick={() => setOpen2(!open2)}>
           Toggle&nbsp;tearsheet&nbsp;2
         </Button>
-        <Button onClick={() => setOpen3(!open3)}>
-          Toggle&nbsp;tearsheet&nbsp;3
-        </Button>
+        {!mixedSizes && (
+          <Button onClick={() => setOpen3(!open3)}>
+            Toggle&nbsp;tearsheet&nbsp;3
+          </Button>
+        )}
       </ButtonSet>
       <div ref={ref}>
         <Tearsheet
@@ -338,7 +343,7 @@ const StackedTemplate = ({ actions, slug, ...args }) => {
             />
           </div>
         </Tearsheet>
-        <Tearsheet
+        <VariableSizeTearsheet
           {...args}
           actions={wiredActions2}
           headerActions={
@@ -367,24 +372,26 @@ const StackedTemplate = ({ actions, slug, ...args }) => {
               labelText="Enter an important value here"
             />
           </div>
-        </Tearsheet>
-        <Tearsheet
-          {...args}
-          actions={wiredActions3}
-          title="Tearsheet 3"
-          open={open3}
-          onClose={() => setOpen3(false)}
-          selectorPrimaryFocus="#stacked-input-3"
-          slug={slug && sampleSlug}
-        >
-          <div className="tearsheet-stories__dummy-content-block">
-            Main content 3
-            <TextInput
-              id="stacked-input-3"
-              labelText="Enter an important value here"
-            />
-          </div>
-        </Tearsheet>
+        </VariableSizeTearsheet>
+        {!mixedSizes && (
+          <Tearsheet
+            {...args}
+            actions={wiredActions3}
+            title="Tearsheet 3"
+            open={open3}
+            onClose={() => setOpen3(false)}
+            selectorPrimaryFocus="#stacked-input-3"
+            slug={slug && sampleSlug}
+          >
+            <div className="tearsheet-stories__dummy-content-block">
+              Main content 3
+              <TextInput
+                id="stacked-input-3"
+                labelText="Enter an important value here"
+              />
+            </div>
+          </Tearsheet>
+        )}
       </div>
     </>
   );
@@ -453,6 +460,19 @@ export const fullyLoaded = prepareStory(Template, {
 export const stacked = prepareStory(StackedTemplate, {
   storyName: 'Stacking tearsheets',
   args: {
+    closeIconDescription,
+    description,
+    height: 'lower',
+    influencer,
+    label,
+    actions: 7,
+  },
+});
+
+export const stackedMixedSizes = prepareStory(StackedTemplate, {
+  storyName: 'Stacking tearsheets, different sizes',
+  args: {
+    mixedSizes: true,
     closeIconDescription,
     description,
     height: 'lower',

--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.js
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.js
@@ -44,7 +44,10 @@ const maxDepth = 3;
 // happens when a tearsheet opens or closes. The 'open' array contains one
 // handler per OPEN tearsheet ordered from lowest to highest in visual z-order.
 // The 'all' array contains all the handlers for open and closed tearsheets.
-const stack = { open: [], all: [] };
+// The 'sizes' array contains an array of the sizes for every stacked tearsheet.
+// This is so we can opt-out of including the stacking scale effect when there
+// are stacked tearsheets with mixed sizes (ie, using wide and narrow together)
+const stack = { open: [], all: [], sizes: [] };
 
 // these props are only applicable when size='wide'
 export const tearsheetShellWideProps = [
@@ -167,6 +170,7 @@ export const TearsheetShell = React.forwardRef(
 
       // Register this tearsheet's stack change callback/listener.
       stack.all.push(handleStackChange);
+      stack.sizes.push(size);
 
       // If the tearsheet is mounting with open=true or open is changing from
       // false to true to open it then append its notification callback to
@@ -183,6 +187,7 @@ export const TearsheetShell = React.forwardRef(
       return function cleanup() {
         // Remove the notification callback from the all handlers array.
         stack.all.splice(stack.all.indexOf(handleStackChange), 1);
+        stack.sizes.splice(stack.sizes.indexOf(size), 1);
 
         // Remove the notification callback from the open handlers array, if
         // it's there, and notify all open tearsheets that the stacking has
@@ -193,7 +198,7 @@ export const TearsheetShell = React.forwardRef(
           notify();
         }
       };
-    }, [open]);
+    }, [open, size]);
 
     function handleFocus() {
       // If something within us is receiving focus but we are not the topmost
@@ -218,6 +223,21 @@ export const TearsheetShell = React.forwardRef(
       // Include an ActionSet if and only if one or more actions is given.
       const includeActions = actions && actions?.length > 0;
 
+      const areAllSameSizeVariant = () => new Set(stack.sizes).size === 1;
+
+      const setScaleValues = () => {
+        if (!areAllSameSizeVariant()) {
+          return {
+            [`--${bc}--stacking-scale-factor-single`]: 1,
+            [`--${bc}--stacking-scale-factor-double`]: 1,
+          };
+        }
+        return {
+          [`--${bc}--stacking-scale-factor-single`]: (width - 32) / width,
+          [`--${bc}--stacking-scale-factor-double`]: (width - 64) / width,
+        };
+      };
+
       return renderPortalUse(
         <ComposedModal
           {
@@ -235,12 +255,10 @@ export const TearsheetShell = React.forwardRef(
             [`${bc}--has-close`]: effectiveHasCloseIcon,
           })}
           slug={slug}
-          style={{
-            [`--${bc}--stacking-scale-factor-single`]: (width - 32) / width,
-            [`--${bc}--stacking-scale-factor-double`]: (width - 64) / width,
-          }}
+          style={setScaleValues()}
           containerClassName={cx(`${bc}__container`, {
             [`${bc}__container--lower`]: verticalPosition === 'lower',
+            [`${bc}__container--mixed-size-stacking`]: !areAllSameSizeVariant(),
           })}
           {...{ onClose, open, selectorPrimaryFocus }}
           onFocus={handleFocus}


### PR DESCRIPTION
Contributes to #4066 

This change will prevent any stacking visual cue to tearsheets of different sizes. If the stacked tearsheets are all the same size, the behavior remains the same as it was before. However, if you now include a wide and a narrow, there is no scaling effect anymore.

#### What did you change?
```
packages/ibm-products-styles/src/components/Tearsheet/_tearsheet.scss
packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.js
packages/ibm-products/src/components/Tearsheet/TearsheetShell.js
```
#### How did you test and verify your work?
Storybook, added new stacking story