### PR TITLE
chore: add test coverage commands

### DIFF
--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -275,9 +275,11 @@ unclear.
     });
     ```
 - The tests should aim to achieve 100% coverage (use
-  `yarn test ComponentName --coverage`). Specific pieces of code that cannot
-  practically be reached can be marked with `istanbul ignore` tags, but these
-  should be used sparingly and only where appropriate.
+  `yarn test:c4p ComponentName --coverage or yarn coverage ComponentName`). You
+  can easily access the coverage report using `yarn coverage:report`. Specific
+  pieces of code that cannot practically be reached can be marked with
+  `istanbul ignore` tags, but these should be used sparingly and only where
+  appropriate.
 - Test cases should not emit warnings, errors or log messages. If the test needs
   to include something that causes a console log, use the appropriate Jest
   mechanisms for catching this.

--- a/docs/MAINTAINER_GUIDELINES.md
+++ b/docs/MAINTAINER_GUIDELINES.md
@@ -34,9 +34,12 @@ To check for component test coverage for a given component, for example in the
 
 ```shell
 yarn test:c4p /ComponentName/ --coverage
+// or
+yarn coverage /ComponentName/
 ```
 
-This will generate a coverage report in `packages/ibm-products/coverage`.
+This will generate a coverage report in `packages/ibm-products/coverage` which
+you can easily access with `yarn coverage:report`.
 
 ## Publishing releases
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "clean:finally:files": "rimraf coverage node_modules results",
     "clean:lerna": "lerna clean --yes",
     "clean:packages": "yarn run-all --no-sort clean",
+    "coverage": "echo 'you can pass a name argument to specify which tests are ran such as `yarn coverage decorator` and then view the results with `yarn coverage:report`'; yarn test:c4p --coverage",
+    "coverage:report": "open ./packages/ibm-products/coverage/index.html",
     "format": "prettier ./packages/**/*.{js,jsx,md,mdx,scss} --write --ignore-unknown",
     "generate": "lerna run generate --loglevel success --scope \"@carbon/ibm-products\" --",
     "lint": "run-p -s 'lint:*'",


### PR DESCRIPTION
while working with Paul on a review it came to my attention that he was unaware about the test coverage tooling. to alleviate this i thought it might help to add additional npm scripts to run the test coverage and open the results.
