### PR TITLE
fix(storybook): use markdown component to render custom docs

### DIFF
--- a/packages/ibm-products/src/global/js/utils/StoryDocsPage.js
+++ b/packages/ibm-products/src/global/js/utils/StoryDocsPage.js
@@ -17,6 +17,7 @@ import {
   Stories,
   AnchorMdx,
   useOf,
+  Markdown,
 } from '@storybook/blocks';
 import { paramCase } from 'change-case';
 
@@ -40,7 +41,7 @@ export const CustomBlocks = ({ blocks }) => {
         {block.subTitle && <h4>{block.subTitle}</h4>}
         {block.image}
         {block.description && typeof block.description === 'string' ? (
-          <Description>{block.description}</Description>
+          <Markdown>{block.description}</Markdown>
         ) : (
           block.description
         )}


### PR DESCRIPTION
Closes #5301 

This enables custom docs to render as expected. It was previously always pulling in the component description because of the `autodocs` tag. Using the `Markdown` component when we have a custom doc block description seems to resolve this issue.

#### What did you change?
```
packages/ibm-products/src/global/js/utils/StoryDocsPage.js
```
#### How did you test and verify your work?
Tested against Datagrid docs page, making sure that the component description is _not_ repeated throughout the doc file