### PR TITLE
fix(pageHeader): PageHeader breadcrumb tooltip displays underneath Carbon UI shell header

### DIFF
--- a/packages/ibm-products/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
+++ b/packages/ibm-products/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
@@ -45,6 +45,7 @@ export let BreadcrumbWithOverflow = ({
   maxVisible,
   noTrailingSlash,
   overflowAriaLabel,
+  overflowTooltipAlign,
   ...other
 }) => {
   const carbonPrefix = usePrefix();
@@ -60,6 +61,7 @@ export let BreadcrumbWithOverflow = ({
     return (
       <BreadcrumbItem key={`breadcrumb-overflow-${internalId.current}`}>
         <OverflowMenu
+          align={overflowTooltipAlign}
           aria-label={overflowAriaLabel}
           iconDescription={overflowAriaLabel} // also needs setting to avoid a11y "Accessible name does not match or contain the visible label text"
           renderIcon={(props) => (
@@ -382,6 +384,10 @@ BreadcrumbWithOverflow.propTypes = {
   overflowAriaLabel: PropTypes.string.isRequired.if(
     ({ breadcrumbs }) => breadcrumbs.length > 1
   ),
+  /**
+   * overflowTooltipAlign: align tooltip position
+   */
+  overflowTooltipAlign: Tooltip.propTypes.align
 };
 
 BreadcrumbWithOverflow.displayName = componentName;

--- a/packages/ibm-products/src/components/PageHeader/PageHeader.js
+++ b/packages/ibm-products/src/components/PageHeader/PageHeader.js
@@ -521,6 +521,7 @@ export let PageHeader = React.forwardRef(
                               ? [breadcrumbItemForTitle]
                               : breadcrumbs // breadcrumbs may be null or undefined
                           }
+                          overflowTooltipAlign="right"
                         />
                       ) : null}
                     </Column>


### PR DESCRIPTION
Contributes to #4800 

Use the new `overflowTooltipAlign` to align tooltip

#### What did you change?
Added a new property `overflowTooltipAlign` to the component `BreadcrumbWithOverflow`.

Now we can align the tooltip from `PageHeader` component like this:
![image](https://github.com/carbon-design-system/ibm-products/assets/9197089/ab449002-4351-419d-9d88-3d7b2af6d04a)


#### How did you test and verify your work?
Storybook