### PR TITLE
feat: full page step description as node to match tearsheet

### DIFF
--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -3878,7 +3878,8 @@ p.c4p--about-modal__copyright-text:first-child {
 }
 
 .cds--data-table td.c4p--datagrid__expandable-row-cell + td,
-.cds--data-table .c4p--datagrid__carbon-nested-row:not(.c4p--datagrid__carbon-row-expandable) td.c4p--datagrid__cell:nth-of-type(2) {
+.cds--data-table .c4p--datagrid__carbon-nested-row:not(.c4p--datagrid__carbon-row-expandable) td.c4p--datagrid__cell:nth-of-type(2),
+.cds--data-table .c4p--datagrid__carbon-nested-row td.c4p--datagrid__cell:nth-of-type(2) + td {
   position: relative;
 }
 

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.stories.js
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.stories.js
@@ -6,7 +6,7 @@
  */
 import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
-import { usePrefix } from '@carbon/react';
+import { usePrefix, Link } from '@carbon/react';
 import { CreateFullPage } from '.';
 import { CreateFullPageStep } from './CreateFullPageStep';
 import { pkg } from '../../settings';
@@ -102,9 +102,16 @@ const Template = ({ ...args }) => {
           title="Partition"
           subtitle="One or more partitions make up a topic. A partition is an ordered list
         of messages."
-          description="Partitions are distributed across the brokers in order to increase the
-        scalability of your topic. You can also use them to distribute
-        messages across the members of a consumer group."
+          description={
+            <>
+              <span>
+                Partitions are distributed across the brokers in order to
+                increase the scalability of your topic. You can also use them to
+                distribute messages across the members of a consumer group.
+              </span>
+              &nbsp;<Link href="#">Learn more.</Link>
+            </>
+          }
           onNext={() => {
             return new Promise((resolve, reject) => {
               setTimeout(() => {

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPageStep.js
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPageStep.js
@@ -97,16 +97,17 @@ export let CreateFullPageStep = forwardRef(
     const span = { span: 50 }; // Half.
 
     const renderDescription = () => {
-      const ColumnAsType = (props) => (
-        <Column {...props} className={`${blockClass}-description`} {...span} />
-      );
-
       if (description) {
+        const common = {
+          children: description,
+          className: `${blockClass}-description`,
+          ...span,
+        };
+
         if (typeof description === 'string') {
-          return <ColumnAsType as="p">{description}</ColumnAsType>;
-        }
-        if (isValidElement(description)) {
-          return <ColumnAsType as="div">{description}</ColumnAsType>;
+          return <Column {...common} as="p" />;
+        } else if (isValidElement(description)) {
+          return <Column {...common} as="div" />;
         }
       }
       return null;

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPageStep.js
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPageStep.js
@@ -5,7 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { forwardRef, useContext, useEffect, useState } from 'react';
+import React, {
+  forwardRef,
+  isValidElement,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { pkg } from '../../settings';
@@ -90,6 +96,22 @@ export let CreateFullPageStep = forwardRef(
 
     const span = { span: 50 }; // Half.
 
+    const renderDescription = () => {
+      const ColumnAsType = (props) => (
+        <Column {...props} className={`${blockClass}-description`} {...span} />
+      );
+
+      if (description) {
+        if (typeof description === 'string') {
+          return <ColumnAsType as="p">{description}</ColumnAsType>;
+        }
+        if (isValidElement(description)) {
+          return <ColumnAsType as="div">{description}</ColumnAsType>;
+        }
+      }
+      return null;
+    };
+
     return stepsContext ? (
       <section
         {
@@ -117,15 +139,7 @@ export let CreateFullPageStep = forwardRef(
                 </Column>
               )}
 
-              {description && (
-                <Column
-                  className={`${blockClass}-description`}
-                  as="p"
-                  {...span}
-                >
-                  {description}
-                </Column>
-              )}
+              {renderDescription()}
             </Grid>
           </Column>
         </Grid>
@@ -169,7 +183,7 @@ CreateFullPageStep.propTypes = {
   /**
    * Sets an optional description on the progress step component
    */
-  description: PropTypes.string,
+  description: PropTypes.node,
 
   /**
    * This will conditionally disable the submit button in the multi step CreateFullPage


### PR DESCRIPTION
Fixes to #4778 

#### What did you change?

Changes CreateTearsheetStep description from string to node.

#### How did you test and verify your work?

Updated a story and ran storybook to check function.