### PR TITLE
fix(sidepanel): resolve border bottom always showing

### DIFF
--- a/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
@@ -678,7 +678,7 @@ export let SidePanel = React.forwardRef(
         <div
           className={cx(`${blockClass}__header`, {
             [`${blockClass}__header--on-detail-step`]: currentStep > 0,
-            [`${blockClass}__header--no-title-animation`]: !doAnimateTitle,
+            [`${blockClass}__header--no-title-animation`]: !animateTitle,
             [`${blockClass}__header--reduced-motion`]: reducedMotion.matches,
             [`${blockClass}__header--has-title`]: title,
           })}


### PR DESCRIPTION
Closes #5142 

#### What did you change?
Show the title border bottom only when `animateTitle` is `false`

#### How did you test and verify your work?
Storybook