### PR TITLE
chore: set yarn version in update action

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -79,6 +79,7 @@ jobs:
 
       - name: Update packages
         run: |
+          yarn set version latest
           yarn upgrade:automatic
           rm yarn.lock
           yarn

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "//upgrade:dependencies:top": "# don't upgrade carbon (done globally), react/react-dom (not tested)",
     "upgrade:dependencies:top": "npm-check-updates -u --dep dev,peer,prod --reject '/(carbon|^react$|^react-dom$|^@testing-library)/'",
     "upgrade:dependencies:packages": "yarn run-all --no-sort --concurrency 1 upgrade-dependencies",
-    "upgrade:dependencies:yarn": "yarn set version latest",
     "upgrade:dependencies:examples": "npm-check-updates -u --dep dev,peer,prod --color --target minor --packageFile 'scripts/example-gallery-builder/update-example/**/package.json'",
     "upgrade:automatic": "run-s -s 'upgrade:dependencies:*'",
     "upgrade:carbon": "npm-check-updates -u --dep dev,peer,prod --packageFile '{package.json,{config/**,packages/**}/package.json}' --filter '/carbon/' --target minor",


### PR DESCRIPTION
Contributes to #4219 

Set version fails as part of the update workflow.
Noticed that when we run `yarn set version latest` locally, this passes but as part of the `upgrade` scripts, it fails. Thought it was worth a shot to separate it out although this makes it harder to test the whole action locally. 🥲 

#### What did you change?
Removed `yarn upgrade:dependencies:yarn` from package.json and instead put a separate line within the update.yml action.

#### How did you test and verify your work?
🤫