### PR TITLE
test(NotificationsPanel): add default state avt test

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,11 +1,7 @@
 {
   "version": "0.1",
   "language": "en",
-  "dictionaries": [
-    "contributors",
-    "html",
-    "packages"
-  ],
+  "dictionaries": ["contributors", "html", "packages"],
   "dictionaryDefinitions": [
     {
       "name": "contributors",
@@ -108,6 +104,7 @@
     "loglevel",
     "namor",
     "noreply",
+    "notificationspanel",
     "overridable",
     "overscroll",
     "pconsole",

--- a/e2e/components/NotificationsPanel/NotificationsPanel-test.avt.e2e.js
+++ b/e2e/components/NotificationsPanel/NotificationsPanel-test.avt.e2e.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../test-utils/storybook';
+
+test.describe('NotificationsPanel @avt', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'NotificationsPanel',
+      id: 'ibm-products-patterns-notifications-notificationspanel--default',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations(
+      'NotificationsPanel @avt-default-state'
+    );
+  });
+});

--- a/e2e/components/NotificationsPanel/NotificationsPanel-test.avt.e2e.js
+++ b/e2e/components/NotificationsPanel/NotificationsPanel-test.avt.e2e.js
@@ -19,6 +19,8 @@ test.describe('NotificationsPanel @avt', () => {
         carbonTheme: 'white',
       },
     });
+
+    await page.getByLabel('Notifications').click();
     await expect(page).toHaveNoACViolations(
       'NotificationsPanel @avt-default-state'
     );


### PR DESCRIPTION
Closes #5059 

#### What did you change?
Created `e2e/components/NotificationsPanel/NotificationsPanel-test.avt.e2e.js`

#### How did you test and verify your work?
`yarn avt`
