### PR TITLE
test(interstitialscreenview): Add default state AVT check

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -108,6 +108,7 @@
     "headshot",
     "homescreen",
     "httperrorother",
+    "interstitialscreenview",
     "inlineedit",
     "inlinetip",
     "listbox",

--- a/e2e/components/InterstitialScreenView/InterstitialScreenView-test.avt.e2e.js
+++ b/e2e/components/InterstitialScreenView/InterstitialScreenView-test.avt.e2e.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../test-utils/storybook';
+
+test.describe('InterstitialScreenView @avt', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'InterstitialScreenView',
+      id: 'ibm-products-novice-to-pro-interstitial-screen-interstitialscreenview--interstitial-screen-view',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations(
+      'InterstitialScreenView @avt-default-state'
+    );
+  });
+});


### PR DESCRIPTION
Closes #5064

Add default state AVT check for InterstitialScreenView

#### What did you change?
Created `e2e/components/InterstitialScreenView/InterstitialScreenView-test.avt.e2e.js`

#### How did you test and verify your work?
yarn avt
