### PR TITLE
fix: added a scroll callback which sets prog step back to 0 on resize

### DIFF
--- a/packages/ibm-products-styles/src/components/InterstitialScreen/_interstitial-screen.scss
+++ b/packages/ibm-products-styles/src/components/InterstitialScreen/_interstitial-screen.scss
@@ -17,13 +17,8 @@
 @use '@carbon/react/scss/colors' as *;
 @use '@carbon/styles/scss/type';
 
-// Other Carbon settings if needed
-// TODO: @use '@carbon/styles/scss/grid';
-// or
-// TODO: @use '@carbon/react/scss/grid';
-
 // InterstitialScreen uses the following Carbon for IBM Products components:
-// TODO: @use(s) of IBM Products component styles used by InterstitialScreen
+@use '../Carousel/carousel';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 $block-class: #{c4p-settings.$pkg-prefix}--interstitial-screen;

--- a/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreen.js
+++ b/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreen.js
@@ -300,7 +300,13 @@ export let InterstitialScreen = React.forwardRef(
                   <div className={cx(`${blockClass}--content`)}>
                     {isMultiStep ? (
                       <div className={`${blockClass}__carousel`}>
-                        <Carousel disableArrowScroll ref={scrollRef}>
+                        <Carousel
+                          disableArrowScroll
+                          ref={scrollRef}
+                          onScroll={(scrollPercent) => {
+                            scrollPercent === 0 && setProgStep(0);
+                          }}
+                        >
                           {children}
                         </Carousel>
                       </div>
@@ -336,7 +342,13 @@ export let InterstitialScreen = React.forwardRef(
             <div className={cx(`${blockClass}--content`)}>
               {isMultiStep ? (
                 <div className={`${blockClass}__carousel`}>
-                  <Carousel disableArrowScroll ref={scrollRef}>
+                  <Carousel
+                    disableArrowScroll
+                    ref={scrollRef}
+                    onScroll={(scrollPercent) => {
+                      scrollPercent === 0 && setProgStep(0);
+                    }}
+                  >
                     {children}
                   </Carousel>
                 </div>

--- a/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreen.stories.js
+++ b/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreen.stories.js
@@ -300,21 +300,21 @@ interstitialScreenModalMultiplesHeader.args = {
       <InterstitialScreenView stepTitle="Step 1">
         <InterstitialScreenViewModule
           size="md"
-          title="Use case-specific heading"
+          title="Use case-specific heading 1"
           description="Use case-specific content that explains the concept. Use case-specific content that explains the concept. Use case-specific content that explains the concept. Use case-specific content that explains the concept."
         />
       </InterstitialScreenView>
       <InterstitialScreenView stepTitle="Step 2">
         <InterstitialScreenViewModule
           size="md"
-          title="Use case-specific heading"
+          title="Use case-specific heading 2"
           description="Use case-specific content that explains the concept. Use case-specific content that explains the concept. Use case-specific content that explains the concept. Use case-specific content that explains the concept."
         />
       </InterstitialScreenView>
       <InterstitialScreenView stepTitle="Step 3">
         <InterstitialScreenViewModule
           size="md"
-          title="Use case-specific heading"
+          title="Use case-specific heading 3"
           description="Use case-specific content that explains the concept. Use case-specific content that explains the concept. Use case-specific content that explains the concept. Use case-specific content that explains the concept."
         />
       </InterstitialScreenView>


### PR DESCRIPTION
Carousel element moving to first step on resize in InterstitialScreen - which is expected behavior... but the navigation and the step indicator was out of sync.

Contributes to [4970](https://github.com/carbon-design-system/ibm-products/issues/4970)

#### What did you change?

- Added a scroll callback which sets prog step back to 0 on resize
- Modified the story to be more clear on what step you are on 
- Updated the stylesheet to use carousels scss - to get the base styles.


#### How did you test and verify your work?
Storybook
