### PR TITLE
fix(NotificationsPanel): fixed glitchy animation after closing the panel

### DIFF
--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -3878,7 +3878,8 @@ p.c4p--about-modal__copyright-text:first-child {
 }
 
 .cds--data-table td.c4p--datagrid__expandable-row-cell + td,
-.cds--data-table .c4p--datagrid__carbon-nested-row:not(.c4p--datagrid__carbon-row-expandable) td.c4p--datagrid__cell:nth-of-type(2) {
+.cds--data-table .c4p--datagrid__carbon-nested-row:not(.c4p--datagrid__carbon-row-expandable) td.c4p--datagrid__cell:nth-of-type(2),
+.cds--data-table .c4p--datagrid__carbon-nested-row td.c4p--datagrid__cell:nth-of-type(2) + td {
   position: relative;
 }
 

--- a/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.js
+++ b/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.js
@@ -391,7 +391,7 @@ export let NotificationsPanel = React.forwardRef(
         className={cx(blockClass, className, `${blockClass}__container`)}
         style={{
           animation: !reducedMotion.matches
-            ? `${open ? 'fade-in 250ms' : 'fade-out 250ms'}`
+            ? `${open ? 'fade-in 250ms' : 'fade-out forwards 250ms'}`
             : null,
         }}
         onAnimationEnd={onAnimationEnd}


### PR DESCRIPTION
Contributes to #4651 

Applied fade-out animation with "forwards" fill mode to prevent animation reset upon completion, resolving the issue.

#### What did you change?
packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.js

#### How did you test and verify your work?
storybook