### PR TITLE
test(playwright): check story has actually rendered before proceeding

### DIFF
--- a/e2e/test-utils/storybook.js
+++ b/e2e/test-utils/storybook.js
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+const { expect } = require('@playwright/test');
+
 async function visitStory(page, options) {
   const { component, story, id, globals, args } = options;
   let url = getStoryUrl({
@@ -32,6 +34,7 @@ async function visitStory(page, options) {
   }
 
   await page.goto(url);
+  await expect(page).toContainAStory(options);
 }
 
 function getStoryUrl({ component, story, id }) {

--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -50,7 +50,7 @@ const decorators = [
     JSON.stringify(args.featureFlags);
 
     return (
-      <div className="preview-position-fix">
+      <div className="preview-position-fix story-wrapper">
         <Style styles={index}>
           {args.featureFlags ? (
             <ActionableNotification

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -112,4 +112,44 @@ expect.extend({
   },
 });
 
+expect.extend({
+  async toContainAStory(page, options) {
+    let pass;
+    try {
+      /**
+       * This isn't a foolproof way to determine that an actual story
+       * has been rendered, but it should determine if a storybook
+       * error page is present or not.
+       */
+      await expect(page.locator('css=.story-wrapper')).toBeInViewport();
+      pass = true;
+    } catch (e) {
+      pass = false;
+    }
+
+    if (pass) {
+      return {
+        pass: true,
+      };
+    } else {
+      return {
+        pass: false,
+        message:
+          () => `An element with the "story-wrapper" class was not found at url:
+          ${page.url()}
+          The url is probably invalid and does not render a story.
+          Check the url locally, and verify the parameters passed to visitStory are correct.
+          {
+            component: ${options.component} 
+            story: ${options.story} 
+            id: ${options.id} 
+            globals: ${JSON.stringify(options.globals)} 
+            args: ${JSON.stringify(options.args)},
+          }
+          `
+      };
+    }
+  },
+});
+
 module.exports = config;


### PR DESCRIPTION
Contributes to #4688 

I noticed that `Cascade` e2e avt test was passing even when it was being passed an incorrect story id which results in storybook's 404 page to display. This PR brings in similar changes @tay1orjones included in https://github.com/carbon-design-system/carbon/pull/16132 after we chatted about this issue.

#### What did you change?
```
e2e/test-utils/storybook.js
packages/core/.storybook/preview.js
playwright.config.js
```
#### How did you test and verify your work?
- Ran playwright tests locally
  - With an incorrect story id, fails
  - And with a correct one, passes