### PR TITLE
chore(release): add git porcelain check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,13 @@ jobs:
           echo "  js:
               functions: {}
               tokens: null" >> telemetry.yml
-          git add telemetry.yml
-          git commit -m "chore(telemetry): update telemetry config"
-          git push origin
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "Mirror is clean, exiting..."
+          else
+            git add telemetry.yml
+            git commit -m "chore(telemetry): update telemetry config"
+            git push origin
+          fi
 
       - name: Continuous integration check (includes build)
         run: yarn ci-check


### PR DESCRIPTION
Running into an issue with the telemetry config generator step in the release where if there are no changes to commit and push in the `telemetry.yml`, it will error out.

#### What did you change?

- added a git porcelain check for the step - thanks @kennylam for the code snippet!

#### How did you test and verify your work?

I created a test branch (I had to edit the release file a bit - commented out the publishing and ci-check steps, and set my own git config so I could test the telemetry step) and ran the workflow on my fork

![Screenshot 2024-05-22 at 10 08 26 AM](https://github.com/carbon-design-system/ibm-products/assets/54281166/29f5bd91-8ea6-458c-8d7d-26385e8330b3)
