### PR TITLE
chore(cspell): ignore all avt tests

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -61,6 +61,7 @@
     "cdai",
     "security",
     "package.json",
+    "*.avt.e2e.js",
     "*.snap",
     "*.log",
     "CHANGELOG.md"


### PR DESCRIPTION
Closes #

We've been having to add to the cspell.json file when working on the AVT e2e tests because cspell doesn't like that the component names in the storybook id/urls aren't camel case. This PR adds avt tests to be ignored by cspell so we don't keep running into conflicts.

#### What did you change?

- add `*.avt.e2e.js` to ignore path field of cspell