### PR TITLE
test(TagOverflow): add default state avt test

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -143,6 +143,7 @@
     "svgid",
     "tabbable",
     "tablist",
+    "tagoverflow",
     "tagset",
     "tearsheet",
     "tearsheets",

--- a/e2e/components/TagOverflow/TagOverflow-test.avt.e2e.js
+++ b/e2e/components/TagOverflow/TagOverflow-test.avt.e2e.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../test-utils/storybook';
+
+test.describe('TagOverflow @avt', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'TagOverflow',
+      id: 'ibm-products-components-tag-overflow-tagoverflow--five-tags',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('TagOverflow @avt-default-state');
+  });
+});


### PR DESCRIPTION
Contributes to #5005 

#### What did you change?
Created e2e/components/TagOverflow/TagOverflow-test.avt.e2e.js
Added `tagoverflow` to cspell.js as it was blocking this commit

#### How did you test and verify your work?
`yarn avt`