### PR TITLE
feat: create action for triaging labeled issues

### DIFF
--- a/.github/workflows/move-issue-to-project-and-set-fields.yml
+++ b/.github/workflows/move-issue-to-project-and-set-fields.yml
@@ -1,0 +1,97 @@
+name: Add issue to project and set field and field option given a specific label
+on:
+  workflow_call:
+    inputs:
+      field:
+        default: ''
+        type: string
+        required: true
+      field_option:
+        default: ''
+        type: string
+        required: true
+      project_number:
+        default: ''
+        type: string
+        required: true
+
+jobs:
+  move_to_project_field:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get project data
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_SET_FIELD }}
+        run: |
+          gh api graphql -f query='
+          query($org: String!, $number: Int!) {
+            organization(login: $org){
+              projectV2(number: $number) {
+                id
+                fields(first:20) {
+                  nodes {
+                    ... on ProjectV2Field {
+                      id
+                      name
+                    }
+                    ... on ProjectV2SingleSelectField {
+                      id
+                      name
+                      options {
+                        id
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }' -f org=${{ github.repository_owner }} -F number=${{ inputs.project_number }} > project_data.json
+
+          echo 'Field and field option are: "${{ inputs.field }}: ${{ inputs.field_option }}"'
+          echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
+          echo 'FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name=="${{ inputs.field }}") | .id' project_data.json) >> $GITHUB_ENV
+          echo 'FIELD_OPTION_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name=="${{ inputs.field }}") | .options[] | select(.name=="${{ inputs.field_option }}") |.id' project_data.json) >> $GITHUB_ENV
+
+      - name: Add issue to project
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_SET_FIELD }}
+          ISSUE_ID: ${{ github.event.issue.node_id }}
+        # Uses [GitHub CLI](https://cli.github.com/manual/) and the API to add the issue that triggered this workflow to the project. The `jq` flag parses the response to get the ID of the created item.
+        run: |
+          item_id="$( gh api graphql -f query='
+            mutation($project:ID!, $issue:ID!) {
+              addProjectV2ItemById(input: {projectId: $project, contentId: $issue}) {
+                item {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID --jq '.data.addProjectV2ItemById.item.id')"
+
+            echo 'ITEM_ID='$item_id >> $GITHUB_ENV
+
+      - name: Set field value
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_SET_FIELD }}
+        # Sets the value of the `field` to the specified `field_option`.
+        run: |
+          gh api graphql -f query='
+            mutation (
+              $project: ID!
+              $item: ID!
+              $field_id: ID!
+              $field_option: String!
+            ) {
+              set_field: updateProjectV2ItemFieldValue(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $field_id
+                value: {
+                  singleSelectOptionId: $field_option
+                  }
+              }) {
+                projectV2Item {
+                  id
+                  }
+              }
+            }' -f project=$PROJECT_ID -f item=$ITEM_ID -f field_id=$FIELD_ID -f field_option=${{ env.FIELD_OPTION_ID }} --silent

--- a/.github/workflows/triage-labeled-issues.yml
+++ b/.github/workflows/triage-labeled-issues.yml
@@ -21,3 +21,11 @@ jobs:
       field_option: '🗺 Migration'
       project_number: '65'
     secrets: inherit
+  move-a11y-issues:
+    if: ${{contains(github.event.label.name, format('type{0} ally ♿', ':'))}}
+    uses: ./.github/workflows/move-issue-to-project-and-set-fields.yml
+    with:
+      field: 'Area'
+      field_option: '♿️ Accessibility'
+      project_number: '65'
+    secrets: inherit

--- a/.github/workflows/triage-labeled-issues.yml
+++ b/.github/workflows/triage-labeled-issues.yml
@@ -22,7 +22,7 @@ jobs:
       project_number: '65'
     secrets: inherit
   move-a11y-issues:
-    if: ${{contains(github.event.label.name, format('type{0} ally ♿', ':'))}}
+    if: ${{contains(github.event.label.name, format('type{0} a11y ♿', ':'))}}
     uses: ./.github/workflows/move-issue-to-project-and-set-fields.yml
     with:
       field: 'Area'

--- a/.github/workflows/triage-labeled-issues.yml
+++ b/.github/workflows/triage-labeled-issues.yml
@@ -1,0 +1,23 @@
+name: Triages labeled issues by adding them to a specific project field
+
+on:
+  issues:
+    types: [ labeled ]
+
+jobs:
+  move-ts-issues:
+    if: ${{contains(github.event.label.name, format('area{0} typescript', ':'))}}
+    uses: ./.github/workflows/move-issue-to-project-and-set-fields.yml
+    with:
+      field: 'Area'
+      field_option: '🟦 Typescript'
+      project_number: '65'
+    secrets: inherit
+  move-migration-issues:
+    if: ${{contains(github.event.label.name, format('area{0} migration ➡️', ':'))}}
+    uses: ./.github/workflows/move-issue-to-project-and-set-fields.yml
+    with:
+      field: 'Area'
+      field_option: '🗺 Migration'
+      project_number: '65'
+    secrets: inherit


### PR DESCRIPTION
Contributes to #4803 

Adds the prototype action I created [here](https://github.com/matthewgallo/ibm-products-vite-template/blob/main/.github/workflows/add-label-move-to-area.yml) into our repo. This action triages labeled issues by adding them to our project board and applying the specified field/field option values. In this case, issues labeled `area: typescript` will be moved into "Area: 🟦 TypeScript" in our project.

Discussed with @tay1orjones about potentially including the reusable workflow in a [shared repo](https://github.com/carbon-design-system/.github) for other teams to use as well, but want to make sure it works here first.

If we want to add this same thing for other labels we should be able to easily by updating `.github/workflows/triage-labeled-issues.yml`. The [Graphql API Explorer](https://docs.github.com/en/graphql/overview/explorer) really helped with being able to see the response and to make sure that the `query` was properly structured.

#### What did you change?
Created two new workflow files
```
.github/workflows/move-issue-to-project-and-set-fields.yml // more generic reusable workflow file
.github/workflows/triage-labeled-issues.yml
```
#### How did you test and verify your work?
[In test repo](https://github.com/matthewgallo/ibm-products-vite-template/tree/main/.github/workflows)