### PR TITLE
refactor: use npx over yarn for commitlint

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn commitlint --edit $1
+npx --no-install commitlint --edit $1


### PR DESCRIPTION
I have repeatedly found that the pre-commit hook fails when it hits the `commitlint` step. See the following screenshot:
![Screenshot 2024-04-02 at 4 04 22 PM](https://github.com/carbon-design-system/ibm-products/assets/10215203/bd1dd4c1-529c-426d-862e-430dfa755108)

Replacing `yarn commitlint` with `npx commitlint` fixes this issue for me locally. Not sure if others have hit this as well, but hoping this will prevent any future errors with commitlint and husky.

#### What did you change?
Updated `.husky/commit-msg`
#### How did you test and verify your work?
Tested this on a separate branch with these changes and the pre-commit runs as expected