### PR TITLE
feat: instrument v1 packages with JS scope

### DIFF
--- a/packages/cdai/package.json
+++ b/packages/cdai/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.20.13",
-    "@ibm/telemetry-js": "^1.3.0",
+    "@ibm/telemetry-js": "^1.5.0",
     "focus-trap-react": "^10.0.2",
     "pluralize": "^8.0.0",
     "react-select": "^5.7.0",

--- a/packages/cdai/telemetry.yml
+++ b/packages/cdai/telemetry.yml
@@ -287,3 +287,5 @@ collect:
         - medium
   npm:
     dependencies: null
+  js:
+    tokens: null

--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -76,7 +76,7 @@
     "@dnd-kit/core": "^6.0.8",
     "@dnd-kit/sortable": "^7.0.2",
     "@dnd-kit/utilities": "^3.2.1",
-    "@ibm/telemetry-js": "^1.2.0",
+    "@ibm/telemetry-js": "^1.5.0",
     "framer-motion": "^6.5.1 <7",
     "immutability-helper": "^3.1.1",
     "lodash": "^4.17.21",

--- a/packages/ibm-products/telemetry.yml
+++ b/packages/ibm-products/telemetry.yml
@@ -814,3 +814,6 @@ collect:
         - light-teal
   npm:
     dependencies: null
+  js:
+    functions: {}
+    tokens: null

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -64,7 +64,7 @@
     "@carbon/motion": "10.29.2",
     "@carbon/themes": "10.55.3",
     "@carbon/type": "10.45.3",
-    "@ibm/telemetry-js": "^1.3.0",
+    "@ibm/telemetry-js": "^1.5.0",
     "carbon-components": "10.58.13",
     "carbon-components-react": "7.59.20",
     "carbon-icons": "7.0.7",

--- a/packages/security/telemetry.yml
+++ b/packages/security/telemetry.yml
@@ -304,3 +304,6 @@ collect:
         - top
   npm:
     dependencies: null
+  js:
+    functions: {}
+    tokens: null

--- a/yarn.lock
+++ b/yarn.lock
@@ -2785,7 +2785,7 @@ __metadata:
     "@babel/preset-env": ^7.20.2
     "@babel/preset-react": ^7.18.6
     "@babel/runtime": ^7.20.13
-    "@ibm/telemetry-js": ^1.3.0
+    "@ibm/telemetry-js": ^1.5.0
     cpx: ^1.5.0
     enzyme: ^3.11.0
     enzyme-adapter-react-16: ^1.15.7
@@ -2895,7 +2895,7 @@ __metadata:
     "@dnd-kit/core": ^6.0.8
     "@dnd-kit/sortable": ^7.0.2
     "@dnd-kit/utilities": ^3.2.1
-    "@ibm/telemetry-js": ^1.2.0
+    "@ibm/telemetry-js": ^1.5.0
     babel-preset-ibm-cloud-cognitive: ^0.14.28
     chalk: ^4.1.2
     change-case: ^4.1.2
@@ -2949,7 +2949,7 @@ __metadata:
     "@carbon/motion": 10.29.2
     "@carbon/themes": 10.55.3
     "@carbon/type": 10.45.3
-    "@ibm/telemetry-js": ^1.3.0
+    "@ibm/telemetry-js": ^1.5.0
     babel-plugin-macros: ^3.1.0
     babel-preset-ibm-cloud-cognitive: ^0.14.28
     carbon-components: 10.58.13
@@ -4192,12 +4192,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm/telemetry-js@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@ibm/telemetry-js@npm:1.3.0"
+"@ibm/telemetry-js@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@ibm/telemetry-js@npm:1.5.0"
   bin:
     ibmtelemetry: dist/collect.js
-  checksum: 9418619b7655c5ff5240feb074eab78895f10eaf5837b0828beed5441ca87012853738ebea9d0ccb3fdbad9106a519aae4ffa66665ca86426d2008dfae756ae5
+  checksum: 7498187a89ad49936233ce933c2cabbf0c437c8c95ac4eae90415d600cfe9d1b2e1e7c5266529d836d1d7fae77932a0010a4863a171720531b52df904dd8b7d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Instrument current packages with [JS scope](https://github.com/ibm-telemetry/telemetry-config-schema?tab=readme-ov-file#js-scope)

#### What did you change?

***@carbon/ibm-cloud-cognitive-cdai***
- Update `@ibm/telemetry-js` version to 1.5.0
- Add [JS Scope](https://github.com/ibm-telemetry/telemetry-config-schema?tab=readme-ov-file#js-scope) config - tokens only -  to `telemetry.yml`

***@carbon/ibm-products***
- Update `@ibm/telemetry-js` version to 1.5.0
- Add [JS Scope](https://github.com/ibm-telemetry/telemetry-config-schema?tab=readme-ov-file#js-scope)  config to `telemetry.yml`

***@carbon/ibm-security***
- Update `@ibm/telemetry-js` version to 1.5.0
- Add [JS Scope](https://github.com/ibm-telemetry/telemetry-config-schema?tab=readme-ov-file#js-scope)  config to `telemetry.yml`

#### How did you test and verify your work?

N/A