### PR TITLE
chore: rename `main_v1` to `v1`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - main_v1
+      - v1
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,12 +4,12 @@ on:
   pull_request:
     branches:
       - main
-      - main_v1
+      - v1
 
   push:
     branches:
       - main
-      - main_v1
+      - v1
 
   merge_group:
     types: [checks_requested]

--- a/.github/workflows/release-v1.yml
+++ b/.github/workflows/release-v1.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0 # https://github.com/actions/checkout/issues/217
           token: ${{ secrets.GH_TOKEN_LERNA }} # https://github.com/lerna/lerna/issues/1957
-          ref: 'main_v1'
+          ref: 'v1'
 
       # https://github.com/actions/checkout#push-a-commit-using-the-built-in-token
       - run: |

--- a/.github/workflows/update-v1.yml
+++ b/.github/workflows/update-v1.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: 'main_v1'
+          ref: 'v1'
 
       - name: Install
         run: yarn

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ other users.
 This project consists of a number of component library packages published on
 npm:
 
-| Package name                                                                                                          | Description                                                                                                       |
-| --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| [`@carbon/ibm-products`](./packages/ibm-products)                                                                     | A curated set of components and patterns, built on top of Carbon and designed by the Carbon for IBM Products team |
-| [`@carbon/ibm-cloud-cognitive-cdai`](https://github.com/carbon-design-system/ibm-products/tree/main_v1/packages/cdai) | (**v1 only**) Legacy and non-curated design implementations used in application integration                       |
-| [`@carbon/ibm-security`](https://github.com/carbon-design-system/ibm-products/tree/main_v1/packages/security)         | (**v1 only**) Legacy and non-curated design implementations used in security                                      |
+| Package name                                                                                                     | Description                                                                                                       |
+| ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| [`@carbon/ibm-products`](./packages/ibm-products)                                                                | A curated set of components and patterns, built on top of Carbon and designed by the Carbon for IBM Products team |
+| [`@carbon/ibm-cloud-cognitive-cdai`](https://github.com/carbon-design-system/ibm-products/tree/v1/packages/cdai) | (**v1 only**) Legacy and non-curated design implementations used in application integration                       |
+| [`@carbon/ibm-security`](https://github.com/carbon-design-system/ibm-products/tree/v1/packages/security)         | (**v1 only**) Legacy and non-curated design implementations used in security                                      |
 
 Also the following additional utility packages are published on npm:
 


### PR DESCRIPTION
Contributes to #4932 

This PR renames all instances of `main_v1` in our workflows/docs to `v1`. The only remaining piece to this is actually renaming the branch within our repo, I believe any PRs that are open and targeting `main_v1` will automatically change to target `v1`.

After renaming within our repo, we can run a v1 prerelease to make sure everything still works as expected after all of the renaming.

#### What did you change?
```
.github/workflows/ci.yml
.github/workflows/codeql.yml
.github/workflows/release-v1.yml
.github/workflows/update-v1.yml
README.md
```
