### PR TITLE
fix(Datagrid): export editable cell hook

### DIFF
--- a/packages/ibm-products/src/components/index.js
+++ b/packages/ibm-products/src/components/index.js
@@ -77,6 +77,7 @@ export {
   useFiltering,
   getAutoSizedColumnWidth,
   useFilterContext,
+  useEditableCell,
 } from './Datagrid';
 export { EditTearsheet, EditTearsheetForm } from './EditTearsheet';
 export { EditTearsheetNarrow } from './EditTearsheetNarrow';


### PR DESCRIPTION
Contributes to #4790 

Exports the `useEditableCell` hook so that it can be imported from our library (work around for now is to import `useInlineEdit` with the deprecation warning).

#### What did you change?
`packages/ibm-products/src/components/index.js`
#### How did you test and verify your work?
