### PR TITLE
build: include webpack optimization config

### DIFF
--- a/packages/core/.storybook/main.js
+++ b/packages/core/.storybook/main.js
@@ -55,6 +55,10 @@ module.exports = {
   // v11 will only show stories for C4P components (or at least until CDAI/Security move from v10 to v11)
   webpackFinal: async (configuration, { configType }) =>
     merge(configuration, {
+      optimization: {
+        removeAvailableModules: true,
+        removeEmptyChunks: true,
+      },
       cache: {
         type: 'filesystem',
         allowCollectingMemory: true,


### PR DESCRIPTION
Addresses #4780

Includes some webpack optimizations found in Storybook's repo/issues. This should hopefully prevent Netlify builds from running out of memory, thus causing our Netlify PR check to fail.

#### What did you change?
`packages/core/.storybook/main.js`
#### How did you test and verify your work?
Build completes and storybook preview deploy works in this PR