### PR TITLE
fix(tearsheet): fix focus capturing issue when first state update

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.js
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.js
@@ -156,7 +156,16 @@ export const TearsheetShell = React.forwardRef(
           firstElement?.focus();
         }, 0);
       }
-    }, [open, firstElement]);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [open]);
+
+    useEffect(() => {
+      if (open && position !== depth) {
+        setTimeout(() => {
+          firstElement?.focus();
+        }, 0);
+      }
+    }, [position, depth, firstElement, open]);
 
     useEffect(() => {
       const notify = () =>


### PR DESCRIPTION
Contributes to #4543 

Focus issue in Tearsheet with navigation when state change (Only first time)

#### What did you change?
Removed `firstElement` from initial `useEffect` code
Added a new `useEffect` to focus first element in stacked Tearsheets 

#### How did you test and verify your work?
storybook
