### PR TITLE
fix(DataSpreadsheet): initialize functions before calling them

### DIFF
--- a/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheet.stories.jsx
+++ b/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheet.stories.jsx
@@ -8,7 +8,7 @@
 import React, { useMemo, useState } from 'react';
 import { DataSpreadsheet } from '.';
 import { generateData } from './utils/generateData';
-// import mdx from './DataSpreadsheet.mdx';
+import mdx from './DataSpreadsheet.mdx';
 
 import styles from './_storybook-styles.scss?inline';
 
@@ -26,11 +26,9 @@ export default {
   },
   parameters: {
     styles,
-    /*
-docs: {
+    docs: {
       page: mdx,
     },
-*/
   },
 };
 

--- a/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheetBody.js
+++ b/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheetBody.js
@@ -268,10 +268,6 @@ export const DataSpreadsheetBody = forwardRef(
       setSelectionAreas,
       visibleColumns,
     ]);
-    //selectionAreas will be set when ever a selection area is made.
-    useEffect(() => {
-      removeDuplicateSelections();
-    }, [selectionAreas, removeDuplicateSelections]);
 
     //this method will check for any duplicate selection area and remove.
     //same selections are those have the same height, width, top, left styles. These inline styles are being set in createCellSelection util.
@@ -309,6 +305,11 @@ export const DataSpreadsheetBody = forwardRef(
         });
       }
     }, [ref, setSelectionAreas, setSelectionAreaData]);
+
+    //selectionAreas will be set when ever a selection area is made.
+    useEffect(() => {
+      removeDuplicateSelections();
+    }, [selectionAreas, removeDuplicateSelections]);
 
     // onClick fn for each cell in the data spreadsheet body,
     // adds the active cell highlight

--- a/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheetBody.js
+++ b/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheetBody.js
@@ -33,6 +33,7 @@ import {
   handleBodyCellHover,
   handleRowHeaderClick,
 } from './utils/commonEventHandlers';
+import { prepareProps } from '../../global/js/utils/props-helper';
 
 const blockClass = `${pkg.prefix}--data-spreadsheet`;
 
