### PR TITLE
fix: removed redundant role from Link

### DIFF
--- a/packages/ibm-products/src/components/FullPageError/FullPageError.stories.js
+++ b/packages/ibm-products/src/components/FullPageError/FullPageError.stories.js
@@ -50,13 +50,9 @@ const defaultProps = {
   kind: 'custom',
   children: (
     <>
-      <Link role="link" href={'/'}>
-        – Forwarding Link 1
-      </Link>
+      <Link href={'/'}>– Forwarding Link 1</Link>
       <br />
-      <Link role="link" href={'/'}>
-        – Forwarding Link 1
-      </Link>
+      <Link href={'/'}>– Forwarding Link 1</Link>
     </>
   ),
 };


### PR DESCRIPTION
Contributes to #4564 

removed the redundant role="link" on <Link/>.

#### What did you change?
packages/ibm-products/src/components/FullPageError/FullPageError.stories.js

#### How did you test and verify your work?
IBM Equal accessibility checker.