### PR TITLE
refactor: flatten story structure and story titles (patterns/internal sections)

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -91,6 +91,7 @@
     "gridcell",
     "guidebanner",
     "haspopup",
+    "headshot",
     "homescreen",
     "inlineedit",
     "inlinetip",

--- a/packages/core/.storybook/manager.js
+++ b/packages/core/.storybook/manager.js
@@ -11,8 +11,39 @@ import { create } from '@storybook/theming/create';
 import React from 'react';
 
 import packageInfo from '../../ibm-products/package.json';
+import { checkCanaryStatus } from '../../ibm-products/src/global/js/utils/story-helper';
 
 const { description, version } = packageInfo;
+
+const renderComponentLabel = (label, dark, type = 'Canary') => {
+  return (
+    <div
+      style={{
+        flex: '1 0 auto',
+        display: 'flex',
+        alignItems: 'stretch',
+        justifyContent: 'space-between',
+      }}
+    >
+      {label}
+      <div
+        style={{
+          background: dark ? '#555555' : '#e0e0e0',
+          /* stylelint-disable-next-line carbon/type-token-use */
+          fontSize: '11px',
+          border: '.1px solid transparent',
+          /* stylelint-disable-next-line carbon/layout-token-use */
+          padding: '0 .5rem',
+          /* stylelint-disable-next-line carbon/layout-token-use */
+          margin: '0 .5em',
+          borderRadius: '8px',
+        }}
+      >
+        {type}
+      </div>
+    </div>
+  );
+};
 
 addons.setConfig({
   theme: create({
@@ -21,74 +52,17 @@ addons.setConfig({
 
   sidebar: {
     renderLabel: (item) => {
-      const parts = item.name.split('#');
+      const isUnstable = !!(
+        item.type === 'component' && checkCanaryStatus(item.name)
+      );
       const dark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-
-      switch (parts[1]) {
-        // if the name has #canary then render a 'Canary' tag on the right
-        case 'canary':
-          return (
-            <div
-              style={{
-                flex: '1 0 auto',
-                display: 'flex',
-                alignItems: 'stretch',
-                justifyContent: 'space-between',
-              }}
-            >
-              {parts[0]}
-              <div
-                style={{
-                  background: dark ? '#555555' : '#e0e0e0',
-                  /* stylelint-disable-next-line carbon/type-token-use */
-                  fontSize: '11px',
-                  border: '.1px solid transparent',
-                  /* stylelint-disable-next-line carbon/layout-token-use */
-                  padding: '0 .5rem',
-                  /* stylelint-disable-next-line carbon/layout-token-use */
-                  margin: '0 .5em',
-                  borderRadius: '8px',
-                }}
-              >
-                Canary
-              </div>
-            </div>
-          );
-
-        // if the name has #legacy then render a 'Legacy' tag on the right
-        case 'legacy':
-          return (
-            <div
-              style={{
-                flex: '1 0 auto',
-                display: 'flex',
-                alignItems: 'stretch',
-                justifyContent: 'space-between',
-              }}
-            >
-              {parts[0]}
-              <div
-                style={{
-                  background: dark ? '#3a3a3a' : '#eeeeee',
-                  /* stylelint-disable-next-line carbon/type-token-use */
-                  fontSize: '11px',
-                  border: '.1px solid transparent',
-                  /* stylelint-disable-next-line carbon/layout-token-use */
-                  padding: '0 .5rem',
-                  /* stylelint-disable-next-line carbon/layout-token-use */
-                  margin: '0 .5em',
-                  borderRadius: '8px',
-                }}
-              >
-                Legacy
-              </div>
-            </div>
-          );
-
-        // if the name doesn't have a recognized # label, just render the name
-        default:
-          return parts[0];
+      if (isUnstable) {
+        // Canary tag is applied if `item.name` (`displayName` of the component) is confirmed
+        // to be canary/not yet released via the checkCanaryStatus utility
+        return renderComponentLabel(item.name, dark);
       }
+
+      return item.name;
     },
   },
 });

--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -122,6 +122,7 @@ const parameters = {
       method: 'alphabetical',
       order: [
         'Overview',
+        ['Welcome', 'Getting started', 'Examples', '*'],
         'IBM Products',
         ['Components', 'Patterns', 'Internal', 'Novice to pro'],
         'Community',

--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -118,19 +118,14 @@ const parameters = {
   layout: 'centered',
   options: {
     showPanel: true,
-    storySort: (a, b) => {
-      const aPosition = getSectionSequence(a[1].kind);
-      const bPosition = getSectionSequence(b[1].kind);
-
-      return aPosition !== bPosition
-        ? // if stories have different positions in the structure, sort by that
-          aPosition - bPosition
-        : a[1].kind === b[1].kind
-        ? // if they have the same kind, use their sequence numbers
-          (a[1]?.parameters?.ccsSettings?.sequence || 0) -
-          (b[1]?.parameters?.ccsSettings?.sequence || 0)
-        : // they must both be unrecognized: fall back to sorting by id (slug)
-          a[1].id.localeCompare(b[1].id, undefined, { numeric: true });
+    storySort: {
+      method: 'alphabetical',
+      order: [
+        'Overview',
+        'IBM Products',
+        ['Components', 'Patterns', 'Internal', 'Novice to pro'],
+        'Community',
+      ],
     },
   },
 

--- a/packages/ibm-products/src/components/APIKeyModal/APIKeyModal.stories.js
+++ b/packages/ibm-products/src/components/APIKeyModal/APIKeyModal.stories.js
@@ -1,9 +1,9 @@
-//
-// Copyright IBM Corp. 2021, 2021
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/**
+ * Copyright IBM Corp. 2021, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import React, { useState } from 'react';
 import {
@@ -18,17 +18,14 @@ import {
 } from '@carbon/react';
 import { action } from '@storybook/addon-actions';
 import { pkg } from '../../settings';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { APIKeyModal } from '.';
 import wait from '../../global/js/utils/wait';
 import styles from './_storybook-styles.scss'; // import index in case more files are added later.
 import DocsPage from './APIKeyModal.docs-page';
 
 export default {
-  title: getStoryTitle(APIKeyModal.displayName),
+  title: 'IBM Products/Patterns/Generating an API key/APIKeyModal',
   component: APIKeyModal,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/AboutModal/AboutModal.stories.js
+++ b/packages/ibm-products/src/components/AboutModal/AboutModal.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,10 +10,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { pkg } from '../../settings';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { AboutModal } from '.';
 
@@ -31,7 +28,7 @@ const blockClass = `${pkg.prefix}--about-modal`;
 import DocsPage from './AboutModal.docs-page';
 
 export default {
-  title: getStoryTitle(AboutModal.displayName),
+  title: 'IBM Products/Patterns/About modal/AboutModal',
   component: AboutModal,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/ActionBar/ActionBar.stories.js
+++ b/packages/ibm-products/src/components/ActionBar/ActionBar.stories.js
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -10,10 +10,7 @@ import { action } from '@storybook/addon-actions';
 
 import { Bee, Lightning } from '@carbon/react/icons';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { DisplayBox } from '../../global/js/utils/DisplayBox';
 
 import { ActionBar } from './ActionBar';
@@ -33,7 +30,7 @@ const getActions = (num) =>
   }));
 
 export default {
-  title: getStoryTitle(ActionBar.displayName),
+  title: 'IBM Products/Internal/ActionBar',
   component: ActionBar,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/ActionSet/ActionSet.stories.js
+++ b/packages/ibm-products/src/components/ActionSet/ActionSet.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,10 +10,7 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 
 import { pkg } from '../../settings';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { DisplayBox } from '../../global/js/utils/DisplayBox';
 
 import { ActionSet } from '.';
@@ -24,7 +21,7 @@ import styles from './_storybook-styles.scss';
 const blockClass = `${pkg.prefix}--action-set`;
 
 export default {
-  title: getStoryTitle(ActionSet.displayName),
+  title: 'IBM Products/Internal/ActionSet',
   component: ActionSet,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/BigNumbers/BigNumbers.mdx
+++ b/packages/ibm-products/src/components/BigNumbers/BigNumbers.mdx
@@ -1,8 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import {
-  getStoryId,
-  CodesandboxLink,
-} from '../../global/js/utils/story-helper';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import { BigNumbers } from '.';
 import * as BigNumbersStories from './BigNumbers.stories';
 

--- a/packages/ibm-products/src/components/BigNumbers/BigNumbers.mdx
+++ b/packages/ibm-products/src/components/BigNumbers/BigNumbers.mdx
@@ -4,6 +4,7 @@ import {
   CodesandboxLink,
 } from '../../global/js/utils/story-helper';
 import { BigNumbers } from '.';
+import * as BigNumbersStories from './BigNumbers.stories';
 
 # BigNumbers
 
@@ -32,13 +33,13 @@ of a button as well as tool tip functionality. The default locale is English
 ### Big numbers
 
 <Canvas>
-  <Story id={getStoryId(BigNumbers.displayName, 'big-numbers')} />
+  <Story of={BigNumbersStories.bigNumbers} />
 </Canvas>
 
 ### Big numbers with edit button
 
 <Canvas>
-  <Story id={getStoryId(BigNumbers.displayName, 'with-edit-button')} />
+  <Story of={BigNumbersStories.withEditButton} />
 </Canvas>
 
 ## Code sample

--- a/packages/ibm-products/src/components/BigNumbers/BigNumbers.stories.js
+++ b/packages/ibm-products/src/components/BigNumbers/BigNumbers.stories.js
@@ -6,14 +6,9 @@
  */
 
 import React from 'react';
-// TODO: import action to handle events if required.
-// import { action } from '@storybook/addon-actions';
 import { Button } from '@carbon/react';
 import { Edit } from '@carbon/react/icons';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { BigNumbers } from '.';
 import { BigNumbersSize } from './constants';
@@ -39,7 +34,7 @@ const numericOptions = {
 };
 
 export default {
-  title: getStoryTitle(BigNumbers.displayName),
+  title: 'IBM Products/Components/BigNumbers',
   component: BigNumbers,
   tags: ['autodocs'],
   // TODO: Define argTypes for props not represented by standard JS types.

--- a/packages/ibm-products/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.stories.js
+++ b/packages/ibm-products/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.stories.js
@@ -1,18 +1,15 @@
-//
-// Copyright IBM Corp. 2020, 2021
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/**
+ * Copyright IBM Corp. 2020, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 
 import { BreadcrumbWithOverflow } from '.';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { DisplayBox } from '../../global/js/utils/DisplayBox';
 import styles from './_storybook-styles.scss';
 
@@ -23,7 +20,7 @@ const lastBreadcrumbs = [
 ];
 
 export default {
-  title: getStoryTitle(BreadcrumbWithOverflow.displayName),
+  title: 'IBM Products/Internal/BreadcrumbWithOverflow',
   component: BreadcrumbWithOverflow,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/ButtonMenu/ButtonMenu.stories.js
+++ b/packages/ibm-products/src/components/ButtonMenu/ButtonMenu.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,10 +9,7 @@ import React from 'react';
 
 import { action } from '@storybook/addon-actions';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { ActionableNotification } from '@carbon/react';
 
 import { ButtonMenu, ButtonMenuItem } from '.';
@@ -23,7 +20,7 @@ import { ButtonMenu, ButtonMenuItem } from '.';
 import { Add } from '@carbon/react/icons';
 
 export default {
-  title: getStoryTitle(ButtonMenu.displayName),
+  title: 'IBM Products/Internal/ButtonMenu',
   component: ButtonMenu,
   tags: ['autodocs'],
   // TODO: Define argTypes for props not represented by standard JS types.

--- a/packages/ibm-products/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.stories.js
+++ b/packages/ibm-products/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.stories.js
@@ -1,18 +1,15 @@
-//
-// Copyright IBM Corp. 2020, 2021
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/**
+ * Copyright IBM Corp. 2020, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import React from 'react';
 
 import { action } from '@storybook/addon-actions';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { ButtonSetWithOverflow } from '.';
 import { DisplayBox } from '../../global/js/utils/DisplayBox';
 import styles from './_storybook-styles.scss';
@@ -20,7 +17,7 @@ import styles from './_storybook-styles.scss';
 // Carbon and package components we use.
 
 export default {
-  title: getStoryTitle(ButtonSetWithOverflow.displayName),
+  title: 'IBM Products/Internal/ButtonSetWithOverflow',
   component: ButtonSetWithOverflow,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/Carousel/Carousel.stories.js
+++ b/packages/ibm-products/src/components/Carousel/Carousel.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2023, 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,17 +7,14 @@
 
 import React from 'react';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { Carousel } from '.';
 import styles from './_storybook-styles.scss';
 import DocsPage from './Carousel.docs-page';
 
 export default {
-  title: getStoryTitle(Carousel.displayName),
+  title: 'IBM Products/Internal/Carousel',
   component: Carousel,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Cascade/Cascade.stories.js
+++ b/packages/ibm-products/src/components/Cascade/Cascade.stories.js
@@ -1,22 +1,19 @@
-//
-// Copyright IBM Corp. 2021, 2021
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/**
+ * Copyright IBM Corp. 2021, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import React from 'react';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { Cascade } from '.';
 import styles from './_storybook-styles.scss'; // import index in case more files are added later.
 import { Column } from '@carbon/react';
 import DocsPage from './Cascade.docs-page';
 
 export default {
-  title: getStoryTitle(Cascade.displayName),
+  title: 'IBM Products/Patterns/Cascade',
   component: Cascade,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/ComboButton/ComboButton.stories.js
+++ b/packages/ibm-products/src/components/ComboButton/ComboButton.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,17 +9,14 @@ import { CloudApp } from '@carbon/react/icons';
 import React from 'react';
 import { ActionableNotification } from '@carbon/react';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { ComboButton, ComboButtonItem } from '..';
 
 // import styles from './_combo-button.scss';
 
 export default {
-  title: getStoryTitle(ComboButton.displayName),
+  title: 'IBM Products/Internal/ComboButton',
   component: ComboButton,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.stories.js
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.stories.js
@@ -1,14 +1,11 @@
 /**
- * Copyright IBM Corp. 2021, 2023
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 import React, { useState } from 'react';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { action } from '@storybook/addon-actions';
 import { usePrefix } from '@carbon/react';
 import { CreateFullPage } from '.';
@@ -45,7 +42,7 @@ const breadcrumbs = {
 };
 
 export default {
-  title: getStoryTitle(CreateFullPage.displayName),
+  title: 'IBM Products/Patterns/Create flows/CreateFullPage',
   component: CreateFullPage,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/CreateModal/CreateModal.stories.js
+++ b/packages/ibm-products/src/components/CreateModal/CreateModal.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -21,17 +21,14 @@ import {
 } from '@carbon/react';
 
 import { pkg } from '../../settings';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { CreateModal } from '.';
 
 import styles from './_storybook-styles.scss';
 import DocsPage from './CreateModal.docs-page';
 
 export default {
-  title: getStoryTitle(CreateModal.displayName),
+  title: 'IBM Products/Patterns/Create flows/CreateModal',
   component: CreateModal,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/CreateSidePanel/CreateSidePanel.stories.js
+++ b/packages/ibm-products/src/components/CreateSidePanel/CreateSidePanel.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -22,10 +22,7 @@ import {
 } from '@carbon/react';
 
 import { pkg } from '../../settings';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { CreateSidePanel } from './CreateSidePanel';
 
@@ -82,7 +79,7 @@ const renderUIShellHeader = () => (
 );
 
 export default {
-  title: getStoryTitle(CreateSidePanel.displayName),
+  title: 'IBM Products/Patterns/Create flows/CreateSidePanel',
   component: CreateSidePanel,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.stories.js
+++ b/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.stories.js
@@ -1,15 +1,12 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { slugArgTypes } from '../../global/js/story-parts/slug';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import styles from './_storybook-styles.scss';
 import { CreateTearsheet } from './CreateTearsheet';
 import DocsPage from './CreateTearsheet.docs-page';
@@ -18,7 +15,7 @@ import { MultiStepWithIntro } from './preview-components/MultiStepWithIntro';
 import { MultiStepWithStepInErrorState } from './preview-components/MultiStepWithStepInErrorState';
 
 export default {
-  title: getStoryTitle(CreateTearsheet.displayName),
+  title: 'IBM Products/Patterns/Create flows/CreateTearsheet',
   component: CreateTearsheet,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.stories.js
+++ b/packages/ibm-products/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,10 +16,7 @@ import {
   FormGroup,
 } from '@carbon/react';
 import { pkg } from '../../settings';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { CreateTearsheetNarrow } from '.';
 import styles from './_storybook-styles.scss';
@@ -27,7 +24,7 @@ import { StoryDocsPage } from '../../global/js/utils/StoryDocsPage';
 import { SlugSample, slugArgTypes } from '../../global/js/story-parts/slug';
 
 export default {
-  title: getStoryTitle(CreateTearsheetNarrow.displayName),
+  title: 'IBM Products/Patterns/Create flows/CreateTearsheetNarrow',
   component: CreateTearsheetNarrow,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheet.stories.js
+++ b/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheet.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,10 +7,7 @@
 
 import React, { useMemo, useState } from 'react';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { DataSpreadsheet } from '.';
 import { generateData } from './utils/generateData';
@@ -19,7 +16,7 @@ import { generateData } from './utils/generateData';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: getStoryTitle(DataSpreadsheet.displayName),
+  title: 'IBM Products/Components/DataSpreadsheet',
   component: DataSpreadsheet,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -8,7 +8,6 @@
 
 import React, { useState, useEffect } from 'react';
 import { makeData } from './utils/makeData';
-import { getStoryTitle } from '../../global/js/utils/story-helper';
 import { action } from '@storybook/addon-actions';
 import { Activity, Add } from '@carbon/react/icons';
 import { TableBatchAction, TableBatchActions } from '@carbon/react';
@@ -35,7 +34,7 @@ import { Wrapper } from './utils/Wrapper';
 import DocsPage from './Datagrid.docs-page';
 
 export default {
-  title: getStoryTitle(Datagrid.displayName),
+  title: 'IBM Products/Components/Datagrid',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,10 +9,7 @@
 import React, { useState } from 'react';
 import { Edit, TrashCan, Add } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../../global/js/utils/story-helper';
 import {
   Datagrid,
   useDatagrid,
@@ -34,7 +31,7 @@ import { SidePanel } from '../../../SidePanel';
 import { StoryDocsPage } from '../../../../global/js/utils/StoryDocsPage';
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/ClickableRow`,
+  title: 'IBM Products/Components/Datagrid/ClickableRow',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,10 +9,7 @@
 import React, { useState } from 'react';
 import { Checkmark, Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../../global/js/utils/story-helper';
 import {
   Datagrid,
   useDatagrid,
@@ -31,9 +28,7 @@ import { CodeSnippet } from '@carbon/react';
 import { pkg } from '../../../../settings';
 
 export default {
-  title: `${getStoryTitle(
-    Datagrid.displayName
-  )}/Extensions/ColumnCustomization`,
+  title: 'IBM Products/Components/Datagrid/ColumnCustomization',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/EditableCell/EditableCell.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/EditableCell/EditableCell.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,10 +9,7 @@
 import React, { useState } from 'react';
 import { Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../../global/js/utils/story-helper';
 import {
   Datagrid,
   useDatagrid,
@@ -30,7 +27,7 @@ const blockClass = `${pkg.prefix}--datagrid`;
 const storybookBlockClass = `storybook-${blockClass}__validation-code-snippet`;
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/EditableCell`,
+  title: 'IBM Products/Components/Datagrid/EditableCell',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
@@ -9,10 +9,7 @@
 import React, { useState } from 'react';
 import { Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../../global/js/utils/story-helper';
 import {
   Datagrid,
   useDatagrid,
@@ -30,7 +27,7 @@ import { DocsPage } from './ExpandableRow.docs-page';
 import { usePrefix } from '../../../../global/js/hooks';
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/ExpandableRow`,
+  title: 'IBM Products/Components/Datagrid/ExpandableRow',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.js
@@ -11,10 +11,7 @@ import React, { useState } from 'react';
 import { Tooltip } from '@carbon/react';
 import { getBatchActions } from '../../Datagrid.stories';
 import { action } from '@storybook/addon-actions';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../../global/js/utils/story-helper';
 import {
   Datagrid,
   useDatagrid,
@@ -31,7 +28,7 @@ import { handleFilterTagLabelText } from '../../utils/handleFilterTagLabelText';
 import { getDateFormat, multiSelectProps } from './Panel.stories';
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/Flyout`,
+  title: 'IBM Products/Components/Datagrid/Flyout',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.js
@@ -15,10 +15,7 @@ import {
   useFiltering,
   useColumnCenterAlign,
 } from '../../index';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../../global/js/utils/story-helper';
 
 import { ARG_TYPES } from '../../utils/getArgTypes';
 import { getBatchActions } from '../../Datagrid.stories';
@@ -31,7 +28,7 @@ import { makeData } from '../../utils/makeData';
 import styles from '../../_storybook-styles.scss';
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/Panel`,
+  title: 'IBM Products/Components/Datagrid/Panel',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,10 +9,7 @@
 import React, { useState } from 'react';
 import { Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../../global/js/utils/story-helper';
 import {
   Datagrid,
   useDatagrid,
@@ -26,7 +23,7 @@ import { ARG_TYPES } from '../../utils/getArgTypes';
 import { StoryDocsPage } from '../../../../global/js/utils/StoryDocsPage';
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/NestedRows`,
+  title: 'IBM Products/Components/Datagrid/NestedRows',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,10 +9,7 @@
 import React, { useState } from 'react';
 import { Add, Edit, TrashCan, Checkmark } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../../global/js/utils/story-helper';
 import {
   Datagrid,
   useDatagrid,
@@ -28,7 +25,7 @@ import { makeData } from '../../utils/makeData';
 import { ARG_TYPES } from '../../utils/getArgTypes';
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/RowActionButtons`,
+  title: 'IBM Products/Components/Datagrid/RowActionButtons',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/RowHeightSettings/RowHeightSettings.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/RowHeightSettings/RowHeightSettings.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,10 +9,7 @@
 import React, { useState } from 'react';
 import { Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../../global/js/utils/story-helper';
 import { Datagrid, useDatagrid } from '../../index';
 import styles from '../../_storybook-styles.scss';
 // import mdx from '../../Datagrid.mdx';
@@ -22,7 +19,7 @@ import { makeData } from '../../utils/makeData';
 import { ARG_TYPES } from '../../utils/getArgTypes';
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/RowHeightSettings`,
+  title: 'IBM Products/Components/Datagrid/RowHeightSettings',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Slug/Slug.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Slug/Slug.stories.js
@@ -18,10 +18,7 @@ import {
   usePrefix,
 } from '@carbon/react';
 import { action } from '@storybook/addon-actions';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../../global/js/utils/story-helper';
 import {
   Datagrid,
   useDatagrid,
@@ -36,7 +33,7 @@ import { ARG_TYPES } from '../../utils/getArgTypes';
 import { StoryDocsPage } from '../../../../global/js/utils/StoryDocsPage';
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/Slug`,
+  title: 'IBM Products/Components/Datagrid/Slug',
   component: Datagrid,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Decorator/Decorator.mdx
+++ b/packages/ibm-products/src/components/Decorator/Decorator.mdx
@@ -1,9 +1,7 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import {
-  getStoryId,
-  CodesandboxLink,
-} from '../../global/js/utils/story-helper';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import { Decorator } from '.';
+import * as DecoratorStories from './Decorator.stories';
 
 # Decorator
 
@@ -25,7 +23,7 @@ element.
 ## Decorator example usage
 
 <Canvas withSource="none">
-  <Story id={getStoryId(Decorator.displayName, 'decorator')} />
+  <Story of={DecoratorStories.decorator} />
 </Canvas>
 
 ## Decorator code sample
@@ -37,7 +35,7 @@ element.
 ## Decorator as Link example usage
 
 <Canvas withSource="none">
-  <Story id={getStoryId(Decorator.displayName, 'as-link')} />
+  <Story of={DecoratorStories.asLink} />
 </Canvas>
 
 ## Decorator as Link code sample
@@ -76,7 +74,7 @@ adding `target="_blank"` to open in a new browser tab.
 ## Decorator as Single Button example usage
 
 <Canvas withSource="none">
-  <Story id={getStoryId(Decorator.displayName, 'as-single-button')} />
+  <Story of={DecoratorStories.asSingleButton} />
 </Canvas>
 
 ## Decorator as Single Button code sample
@@ -99,7 +97,7 @@ adding `target="_blank"` to open in a new browser tab.
 ## Decorator as Dual Button example usage
 
 <Canvas withSource="none">
-  <Story id={getStoryId(Decorator.displayName, 'as-dual-button')} />
+  <Story of={DecoratorStories.asDualButton} />
 </Canvas>
 
 ## Decorator as Dual Button code sample

--- a/packages/ibm-products/src/components/Decorator/Decorator.stories.js
+++ b/packages/ibm-products/src/components/Decorator/Decorator.stories.js
@@ -8,10 +8,7 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { Decorator } from '.';
 import mdx from './Decorator.mdx';
@@ -37,7 +34,7 @@ const scoreOptions = {
 };
 
 export default {
-  title: getStoryTitle(Decorator.displayName),
+  title: 'IBM Products/Components/Decorator',
   component: Decorator,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/DelimitedList/DelimitedList.stories.js
+++ b/packages/ibm-products/src/components/DelimitedList/DelimitedList.stories.js
@@ -7,10 +7,7 @@
 
 import React from 'react';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { DelimitedList } from '.';
 
@@ -20,7 +17,7 @@ import DocsPage from './DelimitedList';
 const storyClass = 'delimited-list-stories';
 
 export default {
-  title: getStoryTitle(DelimitedList.displayName),
+  title: 'IBM Products/Components/DelimitedList',
   component: DelimitedList,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/DescriptionList/DescriptionList.mdx
+++ b/packages/ibm-products/src/components/DescriptionList/DescriptionList.mdx
@@ -1,8 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import {
-  getStoryId,
-  CodesandboxLink,
-} from '../../global/js/utils/story-helper';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import { DescriptionList } from '.';
 import * as DescriptionListStories from './DescriptionList.stories';
 

--- a/packages/ibm-products/src/components/DescriptionList/DescriptionList.mdx
+++ b/packages/ibm-products/src/components/DescriptionList/DescriptionList.mdx
@@ -4,6 +4,7 @@ import {
   CodesandboxLink,
 } from '../../global/js/utils/story-helper';
 import { DescriptionList } from '.';
+import * as DescriptionListStories from './DescriptionList.stories';
 
 # DescriptionList
 
@@ -22,7 +23,7 @@ Type layouts provide an orderly layout of terms and definitions.
 {/* TODO: One example per designed use case. */}
 
 <Canvas>
-  <Story id={getStoryId(DescriptionList.displayName, 'description-list')} />
+  <Story of={DescriptionListStories.descriptionList} />
 </Canvas>
 
 ## Component API

--- a/packages/ibm-products/src/components/DescriptionList/DescriptionList.stories.js
+++ b/packages/ibm-products/src/components/DescriptionList/DescriptionList.stories.js
@@ -1,3 +1,5 @@
+//cspell: disable
+
 /**
  * Copyright IBM Corp. 2024, 2024
  *
@@ -9,10 +11,7 @@ import React from 'react';
 // TODO: import action to handle events if required.
 // import { action } from '@storybook/addon-actions';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import {
   DescriptionList,
@@ -28,7 +27,7 @@ import mdx from './DescriptionList.mdx';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: getStoryTitle(DescriptionList.displayName),
+  title: 'IBM Products/Components/DescriptionList',
   component: DescriptionList,
   tags: ['autodocs'],
   // TODO: Define argTypes for props not represented by standard JS types.

--- a/packages/ibm-products/src/components/DragAndDrop/DragAndDrop.stories.js
+++ b/packages/ibm-products/src/components/DragAndDrop/DragAndDrop.stories.js
@@ -7,10 +7,7 @@
 
 import React from 'react';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import {
   horizontalListSortingStrategy,
@@ -33,7 +30,7 @@ import {
 } from '@dnd-kit/modifiers';
 
 export default {
-  title: getStoryTitle('DragAndDrop'),
+  title: 'IBM Products/Patterns/Drag and drop',
   component: () => {},
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/EditFullPage/EditFullPage.stories.js
+++ b/packages/ibm-products/src/components/EditFullPage/EditFullPage.stories.js
@@ -1,15 +1,12 @@
 /**
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 import React, { useState } from 'react';
 import { carbon } from '../../settings';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { action } from '@storybook/addon-actions';
 import { CreateFullPage } from '../CreateFullPage';
 import { CreateFullPageStep } from '../CreateFullPage/CreateFullPageStep';
@@ -38,7 +35,7 @@ import {
 import DocsPage from './EditFullPage.docs-page';
 
 export default {
-  title: getStoryTitle(EditFullPage.displayName),
+  title: 'IBM Products/Patterns/Edit and update/EditFullPage',
   component: EditFullPage,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/EditInPlace/EditInPlace.stories.js
+++ b/packages/ibm-products/src/components/EditInPlace/EditInPlace.stories.js
@@ -1,15 +1,12 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import React, { useState } from 'react';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { action } from '@storybook/addon-actions';
 import { EditInPlace } from '.';
 import { DisplayBox } from '../../global/js/utils/DisplayBox';
@@ -37,7 +34,7 @@ const tooltipAlignmentOptions = {
 };
 
 export default {
-  title: getStoryTitle(EditInPlace.displayName),
+  title: 'IBM Products/Patterns/Edit and update/EditInPlace',
   component: EditInPlace,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/EditSidePanel/EditSidePanel.stories.js
+++ b/packages/ibm-products/src/components/EditSidePanel/EditSidePanel.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -23,10 +23,7 @@ import {
 } from '@carbon/react';
 import { Copy, TrashCan, Settings } from '@carbon/react/icons';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { EditSidePanel } from '.';
 
@@ -79,7 +76,7 @@ const renderUIShellHeader = () => (
 const prefix = 'edit-side-panel-stories__';
 
 export default {
-  title: getStoryTitle(EditSidePanel.displayName),
+  title: 'IBM Products/Patterns/Edit and update/EditSidePanel',
   component: EditSidePanel,
   tags: ['autodocs'],
   // TODO: Define argTypes for props not represented by standard JS types.

--- a/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.stories.js
+++ b/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.stories.js
@@ -1,14 +1,11 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import styles from './_storybook-styles.scss';
 import { EditTearsheet } from './EditTearsheet';
 import DocsPage from './EditTearsheet.docs-page';
@@ -16,7 +13,7 @@ import { MultiFormEditTearsheet } from './preview-components/MultiFormEditTearsh
 import { slugArgTypes } from '../../global/js/story-parts/slug';
 
 export default {
-  title: getStoryTitle(EditTearsheet.displayName),
+  title: 'IBM Products/Patterns/Edit and update/EditTearsheet',
   component: EditTearsheet,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/EditTearsheetNarrow/EditTearsheetNarrow.stories.js
+++ b/packages/ibm-products/src/components/EditTearsheetNarrow/EditTearsheetNarrow.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,10 +16,7 @@ import {
   FormGroup,
 } from '@carbon/react';
 import { pkg } from '../../settings';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { EditTearsheetNarrow } from '.';
 import { CreateTearsheetNarrow } from '../CreateTearsheetNarrow';
@@ -29,8 +26,8 @@ import { StoryDocsPage } from '../../global/js/utils/StoryDocsPage';
 import { SlugSample, slugArgTypes } from '../../global/js/story-parts/slug';
 
 export default {
-  title: getStoryTitle(EditTearsheetNarrow.displayName),
-  component: CreateTearsheetNarrow,
+  title: 'IBM Products/Patterns/Edit and update/EditTearsheetNarrow',
+  component: EditTearsheetNarrow,
   tags: ['autodocs'],
   parameters: {
     styles,

--- a/packages/ibm-products/src/components/EditUpdateCards/EditUpdateCards.stories.js
+++ b/packages/ibm-products/src/components/EditUpdateCards/EditUpdateCards.stories.js
@@ -1,18 +1,13 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import React, { useState } from 'react';
-// TODO: import action to handle events if required.
-// import { action } from '@storybook/addon-actions';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { EditUpdateCards } from '.';
 
@@ -37,7 +32,7 @@ import { pkg /*, carbon */ } from '../../settings';
 import { StoryDocsPage } from '../../global/js/utils/StoryDocsPage';
 
 export default {
-  title: getStoryTitle(EditUpdateCards.displayName),
+  title: 'IBM Products/Patterns/Edit and update/EditUpdateCards',
   component: EditUpdateCards,
   tags: ['autodocs'],
   // TODO: Define argTypes for props not represented by standard JS types.

--- a/packages/ibm-products/src/components/EmptyStates/EmptyStateV2.stories.js
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyStateV2.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,15 +9,12 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Add } from '@carbon/react/icons';
 import CustomIllustration from './story_assets/empty-state-bright-magnifying-glass.svg';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { EmptyStateV2 } from '.';
 import { StoryDocsPage } from '../../global/js/utils/StoryDocsPage';
 
 export default {
-  title: getStoryTitle(EmptyStateV2.displayName),
+  title: 'IBM Products/Patterns/Empty state/EmptyStateV2',
   component: EmptyStateV2,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/EmptyStates/EmptyStates.stories.js
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyStates.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,10 +9,7 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Add } from '@carbon/react/icons';
 import CustomIllustration from './story_assets/empty-state-bright-magnifying-glass.svg';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 // import mdx from './EmptyState.mdx';
 
 import { EmptyState } from '.';
@@ -21,7 +18,7 @@ import { StoryDocsPage } from '../../global/js/utils/StoryDocsPage';
 // import styles from './_storybook-styles.scss';
 
 export default {
-  title: getStoryTitle(EmptyState.displayName),
+  title: 'IBM Products/Patterns/Empty state/EmptyState',
   component: EmptyState,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.stories.js
+++ b/packages/ibm-products/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,10 +9,7 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Add } from '@carbon/react/icons';
 // import mdx from './ErrorEmptyState.mdx';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../global/js/utils/story-helper';
 
 import { ErrorEmptyState } from '.';
 import { StoryDocsPage } from '../../../global/js/utils/StoryDocsPage';
@@ -20,7 +17,7 @@ import { StoryDocsPage } from '../../../global/js/utils/StoryDocsPage';
 // import styles from '../_index.scss';
 
 export default {
-  title: getStoryTitle(ErrorEmptyState.displayName),
+  title: 'IBM Products/Patterns/Empty state/ErrorEmptyState',
   component: ErrorEmptyState,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.stories.js
+++ b/packages/ibm-products/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,10 +9,7 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Add } from '@carbon/react/icons';
 // import mdx from './NoDataEmptyState.mdx';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../global/js/utils/story-helper';
 
 import { NoDataEmptyState } from '.';
 import { StoryDocsPage } from '../../../global/js/utils/StoryDocsPage';
@@ -20,7 +17,7 @@ import { StoryDocsPage } from '../../../global/js/utils/StoryDocsPage';
 // import styles from '../_index.scss';
 
 export default {
-  title: getStoryTitle(NoDataEmptyState.displayName),
+  title: 'IBM Products/Patterns/Empty state/NoDataEmptyState',
   component: NoDataEmptyState,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.stories.js
+++ b/packages/ibm-products/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,10 +9,7 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Add } from '@carbon/react/icons';
 // import mdx from './NoTagsEmptyState.mdx';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../global/js/utils/story-helper';
 
 import { NoTagsEmptyState } from '.';
 import { StoryDocsPage } from '../../../global/js/utils/StoryDocsPage';
@@ -20,7 +17,7 @@ import { StoryDocsPage } from '../../../global/js/utils/StoryDocsPage';
 // import styles from '../_index.scss';
 
 export default {
-  title: getStoryTitle(NoTagsEmptyState.displayName),
+  title: 'IBM Products/Patterns/Empty state/NoTagsEmptyState',
   component: NoTagsEmptyState,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.stories.js
+++ b/packages/ibm-products/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,17 +9,14 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Add } from '@carbon/react/icons';
 // import mdx from './NotFoundEmptyState.mdx';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../global/js/utils/story-helper';
 import { NotFoundEmptyState } from '.';
 import { StoryDocsPage } from '../../../global/js/utils/StoryDocsPage';
 
 // import styles from '../_index.scss';
 
 export default {
-  title: getStoryTitle(NotFoundEmptyState.displayName),
+  title: 'IBM Products/Patterns/Empty state/NotFoundEmptyState',
   component: NotFoundEmptyState,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.stories.js
+++ b/packages/ibm-products/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,17 +9,14 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Add } from '@carbon/react/icons';
 // import mdx from './NotificationsEmptyState.mdx';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../global/js/utils/story-helper';
 import { NotificationsEmptyState } from '.';
 import { StoryDocsPage } from '../../../global/js/utils/StoryDocsPage';
 
 // import styles from '../_index.scss';
 
 export default {
-  title: getStoryTitle(NotificationsEmptyState.displayName),
+  title: 'IBM Products/Patterns/Empty state/NotificationsEmptyState',
   component: NotificationsEmptyState,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.stories.js
+++ b/packages/ibm-products/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,17 +9,14 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Add } from '@carbon/react/icons';
 // import mdx from './UnauthorizedEmptyState.mdx';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../global/js/utils/story-helper';
 import { UnauthorizedEmptyState } from '.';
 import { StoryDocsPage } from '../../../global/js/utils/StoryDocsPage';
 
 // import styles from '../_index.scss';
 
 export default {
-  title: getStoryTitle(UnauthorizedEmptyState.displayName),
+  title: 'IBM Products/Patterns/Empty state/UnauthorizedEmptyState',
   component: UnauthorizedEmptyState,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/ExampleComponent/ExampleComponent.stories.js
+++ b/packages/ibm-products/src/components/ExampleComponent/ExampleComponent.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -8,10 +8,7 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Add } from '@carbon/react/icons';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { ExampleComponent } from '.';
 import { pkg } from '../../settings';
@@ -20,7 +17,7 @@ import { pkg } from '../../settings';
 // import styles from './_storybook-styles.scss';
 
 export default {
-  title: getStoryTitle(ExampleComponent.displayName),
+  title: 'IBM Products/Internal/ExampleComponent',
   component: ExampleComponent,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/ExportModal/ExportModal.stories.js
+++ b/packages/ibm-products/src/components/ExportModal/ExportModal.stories.js
@@ -1,24 +1,21 @@
-//
-// Copyright IBM Corp. 2020, 2021
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/**
+ * Copyright IBM Corp. 2020, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import React, { useState } from 'react';
 import { Button } from '@carbon/react';
 // import styles from './_storybook-styles.scss'; // import index in case more files are added later.
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { ExportModal } from '.';
 // import mdx from './ExportModal.mdx';
 import wait from '../../global/js/utils/wait';
 import { StoryDocsPage } from '../../global/js/utils/StoryDocsPage';
 
 export default {
-  title: getStoryTitle(ExportModal.displayName),
+  title: 'IBM Products/Patterns/Export/ExportModal',
   component: ExportModal,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.stories.js
+++ b/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.stories.js
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -17,10 +17,7 @@ import {
   unstable__SlugContent as SlugContent,
 } from '@carbon/react';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { ExpressiveCard } from '.';
 // import mdx from './ExpressiveCard.mdx';
 import { action } from '@storybook/addon-actions';
@@ -46,7 +43,7 @@ const sampleSlug = (
 );
 
 export default {
-  title: getStoryTitle(ExpressiveCard.displayName),
+  title: 'IBM Products/Components/Cards/ExpressiveCard',
   component: ExpressiveCard,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/FilterSummary/FilterSummary.stories.js
+++ b/packages/ibm-products/src/components/FilterSummary/FilterSummary.stories.js
@@ -1,22 +1,19 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import React, { useState } from 'react';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { FilterSummary } from '.';
 
 import styles from './_storybook-styles.scss';
 import { DisplayBox } from '../../global/js/utils/DisplayBox';
 
 export default {
-  title: getStoryTitle(FilterSummary.displayName),
+  title: 'IBM Products/Internal/FilterSummary',
   component: FilterSummary,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/FullPageError/FullPageError.stories.js
+++ b/packages/ibm-products/src/components/FullPageError/FullPageError.stories.js
@@ -12,10 +12,7 @@ import React from 'react';
 import { UiShell } from './preview-components/UiShell';
 import { Breadcrumbs } from './preview-components/Breadcrumbs';
 import { Link } from '@carbon/react';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { FullPageError } from '.';
 import mdx from './FullPageError.mdx';
@@ -25,7 +22,7 @@ import styles from './_storybook-styles.scss';
 const storyClass = 'full-page-error-stories';
 
 export default {
-  title: getStoryTitle(FullPageError.displayName),
+  title: 'IBM Products/Patterns/Full-page error/FullPageError',
   component: FullPageError,
   tags: ['autodocs'],
   // TODO: Define argTypes for props not represented by standard JS types.

--- a/packages/ibm-products/src/components/HTTPErrors/HTTPError403/HTTPError403.stories.js
+++ b/packages/ibm-products/src/components/HTTPErrors/HTTPError403/HTTPError403.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,14 +7,11 @@
 
 import React from 'react';
 import { HTTPError403 } from '.';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../global/js/utils/story-helper';
 import { StoryDocsPage } from '../../../global/js/utils/StoryDocsPage';
 
 export default {
-  title: getStoryTitle(HTTPError403.displayName),
+  title: 'IBM Products/Patterns/HTTP errors/HTTPError403',
   component: HTTPError403,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/HTTPErrors/HTTPError404/HTTPError404.stories.js
+++ b/packages/ibm-products/src/components/HTTPErrors/HTTPError404/HTTPError404.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,14 +7,11 @@
 
 import React from 'react';
 import { HTTPError404 } from '.';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../global/js/utils/story-helper';
 import { StoryDocsPage } from '../../../global/js/utils/StoryDocsPage';
 
 export default {
-  title: getStoryTitle(HTTPError404.displayName),
+  title: 'IBM Products/Patterns/HTTP errors/HTTPError404',
   component: HTTPError404,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/HTTPErrors/HTTPErrorOther/HTTPErrorOther.stories.js
+++ b/packages/ibm-products/src/components/HTTPErrors/HTTPErrorOther/HTTPErrorOther.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,14 +7,11 @@
 
 import React from 'react';
 import { HTTPErrorOther } from '.';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../../global/js/utils/story-helper';
+import { prepareStory } from '../../../global/js/utils/story-helper';
 import { StoryDocsPage } from '../../../global/js/utils/StoryDocsPage';
 
 export default {
-  title: getStoryTitle(HTTPErrorOther.displayName),
+  title: 'IBM Products/Patterns/HTTP errors/HTTPErrorOther',
   component: HTTPErrorOther,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/ImportModal/ImportModal.stories.js
+++ b/packages/ibm-products/src/components/ImportModal/ImportModal.stories.js
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2021
+// Copyright IBM Corp. 2021, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -9,16 +9,13 @@ import React, { useState } from 'react';
 import { Button } from '@carbon/react';
 import { action } from '@storybook/addon-actions';
 // import styles from './_storybook-styles.scss'; // import index in case more files are added later.
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { ImportModal } from '.';
 import DocsPage from './ImportModal.docs-page';
 // import mdx from './ImportModal.mdx';
 
 export default {
-  title: getStoryTitle(ImportModal.displayName),
+  title: 'IBM Products/Patterns/Import and upload/ImportModal',
   component: ImportModal,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreen.mdx
+++ b/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreen.mdx
@@ -1,8 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import {
-  getStoryId,
-  CodesandboxLink,
-} from '../../global/js/utils/story-helper';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import { InterstitialScreen } from '.';
 
 # InterstitialScreen

--- a/packages/ibm-products/src/components/MultiAddSelect/MultiAddSelect.stories.js
+++ b/packages/ibm-products/src/components/MultiAddSelect/MultiAddSelect.stories.js
@@ -7,13 +7,9 @@
 
 import React, { useState } from 'react';
 // import styles from './_storybook-styles.scss'; // import index in case more files are added later.
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { MultiAddSelect } from '.';
 import { Button } from '@carbon/react';
-// import { action } from '@storybook/addon-actions';
 import image from '../UserProfileImage/headshot.jpg'; // cspell:disable-line
 import { Group, Document } from '@carbon/react/icons';
 
@@ -22,7 +18,7 @@ import DocsPage from './MultiAddSelect.docs-page';
 const blockClass = `${pkg.prefix}--add-select__meta-panel`;
 
 export default {
-  title: getStoryTitle(MultiAddSelect.displayName),
+  title: 'IBM Products/Patterns/Add select/MultiAddSelect',
   component: MultiAddSelect,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Nav/Nav.mdx
+++ b/packages/ibm-products/src/components/Nav/Nav.mdx
@@ -1,9 +1,7 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import {
-  getStoryId,
-  CodesandboxLink,
-} from '../../global/js/utils/story-helper';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import { Nav } from '.';
+import * as NavStories from './Nav.stories';
 
 # Nav
 
@@ -22,7 +20,7 @@ import { Nav } from '.';
 {/* TODO: One example per designed use case. */}
 
 <Canvas>
-  <Story id={getStoryId('Nav', 'nav')} />
+  <Story of={NavStories.nav} />
 </Canvas>
 
 ## Code sample

--- a/packages/ibm-products/src/components/Nav/Nav.stories.js
+++ b/packages/ibm-products/src/components/Nav/Nav.stories.js
@@ -1,3 +1,5 @@
+//cspell: disable
+
 /**
  * Copyright IBM Corp. 2024, 2024
  *
@@ -8,10 +10,7 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import Nav from './Nav';
 import NavItem from './NavItem';
@@ -21,7 +20,7 @@ import mdx from './Nav.mdx';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: getStoryTitle(Nav.displayName),
+  title: 'IBM Products/Components/Nav',
   component: Nav,
   subcomponents: {
     NavList,

--- a/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.stories.js
+++ b/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -23,10 +23,7 @@ import { pkg } from '../../settings';
 
 import { NotificationsPanel } from '.';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 // import mdx from './NotificationsPanel.mdx';
 import data from './NotificationsPanel_data';
@@ -34,7 +31,7 @@ import data from './NotificationsPanel_data';
 const storyBlockClass = `${pkg.prefix}--notifications-panel__story`;
 
 export default {
-  title: getStoryTitle(NotificationsPanel.displayName),
+  title: 'IBM Products/Patterns/Notifications/NotificationsPanel',
   component: NotificationsPanel,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/OptionsTile/OptionsTile.stories.js
+++ b/packages/ibm-products/src/components/OptionsTile/OptionsTile.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,10 +10,7 @@ import { action } from '@storybook/addon-actions';
 
 import { Dropdown, FormGroup } from '@carbon/react';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import uuidv4 from '../../global/js/utils/uuidv4';
 
 import { OptionsTile } from '.';
@@ -22,7 +19,7 @@ import { OptionsTile } from '.';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: getStoryTitle(OptionsTile.displayName),
+  title: 'IBM Products/Components/OptionsTile',
   component: OptionsTile,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/ibm-products/src/components/PageHeader/PageHeader.stories.js
@@ -42,10 +42,7 @@ import cx from 'classnames';
 
 import { PageHeader } from './PageHeader';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { demoTableHeaders, demoTableData } from './PageHeaderDemo.data';
 
@@ -395,7 +392,7 @@ const fullWidthGrid = {
 };
 
 export default {
-  title: getStoryTitle(PageHeader.displayName),
+  title: 'IBM Products/Components/PageHeader',
   component: PageHeader,
   tags: ['autodocs'],
   parameters: { styles, layout: 'fullscreen' /* docs: { page: mdx } */ },

--- a/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.stories.js
+++ b/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.stories.js
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -15,10 +15,7 @@ import {
   unstable__Slug as Slug,
   unstable__SlugContent as SlugContent,
 } from '@carbon/react';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { ProductiveCard } from '.';
 // import mdx from './ProductiveCard.mdx';
 import { action } from '@storybook/addon-actions';
@@ -44,7 +41,7 @@ const sampleSlug = (
 );
 
 export default {
-  title: getStoryTitle(ProductiveCard.displayName),
+  title: 'IBM Products/Components/Cards/ProductiveCard',
   component: ProductiveCard,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/RemoveModal/RemoveModal.stories.js
+++ b/packages/ibm-products/src/components/RemoveModal/RemoveModal.stories.js
@@ -1,22 +1,19 @@
-//
-// Copyright IBM Corp. 2020, 2021
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/**
+ * Copyright IBM Corp. 2020, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import React, { useState } from 'react';
 import { Button } from '@carbon/react';
 // import styles from './_storybook-styles.scss'; // import index in case more files are added later.
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { RemoveModal } from '.';
 import DocsPage from './RemoveModal.docs-page';
 
 export default {
-  title: getStoryTitle(RemoveModal.displayName),
+  title: 'IBM Products/Patterns/Remove/RemoveModal',
   component: RemoveModal,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Saving/Saving.stories.js
+++ b/packages/ibm-products/src/components/Saving/Saving.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,17 +7,14 @@
 
 import React, { useState, useEffect } from 'react';
 import styles from './_storybook-styles.scss'; // import index in case more files are added later.
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { Saving } from '.';
 // import mdx from './Saving.mdx';
 import wait from '../../global/js/utils/wait';
 import { TextArea } from '@carbon/react';
 
 export default {
-  title: getStoryTitle(Saving.displayName),
+  title: 'IBM Products/Patterns/Saving',
   component: Saving,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/SearchBar/SearchBar.mdx
+++ b/packages/ibm-products/src/components/SearchBar/SearchBar.mdx
@@ -1,8 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import {
-  getStoryId,
-  CodesandboxLink,
-} from '../../global/js/utils/story-helper';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import { SearchBar } from '.';
 import * as SearchBarStories from './SearchBar.stories';
 

--- a/packages/ibm-products/src/components/SearchBar/SearchBar.mdx
+++ b/packages/ibm-products/src/components/SearchBar/SearchBar.mdx
@@ -4,6 +4,7 @@ import {
   CodesandboxLink,
 } from '../../global/js/utils/story-helper';
 import { SearchBar } from '.';
+import * as SearchBarStories from './SearchBar.stories';
 
 # SearchBar
 
@@ -22,31 +23,31 @@ import { SearchBar } from '.';
 ### Default
 
 <Canvas>
-  <Story id={getStoryId(SearchBar.displayName, 'default')} />
+  <Story of={SearchBarStories.Default} />
 </Canvas>
 
 ### Initial Value
 
 <Canvas>
-  <Story id={getStoryId(SearchBar.displayName, 'initial-value')} />
+  <Story of={SearchBarStories.InitialValue} />
 </Canvas>
 
 ### Scopes
 
 <Canvas>
-  <Story id={getStoryId(SearchBar.displayName, 'scopes')} />
+  <Story of={SearchBarStories.Scopes} />
 </Canvas>
 
 ### Unsorted Scopes
 
 <Canvas>
-  <Story id={getStoryId(SearchBar.displayName, 'unsorted-scopes')} />
+  <Story of={SearchBarStories.UnsortedScopes} />
 </Canvas>
 
 ### Selected Scopes
 
 <Canvas>
-  <Story id={getStoryId(SearchBar.displayName, 'selected-scopes')} />
+  <Story of={SearchBarStories.SelectedScopes} />
 </Canvas>
 
 ## Code sample

--- a/packages/ibm-products/src/components/SearchBar/SearchBar.stories.js
+++ b/packages/ibm-products/src/components/SearchBar/SearchBar.stories.js
@@ -8,10 +8,7 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { SearchBar } from '.';
 import mdx from './SearchBar.mdx';
@@ -19,7 +16,7 @@ import mdx from './SearchBar.mdx';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: getStoryTitle(SearchBar.displayName),
+  title: 'IBM Products/Components/SearchBar',
   component: SearchBar,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/SidePanel/SidePanel.stories.js
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -30,10 +30,7 @@ import {
 } from '@carbon/react';
 
 import { Copy, TrashCan, Settings } from '@carbon/react/icons';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { SidePanel } from './SidePanel';
 import { sidePanelDecorator } from '../../global/decorators/sidePanelDecorator';
 // import mdx from './SidePanel.mdx';
@@ -368,7 +365,7 @@ const renderUIShellHeader = () => (
 );
 
 export default {
-  title: getStoryTitle(SidePanel.displayName),
+  title: 'IBM Products/Components/SidePanel',
   component: SidePanel,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/SimpleHeader/SimpleHeader.stories.js
+++ b/packages/ibm-products/src/components/SimpleHeader/SimpleHeader.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2023, 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,10 +7,7 @@
 
 import React from 'react';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { SimpleHeader } from './SimpleHeader';
 
 import DocsPage from './SimpleHeader.docs-page';
@@ -26,7 +23,7 @@ const breadcrumbs = {
 };
 
 export default {
-  title: getStoryTitle(SimpleHeader.displayName),
+  title: 'IBM Products/Internal/SimpleHeader',
   component: SimpleHeader,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/SingleAddSelect/SingleAddSelect.stories.js
+++ b/packages/ibm-products/src/components/SingleAddSelect/SingleAddSelect.stories.js
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2022
+// Copyright IBM Corp. 2022, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -7,17 +7,14 @@
 
 import React, { useState } from 'react';
 // import styles from './_storybook-styles.scss'; // import index in case more files are added later.
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { SingleAddSelect } from '.';
 import { Button } from '@carbon/react';
 import DocsPage from './SingleAddSelect.docs-page';
 // import { action } from '@storybook/addon-actions';
 
 export default {
-  title: getStoryTitle(SingleAddSelect.displayName),
+  title: 'IBM Products/Patterns/Add select/SingleAddSelect',
   component: SingleAddSelect,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/StatusIcon/StatusIcon.stories.js
+++ b/packages/ibm-products/src/components/StatusIcon/StatusIcon.stories.js
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2022
+// Copyright IBM Corp. 2021, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -10,14 +10,11 @@ import React from 'react';
 import { StatusIcon } from '.';
 
 // import styles from './_storybook-styles.scss'; // import storybook which includes component and additional storybook styles
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import DocsPage from './StatusIcon.docs-page';
 
 export default {
-  title: getStoryTitle(StatusIcon.displayName),
+  title: 'IBM Products/Patterns/Status icons/StatusIcon',
   component: StatusIcon,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/StatusIndicator/StatusIndicator.mdx
+++ b/packages/ibm-products/src/components/StatusIndicator/StatusIndicator.mdx
@@ -4,6 +4,7 @@ import {
   CodesandboxLink,
 } from '../../global/js/utils/story-helper';
 import { StatusIndicator } from '.';
+import * as StatusIndicatorStories from './StatusIndicator.stories';
 
 # StatusIndicator
 
@@ -17,7 +18,7 @@ import { StatusIndicator } from '.';
 {/* TODO: One example per designed use case. */}
 
 <Canvas>
-  <Story id={getStoryId(StatusIndicator.displayName, 'status-indicator')} />
+  <Story of={StatusIndicatorStories.statusIndicator} />
 </Canvas>
 
 ## Component API

--- a/packages/ibm-products/src/components/StatusIndicator/StatusIndicator.mdx
+++ b/packages/ibm-products/src/components/StatusIndicator/StatusIndicator.mdx
@@ -1,8 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import {
-  getStoryId,
-  CodesandboxLink,
-} from '../../global/js/utils/story-helper';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import { StatusIndicator } from '.';
 import * as StatusIndicatorStories from './StatusIndicator.stories';
 

--- a/packages/ibm-products/src/components/StatusIndicator/StatusIndicator.stories.js
+++ b/packages/ibm-products/src/components/StatusIndicator/StatusIndicator.stories.js
@@ -8,10 +8,7 @@
 import React, { useEffect, useState } from 'react';
 import { action } from '@storybook/addon-actions';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { StatusIndicator, StatusIndicatorStep } from '.';
 import mdx from './StatusIndicator.mdx';
@@ -19,7 +16,7 @@ import mdx from './StatusIndicator.mdx';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: getStoryTitle(StatusIndicator.displayName),
+  title: 'IBM Products/Components/StatusIndicator',
   component: StatusIndicator,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/StatusIndicator/StatusIndicatorStep.mdx
+++ b/packages/ibm-products/src/components/StatusIndicator/StatusIndicatorStep.mdx
@@ -4,6 +4,7 @@ import {
   CodesandboxLink,
 } from '../../global/js/utils/story-helper';
 import { StatusIndicatorStep } from '.';
+import * as StatusIndicatorStepStories from './StatusIndicatorStep.stories';
 
 # StatusIndicatorStep
 
@@ -18,7 +19,7 @@ import { StatusIndicatorStep } from '.';
 
 <Canvas>
   <Story
-    id={getStoryId(StatusIndicatorStep.displayName, 'status-indicator-step')}
+    of={StatusIndicatorStepStories.statusIndicatorStep}
   />
 </Canvas>
 

--- a/packages/ibm-products/src/components/StatusIndicator/StatusIndicatorStep.mdx
+++ b/packages/ibm-products/src/components/StatusIndicator/StatusIndicatorStep.mdx
@@ -1,8 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import {
-  getStoryId,
-  CodesandboxLink,
-} from '../../global/js/utils/story-helper';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import { StatusIndicatorStep } from '.';
 import * as StatusIndicatorStepStories from './StatusIndicatorStep.stories';
 

--- a/packages/ibm-products/src/components/StatusIndicator/StatusIndicatorStep.stories.js
+++ b/packages/ibm-products/src/components/StatusIndicator/StatusIndicatorStep.stories.js
@@ -7,10 +7,7 @@
 
 import React from 'react';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { StatusIndicatorStep } from '.';
 import mdx from './StatusIndicatorStep.mdx';
@@ -18,7 +15,7 @@ import mdx from './StatusIndicatorStep.mdx';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: getStoryTitle(StatusIndicatorStep.displayName),
+  title: 'IBM Products/Components/StatusIndicator/StatusIndicatorStep',
   component: StatusIndicatorStep,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/SteppedAnimatedMedia/SteppedAnimatedMedia.stories.js
+++ b/packages/ibm-products/src/components/SteppedAnimatedMedia/SteppedAnimatedMedia.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2023, 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,10 +7,7 @@
 
 import React from 'react';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { SteppedAnimatedMedia } from '.';
 
@@ -25,7 +22,7 @@ const storyClass = 'stepped-animated-media-stories';
 import DocsPage from './SteppedAnimatedMedia.docs-page';
 
 export default {
-  title: getStoryTitle(SteppedAnimatedMedia.displayName),
+  title: 'IBM Products/Internal/SteppedAnimatedMedia',
   component: SteppedAnimatedMedia,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/StringFormatter/StringFormatter.mdx
+++ b/packages/ibm-products/src/components/StringFormatter/StringFormatter.mdx
@@ -1,8 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import {
-  getStoryId,
-  CodesandboxLink,
-} from '../../global/js/utils/story-helper';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import { StringFormatter } from '.';
 import * as StringFormatterStories from './StringFormatter.stories';
 

--- a/packages/ibm-products/src/components/StringFormatter/StringFormatter.mdx
+++ b/packages/ibm-products/src/components/StringFormatter/StringFormatter.mdx
@@ -4,6 +4,7 @@ import {
   CodesandboxLink,
 } from '../../global/js/utils/story-helper';
 import { StringFormatter } from '.';
+import * as StringFormatterStories from './StringFormatter.stories';
 
 # StringFormatter
 
@@ -21,7 +22,7 @@ hover or focus with the entirety of the provided copy.
 ## Example usage
 
 <Canvas>
-  <Story id={getStoryId(StringFormatter.displayName, 'string-formatter')} />
+  <Story of={StringFormatterStories.stringFormatter} />
 </Canvas>
 
 ## Code sample

--- a/packages/ibm-products/src/components/StringFormatter/StringFormatter.stories.js
+++ b/packages/ibm-products/src/components/StringFormatter/StringFormatter.stories.js
@@ -9,10 +9,7 @@ import React from 'react';
 // TODO: import action to handle events if required.
 // import { action } from '@storybook/addon-actions';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { StringFormatter } from '.';
 import mdx from './StringFormatter.mdx';
@@ -20,7 +17,7 @@ import mdx from './StringFormatter.mdx';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: getStoryTitle(StringFormatter.displayName),
+  title: 'IBM Products/Components/StringFormatter',
   component: StringFormatter,
   tags: ['autodocs'],
   // TODO: Define argTypes for props not represented by standard JS types.

--- a/packages/ibm-products/src/components/TagSet/TagSet.stories.js
+++ b/packages/ibm-products/src/components/TagSet/TagSet.stories.js
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2022
+// Copyright IBM Corp. 2020, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -9,10 +9,7 @@ import React, { useRef, useState } from 'react';
 
 import { TYPES as tagTypes } from '../TagSet/constants';
 import { pkg } from '../../settings';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { DisplayBox } from '../../global/js/utils/DisplayBox';
 import { TagSet } from '.';
 // import mdx from './TagSet.mdx';
@@ -133,7 +130,7 @@ const overflowAndModalStrings = {
 };
 
 export default {
-  title: getStoryTitle(TagSet.displayName),
+  title: 'IBM Products/Components/TagSet',
   component: TagSet,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.js
+++ b/packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -33,10 +33,7 @@ import {
 } from '../ActionSet/actions.js';
 
 import { getDeprecatedArgTypes } from '../../global/js/utils/props-helper';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import styles from './_storybook-styles.scss';
 import { TearsheetNarrow } from './TearsheetNarrow';
@@ -44,7 +41,7 @@ import { TearsheetNarrow } from './TearsheetNarrow';
 // import mdx from './Tearsheet.mdx';
 
 export default {
-  title: getStoryTitle(Tearsheet.displayName),
+  title: 'IBM Products/Components/Tearsheet',
   component: Tearsheet,
   tags: ['autodocs'],
   parameters: { styles /* docs: { page: mdx } */, layout: 'fullscreen' },

--- a/packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.stories.js
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -29,17 +29,14 @@ import {
 } from '../ActionSet/actions.js';
 
 import { getDeprecatedArgTypes } from '../../global/js/utils/props-helper';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import styles from './_storybook-styles.scss';
 
 // import mdx from './Tearsheet.mdx';
 
 export default {
-  title: getStoryTitle(TearsheetNarrow.displayName),
+  title: 'IBM Products/Components/Tearsheet/TearsheetNarrow',
   component: TearsheetNarrow,
   tags: ['autodocs'],
   parameters: { layout: 'fullscreen', styles /* docs: { page: mdx } */ },

--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.stories.js
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -8,10 +8,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 
 import styles from './_storybook-styles.scss';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { TearsheetShell, deprecatedProps } from './TearsheetShell';
 import { getDeprecatedArgTypes } from '../../global/js/utils/props-helper';
 import {
@@ -23,7 +20,7 @@ import {
 // import mdx from './TearsheetShell.mdx';
 
 export default {
-  title: getStoryTitle(TearsheetShell.displayName),
+  title: 'IBM Products/Internal/TearsheetShell',
   component: TearsheetShell,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/Toolbar/Toolbar.stories.js
+++ b/packages/ibm-products/src/components/Toolbar/Toolbar.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -35,13 +35,11 @@ import { Dropdown, OverflowMenu, OverflowMenuItem } from '@carbon/react';
 
 import React, { useState } from 'react';
 
-import { getStoryTitle } from '../../global/js/utils/story-helper';
-
 import { Toolbar, ToolbarButton, ToolbarGroup } from '../..';
 import DocsPage from './Toolbar.docs-page';
 
 export default {
-  title: getStoryTitle(Toolbar.displayName),
+  title: 'IBM Products/Patterns/Toolbars/Toolbar',
   component: Toolbar,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/TooltipTrigger/TooltipTrigger.stories.js
+++ b/packages/ibm-products/src/components/TooltipTrigger/TooltipTrigger.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2023, 2023
+ * Copyright IBM Corp. 2023, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,10 +7,7 @@
 import React from 'react';
 import { Monster } from '@carbon/react/icons';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { TooltipTrigger } from '.';
 // import { pkg } from '../../settings';
@@ -19,7 +16,7 @@ import { TooltipTrigger } from '.';
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: getStoryTitle(TooltipTrigger.displayName),
+  title: 'IBM Products/Internal/TooltipTrigger',
   component: TooltipTrigger,
   parameters: {
     styles,

--- a/packages/ibm-products/src/components/TruncatedList/TruncatedList.stories.js
+++ b/packages/ibm-products/src/components/TruncatedList/TruncatedList.stories.js
@@ -10,10 +10,7 @@ import { ListItem } from '@carbon/react';
 // TODO: import action to handle events if required.
 import { action } from '@storybook/addon-actions';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { TruncatedList } from '.';
 
@@ -23,7 +20,7 @@ import DocsPage from './TruncatedList';
 const storyClass = 'truncated-list-stories';
 
 export default {
-  title: getStoryTitle(TruncatedList.displayName),
+  title: 'IBM Products/Components/TruncatedList',
   component: TruncatedList,
   tags: ['autodocs'],
   // TODO: Define argTypes for props not represented by standard JS types.

--- a/packages/ibm-products/src/components/UserAvatar/UserAvatar.mdx
+++ b/packages/ibm-products/src/components/UserAvatar/UserAvatar.mdx
@@ -4,6 +4,7 @@ import {
   CodesandboxLink,
 } from '../../global/js/utils/story-helper';
 import { UserAvatar } from '.';
+import * as UserAvatarStories from './UserAvatar.stories';
 
 # UserAvatar
 
@@ -24,13 +25,13 @@ import { UserAvatar } from '.';
 ### Default
 
 <Canvas>
-  <Story id={getStoryId(UserAvatar.displayName, 'default')} />
+  <Story of={UserAvatarStories.Default} />
 </Canvas>
 
 ### With Image
 
 <Canvas>
-  <Story id={getStoryId(UserAvatar.displayName, 'with-image')} />
+  <Story of={UserAvatarStories.WithImage} />
 </Canvas>
 
 ## Code sample

--- a/packages/ibm-products/src/components/UserAvatar/UserAvatar.mdx
+++ b/packages/ibm-products/src/components/UserAvatar/UserAvatar.mdx
@@ -1,8 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import {
-  getStoryId,
-  CodesandboxLink,
-} from '../../global/js/utils/story-helper';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import { UserAvatar } from '.';
 import * as UserAvatarStories from './UserAvatar.stories';
 

--- a/packages/ibm-products/src/components/UserAvatar/UserAvatar.stories.js
+++ b/packages/ibm-products/src/components/UserAvatar/UserAvatar.stories.js
@@ -11,10 +11,7 @@ import React from 'react';
 // TODO: import action to handle events if required.
 // import { action } from '@storybook/addon-actions';
 
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { UserAvatar } from '.';
 import mdx from './UserAvatar.mdx';
@@ -27,7 +24,7 @@ const defaultArgs = {
 };
 
 export default {
-  title: getStoryTitle(UserAvatar.displayName),
+  title: 'IBM Products/Components/UserAvatar',
   component: UserAvatar,
   tags: ['autodocs'],
   // TODO: Define argTypes for props not represented by standard JS types.

--- a/packages/ibm-products/src/components/UserProfileImage/UserProfileImage.stories.js
+++ b/packages/ibm-products/src/components/UserProfileImage/UserProfileImage.stories.js
@@ -1,16 +1,13 @@
-//
-// Copyright IBM Corp. 2021, 2021
-//
-// This source code is licensed under the Apache-2.0 license found in the
-// LICENSE file in the root directory of this source tree.
-//
+/**
+ * Copyright IBM Corp. 2021, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import React from 'react';
 import { UserProfileImage } from '.';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import image from './headshot.jpg'; // cspell:disable-line
 import DocsPage from './UserProfileImage.docs-page';
 
@@ -23,7 +20,7 @@ const defaultArgs = {
 };
 
 export default {
-  title: getStoryTitle(UserProfileImage.displayName),
+  title: 'IBM Products/Patterns/User profile images/UserProfileImage',
   component: UserProfileImage,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/ibm-products/src/components/WebTerminal/WebTerminal.stories.js
+++ b/packages/ibm-products/src/components/WebTerminal/WebTerminal.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2022
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,10 +12,7 @@ import React from 'react';
 import { Code, Copy } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
 import { Navigation } from './preview-components';
-import {
-  getStoryTitle,
-  prepareStory,
-} from '../../global/js/utils/story-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { WebTerminal } from '.';
 import { WebTerminalContentWrapper } from './WebTerminalContentWrapper';
 import { documentationLinks } from './preview-components/documentationLinks';
@@ -87,7 +84,7 @@ export const WithActions = prepareStory(Template, {
 });
 
 export default {
-  title: getStoryTitle(WebTerminal.displayName),
+  title: 'IBM Products/Patterns/Web terminal/WebTerminal',
   tags: ['autodocs'],
   parameters: {
     layout: 'fullscreen',

--- a/packages/ibm-products/src/global/js/utils/story-helper.js
+++ b/packages/ibm-products/src/global/js/utils/story-helper.js
@@ -170,8 +170,9 @@ export const storyDocsPageInfo = (csfFile) => {
 
   if (/components|patterns/i.test(kind)) {
     result.expectCodedExample = true;
-    // components and patterns have an additional level
-    // No longer true
+    // Required until components within 'Patterns' category use the
+    // new approach with setting story titles because they are nested an
+    // extra level
     if (typeof b === 'string') {
       component = b;
     } else {

--- a/packages/ibm-products/src/global/js/utils/story-helper.js
+++ b/packages/ibm-products/src/global/js/utils/story-helper.js
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2021
+// Copyright IBM Corp. 2021, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -12,6 +12,12 @@ import pkg from '../package-settings';
 import { getPathForComponent } from '../../../../../core/story-structure';
 import { paramCase } from 'change-case';
 
+export const checkCanaryStatus = (componentName) =>
+  !pkg.isComponentEnabled(componentName, true) &&
+  pkg.isComponentPublic(componentName, true)
+    ? true
+    : false;
+
 /**
  * A helper function to return the structured story title for a component.
  * @param {string} componentName The name of the component.
@@ -23,11 +29,7 @@ export const getStoryTitle = (componentName) => {
     getPathForComponent('c', componentName) ||
     `Carbon for IBM Products/Lost + found/${componentName}`;
 
-  // add a canary tag if the component is public but not normally enabled
-  return !pkg.isComponentEnabled(componentName, true) &&
-    pkg.isComponentPublic(componentName, true)
-    ? `${title}#canary`
-    : title;
+  return title;
 };
 
 /**
@@ -169,7 +171,13 @@ export const storyDocsPageInfo = (csfFile) => {
   if (/components|patterns/i.test(kind)) {
     result.expectCodedExample = true;
     // components and patterns have an additional level
-    component = b;
+    // No longer true
+    if (typeof b === 'string') {
+      component = b;
+    } else {
+      component = a;
+    }
+
     result.section = a;
 
     result.guidelinesHref = `https://pages.github.ibm.com/cdai-design/pal/${kind}s/${paramCase(


### PR DESCRIPTION
❗❗ **https://github.com/carbon-design-system/ibm-products/pull/4529 should be reviewed first**

Contributes to #3986 

First part of storybook simplification, the majority of the changes in this PR include removing the `getStoryTitle` utility for stories in `IBM Products/components`. I'll wait to do the same for `IBM Products/patterns` to reduce the number of changes required to review since it's a substantial amount.

This removes a lot of abstraction that I don't think is necessary and can make longer term maintenance more difficult.

In addition, I refactored how the `Canary` tag is applied in the side bar items in a way that no longer requires manipulating the story title. As well, as refactoring how we sort our stories (`.storybook/preview.js`).

#### What did you change?
Story files for `IBM Products/Patterns` and `IBM Products/Internal` section
#### How did you test and verify your work?
Storybook