### PR TITLE
fix(GuideBanner): include styles in index-with-carbon.scss

### DIFF
--- a/packages/ibm-products-styles/src/components/_index-with-carbon.scss
+++ b/packages/ibm-products-styles/src/components/_index-with-carbon.scss
@@ -77,3 +77,4 @@
 @use './FilterPanel/index-with-carbon' as *;
 @use './ConditionBuilder/index-with-carbon' as *;
 @use './GetStartedCard/index-with-carbon' as *;
+@use './GuideBanner/index-with-carbon' as *;


### PR DESCRIPTION
Closes #5335 

Includes the `GuideBanner` in `_index-with-carbon.scss` so styles can be imported from `@use '@carbon/ibm-products/css/index';` as expected.

#### What did you change?
```
packages/ibm-products-styles/src/components/_index-with-carbon.scss
```
#### How did you test and verify your work?
Ran build script from `packages/ibm-products-styles` and verified that the associated built files now include GuideBanner styles.