@@ -442,9 +443,11 @@ export const DataSpreadsheetBody = forwardRef(
         const row = rows[index];
         if (rows && rows.length) {
           prepareRow(row);
+          const rowProps = prepareProps(row.getRowProps({ style }), 'key');
           return (
             <div
-              {...row.getRowProps({ style })}
+              key={{ ...row.getRowProps().key }}
+              {...rowProps}
               className={cx(`${blockClass}__tr`)}
               data-row-index={index}
               aria-rowindex={index + 1}
@@ -487,37 +490,40 @@ export const DataSpreadsheetBody = forwardRef(
                 </button>
               </div>
               {/* CELL BUTTONS */}
-              {row.cells.map((cell, index) => (
-                <div
-                  key={`cell_${index}`}
-                  aria-colindex={index + 1}
-                  {...cell.getCellProps()}
-                  role="gridcell"
-                  style={{
-                    ...cell.getCellProps().style,
-                    display: 'grid',
-                    minWidth: cell?.column?.width || defaultColumn?.width,
-                  }}
-                >
-                  <button
-                    id={`${blockClass}__cell--${cell.row.index}--${index}`}
-                    tabIndex={-1}
-                    data-row-index={cell.row.index}
-                    data-column-index={index}
-                    className={cx(
-                      `${blockClass}__td`,
-                      `${blockClass}__body--td`,
-                      `${blockClass}--interactive-cell-element`
-                    )}
-                    onMouseDown={handleBodyCellClickEvent(cell, index)}
-                    onMouseOver={handleBodyCellHoverEvent(cell, index)}
-                    onFocus={() => {}}
-                    type="button"
+              {row.cells.map((cell, index) => {
+                const cellProps = prepareProps(cell.getCellProps(), 'key');
+                return (
+                  <div
+                    key={`cell_${index}`}
+                    aria-colindex={index + 1}
+                    {...cellProps}
+                    role="gridcell"
+                    style={{
+                      ...cell.getCellProps().style,
+                      display: 'grid',
+                      minWidth: cell?.column?.width || defaultColumn?.width,
+                    }}
                   >
-                    {cell.render('Cell')}
-                  </button>
-                </div>
-              ))}
+                    <button
+                      id={`${blockClass}__cell--${cell.row.index}--${index}`}
+                      tabIndex={-1}
+                      data-row-index={cell.row.index}
+                      data-column-index={index}
+                      className={cx(
+                        `${blockClass}__td`,
+                        `${blockClass}__body--td`,
+                        `${blockClass}--interactive-cell-element`
+                      )}
+                      onMouseDown={handleBodyCellClickEvent(cell, index)}
+                      onMouseOver={handleBodyCellHoverEvent(cell, index)}
+                      onFocus={() => {}}
+                      type="button"
+                    >
+                      {cell.render('Cell')}
+                    </button>
+                  </div>
+                );
+              })}
             </div>
           );
         }

--- a/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
+++ b/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
@@ -18,6 +18,7 @@ import { selectAllCells } from './utils/selectAllCells';
 import { getSpreadsheetWidth } from './utils/getSpreadsheetWidth';
 import { useSpreadsheetMouseMove } from './hooks';
 import { checkForHoldingKey } from './utils/checkForHoldingKey';
+import { prepareProps } from '../../global/js/utils/props-helper';
 
 const blockClass = `${pkg.prefix}--data-spreadsheet`;
 
@@ -152,115 +153,123 @@ export const DataSpreadsheetHeader = forwardRef(
 
     return (
       <div className={cx(`${blockClass}__header--container`)} role="rowgroup">
-        {headerGroups.map((headerGroup, index) => (
-          <div
-            key={`header_${index}`}
-            {...headerGroup.getHeaderGroupProps()}
-            style={{
-              ...headerGroup.getHeaderGroupProps().style,
-              width: getSpreadsheetWidth({
-                type: 'header',
-                headerGroup,
-                scrollBarSizeValue,
-                totalVisibleColumns,
-                defaultColumn,
-                visibleColumns,
-              }),
-              overflow: 'hidden',
-            }}
-            className={`${blockClass}__tr`}
-          >
-            {/* SELECT ALL BUTTON */}
+        {headerGroups.map((headerGroup, index) => {
+          const headerProps = prepareProps(
+            headerGroup.getHeaderGroupProps(),
+            'key'
+          );
+          return (
             <div
-              role="columnheader"
-              className={`${blockClass}__select-all-cell-container`}
+              key={`header_${index}`}
+              {...headerProps}
               style={{
-                width: defaultColumn?.rowHeaderWidth,
-                height: defaultColumn?.rowHeight,
+                ...headerGroup.getHeaderGroupProps().style,
+                width: getSpreadsheetWidth({
+                  type: 'header',
+                  headerGroup,
+                  scrollBarSizeValue,
+                  totalVisibleColumns,
+                  defaultColumn,
+                  visibleColumns,
+                }),
+                overflow: 'hidden',
               }}
+              className={`${blockClass}__tr`}
             >
-              <button
-                id={`${blockClass}__cell--header--header`}
-                data-row-index="header"
-                data-column-index="header"
-                type="button"
-                tabIndex={-1}
-                aria-label={selectAllAriaLabel}
-                onClick={handleSelectAllClick}
-                className={cx(
-                  `${blockClass}__th`,
-                  `${blockClass}--interactive-cell-element`,
-                  `${blockClass}__th--select-all`,
-                  {
-                    [`${blockClass}__th--active-header`]:
-                      activeCellCoordinates?.column === 'header' &&
-                      activeCellCoordinates?.row === 'header',
-                  }
-                )}
+              {/* SELECT ALL BUTTON */}
+              <div
+                role="columnheader"
+                className={`${blockClass}__select-all-cell-container`}
+                style={{
+                  width: defaultColumn?.rowHeaderWidth,
+                  height: defaultColumn?.rowHeight,
+                }}
               >
-                &nbsp;
-              </button>
-            </div>
-            {/* COLUMN HEADER BUTTONS */}
-            {headerGroup.headers.map((column, index) => {
-              const selectedHeader = checkSelectedHeaderCell(
-                index,
-                selectionAreas,
-                'column',
-                rows
-              );
-              return (
-                <div
-                  key={`column_${index}`}
-                  role="columnheader"
-                  className={`${blockClass}__columnheader`}
-                  {...column.getHeaderProps()}
+                <button
+                  id={`${blockClass}__cell--header--header`}
+                  data-row-index="header"
+                  data-column-index="header"
+                  type="button"
+                  tabIndex={-1}
+                  aria-label={selectAllAriaLabel}
+                  onClick={handleSelectAllClick}
+                  className={cx(
+                    `${blockClass}__th`,
+                    `${blockClass}--interactive-cell-element`,
+                    `${blockClass}__th--select-all`,
+                    {
+                      [`${blockClass}__th--active-header`]:
+                        activeCellCoordinates?.column === 'header' &&
+                        activeCellCoordinates?.row === 'header',
+                    }
+                  )}
                 >
-                  <button
-                    id={`${blockClass}__cell--header--${index}`}
-                    data-row-index="header"
-                    data-column-index={index}
-                    tabIndex={-1}
-                    onMouseDown={
-                      selectedHeader ? handleHeaderMouseDown(index) : null
-                    }
-                    onMouseUp={
-                      selectedHeader
-                        ? () => setSelectedHeaderReorderActive(false)
-                        : null
-                    }
-                    onClick={
-                      !selectedHeader ? handleColumnHeaderClick(index) : null
-                    }
-                    style={{
-                      height: defaultColumn?.rowHeight,
-                      width: column?.width || defaultColumn?.width,
-                    }}
-                    className={cx(
-                      `${blockClass}__th`,
-                      `${blockClass}--interactive-cell-element`,
-                      {
-                        [`${blockClass}__th--active-header`]:
-                          activeCellCoordinates?.column === index ||
-                          checkActiveHeaderCell(
-                            index,
-                            selectionAreas,
-                            'column'
-                          ),
-                        [`${blockClass}__th--selected-header`]: selectedHeader,
-                        [`${blockClass}__th--selected-header-reorder-active`]:
-                          selectedHeaderReorderActive,
-                      }
-                    )}
-                    type="button"
+                  &nbsp;
+                </button>
+              </div>
+              {/* COLUMN HEADER BUTTONS */}
+              {headerGroup.headers.map((column, index) => {
+                const colProps = prepareProps(column.getHeaderProps(), 'key');
+                const selectedHeader = checkSelectedHeaderCell(
+                  index,
+                  selectionAreas,
+                  'column',
+                  rows
+                );
+                return (
+                  <div
+                    key={`column_${index}`}
+                    role="columnheader"
+                    className={`${blockClass}__columnheader`}
+                    {...colProps}
                   >
-                    {column.render('Header')}
-                  </button>
-                </div>
-              );
-            })}
-          </div>
-        ))}
+                    <button
+                      id={`${blockClass}__cell--header--${index}`}
+                      data-row-index="header"
+                      data-column-index={index}
+                      tabIndex={-1}
+                      onMouseDown={
+                        selectedHeader ? handleHeaderMouseDown(index) : null
+                      }
+                      onMouseUp={
+                        selectedHeader
+                          ? () => setSelectedHeaderReorderActive(false)
+                          : null
+                      }
+                      onClick={
+                        !selectedHeader ? handleColumnHeaderClick(index) : null
+                      }
+                      style={{
+                        height: defaultColumn?.rowHeight,
+                        width: column?.width || defaultColumn?.width,
+                      }}
+                      className={cx(
+                        `${blockClass}__th`,
+                        `${blockClass}--interactive-cell-element`,
+                        {
+                          [`${blockClass}__th--active-header`]:
+                            activeCellCoordinates?.column === index ||
+                            checkActiveHeaderCell(
+                              index,
+                              selectionAreas,
+                              'column'
+                            ),
+                          [`${blockClass}__th--selected-header`]:
+                            selectedHeader,
+                          [`${blockClass}__th--selected-header-reorder-active`]:
+                            selectedHeaderReorderActive,
+                        }
+                      )}
+                      type="button"
+                    >
+                      {column.render('Header')}
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
       </div>
     );
   }

--- a/packages/ibm-products/src/components/DataSpreadsheet/hooks/useMoveActiveCell.js
+++ b/packages/ibm-products/src/components/DataSpreadsheet/hooks/useMoveActiveCell.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,12 +16,6 @@ export const useMoveActiveCell = ({
   activeCellContent,
   isActiveHeaderCellChanged,
 }) => {
-  //new active cell is created when the activeCellContent changes or navigate through headers
-  // Otherwise new active cell will display the old value in a glance
-  useEffect(() => {
-    performCreateActiveCell();
-  }, [activeCellContent, performCreateActiveCell, isActiveHeaderCellChanged]);
-
   const performCreateActiveCell = useCallback(() => {
     const activeCellPlacementElement = spreadsheetRef?.current.querySelector(
       `[data-row-index="${activeCellCoordinates?.row}"][data-column-index="${activeCellCoordinates?.column}"]`
@@ -46,4 +40,10 @@ export const useMoveActiveCell = ({
     containerHasFocus,
     createActiveCell,
   ]);
+
+  //new active cell is created when the activeCellContent changes or navigate through headers
+  // Otherwise new active cell will display the old value in a glance
+  useEffect(() => {
+    performCreateActiveCell();
+  }, [activeCellContent, performCreateActiveCell, isActiveHeaderCellChanged]);
 };

--- a/packages/ibm-products/src/components/DataSpreadsheet/hooks/useMoveActiveCell.js
+++ b/packages/ibm-products/src/components/DataSpreadsheet/hooks/useMoveActiveCell.js
@@ -16,7 +16,14 @@ export const useMoveActiveCell = ({
   activeCellContent,
   isActiveHeaderCellChanged,
 }) => {
-  const performCreateActiveCell = useCallback(() => {
+  let performCreateActiveCell;
+  //new active cell is created when the activeCellContent changes or navigate through headers
+  // Otherwise new active cell will display the old value in a glance
+  useEffect(() => {
+    performCreateActiveCell();
+  }, [activeCellContent, performCreateActiveCell, isActiveHeaderCellChanged]);
+
+  performCreateActiveCell = useCallback(() => {
     const activeCellPlacementElement = spreadsheetRef?.current.querySelector(
       `[data-row-index="${activeCellCoordinates?.row}"][data-column-index="${activeCellCoordinates?.column}"]`
     );
@@ -40,10 +47,4 @@ export const useMoveActiveCell = ({
     containerHasFocus,
     createActiveCell,
   ]);
-
-  //new active cell is created when the activeCellContent changes or navigate through headers
-  // Otherwise new active cell will display the old value in a glance
-  useEffect(() => {
-    performCreateActiveCell();
-  }, [activeCellContent, performCreateActiveCell, isActiveHeaderCellChanged]);
 };


### PR DESCRIPTION
Contributes to #5098 

Allows `DataSpreadsheet` stories to load again, there were some issues with calling some functions before they were initialized.

#### What did you change?
```
packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheetBody.js
packages/ibm-products/src/components/DataSpreadsheet/hooks/useMoveActiveCell.js
```
#### How did you test and verify your work?
Verified locally in storybook that the stories load as expected again