### PR TITLE
fix(Datagrid): v1 added border right with the correct token

### DIFF
--- a/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
@@ -2562,6 +2562,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   position: sticky !important;
   z-index: 1;
   left: 0;
+  border-right: 1px solid var(--cds-active-light-ui, #c6c6c6);
 }
 
 .c4p--datagrid__left-sticky-column-cell.c4p--datagrid__left-sticky-column-cell--with-extra-select-column,

--- a/packages/ibm-products/src/components/Datagrid/styles/_useStickyColumn.scss
+++ b/packages/ibm-products/src/components/Datagrid/styles/_useStickyColumn.scss
@@ -37,6 +37,7 @@
   position: sticky !important;
   z-index: 1;
   left: 0;
+  border-right: 1px solid $active-light-ui;
 }
 
 .#{$block-class}__left-sticky-column-cell.#{$block-class}__left-sticky-column-cell--with-extra-select-column,


### PR DESCRIPTION
Closes #5327 

v1 pr to add the border to the sticky column header with the right token

#### What did you change?
packages/ibm-products/src/components/Datagrid/styles/_useStickyColumn.scss
#### How did you test and verify your work?
storybook