### PR TITLE
fix: import shared filterProps data for flyout example

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.jsx
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.jsx
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable react-hooks/exhaustive-deps */
-
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Datagrid } from '../../index';
@@ -17,6 +15,7 @@ import { handleFilterTagLabelText } from '../../utils/handleFilterTagLabelText';
 import { multiSelectProps } from './Panel.stories';
 import { FilteringUsage } from '../../utils/FilteringUsage';
 import { getDateFormat } from '../../utils/getDateFormat';
+import { filterProps } from './Panel.stories';
 
 export default {
   title: 'IBM Products/Components/Datagrid/Filtering/Flyout',
@@ -34,7 +33,6 @@ export default {
       },
     },
   },
-  excludeStories: ['FilteringUsage', 'filterProps'],
 };
 
 const FilteringTemplateWrapper = ({ ...args }) => {


### PR DESCRIPTION
Noticed that Datagrid filter flyout stories were not loading because of a missing import, likely after the `vite` changes.

#### What did you change?
`Flyout.stories.jsx`
#### How did you test and verify your work?
Flyout filter story pages now load as expected