### PR TITLE
fix: remove sorting in custom column tearsheet

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
@@ -7,7 +7,6 @@
 
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { isColumnVisible } from './common';
 import { TearsheetNarrow } from '../../../../Tearsheet';
 import Columns from './Columns';
 import Actions from './Actions';
@@ -35,28 +34,14 @@ const CustomizeColumnsTearsheet = ({
   const [visibleColumnsCount, setVisibleColumnsCount] = useState('');
   const [totalColumns, setTotalColumns] = useState('');
   const [searchText, setSearchText] = useState('');
-  const [columnObjects, setColumnObjects] = useState(
-    columnDefinitions
-      // only sort the hidden column to the end when modal reopen
-      .sort((defA, defB) => {
-        const isVisibleA = isColumnVisible(defA);
-        const isVisibleB = isColumnVisible(defB);
-        if (isVisibleA && !isVisibleB) {
-          return -1;
-        }
-        if (!isVisibleA && isVisibleB) {
-          return 1;
-        }
-        return 0;
-      })
-  );
-
+  const [columnObjects, setColumnObjects] = useState(columnDefinitions);
   const [isDirty, setIsDirty] = useState(false);
 
   const onRequestClose = () => {
     setColumnObjects(columnDefinitions);
     setIsTearsheetOpen(false);
   };
+
   const onRequestSubmit = () => {
     setIsTearsheetOpen(false);
     const updatedColumns = columnObjects.map((colDef) => ({


### PR DESCRIPTION
Contributes to #4379 

now when customize column tearsheet is opened it won't sort the hidden columns to the bottom.