### PR TITLE
fix(PageHeader): enable canary `ActionBar` inside of `PageHeader`

### DIFF
--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -15,8 +15,8 @@ import index from './index.scss?inline';
 import { StoryDocsPage } from '../../ibm-products/src/global/js/utils/StoryDocsPage';
 
 // Enable all components, whether released or not, for storybook purposes
-// pkg._silenceWarnings(true);
-// pkg.setAllComponents(true);
+pkg._silenceWarnings(true);
+pkg.setAllComponents(true);
 
 const Style = ({ children, styles }) => (
   <>

--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -15,8 +15,8 @@ import index from './index.scss?inline';
 import { StoryDocsPage } from '../../ibm-products/src/global/js/utils/StoryDocsPage';
 
 // Enable all components, whether released or not, for storybook purposes
-pkg._silenceWarnings(true);
-pkg.setAllComponents(true);
+// pkg._silenceWarnings(true);
+// pkg.setAllComponents(true);
 
 const Style = ({ children, styles }) => (
   <>

--- a/packages/ibm-products/src/components/PageHeader/PageHeader.tsx
+++ b/packages/ibm-products/src/components/PageHeader/PageHeader.tsx
@@ -49,6 +49,8 @@ import {
 } from './PageHeaderUtils';
 import { PageHeaderTitle } from './PageHeaderTitle';
 
+pkg.component.ActionBar = true;
+
 // Default values for props
 const defaults = {
   fullWidthGrid: false,


### PR DESCRIPTION
Closes #4979 

When we moved the `ActionBar` from internal to canary it caused issues in the PageHeader because it wasn't being enabled (which is required for _all_ canary components), whether they are used within our `@carbon/ibm-products` components or elsewhere.

The bug can be reproduced locally by removing the [following two lines](https://github.com/carbon-design-system/ibm-products/blob/main/packages/core/.storybook/preview.js#L18-L19) in `packages/core/.storybook/preview.js` . Explicitly enabling the `ActionBar` within the `PageHeader` component fixed this issue.

[This stack blitz reproduces the issue](https://stackblitz.com/edit/github-ywsqfp?file=package.json,src%2FExample%2FExample.jsx).

#### What did you change?
```
packages/ibm-products/src/components/PageHeader/PageHeader.tsx
```
#### How did you test and verify your work?
Removed enabling of all canary components locally within storybook and verified that the canary message is gone and the component renders after adding `pkg.component.ActionBar = true;` to `PageHeader.tsx`.