### PR TITLE
feat(Datagrid): add default expansion state to `useNestedRows`

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.jsx
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.jsx
@@ -7,6 +7,7 @@
  */
 
 import React, { useState } from 'react';
+import { Button } from '@carbon/react';
 import { Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
 import {
@@ -232,7 +233,7 @@ SingleLevelNestedRowsUsageStory.args = {
 
 const NestedRows = ({ ...args }) => {
   const columns = React.useMemo(() => defaultHeader, []);
-  const [data] = useState(makeData(10, 5, 2, 2));
+  const [data, setData] = useState(makeData(5, 5, 2, 2));
   const datagridState = useDatagrid(
     {
       columns,
@@ -243,7 +244,19 @@ const NestedRows = ({ ...args }) => {
     useNestedRows
   );
 
-  return <Datagrid datagridState={{ ...datagridState }} />;
+  return (
+    <div>
+      <Button
+        onClick={() => {
+          const firstRowCopy = data[0];
+          setData([...data, { ...firstRowCopy, defaultExpanded: true }]);
+        }}
+      >
+        Add row
+      </Button>
+      <Datagrid datagridState={{ ...datagridState }} />
+    </div>
+  );
 };
 
 const BasicTemplateWrapper = ({ ...args }) => {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.jsx
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.jsx
@@ -232,7 +232,7 @@ SingleLevelNestedRowsUsageStory.args = {
 
 const NestedRows = ({ ...args }) => {
   const columns = React.useMemo(() => defaultHeader, []);
-  const [data] = useState(makeData(5, 5, 2, 2));
+  const [data] = useState(makeData(10, 5, 2, 2));
   const datagridState = useDatagrid(
     {
       columns,

--- a/packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.jsx
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.jsx
@@ -7,7 +7,6 @@
  */
 
 import React, { useState } from 'react';
-import { Button } from '@carbon/react';
 import { Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
 import {
@@ -233,7 +232,7 @@ SingleLevelNestedRowsUsageStory.args = {
 
 const NestedRows = ({ ...args }) => {
   const columns = React.useMemo(() => defaultHeader, []);
-  const [data, setData] = useState(makeData(5, 5, 2, 2));
+  const [data] = useState(makeData(5, 5, 2, 2));
   const datagridState = useDatagrid(
     {
       columns,
@@ -244,19 +243,7 @@ const NestedRows = ({ ...args }) => {
     useNestedRows
   );
 
-  return (
-    <div>
-      <Button
-        onClick={() => {
-          const firstRowCopy = data[0];
-          setData([...data, { ...firstRowCopy, defaultExpanded: true }]);
-        }}
-      >
-        Add row
-      </Button>
-      <Datagrid datagridState={{ ...datagridState }} />
-    </div>
-  );
+  return <Datagrid datagridState={{ ...datagridState }} />;
 };
 
 const BasicTemplateWrapper = ({ ...args }) => {

--- a/packages/ibm-products/src/components/Datagrid/useNestedRows.js
+++ b/packages/ibm-products/src/components/Datagrid/useNestedRows.js
@@ -18,7 +18,7 @@ const useNestedRows = (hooks) => {
     useEffect(() => {
       const { rows } = instance;
       const defaultExpandedRows = rows.filter(
-        (row) => row.original.defaultExpanded
+        (row) => row?.original?.defaultExpanded
       );
       if (defaultExpandedRows?.length) {
         defaultExpandedRows.map((defaultExpandedRow) => {

--- a/packages/ibm-products/src/components/Datagrid/useNestedRows.js
+++ b/packages/ibm-products/src/components/Datagrid/useNestedRows.js
@@ -15,6 +15,24 @@ const blockClass = `${pkg.prefix}--datagrid`;
 const useNestedRows = (hooks) => {
   useNestedRowExpander(hooks);
   const useInstance = (instance) => {
+    useEffect(() => {
+      const { rows } = instance;
+      const defaultExpandedRows = rows.filter(
+        (row) => row.original.defaultExpanded
+      );
+      if (defaultExpandedRows?.length) {
+        defaultExpandedRows.map((defaultExpandedRow) => {
+          if (
+            !defaultExpandedRow.isExpanded &&
+            !defaultExpandedRow.hasExpanded
+          ) {
+            defaultExpandedRow?.toggleRowExpanded?.();
+            defaultExpandedRow.hasExpanded = true;
+            return;
+          }
+        });
+      }
+    }, [instance, instance.rows]);
     // This useEffect will expand rows if they exist in the initialState obj
     useEffect(() => {
       const { rows, initialState } = instance;


### PR DESCRIPTION
Closes #5260

This PR provides a way to have rows expanded by default (when they're not included as part of `initialState.expandedRowIds`). By adding `defaultExpanded: true` to the row, the `useNestedRows` hook/plugin will toggle the expansion state so that if it is a new row and should be expanded by default, this is now possible.

There is still an issue opened from @flannanl around expansion states being not kept after rerendering, but there is a [separate issue open for this](https://github.com/carbon-design-system/ibm-products/issues/4911).

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/useNestedRows.js
```
#### How did you test and verify your work?
Storybook