### PR TITLE
Build: pre-commit hooks not working in local env

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "lint:js": "eslint packages --fix",
     "lint:styles": "stylelint '**/*.scss'",
     "prepare": "husky install",
+    "postinstall": "husky",
     "run-all": "lerna run --stream --prefix --loglevel success",
     "test": "run-p -s 'test:*'",
     "test:c4p": "lerna run --stream --scope @carbon/ibm-products test --",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "clean:packages": "yarn run-all --no-sort clean",
     "coverage": "echo 'you can pass a name argument to specify which tests are ran such as `yarn coverage decorator` and then view the results with `yarn coverage:report`'; yarn test:c4p --coverage",
     "coverage:report": "open ./packages/ibm-products/coverage/index.html",
-    "format": "prettier ./packages/**/*.{js,jsx,md,mdx,scss} --write --ignore-unknown",
+    "format": "prettier ./packages/**/*.{js,jsx,tsx,md,mdx,scss} --write --ignore-unknown",
     "generate": "lerna run generate --loglevel success --scope \"@carbon/ibm-products\" --",
     "lint": "run-p -s 'lint:*'",
     "lint:js": "eslint packages --fix",


### PR DESCRIPTION
Contributes to #4043 

Currently, Husky is configured using a 'prepare' script.  'Prepare' works for npm and older versions of Yarn, but Yarn 2+ doesn't support it. So I have added a postinstall script for configuring Husky.

#### What did you change?

1. Added `postinstall` script in package.json to fix pre-commit hooks issue
2. Updated `format` script to include tsx files to fix the issue metioned in https://github.com/carbon-design-system/ibm-products/pull/4678#discussion_r1551158510

#### How did you test and verify your work?

Local env