### PR TITLE
test(ImportModal): add default state avt test

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -108,6 +108,7 @@
     "headshot",
     "homescreen",
     "httperrorother",
+    "importmodal",
     "inlineedit",
     "inlinetip",
     "listbox",

--- a/e2e/components/ImportModal/ImportModal-test.avt.e2e.js
+++ b/e2e/components/ImportModal/ImportModal-test.avt.e2e.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../test-utils/storybook';
+import { carbon } from '../../../packages/ibm-products/src/settings';
+
+test.describe('ImportModal @avt', () => {
+  test.only('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'ImportModal',
+      id: 'ibm-products-patterns-import-and-upload-importmodal--standard',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await page.getByText('Launch modal').click();
+    const modalElement = page.locator(`.${carbon.prefix}--modal.is-visible`);
+    await expect(modalElement).toBeVisible();
+    await modalElement.evaluate((element) =>
+      Promise.all(
+        element.getAnimations().map((animation) => animation.finished)
+      )
+    );
+    await expect(page).toHaveNoACViolations('ImportModal @avt-default-state');
+  });
+});

--- a/e2e/components/ImportModal/ImportModal-test.avt.e2e.js
+++ b/e2e/components/ImportModal/ImportModal-test.avt.e2e.js
@@ -12,7 +12,7 @@ import { visitStory } from '../../test-utils/storybook';
 import { carbon } from '../../../packages/ibm-products/src/settings';
 
 test.describe('ImportModal @avt', () => {
-  test.only('@avt-default-state', async ({ page }) => {
+  test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'ImportModal',
       id: 'ibm-products-patterns-import-and-upload-importmodal--standard',


### PR DESCRIPTION
Closes #5089 

Adds default state AVT e2e testing coverage for the `ImportModal`. I found an alternative approach to what @devadula-nandan shared during our team huddle for waiting for an animation/transition to end which seems to work well, and resolved the issues I was having earlier with this test having color contrast violations.

#### What did you change?
```
cspell.json
e2e/components/ImportModal/ImportModal-test.avt.e2e.js
```
#### How did you test and verify your work?
`yarn avt`