### PR TITLE
fix: filterable column counts

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
@@ -79,9 +79,12 @@ const CustomizeColumnsTearsheet = ({
   const string = searchText.trim().toLowerCase();
 
   useEffect(() => {
-    setVisibleColumnsCount(getVisibleColumnsCount());
-    setTotalColumns(columnObjects.length);
-  }, [getVisibleColumnsCount, columnObjects.length]);
+    const notFilterableCount = columnObjects.filter((col) => !col.canFilter);
+    setVisibleColumnsCount(
+      getVisibleColumnsCount() - notFilterableCount.length
+    );
+    setTotalColumns(columnObjects.length - notFilterableCount.length);
+  }, [getVisibleColumnsCount, columnObjects]);
 
   return (
     <TearsheetNarrow


### PR DESCRIPTION
Filterable column count includes the non-filterable spacer column.

#### What did you change?

Filterable column counts to account for this.

#### How did you test and verify your work?

Storybook