### PR TITLE
chore(feature-request-template): add triage status label to template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,7 +1,7 @@
 name: Feature request or enhancement 💡
 description: Suggest a new component/pattern/idea for this project.
 title: '[Feature Request]: '
-labels: 'type: enhancement 💡'
+labels: ['type: enhancement 💡', 'status: needs triage 🕵️‍♀️']
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Contributes to #4999 

#### What did you change?

Adds the triage status label to any new tickets created with the feature request template

#### How did you test and verify your work?
