### PR TITLE
fix(SidePanel): add missing size xl

### DIFF
--- a/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
@@ -157,7 +157,7 @@ type SidePanelBaseProps = {
   /**
    * Sets the size of the side panel
    */
-  size: 'xs' | 'sm' | 'md' | 'lg' | '2xl';
+  size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
 
   /**
    * Determines if this panel slides in


### PR DESCRIPTION
Closes #5020 

#### What did you change?
_size: 'xs' | 'sm' | 'md' | 'lg' | `'xl'` | '2xl';_

#### How did you test and verify your work?
Storybook