### PR TITLE
refactor: flatten story structure and story titles (components section)

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -91,6 +91,7 @@
     "gridcell",
     "guidebanner",
     "haspopup",
+    "headshot",
     "homescreen",
     "inlineedit",
     "inlinetip",

--- a/packages/core/.storybook/manager.js
+++ b/packages/core/.storybook/manager.js
@@ -11,8 +11,39 @@ import { create } from '@storybook/theming/create';
 import React from 'react';
 
 import packageInfo from '../../ibm-products/package.json';
+import { checkCanaryStatus } from '../../ibm-products/src/global/js/utils/story-helper';
 
 const { description, version } = packageInfo;
+
+const renderComponentLabel = (label, dark, type = 'Canary') => {
+  return (
+    <div
+      style={{
+        flex: '1 0 auto',
+        display: 'flex',
+        alignItems: 'stretch',
+        justifyContent: 'space-between',
+      }}
+    >
+      {label}
+      <div
+        style={{
+          background: dark ? '#555555' : '#e0e0e0',
+          /* stylelint-disable-next-line carbon/type-token-use */
+          fontSize: '11px',
+          border: '.1px solid transparent',
+          /* stylelint-disable-next-line carbon/layout-token-use */
+          padding: '0 .5rem',
+          /* stylelint-disable-next-line carbon/layout-token-use */
+          margin: '0 .5em',
+          borderRadius: '8px',
+        }}
+      >
+        {type}
+      </div>
+    </div>
+  );
+};
 
 addons.setConfig({
   theme: create({
@@ -21,74 +52,17 @@ addons.setConfig({
 
   sidebar: {
     renderLabel: (item) => {
-      const parts = item.name.split('#');
+      const isUnstable = !!(
+        item.type === 'component' && checkCanaryStatus(item.name)
+      );
       const dark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-
-      switch (parts[1]) {
-        // if the name has #canary then render a 'Canary' tag on the right
-        case 'canary':
-          return (
-            <div
-              style={{
-                flex: '1 0 auto',
-                display: 'flex',
-                alignItems: 'stretch',
-                justifyContent: 'space-between',
-              }}
-            >
-              {parts[0]}
-              <div
-                style={{
-                  background: dark ? '#555555' : '#e0e0e0',
-                  /* stylelint-disable-next-line carbon/type-token-use */
-                  fontSize: '11px',
-                  border: '.1px solid transparent',
-                  /* stylelint-disable-next-line carbon/layout-token-use */
-                  padding: '0 .5rem',
-                  /* stylelint-disable-next-line carbon/layout-token-use */
-                  margin: '0 .5em',
-                  borderRadius: '8px',
-                }}
-              >
-                Canary
-              </div>
-            </div>
-          );
-
-        // if the name has #legacy then render a 'Legacy' tag on the right
-        case 'legacy':
-          return (
-            <div
-              style={{
-                flex: '1 0 auto',
-                display: 'flex',
-                alignItems: 'stretch',
-                justifyContent: 'space-between',
-              }}
-            >
-              {parts[0]}
-              <div
-                style={{
-                  background: dark ? '#3a3a3a' : '#eeeeee',
-                  /* stylelint-disable-next-line carbon/type-token-use */
-                  fontSize: '11px',
-                  border: '.1px solid transparent',
-                  /* stylelint-disable-next-line carbon/layout-token-use */
-                  padding: '0 .5rem',
-                  /* stylelint-disable-next-line carbon/layout-token-use */
-                  margin: '0 .5em',
-                  borderRadius: '8px',
-                }}
-              >
-                Legacy
-              </div>
-            </div>
-          );
-
-        // if the name doesn't have a recognized # label, just render the name
-        default:
-          return parts[0];
+      if (isUnstable) {
+        // Canary tag is applied if `item.name` (`displayName` of the component) is confirmed
+        // to be canary/not yet released via the checkCanaryStatus utility
+        return renderComponentLabel(item.name, dark);
       }
+
+      return item.name;
     },
   },
 });

--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -122,6 +122,7 @@ const parameters = {
       method: 'alphabetical',
       order: [
         'Overview',
+        ['Welcome', 'Getting started', 'Examples', '*'],
         'IBM Products',
         ['Components', 'Patterns', 'Internal', 'Novice to pro'],
         'Community',

--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -118,19 +118,14 @@ const parameters = {
   layout: 'centered',
   options: {
     showPanel: true,
-    storySort: (a, b) => {
-      const aPosition = getSectionSequence(a[1].kind);
-      const bPosition = getSectionSequence(b[1].kind);
-
-      return aPosition !== bPosition
-        ? // if stories have different positions in the structure, sort by that
-          aPosition - bPosition
-        : a[1].kind === b[1].kind
-        ? // if they have the same kind, use their sequence numbers
-          (a[1]?.parameters?.ccsSettings?.sequence || 0) -
-          (b[1]?.parameters?.ccsSettings?.sequence || 0)
-        : // they must both be unrecognized: fall back to sorting by id (slug)
-          a[1].id.localeCompare(b[1].id, undefined, { numeric: true });
+    storySort: {
+      method: 'alphabetical',
+      order: [
+        'Overview',
+        'IBM Products',
+        ['Components', 'Patterns', 'Internal', 'Novice to pro'],
+        'Community',
+      ],
     },
   },
 

--- a/packages/ibm-products/scripts/generate/templates/DISPLAY_NAME.stories.js
+++ b/packages/ibm-products/scripts/generate/templates/DISPLAY_NAME.stories.js
@@ -20,7 +20,7 @@ import mdx from './DISPLAY_NAME.mdx';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: getStoryTitle(DISPLAY_NAME.displayName),
+  title: `IBM Products/Components/${DISPLAY_NAME}`,
   component: DISPLAY_NAME,
   tags: ['autodocs'],
   // TODO: Define argTypes for props not represented by standard JS types.

--- a/packages/ibm-products/src/components/BigNumbers/BigNumbers.mdx
+++ b/packages/ibm-products/src/components/BigNumbers/BigNumbers.mdx
@@ -1,8 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import {
-  getStoryId,
-  CodesandboxLink,
-} from '../../global/js/utils/story-helper';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import { BigNumbers } from '.';
 import * as BigNumbersStories from './BigNumbers.stories';
 

--- a/packages/ibm-products/src/components/BigNumbers/BigNumbers.mdx
+++ b/packages/ibm-products/src/components/BigNumbers/BigNumbers.mdx
@@ -4,6 +4,7 @@ import {
   CodesandboxLink,
 } from '../../global/js/utils/story-helper';
 import { BigNumbers } from '.';
+import * as BigNumbersStories from './BigNumbers.stories';
 
 # BigNumbers
 
@@ -32,13 +33,13 @@ of a button as well as tool tip functionality. The default locale is English
 ### Big numbers
 
 <Canvas>
-  <Story id={getStoryId(BigNumbers.displayName, 'big-numbers')} />
+  <Story of={BigNumbersStories.bigNumbers} />
 </Canvas>
 
 ### Big numbers with edit button
 
 <Canvas>
-  <Story id={getStoryId(BigNumbers.displayName, 'with-edit-button')} />
+  <Story of={BigNumbersStories.withEditButton} />
 </Canvas>
 
 ## Code sample

--- a/packages/ibm-products/src/components/BigNumbers/BigNumbers.stories.js
+++ b/packages/ibm-products/src/components/BigNumbers/BigNumbers.stories.js
@@ -6,14 +6,9 @@
  */
 
 import React from 'react';
-// TODO: import action to handle events if required.
-// import { action } from '@storybook/addon-actions';
 import { Button } from '@carbon/react';
 import { Edit } from '@carbon/react/icons';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { BigNumbers } from '.';
 import { BigNumbersSize } from './constants';
@@ -39,7 +34,7 @@ const numericOptions = {
 };
 
 export default {
-  title: getStoryTitle(BigNumbers.displayName),
+  title: 'IBM Products/Components/BigNumbers',
   component: BigNumbers,
   tags: ['autodocs'],
   // TODO: Define argTypes for props not represented by standard JS types.

--- a/packages/ibm-products/src/components/BigNumbers/BigNumbers.stories.js
+++ b/packages/ibm-products/src/components/BigNumbers/BigNumbers.stories.js
@@ -34,7 +34,7 @@ const numericOptions = {
 };
 
 export default {
-  title: 'IBM Products/Components/BigNumbers',
+  title: 'IBM Products/Components/Big numbers/BigNumbers',
   component: BigNumbers,
   tags: ['autodocs'],
   // TODO: Define argTypes for props not represented by standard JS types.

--- a/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheet.stories.js
+++ b/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheet.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,10 +7,7 @@
 
 import React, { useMemo, useState } from 'react';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { DataSpreadsheet } from '.';
 import { generateData } from './utils/generateData';
@@ -19,7 +16,7 @@ import { generateData } from './utils/generateData';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: getStoryTitle(DataSpreadsheet.displayName),
+  title: 'IBM Products/Components/DataSpreadsheet',
   component: DataSpreadsheet,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheet.stories.js
+++ b/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheet.stories.js
@@ -16,7 +16,7 @@ import { generateData } from './utils/generateData';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: 'IBM Products/Components/DataSpreadsheet',
+  title: 'IBM Products/Components/Data spreadsheet/DataSpreadsheet',
   component: DataSpreadsheet,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -8,7 +8,6 @@
 
 import React, { useState, useEffect } from 'react';
 import { makeData } from './utils/makeData';
-import { getStoryTitle } from '../../global/js/utils/story-helper';
 import { action } from '@storybook/addon-actions';
 import { Activity, Add } from '@carbon/react/icons';
 import { TableBatchAction, TableBatchActions } from '@carbon/react';
@@ -35,7 +34,7 @@ import { Wrapper } from './utils/Wrapper';
 import DocsPage from './Datagrid.docs-page';
 
 export default {
-  title: getStoryTitle(Datagrid.displayName),
+  title: 'IBM Products/Components/Datagrid',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,10 +9,7 @@
 import React, { useState } from 'react';
 import { Edit, TrashCan, Add } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../../global/js/utils/story-helper';
 import {
   Datagrid,
   useDatagrid,
@@ -34,7 +31,7 @@ import { SidePanel } from '../../../SidePanel';
 import { StoryDocsPage } from '../../../../global/js/utils/StoryDocsPage';
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/ClickableRow`,
+  title: 'IBM Products/Components/Datagrid/ClickableRow',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,10 +9,7 @@
 import React, { useState } from 'react';
 import { Checkmark, Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../../global/js/utils/story-helper';
 import {
   Datagrid,
   useDatagrid,
@@ -31,9 +28,7 @@ import { CodeSnippet } from '@carbon/react';
 import { pkg } from '../../../../settings';
 
 export default {
-  title: `${getStoryTitle(
-    Datagrid.displayName
-  )}/Extensions/ColumnCustomization`,
+  title: 'IBM Products/Components/Datagrid/ColumnCustomization',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/EditableCell/EditableCell.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/EditableCell/EditableCell.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,10 +9,7 @@
 import React, { useState } from 'react';
 import { Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../../global/js/utils/story-helper';
 import {
   Datagrid,
   useDatagrid,
@@ -30,7 +27,7 @@ const blockClass = `${pkg.prefix}--datagrid`;
 const storybookBlockClass = `storybook-${blockClass}__validation-code-snippet`;
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/EditableCell`,
+  title: 'IBM Products/Components/Datagrid/EditableCell',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
@@ -9,10 +9,7 @@
 import React, { useState } from 'react';
 import { Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../../global/js/utils/story-helper';
 import {
   Datagrid,
   useDatagrid,
@@ -30,7 +27,7 @@ import { DocsPage } from './ExpandableRow.docs-page';
 import { usePrefix } from '../../../../global/js/hooks';
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/ExpandableRow`,
+  title: 'IBM Products/Components/Datagrid/ExpandableRow',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
@@ -28,7 +28,7 @@ import { handleFilterTagLabelText } from '../../utils/handleFilterTagLabelText';
 import { getDateFormat, multiSelectProps } from './Panel.stories';
 
 export default {
-  title: 'IBM Products/Components/Datagrid/Flyout',
+  title: 'IBM Products/Components/Datagrid/Filtering/Flyout',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
@@ -11,10 +11,7 @@ import React, { useState } from 'react';
 import { Tooltip } from '@carbon/react';
 import { getBatchActions } from '../../Datagrid.stories';
 import { action } from '@storybook/addon-actions';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../../global/js/utils/story-helper';
 import {
   Datagrid,
   useDatagrid,
@@ -31,7 +28,7 @@ import { handleFilterTagLabelText } from '../../utils/handleFilterTagLabelText';
 import { getDateFormat, multiSelectProps } from './Panel.stories';
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/Flyout`,
+  title: 'IBM Products/Components/Datagrid/Flyout',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
@@ -15,10 +15,7 @@ import {
   useFiltering,
   useColumnCenterAlign,
 } from '../../index';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../../global/js/utils/story-helper';
 
 import { ARG_TYPES } from '../../utils/getArgTypes';
 import { getBatchActions } from '../../Datagrid.stories';
@@ -31,7 +28,7 @@ import { makeData } from '../../utils/makeData';
 import styles from '../../_storybook-styles.scss';
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/Panel`,
+  title: 'IBM Products/Components/Datagrid/Panel',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
@@ -28,7 +28,7 @@ import { makeData } from '../../utils/makeData';
 import styles from '../../_storybook-styles.scss';
 
 export default {
-  title: 'IBM Products/Components/Datagrid/Panel',
+  title: 'IBM Products/Components/Datagrid/Filtering/Panel',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,10 +9,7 @@
 import React, { useState } from 'react';
 import { Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../../global/js/utils/story-helper';
 import {
   Datagrid,
   useDatagrid,
@@ -26,7 +23,7 @@ import { ARG_TYPES } from '../../utils/getArgTypes';
 import { StoryDocsPage } from '../../../../global/js/utils/StoryDocsPage';
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/NestedRows`,
+  title: 'IBM Products/Components/Datagrid/NestedRows',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,10 +9,7 @@
 import React, { useState } from 'react';
 import { Add, Edit, TrashCan, Checkmark } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../../global/js/utils/story-helper';
 import {
   Datagrid,
   useDatagrid,
@@ -28,7 +25,7 @@ import { makeData } from '../../utils/makeData';
 import { ARG_TYPES } from '../../utils/getArgTypes';
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/RowActionButtons`,
+  title: 'IBM Products/Components/Datagrid/RowActionButtons',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/RowHeightSettings/RowHeightSettings.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/RowHeightSettings/RowHeightSettings.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,10 +9,7 @@
 import React, { useState } from 'react';
 import { Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../../global/js/utils/story-helper';
 import { Datagrid, useDatagrid } from '../../index';
 import styles from '../../_storybook-styles.scss';
 // import mdx from '../../Datagrid.mdx';
@@ -22,7 +19,7 @@ import { makeData } from '../../utils/makeData';
 import { ARG_TYPES } from '../../utils/getArgTypes';
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/RowHeightSettings`,
+  title: 'IBM Products/Components/Datagrid/RowHeightSettings',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Slug/Slug.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Slug/Slug.stories.js
@@ -18,10 +18,7 @@ import {
   usePrefix,
 } from '@carbon/react';
 import { action } from '@storybook/addon-actions';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../../global/js/utils/story-helper';
 import {
   Datagrid,
   useDatagrid,
@@ -36,7 +33,7 @@ import { ARG_TYPES } from '../../utils/getArgTypes';
 import { StoryDocsPage } from '../../../../global/js/utils/StoryDocsPage';
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/Slug`,
+  title: 'IBM Products/Components/Datagrid/Slug',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Decorator/Decorator.mdx
+++ b/packages/ibm-products/src/components/Decorator/Decorator.mdx
@@ -1,9 +1,7 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import {
-  getStoryId,
-  CodesandboxLink,
-} from '../../global/js/utils/story-helper';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import { Decorator } from '.';
+import * as DecoratorStories from './Decorator.stories';
 
 # Decorator
 
@@ -25,7 +23,7 @@ element.
 ## Decorator example usage
 
 <Canvas withSource="none">
-  <Story id={getStoryId(Decorator.displayName, 'decorator')} />
+  <Story of={DecoratorStories.decorator} />
 </Canvas>
 
 ## Decorator code sample
@@ -37,7 +35,7 @@ element.
 ## Decorator as Link example usage
 
 <Canvas withSource="none">
-  <Story id={getStoryId(Decorator.displayName, 'as-link')} />
+  <Story of={DecoratorStories.asLink} />
 </Canvas>
 
 ## Decorator as Link code sample
@@ -76,7 +74,7 @@ adding `target="_blank"` to open in a new browser tab.
 ## Decorator as Single Button example usage
 
 <Canvas withSource="none">
-  <Story id={getStoryId(Decorator.displayName, 'as-single-button')} />
+  <Story of={DecoratorStories.asSingleButton} />
 </Canvas>
 
 ## Decorator as Single Button code sample
@@ -99,7 +97,7 @@ adding `target="_blank"` to open in a new browser tab.
 ## Decorator as Dual Button example usage
 
 <Canvas withSource="none">
-  <Story id={getStoryId(Decorator.displayName, 'as-dual-button')} />
+  <Story of={DecoratorStories.asDualButton} />
 </Canvas>
 
 ## Decorator as Dual Button code sample

--- a/packages/ibm-products/src/components/Decorator/Decorator.stories.js
+++ b/packages/ibm-products/src/components/Decorator/Decorator.stories.js
@@ -8,10 +8,7 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { Decorator } from '.';
 import mdx from './Decorator.mdx';
@@ -37,7 +34,7 @@ const scoreOptions = {
 };
 
 export default {
-  title: getStoryTitle(Decorator.displayName),
+  title: 'IBM Products/Components/Decorator',
   component: Decorator,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/DelimitedList/DelimitedList.stories.js
+++ b/packages/ibm-products/src/components/DelimitedList/DelimitedList.stories.js
@@ -7,10 +7,7 @@
 
 import React from 'react';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { DelimitedList } from '.';
 
@@ -20,7 +17,7 @@ import DocsPage from './DelimitedList';
 const storyClass = 'delimited-list-stories';
 
 export default {
-  title: getStoryTitle(DelimitedList.displayName),
+  title: 'IBM Products/Components/DelimitedList',
   component: DelimitedList,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/DelimitedList/DelimitedList.stories.js
+++ b/packages/ibm-products/src/components/DelimitedList/DelimitedList.stories.js
@@ -17,7 +17,7 @@ import DocsPage from './DelimitedList';
 const storyClass = 'delimited-list-stories';
 
 export default {
-  title: 'IBM Products/Components/DelimitedList',
+  title: 'IBM Products/Components/Delimited list/DelimitedList',
   component: DelimitedList,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/DescriptionList/DescriptionList.mdx
+++ b/packages/ibm-products/src/components/DescriptionList/DescriptionList.mdx
@@ -1,8 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import {
-  getStoryId,
-  CodesandboxLink,
-} from '../../global/js/utils/story-helper';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import { DescriptionList } from '.';
 import * as DescriptionListStories from './DescriptionList.stories';
 

--- a/packages/ibm-products/src/components/DescriptionList/DescriptionList.mdx
+++ b/packages/ibm-products/src/components/DescriptionList/DescriptionList.mdx
@@ -4,6 +4,7 @@ import {
   CodesandboxLink,
 } from '../../global/js/utils/story-helper';
 import { DescriptionList } from '.';
+import * as DescriptionListStories from './DescriptionList.stories';
 
 # DescriptionList
 
@@ -22,7 +23,7 @@ Type layouts provide an orderly layout of terms and definitions.
 {/* TODO: One example per designed use case. */}
 
 <Canvas>
-  <Story id={getStoryId(DescriptionList.displayName, 'description-list')} />
+  <Story of={DescriptionListStories.descriptionList} />
 </Canvas>
 
 ## Component API

--- a/packages/ibm-products/src/components/DescriptionList/DescriptionList.stories.js
+++ b/packages/ibm-products/src/components/DescriptionList/DescriptionList.stories.js
@@ -27,7 +27,7 @@ import mdx from './DescriptionList.mdx';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: 'IBM Products/Components/DescriptionList',
+  title: 'IBM Products/Components/Description list/DescriptionList',
   component: DescriptionList,
   tags: ['autodocs'],
   // TODO: Define argTypes for props not represented by standard JS types.

--- a/packages/ibm-products/src/components/DescriptionList/DescriptionList.stories.js
+++ b/packages/ibm-products/src/components/DescriptionList/DescriptionList.stories.js
@@ -1,3 +1,5 @@
+//cspell: disable
+
 /**
  * Copyright IBM Corp. 2024, 2024
  *
@@ -9,10 +11,7 @@ import React from 'react';
 // TODO: import action to handle events if required.
 // import { action } from '@storybook/addon-actions';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import {
   DescriptionList,
@@ -28,7 +27,7 @@ import mdx from './DescriptionList.mdx';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: getStoryTitle(DescriptionList.displayName),
+  title: 'IBM Products/Components/DescriptionList',
   component: DescriptionList,
   tags: ['autodocs'],
   // TODO: Define argTypes for props not represented by standard JS types.

--- a/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.stories.js
+++ b/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.stories.js
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -17,10 +17,7 @@ import {
   unstable__SlugContent as SlugContent,
 } from '@carbon/react';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { ExpressiveCard } from '.';
 // import mdx from './ExpressiveCard.mdx';
 import { action } from '@storybook/addon-actions';
@@ -46,7 +43,7 @@ const sampleSlug = (
 );
 
 export default {
-  title: getStoryTitle(ExpressiveCard.displayName),
+  title: 'IBM Products/Components/Cards/ExpressiveCard',
   component: ExpressiveCard,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreen.mdx
+++ b/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreen.mdx
@@ -1,8 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import {
-  getStoryId,
-  CodesandboxLink,
-} from '../../global/js/utils/story-helper';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import { InterstitialScreen } from '.';
 
 # InterstitialScreen

--- a/packages/ibm-products/src/components/MultiAddSelect/MultiAddSelect.stories.js
+++ b/packages/ibm-products/src/components/MultiAddSelect/MultiAddSelect.stories.js
@@ -7,13 +7,9 @@
 
 import React, { useState } from 'react';
 // import styles from './_storybook-styles.scss'; // import index in case more files are added later.
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { MultiAddSelect } from '.';
 import { Button } from '@carbon/react';
-// import { action } from '@storybook/addon-actions';
 import image from '../UserProfileImage/headshot.jpg'; // cspell:disable-line
 import { Group, Document } from '@carbon/react/icons';
 
@@ -22,7 +18,7 @@ import DocsPage from './MultiAddSelect.docs-page';
 const blockClass = `${pkg.prefix}--add-select__meta-panel`;
 
 export default {
-  title: getStoryTitle(MultiAddSelect.displayName),
+  title: 'IBM Products/Patterns/Add select/MultiAddSelect',
   component: MultiAddSelect,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/MultiAddSelect/MultiAddSelect.stories.js
+++ b/packages/ibm-products/src/components/MultiAddSelect/MultiAddSelect.stories.js
@@ -18,7 +18,7 @@ import DocsPage from './MultiAddSelect.docs-page';
 const blockClass = `${pkg.prefix}--add-select__meta-panel`;
 
 export default {
-  title: 'IBM Products/Patterns/Add select/MultiAddSelect',
+  title: 'IBM Products/Patterns/Add and select/MultiAddSelect',
   component: MultiAddSelect,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Nav/Nav.mdx
+++ b/packages/ibm-products/src/components/Nav/Nav.mdx
@@ -1,9 +1,7 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import {
-  getStoryId,
-  CodesandboxLink,
-} from '../../global/js/utils/story-helper';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import { Nav } from '.';
+import * as NavStories from './Nav.stories';
 
 # Nav
 
@@ -22,7 +20,7 @@ import { Nav } from '.';
 {/* TODO: One example per designed use case. */}
 
 <Canvas>
-  <Story id={getStoryId('Nav', 'nav')} />
+  <Story of={NavStories.nav} />
 </Canvas>
 
 ## Code sample

--- a/packages/ibm-products/src/components/Nav/Nav.stories.js
+++ b/packages/ibm-products/src/components/Nav/Nav.stories.js
@@ -1,3 +1,5 @@
+//cspell: disable
+
 /**
  * Copyright IBM Corp. 2024, 2024
  *
@@ -8,10 +10,7 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import Nav from './Nav';
 import NavItem from './NavItem';
@@ -21,7 +20,7 @@ import mdx from './Nav.mdx';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: getStoryTitle(Nav.displayName),
+  title: 'IBM Products/Components/Nav',
   component: Nav,
   subcomponents: {
     NavList,

--- a/packages/ibm-products/src/components/OptionsTile/OptionsTile.stories.js
+++ b/packages/ibm-products/src/components/OptionsTile/OptionsTile.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,10 +10,7 @@ import { action } from '@storybook/addon-actions';
 
 import { Dropdown, FormGroup } from '@carbon/react';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import uuidv4 from '../../global/js/utils/uuidv4';
 
 import { OptionsTile } from '.';
@@ -22,7 +19,7 @@ import { OptionsTile } from '.';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: getStoryTitle(OptionsTile.displayName),
+  title: 'IBM Products/Components/OptionsTile',
   component: OptionsTile,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/OptionsTile/OptionsTile.stories.js
+++ b/packages/ibm-products/src/components/OptionsTile/OptionsTile.stories.js
@@ -19,7 +19,7 @@ import { OptionsTile } from '.';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: 'IBM Products/Components/OptionsTile',
+  title: 'IBM Products/Components/Options tile/OptionsTile',
   component: OptionsTile,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/ibm-products/src/components/PageHeader/PageHeader.stories.js
@@ -42,10 +42,7 @@ import cx from 'classnames';
 
 import { PageHeader } from './PageHeader';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { demoTableHeaders, demoTableData } from './PageHeaderDemo.data';
 
@@ -395,7 +392,7 @@ const fullWidthGrid = {
 };
 
 export default {
-  title: getStoryTitle(PageHeader.displayName),
+  title: 'IBM Products/Components/PageHeader',
   component: PageHeader,
   tags: ['autodocs'],
   parameters: { styles, layout: 'fullscreen' /* docs: { page: mdx } */ },

--- a/packages/ibm-products/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/ibm-products/src/components/PageHeader/PageHeader.stories.js
@@ -392,7 +392,7 @@ const fullWidthGrid = {
 };
 
 export default {
-  title: 'IBM Products/Components/PageHeader',
+  title: 'IBM Products/Components/Page header/PageHeader',
   component: PageHeader,
   tags: ['autodocs'],
   parameters: { styles, layout: 'fullscreen' /* docs: { page: mdx } */ },

--- a/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.stories.js
+++ b/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.stories.js
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -15,10 +15,7 @@ import {
   unstable__Slug as Slug,
   unstable__SlugContent as SlugContent,
 } from '@carbon/react';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { ProductiveCard } from '.';
 // import mdx from './ProductiveCard.mdx';
 import { action } from '@storybook/addon-actions';
@@ -44,7 +41,7 @@ const sampleSlug = (
 );
 
 export default {
-  title: getStoryTitle(ProductiveCard.displayName),
+  title: 'IBM Products/Components/Cards/ProductiveCard',
   component: ProductiveCard,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/SearchBar/SearchBar.mdx
+++ b/packages/ibm-products/src/components/SearchBar/SearchBar.mdx
@@ -1,8 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import {
-  getStoryId,
-  CodesandboxLink,
-} from '../../global/js/utils/story-helper';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import { SearchBar } from '.';
 import * as SearchBarStories from './SearchBar.stories';
 

--- a/packages/ibm-products/src/components/SearchBar/SearchBar.mdx
+++ b/packages/ibm-products/src/components/SearchBar/SearchBar.mdx
@@ -4,6 +4,7 @@ import {
   CodesandboxLink,
 } from '../../global/js/utils/story-helper';
 import { SearchBar } from '.';
+import * as SearchBarStories from './SearchBar.stories';
 
 # SearchBar
 
@@ -22,31 +23,31 @@ import { SearchBar } from '.';
 ### Default
 
 <Canvas>
-  <Story id={getStoryId(SearchBar.displayName, 'default')} />
+  <Story of={SearchBarStories.Default} />
 </Canvas>
 
 ### Initial Value
 
 <Canvas>
-  <Story id={getStoryId(SearchBar.displayName, 'initial-value')} />
+  <Story of={SearchBarStories.InitialValue} />
 </Canvas>
 
 ### Scopes
 
 <Canvas>
-  <Story id={getStoryId(SearchBar.displayName, 'scopes')} />
+  <Story of={SearchBarStories.Scopes} />
 </Canvas>
 
 ### Unsorted Scopes
 
 <Canvas>
-  <Story id={getStoryId(SearchBar.displayName, 'unsorted-scopes')} />
+  <Story of={SearchBarStories.UnsortedScopes} />
 </Canvas>
 
 ### Selected Scopes
 
 <Canvas>
-  <Story id={getStoryId(SearchBar.displayName, 'selected-scopes')} />
+  <Story of={SearchBarStories.SelectedScopes} />
 </Canvas>
 
 ## Code sample

--- a/packages/ibm-products/src/components/SearchBar/SearchBar.stories.js
+++ b/packages/ibm-products/src/components/SearchBar/SearchBar.stories.js
@@ -16,7 +16,7 @@ import mdx from './SearchBar.mdx';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: 'IBM Products/Components/SearchBar',
+  title: 'IBM Products/Components/Search bar/SearchBar',
   component: SearchBar,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/SearchBar/SearchBar.stories.js
+++ b/packages/ibm-products/src/components/SearchBar/SearchBar.stories.js
@@ -8,10 +8,7 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { SearchBar } from '.';
 import mdx from './SearchBar.mdx';
@@ -19,7 +16,7 @@ import mdx from './SearchBar.mdx';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: getStoryTitle(SearchBar.displayName),
+  title: 'IBM Products/Components/SearchBar',
   component: SearchBar,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/SidePanel/SidePanel.stories.js
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -30,10 +30,7 @@ import {
 } from '@carbon/react';
 
 import { Copy, TrashCan, Settings } from '@carbon/react/icons';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { SidePanel } from './SidePanel';
 import { sidePanelDecorator } from '../../global/decorators/sidePanelDecorator';
 // import mdx from './SidePanel.mdx';
@@ -368,7 +365,7 @@ const renderUIShellHeader = () => (
 );
 
 export default {
-  title: getStoryTitle(SidePanel.displayName),
+  title: 'IBM Products/Components/SidePanel',
   component: SidePanel,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/SidePanel/SidePanel.stories.js
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.stories.js
@@ -365,7 +365,7 @@ const renderUIShellHeader = () => (
 );
 
 export default {
-  title: 'IBM Products/Components/SidePanel',
+  title: 'IBM Products/Components/Side panel/SidePanel',
   component: SidePanel,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/SingleAddSelect/SingleAddSelect.stories.js
+++ b/packages/ibm-products/src/components/SingleAddSelect/SingleAddSelect.stories.js
@@ -14,7 +14,7 @@ import DocsPage from './SingleAddSelect.docs-page';
 // import { action } from '@storybook/addon-actions';
 
 export default {
-  title: 'IBM Products/Patterns/Add select/SingleAddSelect',
+  title: 'IBM Products/Patterns/Add and select/SingleAddSelect',
   component: SingleAddSelect,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/SingleAddSelect/SingleAddSelect.stories.js
+++ b/packages/ibm-products/src/components/SingleAddSelect/SingleAddSelect.stories.js
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2022
+// Copyright IBM Corp. 2022, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -7,17 +7,14 @@
 
 import React, { useState } from 'react';
 // import styles from './_storybook-styles.scss'; // import index in case more files are added later.
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { SingleAddSelect } from '.';
 import { Button } from '@carbon/react';
 import DocsPage from './SingleAddSelect.docs-page';
 // import { action } from '@storybook/addon-actions';
 
 export default {
-  title: getStoryTitle(SingleAddSelect.displayName),
+  title: 'IBM Products/Patterns/Add select/SingleAddSelect',
   component: SingleAddSelect,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/StatusIndicator/StatusIndicator.mdx
+++ b/packages/ibm-products/src/components/StatusIndicator/StatusIndicator.mdx
@@ -4,6 +4,7 @@ import {
   CodesandboxLink,
 } from '../../global/js/utils/story-helper';
 import { StatusIndicator } from '.';
+import * as StatusIndicatorStories from './StatusIndicator.stories';
 
 # StatusIndicator
 
@@ -17,7 +18,7 @@ import { StatusIndicator } from '.';
 {/* TODO: One example per designed use case. */}
 
 <Canvas>
-  <Story id={getStoryId(StatusIndicator.displayName, 'status-indicator')} />
+  <Story of={StatusIndicatorStories.statusIndicator} />
 </Canvas>
 
 ## Component API

--- a/packages/ibm-products/src/components/StatusIndicator/StatusIndicator.mdx
+++ b/packages/ibm-products/src/components/StatusIndicator/StatusIndicator.mdx
@@ -1,8 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import {
-  getStoryId,
-  CodesandboxLink,
-} from '../../global/js/utils/story-helper';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import { StatusIndicator } from '.';
 import * as StatusIndicatorStories from './StatusIndicator.stories';
 

--- a/packages/ibm-products/src/components/StatusIndicator/StatusIndicator.stories.js
+++ b/packages/ibm-products/src/components/StatusIndicator/StatusIndicator.stories.js
@@ -8,10 +8,7 @@
 import React, { useEffect, useState } from 'react';
 import { action } from '@storybook/addon-actions';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { StatusIndicator, StatusIndicatorStep } from '.';
 import mdx from './StatusIndicator.mdx';
@@ -19,7 +16,7 @@ import mdx from './StatusIndicator.mdx';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: getStoryTitle(StatusIndicator.displayName),
+  title: 'IBM Products/Components/StatusIndicator',
   component: StatusIndicator,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/StatusIndicator/StatusIndicator.stories.js
+++ b/packages/ibm-products/src/components/StatusIndicator/StatusIndicator.stories.js
@@ -16,7 +16,7 @@ import mdx from './StatusIndicator.mdx';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: 'IBM Products/Components/StatusIndicator',
+  title: 'IBM Products/Components/Status indicator/StatusIndicator',
   component: StatusIndicator,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/StatusIndicator/StatusIndicatorStep.mdx
+++ b/packages/ibm-products/src/components/StatusIndicator/StatusIndicatorStep.mdx
@@ -4,6 +4,7 @@ import {
   CodesandboxLink,
 } from '../../global/js/utils/story-helper';
 import { StatusIndicatorStep } from '.';
+import * as StatusIndicatorStepStories from './StatusIndicatorStep.stories';
 
 # StatusIndicatorStep
 
@@ -18,7 +19,7 @@ import { StatusIndicatorStep } from '.';
 
 <Canvas>
   <Story
-    id={getStoryId(StatusIndicatorStep.displayName, 'status-indicator-step')}
+    of={StatusIndicatorStepStories.statusIndicatorStep}
   />
 </Canvas>
 

--- a/packages/ibm-products/src/components/StatusIndicator/StatusIndicatorStep.mdx
+++ b/packages/ibm-products/src/components/StatusIndicator/StatusIndicatorStep.mdx
@@ -1,8 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import {
-  getStoryId,
-  CodesandboxLink,
-} from '../../global/js/utils/story-helper';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import { StatusIndicatorStep } from '.';
 import * as StatusIndicatorStepStories from './StatusIndicatorStep.stories';
 

--- a/packages/ibm-products/src/components/StatusIndicator/StatusIndicatorStep.stories.js
+++ b/packages/ibm-products/src/components/StatusIndicator/StatusIndicatorStep.stories.js
@@ -15,7 +15,7 @@ import mdx from './StatusIndicatorStep.mdx';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: 'IBM Products/Components/StatusIndicator/StatusIndicatorStep',
+  title: 'IBM Products/Components/Status indicator/StatusIndicatorStep',
   component: StatusIndicatorStep,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/StatusIndicator/StatusIndicatorStep.stories.js
+++ b/packages/ibm-products/src/components/StatusIndicator/StatusIndicatorStep.stories.js
@@ -7,10 +7,7 @@
 
 import React from 'react';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { StatusIndicatorStep } from '.';
 import mdx from './StatusIndicatorStep.mdx';
@@ -18,7 +15,7 @@ import mdx from './StatusIndicatorStep.mdx';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: getStoryTitle(StatusIndicatorStep.displayName),
+  title: 'IBM Products/Components/StatusIndicator/StatusIndicatorStep',
   component: StatusIndicatorStep,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/StringFormatter/StringFormatter.mdx
+++ b/packages/ibm-products/src/components/StringFormatter/StringFormatter.mdx
@@ -1,8 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import {
-  getStoryId,
-  CodesandboxLink,
-} from '../../global/js/utils/story-helper';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import { StringFormatter } from '.';
 import * as StringFormatterStories from './StringFormatter.stories';
 

--- a/packages/ibm-products/src/components/StringFormatter/StringFormatter.mdx
+++ b/packages/ibm-products/src/components/StringFormatter/StringFormatter.mdx
@@ -4,6 +4,7 @@ import {
   CodesandboxLink,
 } from '../../global/js/utils/story-helper';
 import { StringFormatter } from '.';
+import * as StringFormatterStories from './StringFormatter.stories';
 
 # StringFormatter
 
@@ -21,7 +22,7 @@ hover or focus with the entirety of the provided copy.
 ## Example usage
 
 <Canvas>
-  <Story id={getStoryId(StringFormatter.displayName, 'string-formatter')} />
+  <Story of={StringFormatterStories.stringFormatter} />
 </Canvas>
 
 ## Code sample

--- a/packages/ibm-products/src/components/StringFormatter/StringFormatter.stories.js
+++ b/packages/ibm-products/src/components/StringFormatter/StringFormatter.stories.js
@@ -17,7 +17,7 @@ import mdx from './StringFormatter.mdx';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: 'IBM Products/Components/StringFormatter',
+  title: 'IBM Products/Components/String formatter/StringFormatter',
   component: StringFormatter,
   tags: ['autodocs'],
   // TODO: Define argTypes for props not represented by standard JS types.

--- a/packages/ibm-products/src/components/StringFormatter/StringFormatter.stories.js
+++ b/packages/ibm-products/src/components/StringFormatter/StringFormatter.stories.js
@@ -9,10 +9,7 @@ import React from 'react';
 // TODO: import action to handle events if required.
 // import { action } from '@storybook/addon-actions';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { StringFormatter } from '.';
 import mdx from './StringFormatter.mdx';
@@ -20,7 +17,7 @@ import mdx from './StringFormatter.mdx';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: getStoryTitle(StringFormatter.displayName),
+  title: 'IBM Products/Components/StringFormatter',
   component: StringFormatter,
   tags: ['autodocs'],
   // TODO: Define argTypes for props not represented by standard JS types.

--- a/packages/ibm-products/src/components/TagSet/TagSet.stories.js
+++ b/packages/ibm-products/src/components/TagSet/TagSet.stories.js
@@ -130,7 +130,7 @@ const overflowAndModalStrings = {
 };
 
 export default {
-  title: 'IBM Products/Components/TagSet',
+  title: 'IBM Products/Components/Tag set/TagSet',
   component: TagSet,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/TagSet/TagSet.stories.js
+++ b/packages/ibm-products/src/components/TagSet/TagSet.stories.js
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2022
+// Copyright IBM Corp. 2020, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -9,10 +9,7 @@ import React, { useRef, useState } from 'react';
 
 import { TYPES as tagTypes } from '../TagSet/constants';
 import { pkg } from '../../settings';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { DisplayBox } from '../../global/js/utils/DisplayBox';
 import { TagSet } from '.';
 // import mdx from './TagSet.mdx';
@@ -133,7 +130,7 @@ const overflowAndModalStrings = {
 };
 
 export default {
-  title: getStoryTitle(TagSet.displayName),
+  title: 'IBM Products/Components/TagSet',
   component: TagSet,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.js
+++ b/packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -33,10 +33,7 @@ import {
 } from '../ActionSet/actions.js';
 
 import { getDeprecatedArgTypes } from '../../global/js/utils/props-helper';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import styles from './_storybook-styles.scss';
 import { TearsheetNarrow } from './TearsheetNarrow';
@@ -44,7 +41,7 @@ import { TearsheetNarrow } from './TearsheetNarrow';
 // import mdx from './Tearsheet.mdx';
 
 export default {
-  title: getStoryTitle(Tearsheet.displayName),
+  title: 'IBM Products/Components/Tearsheet',
   component: Tearsheet,
   tags: ['autodocs'],
   parameters: { styles /* docs: { page: mdx } */, layout: 'fullscreen' },

--- a/packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.stories.js
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -29,17 +29,14 @@ import {
 } from '../ActionSet/actions.js';
 
 import { getDeprecatedArgTypes } from '../../global/js/utils/props-helper';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import styles from './_storybook-styles.scss';
 
 // import mdx from './Tearsheet.mdx';
 
 export default {
-  title: getStoryTitle(TearsheetNarrow.displayName),
+  title: 'IBM Products/Components/Tearsheet/TearsheetNarrow',
   component: TearsheetNarrow,
   tags: ['autodocs'],
   parameters: { layout: 'fullscreen', styles /* docs: { page: mdx } */ },

--- a/packages/ibm-products/src/components/TruncatedList/TruncatedList.stories.js
+++ b/packages/ibm-products/src/components/TruncatedList/TruncatedList.stories.js
@@ -10,10 +10,7 @@ import { ListItem } from '@carbon/react';
 // TODO: import action to handle events if required.
 import { action } from '@storybook/addon-actions';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { TruncatedList } from '.';
 
@@ -23,7 +20,7 @@ import DocsPage from './TruncatedList';
 const storyClass = 'truncated-list-stories';
 
 export default {
-  title: getStoryTitle(TruncatedList.displayName),
+  title: 'IBM Products/Components/TruncatedList',
   component: TruncatedList,
   tags: ['autodocs'],
   // TODO: Define argTypes for props not represented by standard JS types.

--- a/packages/ibm-products/src/components/TruncatedList/TruncatedList.stories.js
+++ b/packages/ibm-products/src/components/TruncatedList/TruncatedList.stories.js
@@ -20,7 +20,7 @@ import DocsPage from './TruncatedList';
 const storyClass = 'truncated-list-stories';
 
 export default {
-  title: 'IBM Products/Components/TruncatedList',
+  title: 'IBM Products/Components/Truncated list/TruncatedList',
   component: TruncatedList,
   tags: ['autodocs'],
   // TODO: Define argTypes for props not represented by standard JS types.

--- a/packages/ibm-products/src/components/UserAvatar/UserAvatar.mdx
+++ b/packages/ibm-products/src/components/UserAvatar/UserAvatar.mdx
@@ -4,6 +4,7 @@ import {
   CodesandboxLink,
 } from '../../global/js/utils/story-helper';
 import { UserAvatar } from '.';
+import * as UserAvatarStories from './UserAvatar.stories';
 
 # UserAvatar
 
@@ -24,13 +25,13 @@ import { UserAvatar } from '.';
 ### Default
 
 <Canvas>
-  <Story id={getStoryId(UserAvatar.displayName, 'default')} />
+  <Story of={UserAvatarStories.Default} />
 </Canvas>
 
 ### With Image
 
 <Canvas>
-  <Story id={getStoryId(UserAvatar.displayName, 'with-image')} />
+  <Story of={UserAvatarStories.WithImage} />
 </Canvas>
 
 ## Code sample

--- a/packages/ibm-products/src/components/UserAvatar/UserAvatar.mdx
+++ b/packages/ibm-products/src/components/UserAvatar/UserAvatar.mdx
@@ -1,8 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import {
-  getStoryId,
-  CodesandboxLink,
-} from '../../global/js/utils/story-helper';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import { UserAvatar } from '.';
 import * as UserAvatarStories from './UserAvatar.stories';
 

--- a/packages/ibm-products/src/components/UserAvatar/UserAvatar.stories.js
+++ b/packages/ibm-products/src/components/UserAvatar/UserAvatar.stories.js
@@ -11,10 +11,7 @@ import React from 'react';
 // TODO: import action to handle events if required.
 // import { action } from '@storybook/addon-actions';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { UserAvatar } from '.';
 import mdx from './UserAvatar.mdx';
@@ -27,7 +24,7 @@ const defaultArgs = {
 };
 
 export default {
-  title: getStoryTitle(UserAvatar.displayName),
+  title: 'IBM Products/Components/UserAvatar',
   component: UserAvatar,
   tags: ['autodocs'],
   // TODO: Define argTypes for props not represented by standard JS types.

--- a/packages/ibm-products/src/components/UserAvatar/UserAvatar.stories.js
+++ b/packages/ibm-products/src/components/UserAvatar/UserAvatar.stories.js
@@ -24,7 +24,7 @@ const defaultArgs = {
 };
 
 export default {
-  title: 'IBM Products/Components/UserAvatar',
+  title: 'IBM Products/Components/User avatar/UserAvatar',
   component: UserAvatar,
   tags: ['autodocs'],
   // TODO: Define argTypes for props not represented by standard JS types.

--- a/packages/ibm-products/src/global/js/utils/story-helper.js
+++ b/packages/ibm-products/src/global/js/utils/story-helper.js
@@ -170,8 +170,9 @@ export const storyDocsPageInfo = (csfFile) => {
 
   if (/components|patterns/i.test(kind)) {
     result.expectCodedExample = true;
-    // components and patterns have an additional level
-    // No longer true
+    // Required until components within 'Patterns' category use the
+    // new approach with setting story titles because they are nested an
+    // extra level
     if (typeof b === 'string') {
       component = b;
     } else {

--- a/packages/ibm-products/src/global/js/utils/story-helper.js
+++ b/packages/ibm-products/src/global/js/utils/story-helper.js
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2021
+// Copyright IBM Corp. 2021, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -12,6 +12,12 @@ import pkg from '../package-settings';
 import { getPathForComponent } from '../../../../../core/story-structure';
 import { paramCase } from 'change-case';
 
+export const checkCanaryStatus = (componentName) =>
+  !pkg.isComponentEnabled(componentName, true) &&
+  pkg.isComponentPublic(componentName, true)
+    ? true
+    : false;
+
 /**
  * A helper function to return the structured story title for a component.
  * @param {string} componentName The name of the component.
@@ -23,11 +29,7 @@ export const getStoryTitle = (componentName) => {
     getPathForComponent('c', componentName) ||
     `Carbon for IBM Products/Lost + found/${componentName}`;
 
-  // add a canary tag if the component is public but not normally enabled
-  return !pkg.isComponentEnabled(componentName, true) &&
-    pkg.isComponentPublic(componentName, true)
-    ? `${title}#canary`
-    : title;
+  return title;
 };
 
 /**
@@ -169,7 +171,13 @@ export const storyDocsPageInfo = (csfFile) => {
   if (/components|patterns/i.test(kind)) {
     result.expectCodedExample = true;
     // components and patterns have an additional level
-    component = b;
+    // No longer true
+    if (typeof b === 'string') {
+      component = b;
+    } else {
+      component = a;
+    }
+
     result.section = a;
 
     result.guidelinesHref = `https://pages.github.ibm.com/cdai-design/pal/${kind}s/${paramCase(


### PR DESCRIPTION
Contributes to #3986 

First part of storybook simplification, the majority of the changes in this PR include removing the `getStoryTitle` utility for stories in `IBM Products/components`. I'll wait to do the same for `IBM Products/patterns` to reduce the number of changes required to review since it's a substantial amount.

This removes a lot of abstraction that I don't think is necessary and can make longer term maintenance more difficult.

In addition, I refactored how the `Canary` tag is applied in the side bar items in a way that no longer requires manipulating the story title. As well, as refactoring how we sort our stories (`.storybook/preview.js`).

#### What did you change?
Story files for `IBM Products/Components` section
#### How did you test and verify your work?
Storybook