### PR TITLE
style: remove component level style imports from `_storybook-styles.scss`, already included

### DIFF
--- a/packages/core/.storybook/carbon.scss
+++ b/packages/core/.storybook/carbon.scss
@@ -8,4 +8,4 @@
 // a build of carbon css with our required feature flags set
 
 @use '@carbon/styles';
-@use '../../ibm-products-styles/src/global/styles/project-settings'
+@use '../../ibm-products-styles/src/global/styles/project-settings';

--- a/packages/ibm-products/src/components/AboutModal/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/AboutModal/_storybook-styles.scss
@@ -8,7 +8,6 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/type';
-@use '@carbon/styles/scss/components/ui-shell' as *;
 @use 'ALIAS_STORY_STYLE_CONFIG' as c4p-settings;
 
 // The block part of our conventional BEM class names (blockClass__E--M).

--- a/packages/ibm-products/src/components/PageHeader/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/PageHeader/_storybook-styles.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -8,10 +8,6 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/react/scss/spacing' as *;
 @use '@carbon/styles/scss/type';
-
-@use '@carbon/react/scss/components/ui-shell';
-@use '@carbon/react/scss/components/data-table';
-@use '@carbon/react/scss/components/button';
 
 $story-class: 'page-header-stories';
 


### PR DESCRIPTION
Closes #5157 

This PR addresses the style inconsistencies we've seen pop up after the move to `vite`. This happened because we've already included the full Carbon styles and then in some cases component styles are imported from `_storybook-styles.scss` files as well which ends up taking precedence and override other styling. For example, in the case of `AboutModal` the button styles are imported in `_storybook-styles.scss` but as well already included when we include `@use '@carbon/styles';` in `packages/core/.storybook/index.scss`.

#### What did you change?
```
packages/core/.storybook/carbon.scss
packages/ibm-products/src/components/AboutModal/_storybook-styles.scss
packages/ibm-products/src/components/PageHeader/_storybook-styles.scss
```
#### How did you test and verify your work?
Verified with the stories that had been having style issues