### PR TITLE
fix(e2e): use updated path to cascade story

### DIFF
--- a/e2e/components/Cascade/Cascade-test.avt.e2e.js
+++ b/e2e/components/Cascade/Cascade-test.avt.e2e.js
@@ -14,7 +14,7 @@ test.describe('Cascade @avt', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'Cascade',
-      id: 'ibm-products-patterns-cascade-cascade--without-grid',
+      id: 'ibm-products-patterns-cascade--without-grid',
       globals: {
         carbonTheme: 'white',
       },


### PR DESCRIPTION
After some of the storybook refactoring, there were changes to story id's which included the Cascade component. This caused the Cascade e2e avt test to have an incorrect story id (essentially causing a 404). The test never failed however, so we might want to verify the component is on the page in addition to the `.toHaveNoACViolations()` check.

#### What did you change?
```
e2e/components/Cascade/Cascade-test.avt.e2e.js
```
#### How did you test and verify your work?
Ran playwright locally and checked the output of `const html = await page.content()` to make sure it rendered the `Cascade` component.