### PR TITLE
feat(datagrid): added feature to control number of skeleton rows

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -251,7 +251,7 @@ DatagridContent.propTypes = {
       PropTypes.element,
       PropTypes.func,
     ]),
-    isFetching: PropTypes.bool,
+    isFetching: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
     fullHeightDatagrid: PropTypes.bool,
     filterProps: PropTypes.object,
     variableRowHeight: PropTypes.bool,

--- a/packages/ibm-products/src/components/Datagrid/useSkeletonRows.js
+++ b/packages/ibm-products/src/components/Datagrid/useSkeletonRows.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,11 +9,12 @@ const useSkeletons = (hooks) => {
   const useInstance = (instance) => {
     const { isFetching, rows } = instance;
     const skeletonRow = (id) => ({ isSkeleton: true, values: 'skeleton', id });
+    const numRows = typeof isFetching === 'number' ? isFetching : 3;
     const rowsWithSkeletons = [
       ...rows,
-      skeletonRow('skeleton-row-1'),
-      skeletonRow('skeleton-row-2'),
-      skeletonRow('skeleton-row-3'),
+      ...Array.from({ length: numRows }, (_, index) =>
+        skeletonRow(`skeleton-row-${index + 1}`)
+      ),
     ];
     Object.assign(instance, { rows: isFetching ? rowsWithSkeletons : rows });
   };


### PR DESCRIPTION
Contributes to #4750 

isFetching prop now accepts a number and a boolean.
if its boolean and true, it shows 3 row skeletons by default.
if it is a number, it shows the number of row skeletons.

#### What did you change?
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
packages/ibm-products/src/components/Datagrid/useSkeletonRows.js

#### How did you test and verify your work?
in Datagrid.stories.js at line 615 in `Skeleton` story, i have set the isFetching prop to `true`, `false`, `0`, `a random number`.
And got empty states for `false` and `0`
and `3` skeletons for passing true, and expected number of skeletons for the provided number