### PR TITLE
fix: options tile refactor

### DIFF
--- a/packages/ibm-products/src/components/OptionsTile/OptionsTile.js
+++ b/packages/ibm-products/src/components/OptionsTile/OptionsTile.js
@@ -61,26 +61,26 @@ export let OptionsTile = React.forwardRef(
     };
 
     const getIcon = () => {
+      if (locked) {
+        return Locked;
+      }
       if (invalid) {
         return WarningFilled;
       }
       if (warn) {
         return WarningAltFilled;
       }
-      if (locked) {
-        return Locked;
-      }
     };
 
     const getText = () => {
+      if (locked) {
+        return lockedText;
+      }
       if (invalid) {
         return invalidText;
       }
       if (warn) {
         return warnText;
-      }
-      if (locked) {
-        return lockedText;
       }
       return summary;
     };
@@ -196,8 +196,7 @@ OptionsTile.propTypes = {
    */
   lockedText: PropTypes.string,
   /**
-   * Provide a function which will be called each time the user
-   * interacts with the toggle.
+   * Callback function for the built Carbon toggle element.
    */
   onToggle: PropTypes.func,
   /**

--- a/packages/ibm-products/src/components/OptionsTile/OptionsTile.js
+++ b/packages/ibm-products/src/components/OptionsTile/OptionsTile.js
@@ -1,23 +1,15 @@
 /**
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-// Import portions of React that are needed.
-import React, { useState, useRef } from 'react';
-
-// Other standard imports.
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
-import uuidv4 from '../../global/js/utils/uuidv4';
 import { pkg } from '../../settings';
-import { useControllableState } from '../../global/js/hooks';
-
-// Carbon and package components we use.
 import { Layer, Toggle } from '@carbon/react';
 import {
   ChevronDown,
@@ -25,267 +17,127 @@ import {
   WarningAltFilled,
   WarningFilled,
 } from '@carbon/react/icons';
-import * as carbonMotion from '@carbon/motion';
+// import * as carbonMotion from '@carbon/motion';
 
-// The block part of our conventional BEM class names (blockClass__E--M).
 const blockClass = `${pkg.prefix}--options-tile`;
 const componentName = 'OptionsTile';
 
-// NOTE: the component SCSS is not imported here: it is rolled up separately.
-
-// Default values for props
-const defaults = {
-  onChange: () => {},
-  size: 'xl',
-};
-
-/**
- * TODO: A description of the component.
- */
 export let OptionsTile = React.forwardRef(
   (
     {
-      // The component props, in alphabetical order (for consistency).
-
       children,
       className,
-      enabled,
+      defaultOpen,
+      defaultToggled,
+      id,
       invalid,
       invalidText,
       locked,
       lockedText,
-      onChange = defaults.onChange,
       onToggle,
-      open,
-      size = defaults.size,
+      size = 'xl',
       summary,
       title,
-      titleId: userDefinedTitleId,
+      toggle,
       warn,
       warnText,
-
-      // Collect any other property values passed in.
       ...rest
     },
     ref
   ) => {
-    const [prevIsOpen, setPrevIsOpen] = useState(open);
-    const [closing, setClosing] = useState(false);
+    const [toggled, setToggled] = useState(false);
 
-    const [isOpen, setIsOpen] = useControllableState({
-      value: open,
-      defaultValue: open || null,
-      onChange: (value) => onChange(value),
-    });
-
-    const detailsRef = useRef(null);
-    const contentRef = useRef(null);
-
-    const id = uuidv4();
-    const titleId = userDefinedTitleId ?? `${id}-title`;
-
-    const isExpandable = children !== undefined;
-
-    const isInvalid = invalid;
-    const isWarn = !isInvalid && warn;
-    const isLocked = !isInvalid && !isWarn && locked;
-
-    const reducedMotion =
-      window && window.matchMedia
-        ? window.matchMedia('(prefers-reduced-motion: reduce)')
-        : { matches: true };
-
-    if (open !== prevIsOpen) {
-      if (isOpen && !open) {
-        collapse();
-      } else if (!isOpen && open) {
-        expand();
+    useEffect(() => {
+      if (defaultToggled) {
+        setToggled(true);
       }
-      setPrevIsOpen(open);
-    }
+    }, [defaultToggled]);
 
-    function expand() {
-      if (detailsRef.current && contentRef.current && !reducedMotion.matches) {
-        setIsOpen(true);
-
-        detailsRef.current.open = true;
-        const { paddingTop, paddingBottom, height } = getComputedStyle(
-          contentRef.current
-        );
-
-        contentRef.current.animate(
-          [
-            {
-              paddingTop: 0,
-              paddingBottom: 0,
-              height: 0,
-              opacity: 0,
-              overflow: 'hidden',
-            },
-            {
-              paddingTop,
-              paddingBottom,
-              height,
-              opacity: 1,
-              overflow: 'hidden',
-            },
-          ],
-          {
-            duration: Number(carbonMotion.moderate01.replace('ms', '')),
-            easing: carbonMotion.easings.entrance.productive,
-          }
-        );
-      } else {
-        // in case the refs are not set or the user prefers reduced motion, skip the animation
-        setIsOpen(true);
+    const handleToggle = (toggled) => {
+      setToggled(toggled);
+      if (onToggle) {
+        onToggle(toggled);
       }
-    }
+    };
 
-    function collapse() {
-      if (contentRef.current && !reducedMotion.matches) {
-        setClosing(true);
-
-        const { paddingTop, paddingBottom, height } = getComputedStyle(
-          contentRef.current
-        );
-
-        const animation = contentRef.current.animate(
-          [
-            {
-              paddingTop,
-              paddingBottom,
-              height,
-              opacity: 1,
-            },
-            {
-              paddingTop: 0,
-              paddingBottom: 0,
-              height: 0,
-              opacity: 0,
-            },
-          ],
-          {
-            duration: Number(carbonMotion.moderate01.replace('ms', '')),
-            easing: carbonMotion.easings.entrance.productive,
-          }
-        );
-
-        const callback = () => {
-          setIsOpen(false);
-          setClosing(false);
-        };
-
-        animation.onfinish = callback;
-        animation.oncancel = callback;
-      } else {
-        // in case the ref is not set or the user prefers reduced motion, skip the animation
-        setIsOpen(false);
-      }
-    }
-
-    function toggle(e) {
-      e.preventDefault();
-
-      if (isOpen) {
-        collapse();
-      } else {
-        expand();
-      }
-    }
-
-    function renderTitle() {
-      let Icon = null;
-      let text = summary;
-      const summaryClasses = [`${blockClass}__summary`];
-
+    const getIcon = () => {
       if (invalid) {
-        Icon = WarningFilled;
-        text = invalidText;
-        summaryClasses.push(`${blockClass}__summary--invalid`);
-      } else if (warn) {
-        Icon = WarningAltFilled;
-        text = warnText;
-        summaryClasses.push(`${blockClass}__summary--warn`);
-      } else if (locked) {
-        Icon = Locked;
-        summaryClasses.push(`${blockClass}__summary--locked`);
-
-        if (!text) {
-          text = lockedText;
-        }
+        return WarningFilled;
       }
-
-      const hasValidationState = invalid || warn || locked;
-      const summaryHidden = !hasValidationState && enabled === false;
-
-      if (summaryHidden) {
-        summaryClasses.push(`${blockClass}__summary--hidden`);
+      if (warn) {
+        return WarningAltFilled;
       }
+      if (locked) {
+        return Locked;
+      }
+    };
+
+    const getText = () => {
+      if (invalid) {
+        return invalidText;
+      }
+      if (warn) {
+        return warnText;
+      }
+      if (locked) {
+        return lockedText;
+      }
+      return summary;
+    };
+
+    const renderTitle = () => {
+      const Icon = getIcon();
+      const text = getText();
 
       return (
         <div className={`${blockClass}__heading`}>
-          <h6 id={titleId} className={`${blockClass}__title`}>
-            {title}
-          </h6>
+          <h6 className={`${blockClass}__title`}>{title}</h6>
           {text && (
-            <span className={cx(summaryClasses)} aria-hidden={summaryHidden}>
+            <span
+              className={cx(`${blockClass}__summary`, {
+                [`${blockClass}__summary--invalid`]: invalid,
+                [`${blockClass}__summary--warn`]: warn,
+                [`${blockClass}__summary--locked`]: locked,
+              })}
+            >
               {Icon && <Icon size={16} />}
               <span className={`${blockClass}__summary-text`}>{text}</span>
             </span>
           )}
         </div>
       );
-    }
+    };
 
     return (
       <div
-        {
-          // Pass through any other property values as HTML attributes.
-          ...rest
-        }
-        className={cx(
-          blockClass, // Apply the block class to the main HTML element
-          className, // Apply any supplied class names to the main HTML element.
-          `${blockClass}--${size}`,
-          {
-            // switched classes dependant on props or state
-            [`${blockClass}--closing`]: closing,
-          }
-        )}
+        {...rest}
+        className={cx(blockClass, className, `${blockClass}--${size}`)}
         ref={ref}
         {...getDevtoolsProps(componentName)}
       >
-        {enabled !== undefined && (
+        {toggle && (
           <div className={`${blockClass}__toggle-container`}>
             <Toggle
-              id={`${titleId}-toggle`}
+              aria-labelledby={id}
               className={`${blockClass}__toggle`}
-              toggled={enabled}
-              aria-labelledby={titleId}
+              disabled={locked}
               hideLabel
-              onToggle={onToggle}
+              id={`${id}-toggle`}
+              onToggle={handleToggle}
               size="sm"
-              disabled={isLocked}
+              toggled={toggled}
             />
           </div>
         )}
-        {isExpandable ? (
-          <details open={isOpen} ref={detailsRef}>
-            {
-              /* summary should not be considered non-interactive
-               * https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/656
-               * https://github.com/A11yance/axobject-query/issues/319
-               */
-              /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
-              <summary className={`${blockClass}__header`} onClick={toggle}>
-                <ChevronDown size={16} className={`${blockClass}__chevron`} />
-                {renderTitle()}
-              </summary>
-            }
-
-            <div className={`${blockClass}__content`} ref={contentRef}>
+        {children ? (
+          <details open={defaultOpen}>
+            <summary className={`${blockClass}__header`}>
+              <ChevronDown size={16} className={`${blockClass}__chevron`} />
+              {renderTitle()}
+            </summary>
+            <div className={`${blockClass}__content`}>
               <Layer>
-                {isLocked && (
+                {locked && (
                   <p className={`${blockClass}__locked-text`}>
                     <Locked size={16} />
                     {lockedText}
@@ -303,96 +155,71 @@ export let OptionsTile = React.forwardRef(
   }
 );
 
-// Return a placeholder if not released and not enabled by feature flag
 OptionsTile = pkg.checkComponentEnabled(OptionsTile, componentName);
-
-// The display name of the component, used by React. Note that displayName
-// is used in preference to relying on function.name.
 OptionsTile.displayName = componentName;
-
-// The types and DocGen commentary for the component props,
-// in alphabetical order (for consistency).
-// See https://www.npmjs.com/package/prop-types#usage.
 OptionsTile.propTypes = {
   /**
    * Provide content to render as expandable OptionsTile. If no children
    * are present, the OptionsTile will render as its variant.
    */
   children: PropTypes.node,
-
   /**
    * Provide an optional class to be applied to the containing node.
    */
   className: PropTypes.string,
-
   /**
-   * Whether the toggle is enabled or disabled. If nothing is passed,
-   * no toggle will be rendered.
+   * Designates if the tile is open by default
    */
-  enabled: PropTypes.bool,
-
+  defaultOpen: PropTypes.bool,
+  /**
+   * Designates if the toggle is toggled by default
+   */
+  defaultToggled: PropTypes.bool,
+  /**
+   * Optional id
+   */
+  id: PropTypes.string,
   /**
    * Whether the OptionsTile is in invalid validation state.
    */
   invalid: PropTypes.bool,
-
   /**
    * Provide a text explaining why the OptionsTile is in invalid state.
    */
   invalidText: PropTypes.string,
-
   /**
    * Whether the OptionsTile is in locked validation state.
    */
   locked: PropTypes.bool,
-
   /**
    * Provide a text explaining why the OptionsTile is in locked state.
    */
   lockedText: PropTypes.string,
-
-  /**
-   * Provide a function which will be called each time the user
-   * toggles the open state of the OptionsTile.
-   */
-  onChange: PropTypes.func,
-
   /**
    * Provide a function which will be called each time the user
    * interacts with the toggle.
    */
   onToggle: PropTypes.func,
-
-  /**
-   * Whether the OptionsTile is in open state.
-   */
-  open: PropTypes.bool,
-
   /**
    * Define the size of the OptionsTile.
    */
   size: PropTypes.oneOf(['lg', 'xl']),
-
   /**
    * Optionally provide a text summarizing the current state of the content.
    */
   summary: PropTypes.string,
-
   /**
    * Provide the title for this OptionsTile.
    */
-  title: PropTypes.string.isRequired,
-
+  title: PropTypes.string,
   /**
-   * Optionally provide an id which should be used for the title.
+   * Designates if the toggle is displayed
    */
-  titleId: PropTypes.string,
-
+  toggle: PropTypes.bool,
   /**
    * Whether the OptionsTile is in warning validation state.
    */
   warn: PropTypes.bool,
-
   /**
    * Provide a text explaining why the OptionsTile is in warning state.
    */

--- a/packages/ibm-products/src/components/OptionsTile/OptionsTile.js
+++ b/packages/ibm-products/src/components/OptionsTile/OptionsTile.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
@@ -18,6 +18,8 @@ import {
   WarningFilled,
 } from '@carbon/react/icons';
 // import * as carbonMotion from '@carbon/motion';
+
+import { useControllableState } from '../../global/js/hooks';
 
 const blockClass = `${pkg.prefix}--options-tile`;
 const componentName = 'OptionsTile';
@@ -34,31 +36,33 @@ export let OptionsTile = React.forwardRef(
       invalidText,
       locked,
       lockedText,
+      onChange,
       onToggle,
+      open: openProp,
       size = 'xl',
       summary,
       title,
       toggle,
+      toggled: toggledProp,
       warn,
       warnText,
       ...rest
     },
     ref
   ) => {
-    const [toggled, setToggled] = useState(false);
+    const [toggled, setToggled] = useControllableState({
+      controlled: toggledProp,
+      default: defaultToggled,
+      name: componentName,
+      state: 'toggled',
+    });
 
-    useEffect(() => {
-      if (defaultToggled) {
-        setToggled(true);
-      }
-    }, [defaultToggled]);
-
-    const handleToggle = (toggled) => {
-      setToggled(toggled);
-      if (onToggle) {
-        onToggle(toggled);
-      }
-    };
+    const [open, setOpen] = useControllableState({
+      controlled: openProp,
+      default: defaultOpen,
+      name: componentName,
+      state: 'open',
+    });
 
     const getIcon = () => {
       if (locked) {
@@ -108,6 +112,22 @@ export let OptionsTile = React.forwardRef(
       );
     };
 
+    const handleToggle = () => {
+      setToggled(!toggled);
+
+      if (onToggle) {
+        onToggle(!toggled);
+      }
+    };
+
+    const handleChange = () => {
+      setOpen(!open);
+
+      if (onChange) {
+        onChange(!open);
+      }
+    };
+
     return (
       <div
         {...rest}
@@ -130,7 +150,7 @@ export let OptionsTile = React.forwardRef(
           </div>
         )}
         {children ? (
-          <details open={defaultOpen}>
+          <details open={open} onToggle={handleChange}>
             <summary className={`${blockClass}__header`}>
               <ChevronDown size={16} className={`${blockClass}__chevron`} />
               {renderTitle()}
@@ -195,10 +215,12 @@ OptionsTile.propTypes = {
    * Provide a text explaining why the OptionsTile is in locked state.
    */
   lockedText: PropTypes.string,
+  onChange: PropTypes.func,
   /**
    * Callback function for the built Carbon toggle element.
    */
   onToggle: PropTypes.func,
+  open: PropTypes.bool,
   /**
    * Define the size of the OptionsTile.
    */
@@ -215,6 +237,7 @@ OptionsTile.propTypes = {
    * Designates if the toggle is displayed
    */
   toggle: PropTypes.bool,
+  toggled: PropTypes.bool,
   /**
    * Whether the OptionsTile is in warning validation state.
    */

--- a/packages/ibm-products/src/components/OptionsTile/OptionsTile.stories.js
+++ b/packages/ibm-products/src/components/OptionsTile/OptionsTile.stories.js
@@ -5,8 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import { action } from '@storybook/addon-actions';
+import React, { useState } from 'react';
 import { Dropdown, FormGroup } from '@carbon/react';
 import { OptionsTile } from '.';
 // import mdx from './OptionsTile.mdx';
@@ -23,6 +22,7 @@ export default {
 };
 
 const Template = (args) => {
+  const { expandable, ...props } = args;
   // spell-checker:disable
   const languages = [
     { label: 'English', id: 'en' },
@@ -65,65 +65,75 @@ const Template = (args) => {
     { label: 'Turkish', id: 'tr' },
   ];
 
+  const [open, setOpen] = useState(false);
+  const [toggled, setToggled] = useState(false);
+
+  const openHandler = (open) => {
+    setOpen(open);
+  };
+
   const toggleHandler = (toggled) => {
-    action('onToggle', toggled);
+    setToggled(toggled);
   };
 
   return (
-    <OptionsTile {...args} onToggle={toggleHandler}>
-      <FormGroup>
-        <p>
-          User interface defines the language the application is displayed in.
-          Locale sets the regional display formats for information like time,
-          date, currency and decimal delimiters.
-        </p>
-        <Dropdown
-          id="language"
-          titleText="User interface"
-          label="User interface"
-          items={languages}
-          initialSelectedItem={languages[0]}
-          invalidText="Non-latin languages are not supported by system"
-          warnText="A language change requires a restart of the application"
-        />
-        <Dropdown
-          id="locale"
-          titleText="Locale"
-          label="Locale"
-          items={locales}
-          initialSelectedItem={locales[0]}
-        />
-      </FormGroup>
+    <OptionsTile
+      {...props}
+      open={open}
+      onChange={openHandler}
+      toggled={toggled}
+      onToggle={toggleHandler}
+    >
+      {expandable && (
+        <FormGroup>
+          <p>
+            User interface defines the language the application is displayed in.
+            Locale sets the regional display formats for information like time,
+            date, currency and decimal delimiters.
+          </p>
+          <Dropdown
+            id="language"
+            titleText="User interface"
+            label="User interface"
+            items={languages}
+            initialSelectedItem={languages[0]}
+            invalidText="Non-latin languages are not supported by system"
+            warnText="A language change requires a restart of the application"
+          />
+          <Dropdown
+            id="locale"
+            titleText="Locale"
+            label="Locale"
+            items={locales}
+            initialSelectedItem={locales[0]}
+          />
+        </FormGroup>
+      )}
     </OptionsTile>
   );
 };
 
 const defaultProps = {
   className: 'optional-class',
-  defaultOpen: false,
-  defaultToggled: false,
   id: 'optional-id',
   invalid: false,
   invalidText: 'Your system does not support this configuration',
   locked: false,
   lockedText: 'This option is managed by your administrator',
-  onToggle: () => {},
   size: 'xl',
   summary: 'English | Locale: English',
   title: 'Language',
-  toggle: false,
   warn: false,
   warnText: 'A restart is required to apply these settings',
 };
 
 export const optionsTile = Template.bind({});
-optionsTile.args = { ...defaultProps };
-
-const StaticTemplate = (args) => {
-  return <OptionsTile {...args} />;
+optionsTile.args = {
+  ...defaultProps,
+  expandable: true,
 };
 
-export const staticOptionsTile = StaticTemplate.bind({});
+export const staticOptionsTile = Template.bind({});
 staticOptionsTile.args = {
   ...defaultProps,
   defaultToggled: true,

--- a/packages/ibm-products/src/components/OptionsTile/OptionsTile.stories.js
+++ b/packages/ibm-products/src/components/OptionsTile/OptionsTile.stories.js
@@ -98,8 +98,7 @@ const Template = (args) => {
   );
 };
 
-export const optionsTile = Template.bind({});
-optionsTile.args = {
+const defaultProps = {
   className: 'optional-class',
   defaultOpen: false,
   defaultToggled: false,
@@ -117,13 +116,16 @@ optionsTile.args = {
   warnText: 'A restart is required to apply these settings',
 };
 
+export const optionsTile = Template.bind({});
+optionsTile.args = { ...defaultProps };
+
 const StaticTemplate = (args) => {
   return <OptionsTile {...args} />;
 };
 
 export const staticOptionsTile = StaticTemplate.bind({});
 staticOptionsTile.args = {
-  title: 'Hardware acceleration',
-  toggle: true,
+  ...defaultProps,
   defaultToggled: true,
+  toggle: true,
 };

--- a/packages/ibm-products/src/components/OptionsTile/OptionsTile.stories.js
+++ b/packages/ibm-products/src/components/OptionsTile/OptionsTile.stories.js
@@ -5,13 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import { action } from '@storybook/addon-actions';
-
 import { Dropdown, FormGroup } from '@carbon/react';
-
-import uuidv4 from '../../global/js/utils/uuidv4';
-
 import { OptionsTile } from '.';
 // import mdx from './OptionsTile.mdx';
 
@@ -23,11 +19,6 @@ export default {
   tags: ['autodocs'],
   parameters: {
     styles,
-    /*
-docs: {
-      page: mdx,
-    },
-*/
   },
 };
 
@@ -73,87 +64,66 @@ const Template = (args) => {
     { label: 'Portuguese-Brazil', id: 'pt-BR' },
     { label: 'Turkish', id: 'tr' },
   ];
-  // spell-checker:enable
 
-  const id = uuidv4();
-  const titleId = args.titleId ?? `${id}-title`;
-
-  const isInvalid = args.invalid;
-  const isWarn = !isInvalid && args.warn;
-  const isLocked = !isInvalid && !isWarn && args.locked;
-  const disableControls = args.enabled === false || isLocked;
+  const toggleHandler = (toggled) => {
+    action('onToggle', toggled);
+  };
 
   return (
-    <OptionsTile
-      onToggle={action('onToggle')}
-      onChange={action('onChange')}
-      {...args}
-    >
-      <FormGroup aria-labelledby={titleId} legendText="">
+    <OptionsTile {...args} onToggle={toggleHandler}>
+      <FormGroup>
         <p>
           User interface defines the language the application is displayed in.
           Locale sets the regional display formats for information like time,
           date, currency and decimal delimiters.
         </p>
         <Dropdown
-          id={`${id}-language`}
+          id="language"
           titleText="User interface"
           label="User interface"
           items={languages}
           initialSelectedItem={languages[0]}
-          invalid={isInvalid}
           invalidText="Non-latin languages are not supported by system"
-          warn={isWarn}
           warnText="A language change requires a restart of the application"
-          disabled={disableControls}
         />
         <Dropdown
-          id={`${id}-locale`}
+          id="locale"
           titleText="Locale"
           label="Locale"
           items={locales}
           initialSelectedItem={locales[0]}
-          disabled={disableControls}
         />
       </FormGroup>
     </OptionsTile>
   );
 };
 
-// eslint-disable-next-line react/prop-types
-const TemplateStatic = ({ enabled, ...rest }) => {
-  const [liveEnabled, setLiveEnabled] = useState(enabled);
-
-  function onToggle(e) {
-    setLiveEnabled(e);
-    action('onToggle')(e);
-  }
-
-  function onChange(value) {
-    action('onChange')(value);
-  }
-
-  return (
-    <OptionsTile
-      onToggle={onToggle}
-      onChange={onChange}
-      {...rest}
-      enabled={liveEnabled}
-    />
-  );
-};
-
 export const optionsTile = Template.bind({});
 optionsTile.args = {
-  title: 'Language',
-  summary: 'English | Locale: English',
+  className: 'optional-class',
+  defaultOpen: false,
+  defaultToggled: false,
+  id: 'optional-id',
+  invalid: false,
   invalidText: 'Your system does not support this configuration',
-  warnText: 'A restart is required to apply these settings',
+  locked: false,
   lockedText: 'This option is managed by your administrator',
+  onToggle: () => {},
+  size: 'xl',
+  summary: 'English | Locale: English',
+  title: 'Language',
+  toggle: false,
+  warn: false,
+  warnText: 'A restart is required to apply these settings',
 };
 
-export const staticOptionsTile = TemplateStatic.bind({});
+const StaticTemplate = (args) => {
+  return <OptionsTile {...args} />;
+};
+
+export const staticOptionsTile = StaticTemplate.bind({});
 staticOptionsTile.args = {
   title: 'Hardware acceleration',
-  enabled: true,
+  toggle: true,
+  defaultToggled: true,
 };


### PR DESCRIPTION
Contributes to #4576 

refactors `OptionsTile` to bring it more into line with our current code standards. does a ton of cleanup and also addresses some accessibility concerns.

my initial commit does not include any updates to the styles and removes the current animation, which doesn't look great. you can clearly see jumpy behavior when opening and closing the tile. maybe someone else might want to tackle that specifically or i can continue to do it.

I think that one of the main things to be mindful of is usage of the `details` element. it's definitely handy to have a native accordion style element that internally handles the `open` and `onToggle` state. the caveat here though is that we can't specify our own `open` state because of how it works under the hood. basically it'll cause an infinite loop of state changes if you try to use them together and mange the state separately. there could be work arounds if we need to specifically expose an `onToggle` callback prop, but for the initial commit i've opted to not manage the `open` state with the exception of using `defaultOpen`.

also the testing has not been updated. i wanted to get feedback initially before updating tests.