### PR TITLE
fix(Datagrid): add disable column support

### DIFF
--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_useInlineEdit.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_useInlineEdit.scss
@@ -80,6 +80,12 @@ $row-heights: (
   align-items: center;
 }
 
+.#{variables.$block-class}__static--outer-cell {
+  display: flex;
+  height: -webkit-fill-available;
+  align-items: center;
+}
+
 .#{variables.$block-class}__inline-edit--outer-cell-button {
   width: 100%;
   height: calc(100% + 2px); // account for borders

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditButton/InlineEditButton.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditButton/InlineEditButton.js
@@ -14,9 +14,9 @@ const blockClass = `${pkg.prefix}--datagrid`;
 export const InlineEditButton = ({
   label,
   renderIcon: Icon,
-  disabled,
   labelIcon: LabelIcon,
   placeholder,
+  disabledCell,
   nonEditCell,
   isActiveCell,
   columnConfig,
@@ -25,8 +25,7 @@ export const InlineEditButton = ({
   return (
     <div
       className={cx(`${blockClass}__inline-edit-button`, {
-        [`${blockClass}__inline-edit-button--disabled`]:
-          disabled || nonEditCell,
+        [`${blockClass}__inline-edit-button--disabled`]: disabledCell,
         [`${blockClass}__inline-edit-button--with-label-icon`]: LabelIcon,
         [`${blockClass}__inline-edit-button--non-edit`]: nonEditCell,
         [`${blockClass}__inline-edit-button--active`]: isActiveCell,
@@ -34,8 +33,8 @@ export const InlineEditButton = ({
           type === 'date' || type === 'selection',
       })}
       tabIndex={isActiveCell ? 0 : -1}
-      data-disabled={disabled || nonEditCell}
-      aria-disabled={disabled || nonEditCell}
+      data-disabled={disabledCell}
+      aria-disabled={disabledCell}
       role="button"
       title={label}
     >
@@ -68,7 +67,7 @@ export const InlineEditButton = ({
 
 InlineEditButton.propTypes = {
   columnConfig: PropTypes.object,
-  disabled: PropTypes.bool,
+  disabledCell: PropTypes.bool,
   isActiveCell: PropTypes.bool,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   labelIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
@@ -32,6 +32,7 @@ const blockClass = `${pkg.prefix}--datagrid`;
 export const InlineEditCell = ({
   cell,
   config,
+  disabledCell = false,
   instance,
   placeholder = '',
   tabIndex,
@@ -347,6 +348,10 @@ export const InlineEditCell = ({
     }
   };
 
+  const renderRegularCell = () => {
+    return <span {...inputProps} id={cellId}></span>;
+  };
+
   const renderDateCell = () => {
     const datePickerPreparedProps = prepareProps(config.inputProps, [
       'datePickerInputProps',
@@ -474,7 +479,7 @@ export const InlineEditCell = ({
       data-cell-id={cellId}
       data-column-index={columnIndex}
       data-row-index={cell.row.index}
-      data-disabled={nonEditCell}
+      data-disabled={disabledCell}
       data-inline-type={type}
       onClick={!nonEditCell ? handleInlineCellClick : addActiveState}
       onKeyDown={!nonEditCell ? handleKeyDown : null}
@@ -483,9 +488,11 @@ export const InlineEditCell = ({
         [`${blockClass}__inline-edit--outer-cell-button--lg`]: !rowSize,
         [`${blockClass}__inline-edit--outer-cell-button--invalid`]:
           config?.validator?.(cellValue),
+        [`${blockClass}__static--outer-cell`]: !disabledCell,
       })}
     >
-      {!inEditMode && (
+      {!nonEditCell && !disabledCell && renderRegularCell()}
+      {(!inEditMode || disabledCell) && (
         <InlineEditButton
           isActiveCell={cellId === activeCellId}
           renderIcon={setRenderIcon()}
@@ -496,6 +503,7 @@ export const InlineEditCell = ({
               ? buildDate(value)
               : value
           }
+          disabledCell={disabledCell}
           labelIcon={value?.icon || null}
           placeholder={placeholder}
           tabIndex={tabIndex}
@@ -519,6 +527,7 @@ export const InlineEditCell = ({
 InlineEditCell.propTypes = {
   cell: PropTypes.object,
   config: PropTypes.object,
+  disabledCell: PropTypes.bool,
   instance: PropTypes.shape({
     columns: PropTypes.arrayOf(PropTypes.object),
     onDataUpdate: PropTypes.func,

--- a/packages/ibm-products/src/components/Datagrid/useInlineEdit.js
+++ b/packages/ibm-products/src/components/Datagrid/useInlineEdit.js
@@ -25,6 +25,7 @@ const useInlineEdit = (hooks, usingEditableCell) => {
   const addInlineEdit = (props, { cell, instance }) => {
     const columnInlineEditConfig = cell.column.inlineEdit;
     const inlineEditType = cell.column?.inlineEdit?.type;
+    const isDisabled = cell.column?.isDisabled;
 
     const renderInlineEditComponent = (type) => (
       <InlineEditCell
@@ -32,6 +33,7 @@ const useInlineEdit = (hooks, usingEditableCell) => {
         tabIndex={-1}
         value={cell.value}
         cell={cell}
+        isDisabled={isDisabled}
         instance={instance}
         type={type}
       />
@@ -76,7 +78,7 @@ const useInlineEdit = (hooks, usingEditableCell) => {
                 value={cell.value}
                 cell={cell}
                 instance={instance}
-                disabled
+                disabledCell={isDisabled}
                 nonEditCell
                 type="text"
               />

--- a/packages/ibm-products/src/components/Datagrid/utils/getInlineEditColumns.js
+++ b/packages/ibm-products/src/components/Datagrid/utils/getInlineEditColumns.js
@@ -38,6 +38,11 @@ export const getInlineEditColumns = () => {
       id: 'rowIndex', // id is required when accessor is a function.
     },
     {
+      Header: 'Disabled column',
+      accessor: 'disabledColumn',
+      isDisabled: true,
+    },
+    {
       Header: 'First Name',
       accessor: 'firstName',
       inlineEdit: {

--- a/packages/ibm-products/src/components/Datagrid/utils/makeData.js
+++ b/packages/ibm-products/src/components/Datagrid/utils/makeData.js
@@ -93,6 +93,7 @@ const newPerson = (index, config) => {
   twoDaysAgoDate.setDate(twoDaysAgoDate.getDate() - 2);
 
   return {
+    disabledColumn: namor.generate({ words: 1, numbers: 0 }),
     firstName: namor.generate({ words: 1, numbers: 0 }),
     lastName: namor.generate({ words: 1, numbers: 0 }),
     age: Math.floor(Math.random() * 30),


### PR DESCRIPTION
Closes #5378 

#### What did you change?

What I changed was that when user adds condition for `isDisabled` and set it to true, it will make the column look disabled. Otherwise the column when it is not editable it will be a static text cell. This will resolve 5378 while retaining a use case where if user wanted it to actually be disabled, they can do so


#### How did you test and verify your work?

![Screenshot 2024-05-31 at 12 18 38 PM](https://github.com/carbon-design-system/ibm-products/assets/10100397/fb3679a5-fad4-44ff-9563-715644e2813b)
