### PR TITLE
build: update commit lint types

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,6 +184,7 @@
           "perf",
           "refactor",
           "revert",
+          "style",
           "test"
         ]
       ]


### PR DESCRIPTION
Contributes to #4657 

Adds the `style` commit lint type as this can probably be a frequently used type for us.

#### What did you change?
`package.json`

#### How did you test and verify your work?
N/A 😱 