### PR TITLE
test(ExportModal): add avt test coverage default state

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -96,6 +96,7 @@
     "editinplace",
     "editsidepanel",
     "emptystate",
+    "exportmodal",
     "expressivecard",
     "gridcell",
     "guidebanner",

--- a/e2e/components/ExportModal/ExportModal-test.avt.e2e.js
+++ b/e2e/components/ExportModal/ExportModal-test.avt.e2e.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../test-utils/storybook';
+
+test.describe('ExportModal @avt', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'ExportModal',
+      id: 'ibm-products-patterns-export-exportmodal--standard',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('ExportModal @avt-default-state');
+  });
+});


### PR DESCRIPTION
Closes #5088 

Adds avt default state test coverage for the `ExportModal` component.

#### What did you change?
```
cspell.json
e2e/components/ExportModal/ExportModal-test.avt.e2e.js
```
#### How did you test and verify your work?
Ran avt tests locally, `yarn avt`