### PR TITLE
refactor(ImportModal): convert to typescript

### DIFF
--- a/packages/ibm-products/src/custom-typings/index.d.ts
+++ b/packages/ibm-products/src/custom-typings/index.d.ts
@@ -192,5 +192,6 @@ declare module '@carbon/react' {
     UIShell,
     UnorderedList,
     TagTypeName,
+    usePrefix,
   } from '@carbon/react';
 }


### PR DESCRIPTION
Contributes to #4507 

Converts `ImportModal` to TypeScript and added Carbon's `usePrefix` to our custom-typings declaration file.

#### What did you change?
```
packages/ibm-products/src/components/ImportModal/ImportModal.tsx
packages/ibm-products/src/custom-typings/index.d.ts
```
#### How did you test and verify your work?
Locally, vscode and made sure component still functions the same in storybook