### PR TITLE
feat(Coachmark): convert to .tsx

### DIFF
--- a/packages/ibm-products/src/components/Coachmark/CoachmarkDragbar.tsx
+++ b/packages/ibm-products/src/components/Coachmark/CoachmarkDragbar.tsx
@@ -32,11 +32,46 @@ const defaults = {
   theme: 'light',
 };
 
+interface CoachmarkDragbarProps {
+  /**
+   * Handler to manage keyboard interactions with the dragbar.
+   */
+  a11yKeyboardHandler: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
+  /**
+   * Tooltip text and aria label for the Close button icon.
+   */
+  closeIconDescription?: string;
+  /**
+   * Function to call when the close button is clicked.
+   */
+  onClose?: () => void;
+  /**
+   * Function to call when the user clicks and drags the Coachmark.
+   * For internal use only by the parent CoachmarkOverlay.
+   */
+  onDrag?: (movementX: number, movementY: number) => void;
+  /**
+   * Show/hide the "X" close button.
+   */
+  showCloseButton?: boolean;
+  /**
+   * Determines the theme of the component.
+   */
+  theme?: 'light' | 'dark';
+  /**
+   * Additional props passed to the component.
+   */
+  [key: string]: any;
+}
+
 /**
  * DO NOT USE. This component is for the exclusive use
  * of other Novice to Pro components.
  */
-export let CoachmarkDragbar = React.forwardRef(
+export let CoachmarkDragbar = React.forwardRef<
+  HTMLElement,
+  CoachmarkDragbarProps
+>(
   (
     {
       a11yKeyboardHandler,
@@ -96,6 +131,8 @@ export let CoachmarkDragbar = React.forwardRef(
           className={`${overlayBlockClass}__handle`}
           onMouseDown={handleDragStart}
           onKeyDown={a11yKeyboardHandler}
+          // TODO: i18n
+          title="Drag Handle"
         >
           <Draggable size="16" />
         </button>

--- a/packages/ibm-products/src/components/Coachmark/CoachmarkHeader.tsx
+++ b/packages/ibm-products/src/components/Coachmark/CoachmarkHeader.tsx
@@ -29,11 +29,33 @@ const defaults = {
   theme: 'light',
 };
 
+interface CoachmarkHeaderProps {
+  /**
+   * Tooltip text and aria label for the Close button icon.
+   */
+  closeIconDescription?: string;
+  /**
+   * Function to call when the close button is clicked.
+   */
+  onClose?: () => void;
+  /**
+   * Show/hide the "X" close button.
+   */
+  showCloseButton?: boolean;
+  /**
+   * Determines the theme of the component.
+   */
+  theme?: 'light' | 'dark';
+}
+
 /**
  * DO NOT USE. This component is for the exclusive use
  * of other Novice to Pro components.
  */
-export let CoachmarkHeader = React.forwardRef(
+export let CoachmarkHeader = React.forwardRef<
+  HTMLElement,
+  CoachmarkHeaderProps
+>(
   (
     {
       closeIconDescription = defaults.closeIconDescription,

--- a/packages/ibm-products/src/components/Coachmark/CoachmarkTagline.tsx
+++ b/packages/ibm-products/src/components/Coachmark/CoachmarkTagline.tsx
@@ -27,11 +27,33 @@ const defaults = {
   theme: 'light',
 };
 
+interface CoachmarkTaglineProps {
+  /**
+   * Tooltip text and aria label for the Close button icon.
+   */
+  closeIconDescription?: string;
+  /**
+   * Function to call when the close button is clicked.
+   */
+  onClose?: () => void;
+  /**
+   * Determines the theme of the component.
+   */
+  theme?: 'light' | 'dark';
+  /**
+   * The title of the tagline.
+   */
+  title: string;
+}
+
 /**
  * DO NOT USE. This component is for the exclusive use
  * of other Novice to Pro components.
  */
-export let CoachmarkTagline = React.forwardRef(
+export let CoachmarkTagline = React.forwardRef<
+  HTMLDivElement,
+  CoachmarkTaglineProps
+>(
   (
     {
       closeIconDescription = defaults.closeIconDescription,

--- a/packages/ibm-products/src/components/Coachmark/utils/enums.ts
+++ b/packages/ibm-products/src/components/Coachmark/utils/enums.ts
@@ -14,27 +14,27 @@ export enum BEACON_KIND {
  * @param FIXED is fixed to the bottom-right of the viewport.
  * @param STACKED is fixed to the bottom-right of the viewport, includes links to show more, stackable Coachmarks if included.
  */
-export const COACHMARK_OVERLAY_KIND = {
-  TOOLTIP: 'tooltip',
-  FLOATING: 'floating',
-  FIXED: 'fixed',
-  STACKED: 'stacked',
-};
+export enum COACHMARK_OVERLAY_KIND {
+  TOOLTIP = 'tooltip',
+  FLOATING = 'floating',
+  FIXED = 'fixed',
+  STACKED = 'stacked',
+}
 /**
  * Where to render the Coachmark relative to its target.
  * Applies only to Floating and Tooltip Coachmarks.
  */
-export const COACHMARK_ALIGNMENT = {
-  BOTTOM: 'bottom',
-  BOTTOM_LEFT: 'bottom-left',
-  BOTTOM_RIGHT: 'bottom-right',
-  LEFT: 'left',
-  LEFT_TOP: 'left-top',
-  LEFT_BOTTOM: 'left-bottom',
-  RIGHT: 'right',
-  RIGHT_TOP: 'right-top',
-  RIGHT_BOTTOM: 'right-bottom',
-  TOP: 'top',
-  TOP_LEFT: 'top-left',
-  TOP_RIGHT: 'top-right',
-};
+export enum COACHMARK_ALIGNMENT {
+  BOTTOM = 'bottom',
+  BOTTOM_LEFT = 'bottom-left',
+  BOTTOM_RIGHT = 'bottom-right',
+  LEFT = 'left',
+  LEFT_TOP = 'left-top',
+  LEFT_BOTTOM = 'left-bottom',
+  RIGHT = 'right',
+  RIGHT_TOP = 'right-top',
+  RIGHT_BOTTOM = 'right-bottom',
+  TOP = 'top',
+  TOP_LEFT = 'top-left',
+  TOP_RIGHT = 'top-right',
+}


### PR DESCRIPTION
Contributes to #5095

This PR converts `Coachmark` to TypeScript. Will unblock #4494 

one thing to note is the hard coded drag handle string in `CoachmarkDragbar.tsx`, this will need updating once our i18n strategy for strings is figured out.

one other thing is the `overlayRef` prop type declaration in `Coachmark.tsx`, it may need a second look

#### What did you change?

- file extension
- TS interface
- Coachmark enums

#### How did you test and verify your work?

storybook build and type checks
