### PR TITLE
refactor: replace actionable notification with static

### DIFF
--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -6,7 +6,7 @@
  */
 
 import React, { useEffect } from 'react';
-import { ActionableNotification, UnorderedList, ListItem } from '@carbon/react';
+import { StaticNotification, UnorderedList, ListItem } from '@carbon/react';
 import { white, g10, g90, g100 } from '@carbon/themes';
 
 import { pkg } from '../../ibm-products/src/settings';
@@ -50,7 +50,7 @@ const decorators = [
       <div className="preview-position-fix story-wrapper">
         <Style styles={index}>
           {args.featureFlags ? (
-            <ActionableNotification
+            <StaticNotification
               className="preview__notification--feature-flag"
               kind="warning"
               inline
@@ -58,6 +58,8 @@ const decorators = [
               actionButtonLabel="Learn more"
               statusIconDescription="describes the close button"
               title="This story uses the following feature flags to enable or disable some functionality."
+              titleId="storybook--feature-flag-warning-notification"
+              aria-describedby="storybook--feature-flag-warning-notification"
               onActionButtonClick={() => {
                 window.open(
                   'https://github.com/carbon-design-system/ibm-products/tree/main/packages/ibm-products#enabling-canary-components-and-flagged-features'
@@ -71,7 +73,7 @@ const decorators = [
                   </ListItem>
                 ))}
               </UnorderedList>
-            </ActionableNotification>
+            </StaticNotification>
           ) : null}
           {styles ? <Style styles={styles}>{story}</Style> : story}
         </Style>

--- a/packages/ibm-products/src/components/ButtonMenu/ButtonMenu.stories.jsx
+++ b/packages/ibm-products/src/components/ButtonMenu/ButtonMenu.stories.jsx
@@ -8,7 +8,7 @@
 import React from 'react';
 
 import { action } from '@storybook/addon-actions';
-import { ActionableNotification } from '@carbon/react';
+import { StaticNotification } from '@carbon/react';
 
 import { ButtonMenu, ButtonMenuItem } from '.';
 // import mdx from './ButtonMenu.mdx';
@@ -38,7 +38,7 @@ docs: {
 const Template = (args) => {
   return (
     <>
-      <ActionableNotification
+      <StaticNotification
         title="Deprecation notice"
         subtitle="This component is deprecated and will be removed in the next major version. Please migrate to Carbon’s MenuButton."
         inline
@@ -52,6 +52,8 @@ const Template = (args) => {
             'https://react.carbondesignsystem.com/?path=/docs/components-menubutton--overview'
           );
         }}
+        titleId="storybook--deprecation-warning-notification"
+        aria-describedby="storybook--deprecation-warning-notification"
         style={{ marginBottom: '1rem' }}
       />
       <ButtonMenu

--- a/packages/ibm-products/src/components/ComboButton/ComboButton.stories.jsx
+++ b/packages/ibm-products/src/components/ComboButton/ComboButton.stories.jsx
@@ -7,8 +7,9 @@
 
 import { CloudApp } from '@carbon/react/icons';
 import React from 'react';
-import { ActionableNotification } from '@carbon/react';
+import { StaticNotification } from '@carbon/react';
 import { ComboButton, ComboButtonItem } from '..';
+import { StaticNotification } from '@carbon/react';
 
 // import styles from './_combo-button.scss';
 
@@ -24,7 +25,7 @@ export default {
 // eslint-disable-next-line no-unused-vars -- args not used in this template
 const Template = (args) => (
   <>
-    <ActionableNotification
+    <StaticNotification
       title="Deprecation notice"
       subtitle="This component is deprecated and will be removed in the next major version. Please migrate to Carbon’s ComboButton."
       inline
@@ -38,6 +39,8 @@ const Template = (args) => (
           'https://react.carbondesignsystem.com/?path=/docs/components-combobutton--overview'
         );
       }}
+      titleId="storybook--deprecation-warning-notification"
+      aria-describedby="storybook--deprecation-warning-notification"
       style={{ marginBottom: '1rem' }}
     />
     <ComboButton>

--- a/packages/ibm-products/src/components/ComboButton/ComboButton.stories.jsx
+++ b/packages/ibm-products/src/components/ComboButton/ComboButton.stories.jsx
@@ -9,7 +9,6 @@ import { CloudApp } from '@carbon/react/icons';
 import React from 'react';
 import { StaticNotification } from '@carbon/react';
 import { ComboButton, ComboButtonItem } from '..';
-import { StaticNotification } from '@carbon/react';
 
 // import styles from './_combo-button.scss';
 


### PR DESCRIPTION
Closes #5080 

This PR replaces all `ActionableNotification` with `StaticNotification` as it is more appropriate given the current usage.

#### What did you change?
```
packages/core/.storybook/preview.js
packages/ibm-products/src/components/ButtonMenu/ButtonMenu.stories.jsx
packages/ibm-products/src/components/ComboButton/ComboButton.stories.jsx
```
#### How did you test and verify your work?
Storybook