### PR TITLE
feat: adds triage label when issue opened or reopened

### DIFF
--- a/.github/workflows/add-triage-label.yml
+++ b/.github/workflows/add-triage-label.yml
@@ -1,4 +1,4 @@
-name: Label issues
+name: Add triage labe to opened/reopened issues
 on:
   issues:
     types:

--- a/.github/workflows/add-triage-label.yml
+++ b/.github/workflows/add-triage-label.yml
@@ -1,0 +1,18 @@
+name: Label issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: 'status: needs triage 🕵️‍♀️'

--- a/.github/workflows/add-triage-label.yml
+++ b/.github/workflows/add-triage-label.yml
@@ -1,4 +1,4 @@
-name: Add triage labe to opened/reopened issues
+name: Add triage label to opened/reopened issues
 on:
   issues:
     types:


### PR DESCRIPTION
Closes #5198 

If an issue is opened without using one of the issue templates it is possible for it to not receive the `status: needs triage` label. This action will catch those issue and apply the triage label whenever an issue is opened or reopened in our repo.

#### What did you change?
```
.github/workflows/add-triage-label.yml
```
#### How did you test and verify your work?
Tested in [example repo](https://github.com/matthewgallo/ibm-products-vite-template/commit/333df2b850579fa2de8d1cf5a34c3d53e8237f15) with [test issue](https://github.com/matthewgallo/ibm-products-vite-template/issues/7).