### PR TITLE
test(InlineTip): add default state avt check

### DIFF
--- a/e2e/components/InlineTip/InlineTip-test.avt.e2e.js
+++ b/e2e/components/InlineTip/InlineTip-test.avt.e2e.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../test-utils/storybook';
+
+test.describe('InlineTip @avt', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'InlineTip',
+      id: 'ibm-products-novice-to-pro-inline-tip-inlinetip--inline-tip',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('InlineTip @avt-default-state');
+  });
+});

--- a/e2e/components/InlineTip/InlineTip-test.avt.e2e.js
+++ b/e2e/components/InlineTip/InlineTip-test.avt.e2e.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2024
+ * Copyright IBM Corp. 2024, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Closes #4666 

add default state avt for InlineTip component

#### What did you change?
e2e/components/InlineTip/InlineTip-test.avt.e2e.js

#### How did you test and verify your work?
 yarn playwright test e2e/components/InlineTip/InlineTip-test.avt.e2e.js