### PR TITLE
fix: use same node options as v1 for storybook build script

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "run-s build:carbon build:storybook",
     "build:carbon": "sass --style=expanded --load-path ../ibm-products/node_modules --load-path ../../node_modules --load-path node_modules .storybook/carbon.scss:css/carbon.css",
-    "build:storybook": "yarn dlx cross-env \"NODE_OPTIONS=--max_old_space_size=2048\" && storybook build",
+    "build:storybook": "yarn dlx cross-env \"NODE_OPTIONS=--max_old_space_size=4096\" && storybook build",
     "clean": "yarn dlx rimraf storybook-static css",
     "start": "run-s build:carbon start:storybook",
     "start:storybook": "storybook dev ./public -p 3000",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "run-s build:carbon build:storybook",
     "build:carbon": "sass --style=expanded --load-path ../ibm-products/node_modules --load-path ../../node_modules --load-path node_modules .storybook/carbon.scss:css/carbon.css",
-    "build:storybook": "storybook build",
+    "build:storybook": "yarn dlx cross-env \"NODE_OPTIONS=--max_old_space_size=2048\" && storybook build",
     "clean": "yarn dlx rimraf storybook-static css",
     "start": "run-s build:carbon start:storybook",
     "start:storybook": "storybook dev ./public -p 3000",


### PR DESCRIPTION
Contributes to #4780 

This PR includes the same node options that we specify for extra memory allocation that we use in `v1`. This likely was just unintentionally not included from v1 to v2. With all of the Netlify preview deploys not working because of memory issues, turns out we need to include this.

#### What did you change?
```
packages/core/package.json
```
#### How did you test and verify your work?
We'll see if the Netlify build in this PR works 😄 