### PR TITLE
fix(Datagrid): show column headers for empty infinite scroll

### DIFF
--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -3636,7 +3636,8 @@ p.c4p--about-modal__copyright-text:first-child {
   background: transparent;
 }
 
-.c4p--datagrid__empty-state .c4p--datagrid__table-simple td {
+.c4p--datagrid__empty-state .c4p--datagrid__table-simple td,
+.c4p--datagrid__empty-state .c4p--datagrid__table-virtual-scroll td {
   padding: 5rem;
 }
 

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_datagrid.scss
@@ -394,7 +394,8 @@
   background: transparent;
 }
 
-.#{$block-class}__empty-state .#{$block-class}__table-simple td {
+.#{$block-class}__empty-state .#{$block-class}__table-simple td,
+.#{$block-class}__empty-state .#{$block-class}__table-virtual-scroll td {
   padding: $spacing-11;
 }
 

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -88,7 +88,9 @@ export const DatagridContent = ({ datagridState, title, ariaToolbarLabel }) => {
         <Table
           {...getTableProps()}
           className={cx(
-            withVirtualScroll ? '' : `${blockClass}__table-simple`,
+            withVirtualScroll
+              ? `${blockClass}__table-virtual-scroll`
+              : `${blockClass}__table-simple`,
             `${blockClass}__vertical-align-${verticalAlign}`,
             { [`${blockClass}__variable-row-height`]: variableRowHeight },
             { [`${blockClass}__table-with-inline-edit`]: withInlineEdit },
@@ -120,7 +122,10 @@ export const DatagridContent = ({ datagridState, title, ariaToolbarLabel }) => {
           }
           title={title}
         >
-          {!withVirtualScroll && <DatagridHead {...datagridState} />}
+          {(!withVirtualScroll ||
+            (withVirtualScroll && !isFetching && !contentRows.length)) && (
+            <DatagridHead {...datagridState} />
+          )}
           <DatagridBody {...datagridState} rows={contentRows} />
         </Table>
         {filterProps?.variation === 'panel' && renderPagination()}


### PR DESCRIPTION
Closes #5240 

This PR displays the column headers for empty virtualized/infinite scroll Datagrids. The column headers typically are rendered as part of `<DatagridVirtualBody />` because there is special sizing that is required but when there is no data this presents a problem because the headers are not displayed. This renders them normally if we have a `withVirtualScroll` Datagrid that is empty.

#### What did you change?
```
packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
packages/ibm-products-styles/src/components/Datagrid/styles/_datagrid.scss
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.js
```
#### How did you test and verify your work?
Storybook