### PR TITLE
feat: instrument current packages with js scope

### DIFF
--- a/config/storybook-addon-carbon-theme/package.json
+++ b/config/storybook-addon-carbon-theme/package.json
@@ -45,7 +45,7 @@
     "vue": "*"
   },
   "dependencies": {
-    "@ibm/telemetry-js": "^1.3.0",
+    "@ibm/telemetry-js": "^1.5.0",
     "@storybook/addons": "^7.6.10",
     "@storybook/api": "^7.6.10",
     "@storybook/client-api": "^7.6.10",

--- a/config/storybook-addon-carbon-theme/telemetry.yml
+++ b/config/storybook-addon-carbon-theme/telemetry.yml
@@ -5,3 +5,6 @@ endpoint: 'https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.clo
 collect:
   npm:
     dependencies: null
+  js:
+    functions: {}
+    tokens: null

--- a/packages/ibm-products-styles/package.json
+++ b/packages/ibm-products-styles/package.json
@@ -68,6 +68,6 @@
     "@carbon/type": "^11.26.0"
   },
   "dependencies": {
-    "@ibm/telemetry-js": "^1.3.0"
+    "@ibm/telemetry-js": "^1.5.0"
   }
 }

--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -96,7 +96,7 @@
     "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@ibm/telemetry-js": "^1.2.0",
+    "@ibm/telemetry-js": "^1.5.0",
     "framer-motion": "^6.5.1 < 7",
     "immutability-helper": "^3.1.1",
     "lodash": "^4.17.21",

--- a/packages/ibm-products/telemetry.yml
+++ b/packages/ibm-products/telemetry.yml
@@ -788,3 +788,6 @@ collect:
         - 'light-magenta'
         - 'light-purple'
         - 'light-teal'
+  js:
+    functions: {}
+    tokens: null

--- a/yarn.lock
+++ b/yarn.lock
@@ -2038,7 +2038,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@carbon/ibm-products-styles@workspace:packages/ibm-products-styles"
   dependencies:
-    "@ibm/telemetry-js": "npm:^1.3.0"
+    "@ibm/telemetry-js": "npm:^1.5.0"
     chalk: "npm:^4.1.2"
     copyfiles: "npm:^2.4.1"
     cross-env: "npm:^7.0.3"
@@ -2080,7 +2080,7 @@ __metadata:
     "@dnd-kit/modifiers": "npm:^7.0.0"
     "@dnd-kit/sortable": "npm:^8.0.0"
     "@dnd-kit/utilities": "npm:^3.2.2"
-    "@ibm/telemetry-js": "npm:^1.2.0"
+    "@ibm/telemetry-js": "npm:^1.5.0"
     "@rollup/plugin-babel": "npm:^6.0.0"
     "@rollup/plugin-commonjs": "npm:^25.0.0"
     "@rollup/plugin-node-resolve": "npm:^15.0.0"
@@ -2206,7 +2206,7 @@ __metadata:
     "@babel/cli": "npm:^7.23.9"
     "@babel/core": "npm:^7.23.9"
     "@babel/preset-react": "npm:^7.23.3"
-    "@ibm/telemetry-js": "npm:^1.3.0"
+    "@ibm/telemetry-js": "npm:^1.5.0"
     "@storybook/addons": "npm:^7.6.10"
     "@storybook/api": "npm:^7.6.10"
     "@storybook/client-api": "npm:^7.6.10"
@@ -3406,15 +3406,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm/telemetry-js@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@ibm/telemetry-js@npm:1.2.0"
-  bin:
-    ibmtelemetry: dist/collect.js
-  checksum: dd942eaecc6bdf40f91309fc783b2d1b654e9cb73dd0b98ec54eef53816cad027c60ccaf6415cc81dd3ee1f8686159733ac226f6c13288419269a001a7b81b3b
-  languageName: node
-  linkType: hard
-
 "@ibm/telemetry-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "@ibm/telemetry-js@npm:1.2.1"
@@ -3424,12 +3415,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm/telemetry-js@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@ibm/telemetry-js@npm:1.3.0"
+"@ibm/telemetry-js@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@ibm/telemetry-js@npm:1.5.0"
   bin:
     ibmtelemetry: dist/collect.js
-  checksum: 5581511e540b0edf79d7d1badf9a994bcd97d99c27a295909c3184871f76629a9f4095a66c3ca5e835035b90e895c324271786fb958cad9c58f37717b97ca353
+  checksum: 063e1e4a49aec6a61ca523287f090f005bf5032962df6407bcf7f86e7899e6163be7ac0b63cd9fbcffcbd90bc284288cb2b4f246289cd4fff7d27612d38a6221
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Instrument current packages with [JS scope](https://github.com/ibm-telemetry/telemetry-config-schema?tab=readme-ov-file#js-scope)

#### What did you change?

***@carbon/storybook-addon-theme***
- Update `@ibm/telemetry-js` version to 1.5.0
- Add [JS Scope](https://github.com/ibm-telemetry/telemetry-config-schema?tab=readme-ov-file#js-scope)  config to `telemetry.yml`

***@carbon/ibm-products-styles***
- Update `@ibm/telemetry-js` version to 1.5.0

***@carbon/ibm-products***
- Update `@ibm/telemetry-js` version to 1.5.0
- Add [JS Scope](https://github.com/ibm-telemetry/telemetry-config-schema?tab=readme-ov-file#js-scope)  config to `telemetry.yml`

#### How did you test and verify your work?

N/A