### PR TITLE
fix: productive card flex fix

### DIFF
--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -3878,7 +3878,8 @@ p.c4p--about-modal__copyright-text:first-child {
 }
 
 .cds--data-table td.c4p--datagrid__expandable-row-cell + td,
-.cds--data-table .c4p--datagrid__carbon-nested-row:not(.c4p--datagrid__carbon-row-expandable) td.c4p--datagrid__cell:nth-of-type(2) {
+.cds--data-table .c4p--datagrid__carbon-nested-row:not(.c4p--datagrid__carbon-row-expandable) td.c4p--datagrid__cell:nth-of-type(2),
+.cds--data-table .c4p--datagrid__carbon-nested-row td.c4p--datagrid__cell:nth-of-type(2) + td {
   position: relative;
 }
 
@@ -9012,6 +9013,10 @@ button.c4p--add-select__global-filter-toggle--open {
   z-index: 7999;
 }
 
+.c4p--card__productive {
+  display: flex;
+  flex-direction: column;
+}
 .c4p--card__productive .c4p--card__title {
   font-size: var(--cds-heading-compact-02-font-size, 1rem);
   font-weight: var(--cds-heading-compact-02-font-weight, 600);
@@ -9086,6 +9091,14 @@ button.c4p--add-select__global-filter-toggle--open {
 }
 .c4p--card__productive .c4p--card__header-container {
   align-items: flex-start;
+}
+.c4p--card__productive .c4p--card__content-container {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+.c4p--card__productive .c4p--card__header-body-container {
+  flex: 1;
 }
 
 .c4p--remove-modal .cds--modal-footer .cds--btn {

--- a/packages/ibm-products-styles/src/components/ProductiveCard/_productive-card.scss
+++ b/packages/ibm-products-styles/src/components/ProductiveCard/_productive-card.scss
@@ -16,6 +16,9 @@
 $block-class: #{c4p-settings.$pkg-prefix}--card;
 
 .#{$block-class}__productive {
+  display: flex;
+  flex-direction: column;
+
   .#{$block-class}__title {
     @include type.type-style('heading-compact-02');
   }
@@ -100,5 +103,15 @@ $block-class: #{c4p-settings.$pkg-prefix}--card;
 
   .#{$block-class}__header-container {
     align-items: flex-start;
+  }
+
+  .#{$block-class}__content-container {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+  }
+
+  .#{$block-class}__header-body-container {
+    flex: 1;
   }
 }


### PR DESCRIPTION
Contributes to #4756 

alleviates styling issue where productive card wasn't flexing to match it's siblings

![Screenshot 2024-04-05 at 12 11 27 PM](https://github.com/carbon-design-system/ibm-products/assets/6370760/87eac629-f677-4414-9b57-caf4917d290d)
