### PR TITLE
chore: onboard @carbon/ibm-products-styles to IBM Telemetry 🚀 

### DIFF
--- a/config/storybook-addon-carbon-theme/README.md
+++ b/config/storybook-addon-carbon-theme/README.md
@@ -148,3 +148,12 @@ $feature-flags: (
   );
 }
 ```
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/config/storybook-addon-carbon-theme/package.json
+++ b/config/storybook-addon-carbon-theme/package.json
@@ -14,7 +14,8 @@
   "files": [
     "dist/**/*",
     "README.md",
-    "*.js"
+    "*.js",
+    "telemetry.yml"
   ],
   "keywords": [
     "addon",
@@ -34,6 +35,7 @@
     "clean": "rimraf dist",
     "build": "run-s clean build:js",
     "build:js": "babel src --out-dir dist -s",
+    "postinstall": "ibmtelemetry --config=telemetry.yml",
     "prepare": "npm run build",
     "//upgrade-dependencies": "# don't upgrade carbon (done globally)",
     "upgrade-dependencies": "npm-check-updates -u --dep dev,peer,prod --color --reject '/(carbon)/'"
@@ -43,6 +45,7 @@
     "vue": "*"
   },
   "dependencies": {
+    "@ibm/telemetry-js": "^1.3.0",
     "@storybook/addons": "^7.6.10",
     "@storybook/api": "^7.6.10",
     "@storybook/client-api": "^7.6.10",

--- a/config/storybook-addon-carbon-theme/telemetry.yml
+++ b/config/storybook-addon-carbon-theme/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: '55e814ff-85db-406f-9e37-2d0c92a753b0'
+endpoint: 'https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics'
+collect:
+  npm:
+    dependencies: null

--- a/packages/ibm-products-styles/README.md
+++ b/packages/ibm-products-styles/README.md
@@ -27,3 +27,12 @@ $ npm install @carbon/ibm-products-styles
 Follow the in the ibm-products README to change the prefix.
 
 [Prefix setting instructions](https://github.com/carbon-design-system/ibm-products/blob/main/packages/ibm-products/README.md#package-prefix)
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this
+package as a dependency you are agreeing to telemetry collection. To opt out,
+see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/ibm-products-styles/package.json
+++ b/packages/ibm-products-styles/package.json
@@ -19,7 +19,8 @@
   "files": [
     "css",
     "scss",
-    "index.scss"
+    "index.scss",
+    "telemetry.yml"
   ],
   "keywords": [
     "carbon",
@@ -40,6 +41,7 @@
     "build:css-min": "sass --style=compressed --load-path node_modules --load-path ../../node_modules scss/index.scss:css/index.min.css scss/index-full-carbon.scss:css/index-full-carbon.min.css scss/index-without-carbon.scss:css/index-without-carbon.min.css scss/index-without-carbon-released-only.scss:css/index-without-carbon-released-only.min.css",
     "build-css-update-maps": "node ../../scripts/updateSourceMaps.js",
     "clean": "rimraf css scss",
+    "postinstall": "ibmtelemetry --config=telemetry.yml",
     "test": "jest --colors",
     "//upgrade-dependencies": "# don't upgrade carbon (done globally), react/react-dom (explicit range peer dependency), chalk (issue #1596)",
     "upgrade-dependencies": "npm-check-updates -u --dep dev,peer,prod --color --reject '/(carbon|^react$|^react-dom$|^chalk$|^namor)/'"
@@ -64,5 +66,8 @@
     "@carbon/motion": "^11.17.0",
     "@carbon/themes": "^11.33.0",
     "@carbon/type": "^11.26.0"
+  },
+  "dependencies": {
+    "@ibm/telemetry-js": "^1.3.0"
   }
 }

--- a/packages/ibm-products-styles/telemetry.yml
+++ b/packages/ibm-products-styles/telemetry.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: '178994d9-2db9-4965-8155-4b10d588faa6'
+endpoint: 'https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics'
+collect:
+  npm:
+    dependencies: null

--- a/yarn.lock
+++ b/yarn.lock
@@ -2201,6 +2201,7 @@ __metadata:
     "@babel/cli": "npm:^7.23.9"
     "@babel/core": "npm:^7.23.9"
     "@babel/preset-react": "npm:^7.23.3"
+    "@ibm/telemetry-js": "npm:^1.3.0"
     "@storybook/addons": "npm:^7.6.10"
     "@storybook/api": "npm:^7.6.10"
     "@storybook/client-api": "npm:^7.6.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2035,6 +2035,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@carbon/ibm-products-styles@workspace:packages/ibm-products-styles"
   dependencies:
+    "@ibm/telemetry-js": "npm:^1.3.0"
     chalk: "npm:^4.1.2"
     copyfiles: "npm:^2.4.1"
     cross-env: "npm:^7.0.3"
@@ -3400,6 +3401,15 @@ __metadata:
   bin:
     ibmtelemetry: dist/collect.js
   checksum: 672a116f050f89160015c370f49ce1b7478f21d2686252df3456d62f41a4c4f170ed345a6454c1de3005e03397492ed3aee8d98cf7b5cf27d13b054306dcc21b
+  languageName: node
+  linkType: hard
+
+"@ibm/telemetry-js@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@ibm/telemetry-js@npm:1.3.0"
+  bin:
+    ibmtelemetry: dist/collect.js
+  checksum: 5581511e540b0edf79d7d1badf9a994bcd97d99c27a295909c3184871f76629a9f4095a66c3ca5e835035b90e895c324271786fb958cad9c58f37717b97ca353
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds the config file and dependency necessary to start tracking telemetry data via [IBM Telemetry](https://github.com/ibm-telemetry/telemetry-js) for the packages:

- `@carbon/ibm-products-styles`
- `@carbon/storybook-addon-theme`

#### What did you change?

**New**

- Adds @ibm/telemetry-js dependency
- Adds telemetry.yml config file
- Adds readme telemetry notice
- Adds postinstall script to use the telemetry command
- Adds telemetry.yml as an exported file if the package specifies `files`

**Changed**

- N/A

**Removed**

- N/A

#### How did you test and verify your work?

Please look through package.json config files and ensure all necessary modifications have been made so that the "telemetry.yml" config file is included in the release version of each package.

**PLEASE NOTE:** In order for IBM Telemetry to start collecting data for this project, a new build must be published including these changes.