### PR TITLE
fix(StringFormatter): scope popover to string formatter block class

### DIFF
--- a/packages/ibm-products-styles/src/components/StringFormatter/_string-formatter.scss
+++ b/packages/ibm-products-styles/src/components/StringFormatter/_string-formatter.scss
@@ -48,7 +48,7 @@ $popover-block-class: #{c4p-settings.$carbon-prefix}--popover;
   line-height: inherit;
 }
 
-.#{$popover-block-class} {
+.#{$block-class} .#{$popover-block-class} {
   max-width: $spacing-05;
   margin: 0 auto;
 }


### PR DESCRIPTION
Closes #5314 

Scopes the popover styles in `_string-formatter.scss` to the StringFormatter block class so we don't unintentionally change popovers that aren't associated with the string formatter.

#### What did you change?
```
packages/ibm-products-styles/src/components/StringFormatter/_string-formatter.scss
```
#### How did you test and verify your work?
Confirmed locally in Storybook that there are no visual changes in `StringFormatter`