### PR TITLE
fix(ExportModal): skip blank spaces check for password

### DIFF
--- a/packages/ibm-products/src/components/ExportModal/ExportModal.js
+++ b/packages/ibm-products/src/components/ExportModal/ExportModal.js
@@ -119,7 +119,10 @@ export let ExportModal = forwardRef(
     const blockClass = `${pkg.prefix}--export-modal`;
     const internalId = useRef(uuidv4());
     const primaryButtonDisabled =
-      loading || !name?.trim() || inputProps?.invalid || hasInvalidExtension();
+      inputProps?.invalid ||
+      loading ||
+      (inputType === 'text' ? !name?.trim() : !name) ||
+      hasInvalidExtension();
     const submitted = loading || error || successful;
 
     const commonInputProps = {


### PR DESCRIPTION
minor correction for merged pr https://github.com/carbon-design-system/ibm-products/pull/4566

the blank space validation (`.trim()` check) should only be made when inputType is `text`, as it is ok to have blank spaces in a password. the variable `name` led me to believe it would only apply to textinput, but later on realised it is also reused for password input.