### PR TITLE
test(TagSet): add default avt test coverage

### DIFF
--- a/e2e/components/TagSet/TagSet-test.avt.e2e.js
+++ b/e2e/components/TagSet/TagSet-test.avt.e2e.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../test-utils/storybook';
+
+test.describe('TagSet @avt', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'TagSet',
+      id: 'ibm-products-components-tag-set-tagset--five-tags',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('TagSet @avt-default-state');
+  });
+});


### PR DESCRIPTION
Closes #5004 

Adds default AVT test coverage for TagSet component.

#### What did you change?
```
e2e/components/TagSet/TagSet-test.avt.e2e.js
```
#### How did you test and verify your work?
Ran playwright tests locally