### PR TITLE
test(HTTPErrorOther): add default state AVT check

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -101,6 +101,7 @@
     "haspopup",
     "headshot",
     "homescreen",
+    "httperrorother",
     "inlineedit",
     "inlinetip",
     "listbox",

--- a/e2e/components/HTTPErrorOther/HTTPErrorOther-test.avt.e2e.js
+++ b/e2e/components/HTTPErrorOther/HTTPErrorOther-test.avt.e2e.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../test-utils/storybook';
+
+test.describe('HTTPErrorOther @avt', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'HTTPErrorOther',
+      id: 'ibm-products-patterns-http-errors-httperrorother--with-all-props-set',
+      globals: {
+        carbonTheme: 'white',
+        errorCodeLabel: 'Error 502',
+        title: 'Bad gateway',
+        description: 'Received an invalid response.',
+      },
+    });
+    await expect(page).toHaveNoACViolations(
+      'HTTPErrorOther @avt-default-state'
+    );
+  });
+});


### PR DESCRIPTION
Contributes to #5077 

#### What did you change?
Create file: `e2e/components/HTTPErrorOther/HTTPErrorOther-test.avt.e2e.js`

#### How did you test and verify your work?
`yarn avt`