### PR TITLE
test(EditUpdateCards): add default state AVT check

### DIFF
--- a/e2e/components/EditUpdateCards/EditUpdateCards-test.avt.e2e.js
+++ b/e2e/components/EditUpdateCards/EditUpdateCards-test.avt.e2e.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../test-utils/storybook';
+
+test.describe('EditUpdateCards @avt', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'EditUpdateCards',
+      id: 'ibm-products-patterns-edit-and-update-editupdatecards--edit-update-cards',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations(
+      'EditUpdateCards @avt-default-state'
+    );
+  });
+});

--- a/packages/ibm-products/src/components/EditUpdateCards/EditUpdateCards.stories.jsx
+++ b/packages/ibm-products/src/components/EditUpdateCards/EditUpdateCards.stories.jsx
@@ -250,9 +250,9 @@ const Template = (args) => {
           primaryButtonText={editMode && !loading ? 'Save' : null}
           secondaryButtonIcon={null}
           secondaryButtonText={editMode && !loading ? 'Cancel' : null}
-          id={`${
-            editMode ? pkg.prefix + '--edit-update-cards--edit' : ''
-          }`} /*Used id for overriding the SVG(icon) path fill*/
+          id={
+            editMode ? pkg.prefix + '--edit-update-cards--edit' : undefined
+          } /*Used id for overriding the SVG(icon) path fill*/
         />
       </Column>
     </Grid>


### PR DESCRIPTION
Closes #5212 

Created e2e/components/EditUpdateCards/EditUpdateCards-test.avt.e2e.js

#### What did you change? 
e2e/components/EditUpdateCards/EditUpdateCards-test.avt.e2e.js
packages/ibm-products/src/components/EditUpdateCards/EditUpdateCards.stories.jsx

#### How did you test and verify your work? yarn avt
