### PR TITLE
fix(datagrid): pass classname from header props directly

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -193,7 +193,6 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
             ...headerProps
           } = header.getHeaderProps();
 
-          console.log('header props', headerProps);
           const resizerProps = header?.getResizerProps?.();
           return (
             <TableHeader

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -190,14 +190,15 @@ const HeaderRow = (datagridState, headRef, headerGroup) => {
           const {
             // eslint-disable-next-line no-unused-vars
             role,
-            className: headerClassName,
             ...headerProps
           } = header.getHeaderProps();
+
+          console.log('header props', headerProps);
           const resizerProps = header?.getResizerProps?.();
           return (
             <TableHeader
               {...headerProps}
-              className={cx(headerClassName, {
+              className={cx(header.className, {
                 [`${blockClass}__resizableColumn`]: resizerProps,
                 [`${blockClass}__isResizing`]: header.isResizing,
                 [`${blockClass}__sortableColumn`]:


### PR DESCRIPTION
Closes #[5272](https://github.com/carbon-design-system/ibm-products/issues/5272)

When passing a custom classname to the header props, the classname was coming through as `undefined` and not being applied to the column header `<th>` element. It comes through as `undefined` as `header.getHeaderProps()` doesn't return any `className` field.

#### What did you change?

Reference the `className` from `header` object directly.

#### How did you test and verify your work?

Tested in the `Basic usage` story where we are passing in the custom classname `test-column` in the story

<img width="915" alt="Screenshot 2024-05-29 at 9 25 32 AM" src="https://github.com/carbon-design-system/ibm-products/assets/54281166/ef052e5f-0500-42bd-ae92-1f4325840148">