### PR TITLE
fix(Datagrid): address keyboard support with selectable/dropdown editable cells

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -112,6 +112,7 @@ export const DatagridContent = ({ datagridState, title, ariaToolbarLabel }) => {
                 keysPressedList,
                 state: inlineEditState,
                 usingMac,
+                ref: multiKeyTrackingRef,
               }))
           }
           onFocus={

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
@@ -166,6 +166,9 @@ export const InlineEditCell = ({
       if (type === 'number') {
         numberInputRef.current.focus();
       }
+      if (type === 'selection') {
+        dropdownRef?.current?.focus();
+      }
     }
   }, [inEditMode, type]);
 

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/handleGridKeyPress.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/handleGridKeyPress.js
@@ -18,6 +18,7 @@ export const handleGridKeyPress = ({
   instance,
   keysPressedList,
   usingMac,
+  ref,
 }) => {
   const { key } = event;
   const { gridActive, activeCellId, editId } = state;
@@ -55,13 +56,10 @@ export const handleGridKeyPress = ({
 
   // Checks if the dropdown menu is open
   const dropdownIsActive = () => {
-    const focusedElementRole = document.activeElement.getAttribute('role');
-    if (
-      focusedElementRole === 'listbox' &&
-      document.activeElement.classList.contains(
-        `${carbon.prefix}--list-box__menu`
-      )
-    ) {
+    const selectedDropdown = ref?.current.querySelector(`
+      #${instance.tableId} .${blockClass}__table-with-inline-edit [data-cell-id="${activeCellId}"] button[role='combobox']
+    `);
+    if (selectedDropdown) {
       // Prevents arrow keys from scrolling any other content when dropdown menu is open
       event.preventDefault();
       return true;


### PR DESCRIPTION
Contributes to #4147 

We need to keep the focus on the dropdown/selectable cell while it is in edit mode, otherwise the focus moves to the overall grid and prevents interaction with just the dropdown itself. The second part of this fix included fixing a selector that checks if the dropdown is open/active.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/handleGridKeyPress.js
```
#### How did you test and verify your work?
Storybook