### PR TITLE
build: fix legacy rename

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn dlx commitlint --edit $1
+yarn commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn update-gallery-config
+# yarn update-gallery-config
 yarn lint-staged

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint:prettier:files": "yarn format:prettier:files --check --loglevel warn",
     "lint:style": "yarn lint:style:files 'packages/*/src/**/*.scss' 'scripts/**/*.scss' 'examples/**/src/*.scss'",
     "lint:style:files": "stylelint --report-needless-disables --report-invalid-scope-disables",
-    "prepare": "husky install",
+    "postinstall": "husky",
     "run-all": "nx run-many --target=build --all --exclude=@carbon/ibm-cloud-cognitive-core",
     "test": "run-p -s 'test:*'",
     "test:cdai": "lerna run --stream --scope @carbon/ibm-cloud-cognitive-cdai test --",


### PR DESCRIPTION
Closes #4878 🤞 

- Update husky config and precommit
- Remove gallery update 

#### What did you change?
Port @szinta’s precommit fixes from #4746 to v1

#### How did you test and verify your work?
Successful precommit run locally without extra gallery update commit