### PR TITLE
fix(CreateInfluencer): removed empty p tag render

### DIFF
--- a/packages/ibm-products/src/components/CreateInfluencer/CreateInfluencer.tsx
+++ b/packages/ibm-products/src/components/CreateInfluencer/CreateInfluencer.tsx
@@ -92,7 +92,7 @@ export const CreateInfluencer = ({
                 <ProgressStep
                   label={step.title}
                   key={stepIndex}
-                  secondaryLabel={step.secondaryLabel}
+                  secondaryLabel={step.secondaryLabel || undefined}
                   invalid={(step as any).invalid}
                 />
               );


### PR DESCRIPTION
After pr #5086 gets merged, we would notice an empty p tag being rendered for `secondaryLabel`, if it is passed as an empty string or undefined. as shown below
<img width="885" alt="Screenshot 2024-05-21 at 3 30 13 PM" src="https://github.com/carbon-design-system/ibm-products/assets/47176249/a364f9e8-c774-45fa-8980-07c74b2e427d">

this pr would fix that issue.
#### What did you change?
packages/ibm-products/src/components/CreateInfluencer/CreateInfluencer.tsx
#### How did you test and verify your work?
storybook, dev tools.