### PR TITLE
fix: support provided classname for TableCell #4965

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.js
@@ -62,6 +62,7 @@ const getColumns = (rows) => {
       sticky: 'left',
       id: 'rowIndex', // id is required when accessor is a function.
       width: getAutoSizedColumnWidth(rows, 'rowIndex', 'Row Index'),
+      className: 'test-column',
     },
     {
       Header: 'First Name',

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.js
@@ -167,6 +167,7 @@ const DatagridRow = (datagridState) => {
           const cellProps = cell.getCellProps();
           // eslint-disable-next-line no-unused-vars
           const { children, role, ...restProps } = cellProps;
+          const columnClassname = cell?.column?.className;
           const content = children || (
             <>
               {!row.isSkeleton && cell.render('Cell')}
@@ -183,16 +184,20 @@ const DatagridRow = (datagridState) => {
           );
           return (
             <TableCell
-              className={cx(`${blockClass}__cell`, {
-                [`${blockClass}__expandable-row-cell`]:
-                  row.canExpand && index === 0,
-                [`${blockClass}__expandable-row-cell--is-expanded`]:
-                  row.isExpanded && index === 0,
-                [`${blockClass}__slug--cell`]:
-                  associatedHeader &&
-                  associatedHeader.length &&
-                  isValidElement(associatedHeader[0]?.slug),
-              })}
+              className={cx(
+                `${blockClass}__cell`,
+                {
+                  [`${blockClass}__expandable-row-cell`]:
+                    row.canExpand && index === 0,
+                  [`${blockClass}__expandable-row-cell--is-expanded`]:
+                    row.isExpanded && index === 0,
+                  [`${blockClass}__slug--cell`]:
+                    associatedHeader &&
+                    associatedHeader.length &&
+                    isValidElement(associatedHeader[0]?.slug),
+                },
+                columnClassname
+              )}
               {...restProps}
               key={cell.column.id}
               title={title}

--- a/packages/ibm-products/src/components/Datagrid/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/Datagrid/_storybook-styles.scss
@@ -155,3 +155,7 @@ div[data-story-title*='#{$story-anchor}']
   cursor: pointer;
   text-align: start;
 }
+
+.test-column {
+  z-index: 10;
+}


### PR DESCRIPTION
Contributes to #4965

{{short description}}

#### What did you change?
<TableCell /> takes provided classname

#### How did you test and verify your work?
storybook

![Screenshot 2024-04-22 at 3 35 25 PM](https://github.com/carbon-design-system/ibm-products/assets/144151347/cab98335-9484-451f-a01f-2f2e06049a75)
