### PR TITLE
test(FullPageError): add default state avt test

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,11 +1,7 @@
 {
   "version": "0.1",
   "language": "en",
-  "dictionaries": [
-    "contributors",
-    "html",
-    "packages"
-  ],
+  "dictionaries": ["contributors", "html", "packages"],
   "dictionaryDefinitions": [
     {
       "name": "contributors",
@@ -97,6 +93,7 @@
     "editsidepanel",
     "emptystate",
     "expressivecard",
+    "fullpageerror",
     "gridcell",
     "guidebanner",
     "haspopup",

--- a/e2e/components/FullPageError/FullPageError-test.avt.e2e.js
+++ b/e2e/components/FullPageError/FullPageError-test.avt.e2e.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/e2e/components/FullPageError/FullPageError-test.avt.e2e.js
+++ b/e2e/components/FullPageError/FullPageError-test.avt.e2e.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../test-utils/storybook';
+
+test.describe('FullPageError @avt', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'FullPageError',
+      id: 'ibm-products-patterns-full-page-error-fullpageerror--full-page-error',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('FullPageError @avt-default-state');
+  });
+});


### PR DESCRIPTION
Closes #5010 

#### What did you change?
Created `e2e/components/FullPageError/FullPageError-test.avt.e2e.js`

#### How did you test and verify your work?
`yarn avt`