### PR TITLE
fix(storybook): revert default theme to g10

### DIFF
--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -172,7 +172,7 @@ const globalTypes = {
   theme: {
     name: 'Theme',
     description: 'Set the global theme for displaying components',
-    defaultValue: 'white',
+    defaultValue: 'g10',
     toolbar: {
       icon: 'paintbrush',
       items: ['white', 'g10', 'g90', 'g100'],


### PR DESCRIPTION
This PR reverts the default storybook theme to `g10`, this was unintentionally changed as part of the move to `vite` when we swapped out `storybook-addon-carbon-theme` for a theme switcher included as part of `@storybook/addon-essentials`.

#### What did you change?
`packages/core/.storybook/preview.js`
#### How did you test and verify your work?
Ran storybook locally to make sure it defaults to `g10`