### PR TITLE
test(FilterPanel): add default state AVT check

### DIFF
--- a/e2e/components/FilterPanel/FilterPanel-test.avt.e2e.js
+++ b/e2e/components/FilterPanel/FilterPanel-test.avt.e2e.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../test-utils/storybook';
+import { carbon } from '../../../packages/ibm-products/src/settings';
+
+test.describe('FilterPanel @avt', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'FilterPanel',
+      id: 'ibm-products-components-filter-panel-filterpanel--default',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+
+    await page.click(`.${carbon.prefix}--accordion__heading`);
+    await page
+      .locator(`.${carbon.prefix}--accordion__item--active`)
+      .screenshot({ animations: 'disabled' });
+
+    await expect(page).toHaveNoACViolations('FilterPanel @avt-default-state');
+  });
+});


### PR DESCRIPTION
Closes #5215 
 
 Created e2e/components/FilterPanel/FilterPanel-test.avt.e2e.js
 
#### What did you change? e2e/components/FilterPanel/FilterPanel-test.avt.e2e.js

#### How did you test and verify your work? yarn avt
