### PR TITLE
test(CreateModal): add default state AVT check

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -81,6 +81,7 @@
     "colindex",
     "columnheader",
     "combobox",
+    "createmodal",
     "csstools",
     "dasharray",
     "data-testid",

--- a/e2e/components/CreateModal/CreateModal-test.avt.e2e.js
+++ b/e2e/components/CreateModal/CreateModal-test.avt.e2e.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../test-utils/storybook';
+
+test.describe('CreateModal @avt', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'CreateModal',
+      id: 'ibm-products-patterns-create-flows-createmodal--default',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('CreateModal @avt-default-state');
+  });
+});


### PR DESCRIPTION
Contributes to #4662 

#### What did you change?
Created file: `e2e/components/CreateModal/CreateModal-test.avt.e2e.js`

#### How did you test and verify your work?
`yarn avt`