### PR TITLE
test(InterstitialScreenViewModule): add default state AVT check

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -93,6 +93,7 @@
     "disttags",
     "dragbar",
     "draggable",
+    "interstitialscreenviewmodule",
     "draghandle",
     "dragmode",
     "editinplace",

--- a/e2e/components/InterstitialScreenViewModule/InterstitialScreenViewModule-test.avt.e2e.js
+++ b/e2e/components/InterstitialScreenViewModule/InterstitialScreenViewModule-test.avt.e2e.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../test-utils/storybook';
+
+test.describe('InterstitialScreenViewModule @avt', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'InterstitialScreenViewModule',
+      id: 'ibm-products-novice-to-pro-interstitial-screen-interstitialscreenviewmodule--interstitial-screen-view-module',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations(
+      'InterstitialScreenViewModule @avt-default-state'
+    );
+  });
+});


### PR DESCRIPTION
Closes #5065

Add default state AVT check for InterstitialScreenViewModule

#### What did you change?
Created `e2e/components/InterstitialScreenViewModule/InterstitialScreenViewModule-test.avt.e2e.js`



#### How did you test and verify your work?
yarn avt
