### PR TITLE
fix: added use statement to pull in base styles for carousel

### DIFF
--- a/packages/ibm-products-styles/src/components/CoachmarkOverlayElements/_coachmark-overlay-elements.scss
+++ b/packages/ibm-products-styles/src/components/CoachmarkOverlayElements/_coachmark-overlay-elements.scss
@@ -20,7 +20,7 @@
 // TODO: @use '@carbon/react/scss/grid';
 
 // CoachmarkOverlayElements uses the following Carbon for IBM Products components:
-// TODO: @use(s) of IBM Products component styles used by CoachmarkOverlayElements
+@use '../Carousel/carousel';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 $block-class: #{c4p-settings.$pkg-prefix}--coachmark-overlay-elements;

--- a/packages/ibm-products-styles/src/components/Guidebanner/_guidebanner.scss
+++ b/packages/ibm-products-styles/src/components/Guidebanner/_guidebanner.scss
@@ -32,6 +32,9 @@
 @use '@carbon/styles/scss/type' as *;
 @use '../../global/styles/project-settings' as c4p-settings;
 
+// Guidebanner uses the following Carbon for IBM Products components:
+@use '../Carousel/carousel';
+
 // The block part of our conventional BEM class names (blockClass__E--M).
 $block-class: #{c4p-settings.$pkg-prefix}--guidebanner;
 


### PR DESCRIPTION
Contributes to [5067](https://github.com/carbon-design-system/ibm-products/issues/5067)

Novice to pro components using the internal Carousel component are not including the carousel scss file in their scss

#### What did you change?
added `@use '../Carousel/carousel';` to the guidebanner.scss and _coachmark-overlay-elements.scss


#### How did you test and verify your work?
storybook