### PR TITLE
fix(FullPageError): alphabetize prop types

### DIFF
--- a/packages/ibm-products/src/components/FullPageError/FullPageError.js
+++ b/packages/ibm-products/src/components/FullPageError/FullPageError.js
@@ -126,14 +126,17 @@ FullPageError.propTypes = {
    * This is optional for 403 and 404 kinds, and passing this would override their default descriptions.
    */
   description: PropTypes.string.isRequired,
-  /**
-   * String that will describe the error that occurred
-   */
-  label: PropTypes.string.isRequired,
+
   /**
    * The kind of error page to be displayed, default is custom
    */
   kind: PropTypes.oneOf(['custom', '403', '404']),
+
+  /**
+   * String that will describe the error that occurred
+   */
+  label: PropTypes.string.isRequired,
+
   /**
    * This will be for the main title of the FullPageError component
    */


### PR DESCRIPTION
Last week's release failed because of `FullPageError` and my guess is that it is related to this linting error about the prop types not being alphabetized.

#### What did you change?
`FullPageError.js`
#### How did you test and verify your work?
Linting error was removed.