### PR TITLE
test(ProductiveCard): add default state AVT test

### DIFF
--- a/e2e/components/ProductiveCard/ProductiveCard-test.avt.e2e.js
+++ b/e2e/components/ProductiveCard/ProductiveCard-test.avt.e2e.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../test-utils/storybook';
+
+test.describe('ProductiveCard @avt', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'ProductiveCard',
+      id: 'ibm-products-components-cards-productivecard--default',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations(
+      'ProductiveCard @avt-default-state'
+    );
+  });
+});


### PR DESCRIPTION
Closes #5002

#### What did you change?

add e2e test for `ProductiveCard`

#### How did you test and verify your work?

`yarn run avt`
