### PR TITLE
fix(Coachmark): ssr issues with `instanceOf(HTMLElement)`

### DIFF
--- a/packages/ibm-products/src/components/Coachmark/Coachmark.tsx
+++ b/packages/ibm-products/src/components/Coachmark/Coachmark.tsx
@@ -277,6 +277,11 @@ export let Coachmark = forwardRef<HTMLElement, CoachmarkProps>(
   }
 );
 
+export const overlayRefType =
+  typeof HTMLElement === 'undefined'
+    ? PropTypes.object
+    : PropTypes.instanceOf(HTMLElement);
+
 // Return a placeholder if not released and not enabled by feature flag
 Coachmark = pkg.checkComponentEnabled(Coachmark, componentName);
 
@@ -333,9 +338,7 @@ Coachmark.propTypes = {
   overlayKind: PropTypes.oneOf(['tooltip', 'floating', 'stacked']),
 
   overlayRef: PropTypes.shape({
-    current: PropTypes.instanceOf(
-      HTMLElement
-    ) as PropTypes.Validator<HTMLElement | null>,
+    current: overlayRefType as PropTypes.Validator<HTMLElement | null>,
   }),
 
   /**

--- a/packages/ibm-products/src/components/Coachmark/Coachmark.tsx
+++ b/packages/ibm-products/src/components/Coachmark/Coachmark.tsx
@@ -277,7 +277,7 @@ export let Coachmark = forwardRef<HTMLElement, CoachmarkProps>(
   }
 );
 
-export const overlayRefType =
+const overlayRefType =
   typeof HTMLElement === 'undefined'
     ? PropTypes.object
     : PropTypes.instanceOf(HTMLElement);


### PR DESCRIPTION
Closes #5381 

This fixes issues in SSR apps as `HTMLElement` is available client side only, causing SSR apps to crash because of it's current usage in `Coachmark` prop types. We faced a very similar issue before with the `Tearsheet`, see [here](https://github.com/carbon-design-system/ibm-products/pull/3621).

#### What did you change?
```
packages/ibm-products/src/components/Coachmark/Coachmark.tsx
```
#### How did you test and verify your work?
All PR checks pass