### PR TITLE
fix(Datagrid): add optional chain to prevent errors with `disableResizing` (v1)

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.mdx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.mdx
@@ -201,7 +201,6 @@ useDatagrid({
   columns,
   data,
   disableResizing: true,
-  resizerAriaLabel: 'Resize column',
 });
 ```
 

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -97,7 +97,7 @@ export const DatagridContent = ({ ariaToolbarLabel, datagridState, title }) => {
             { [`${blockClass}__table-grid-active`]: gridActive },
             {
               [`${blockClass}__table-is-resizing`]:
-                typeof columnResizing.isResizingColumn === 'string',
+                typeof columnResizing?.isResizingColumn === 'string',
             },
             getTableProps()?.className
           )}


### PR DESCRIPTION
Issue brought up via slack, if `disableResizing` is passed to `useDatagrid` hook it can cause the app to crash. Adding an optional chain to the logic that adds the resizing class within `DatagridContent` fixes this. I also removed the aria label property in the docs example for disable resizing because it's not applicable if resizing is disabled.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid.mdx
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
```
#### How did you test and verify your work?
Storybook