### PR TITLE
fix(Datagrid): replaced border tokens with the right ones

### DIFF
--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_useStickyColumn.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_useStickyColumn.scss
@@ -16,7 +16,7 @@
   right: 0;
   display: flex;
   align-items: center;
-  border-left: 1px solid $layer-active-02;
+  border-left: 1px solid $border-subtle;
 }
 
 .#{variables.$block-class}__right-sticky-column-header {
@@ -31,7 +31,7 @@
   left: 0;
   display: flex;
   align-items: center;
-  border-right: 1px solid $layer-active-02;
+  border-right: 1px solid $border-subtle;
 }
 
 .#{variables.$block-class}__left-sticky-column-header {
@@ -39,11 +39,11 @@
   position: sticky !important;
   z-index: 1;
   left: 0;
-  border-right: 1px solid $layer-active-02;
+  border-right: 1px solid $border-subtle;
 }
 
 .#{variables.$block-class}__right-sticky-column-header {
-  border-left: 1px solid $layer-active-02;
+  border-left: 1px solid $border-subtle;
 }
 
 .#{variables.$block-class}__left-sticky-column-cell.#{variables.$block-class}__left-sticky-column-cell--with-extra-select-column,


### PR DESCRIPTION
Closes #5327 

replaced the border of frozen columns with right tokens

#### What did you change?
packages/ibm-products-styles/src/components/Datagrid/styles/_useStickyColumn.scss

#### How did you test and verify your work?
storybook