### PR TITLE
test(AboutModal): add default avt test and add avt script to help test

### DIFF
--- a/e2e/components/AboutModal/AboutModal-test.avt.e2e.js
+++ b/e2e/components/AboutModal/AboutModal-test.avt.e2e.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../test-utils/storybook';
+
+test.describe('AboutModal @avt', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'AboutModal',
+      id: 'ibm-products-patterns-about-modal-aboutmodal--about-modal',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('AboutModal @avt-default-state');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "audit": "node scripts/audit.js '--environment production' moderate",
+    "avt": "yarn playwright test --project chromium --grep @avt",
     "build": "run-s -s 'build:*' storybook:build:storybook",
     "build:packages": "yarn run-all --include-dependencies build",
     "ci-check": "run-s -s 'ci-check:*' storybook:build",


### PR DESCRIPTION
Closes #4660 

Adds e2e AVT default state coverage for the `AboutModal` component. I also added a script in our package.json to run the AVT tests locally.

#### What did you change?
```
e2e/components/AboutModal/AboutModal-test.avt.e2e.js
package.json
```
#### How did you test and verify your work?
Ran `yarn avt` to check that new test passes