### PR TITLE
fix: remove previously used class name

### DIFF
--- a/packages/ibm-products/src/components/Card/Card.js
+++ b/packages/ibm-products/src/components/Card/Card.js
@@ -299,7 +299,7 @@ export let Card = forwardRef(
         )}
         <div className={`${blockClass}__content-container`}>
           <div {...getHeaderBodyProps()}>
-            <div className={`${blockClass}__header-container`}>
+            <div className={`${blockClass}__header-wrapper`}>
               <CardHeader {...getHeaderProps()} />
               <div {...getBodyProps()}>{children}</div>
             </div>


### PR DESCRIPTION
Closes #5281 

turns out the `header-container` class is already in use and because it was applied here it caused a visual bug. this just renames that class to something else.

here is the offending class
```
.#{$block-class}__header-container {
  display: flex;
  flex-direction: row;
  align-items: center;
  justify-content: space-between;
}
```

after fix:

<img width="397" alt="Screenshot 2024-05-21 at 9 00 58 AM" src="https://github.com/carbon-design-system/ibm-products/assets/6370760/9b8a8e6c-edf8-4444-aa39-688a1c7b177e">
<img width="423" alt="Screenshot 2024-05-21 at 9 01 08 AM" src="https://github.com/carbon-design-system/ibm-products/assets/6370760/c5ec964a-c85f-4c66-b3d3-d3789b6a369b">
