### PR TITLE
perf: use `lazyCompilation` and `fsCache` to increase storybook start times

### DIFF
--- a/packages/core/.storybook/main.js
+++ b/packages/core/.storybook/main.js
@@ -50,6 +50,16 @@ module.exports = {
     },
   ],
 
+  core: {
+    builder: {
+      name: 'webpack5',
+      options: {
+        lazyCompilation: true,
+        fsCache: true,
+      },
+    },
+  },
+
   framework: {
     name: '@storybook/react-webpack5',
     options: {},


### PR DESCRIPTION
Closes #4921 

This is a follow up PR to https://github.com/carbon-design-system/ibm-products/pull/4937 which enabled `storyStoreV7`. This addition uses the `lazyCompilation` and `fsCache` settings in `.storybook/main.js`. There is an article [here](https://storybook.js.org/blog/storybook-lazy-compilation-for-webpack/) discussing in more detail the performance improvements. We previously couldn't use it because it requries `storyStoreV7`.

Below are some screenshots of storybook startup times with and without this setting:

_Without file system cache or lazy compilation_  -- **1.45 min**
<img width="794" alt="Screenshot 2024-04-17 at 9 34 42 PM" src="https://github.com/carbon-design-system/ibm-products/assets/10215203/6565bf09-4769-4c09-9db5-5e5b161824b2">

_With file system cache or lazy compilation_  -- **13 sec**
![Screenshot 2024-04-18 at 8 52 14 AM](https://github.com/carbon-design-system/ibm-products/assets/10215203/c67fa245-848e-4724-bf23-9a0041643f6e)


#### What did you change?
`packages/core/.storybook/main.js`
#### How did you test and verify your work?
Made sure storybook still loads and builds as expected