### PR TITLE
test(OptionTile): add default state avt test

### DIFF
--- a/e2e/components/OptionsTile/OptionsTile-test.avt.e2e.js
+++ b/e2e/components/OptionsTile/OptionsTile-test.avt.e2e.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../test-utils/storybook';
+import { pkg } from '../../../packages/ibm-products/src/settings';
+
+test.describe('OptionsTile @avt', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'OptionsTile',
+      id: 'ibm-products-components-options-tile-optionstile--options-tile',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+
+    const blockClass = `${pkg.prefix}--options-tile`;
+
+    await page.getByRole('heading', { name: 'Language' }).click();
+
+    await page
+      .locator(`.dev-prefix--${blockClass}__content`)
+      .screenshot({ animations: 'disabled' });
+
+    await expect(page).toHaveNoACViolations('OptionsTile @avt-default-state');
+  });
+});


### PR DESCRIPTION
Closes #4668 

default state avt test

#### What did you change?
created a new test file : e2e/components/OptionsTile/OptionsTile-test.avt.e2e.js
This is an animated collapsible component. I am taking a screenshot of the component by disabling animation using playwright screenshot option, before running `expect(page).toHaveNoACViolations`. This will fix text contrast violation.
![image](https://github.com/carbon-design-system/ibm-products/assets/153802538/34c6a71d-a205-44a6-98b7-6df89626919e)


#### How did you test and verify your work? 
yarn avt
