### PR TITLE
fix(Datagrid): implemented nestedRow dynamic width

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useNestedRows.js
+++ b/packages/ibm-products/src/components/Datagrid/useNestedRows.js
@@ -60,15 +60,6 @@ const useNestedRows = (hooks) => {
       // reduce the "first cell"s width to compensate added (left) margin
       const isFirstCell =
         instance.columns.findIndex((c) => c.id === cell.column.id) === 0;
-      // if (
-      //   isFirstCell &&
-      //   cell.row.depth > 0 &&
-      //   parseInt(props.style.width, 10) <= 100
-      // ) {
-      //   console.log(
-      //     -32 * cell.row.depth - 18 + parseInt(props.style.width, 10) - 50
-      //   );
-      // }
       return [
         props,
         {
@@ -76,7 +67,7 @@ const useNestedRows = (hooks) => {
             marginRight:
               isFirstCell &&
               cell.row.depth > 0 &&
-              parseInt(props.style.width, 10) <= 100
+              parseInt(props.style.width, 10) <= 32 * cell.row.depth + 18 + 50
                 ? `${
                     -32 * cell.row.depth -
                     18 +

--- a/packages/ibm-products/src/components/Datagrid/useNestedRows.js
+++ b/packages/ibm-products/src/components/Datagrid/useNestedRows.js
@@ -56,7 +56,7 @@ const useNestedRows = (hooks) => {
         },
       },
     ];
-    const getIndentation = (depth) => 32 * depth + 16;
+    const getIndentation = (depth) => 32 * depth + 16; // row indentation padding
     const getCellProps = (props, { cell, instance }) => {
       // we add a dynamic -ve margin right only if the cell is resized below minimum width i.e 50px, else we set the width based on indentation at different levels
       const isFirstCell =
@@ -69,7 +69,7 @@ const useNestedRows = (hooks) => {
               isFirstCell &&
               cell.row.depth > 0 &&
               parseInt(props.style.width, 10) <=
-                getIndentation(cell.row.depth) + 50
+                getIndentation(cell.row.depth) + 50 // indentation padding + expander cell or empty cell width
                 ? `${
                     parseInt(props.style.width, 10) -
                     (getIndentation(cell.row.depth) + 50)

--- a/packages/ibm-products/src/components/Datagrid/useNestedRows.js
+++ b/packages/ibm-products/src/components/Datagrid/useNestedRows.js
@@ -60,15 +60,34 @@ const useNestedRows = (hooks) => {
       // reduce the "first cell"s width to compensate added (left) margin
       const isFirstCell =
         instance.columns.findIndex((c) => c.id === cell.column.id) === 0;
+      // if (
+      //   isFirstCell &&
+      //   cell.row.depth > 0 &&
+      //   parseInt(props.style.width, 10) <= 100
+      // ) {
+      //   console.log(
+      //     -32 * cell.row.depth - 18 + parseInt(props.style.width, 10) - 50
+      //   );
+      // }
       return [
         props,
         {
           style: {
-            marginRight: `${
+            marginRight:
+              isFirstCell &&
+              cell.row.depth > 0 &&
+              parseInt(props.style.width, 10) <= 100
+                ? `${
+                    -32 * cell.row.depth -
+                    18 +
+                    parseInt(props.style.width, 10) -
+                    50
+                  }px`
+                : '',
+            width:
               isFirstCell && cell.row.depth > 0
-                ? `${-32 * cell.row.depth - 18}px`
-                : ''
-            }`,
+                ? parseInt(props.style.width, 10) + (-32 * cell.row.depth - 18)
+                : props.style.width,
           },
         },
       ];

--- a/packages/ibm-products/src/components/Datagrid/useNestedRows.js
+++ b/packages/ibm-products/src/components/Datagrid/useNestedRows.js
@@ -58,7 +58,7 @@ const useNestedRows = (hooks) => {
     ];
     const getIndentation = (depth) => 32 * depth + 16;
     const getCellProps = (props, { cell, instance }) => {
-      // we add a -ve margin right only if the cell is resized below minimum width i.e 50px, else we set the width based on indentation at different levels
+      // we add a dynamic -ve margin right only if the cell is resized below minimum width i.e 50px, else we set the width based on indentation at different levels
       const isFirstCell =
         instance.columns.findIndex((c) => c.id === cell.column.id) === 0;
       return [

--- a/packages/ibm-products/src/components/Datagrid/useNestedRows.js
+++ b/packages/ibm-products/src/components/Datagrid/useNestedRows.js
@@ -56,8 +56,9 @@ const useNestedRows = (hooks) => {
         },
       },
     ];
+    const getIndentation = (depth) => 32 * depth + 16;
     const getCellProps = (props, { cell, instance }) => {
-      // reduce the "first cell"s width to compensate added (left) margin
+      // we add a -ve margin right only if the cell is resized below minimum width i.e 50px, else we set the width based on indentation at different levels
       const isFirstCell =
         instance.columns.findIndex((c) => c.id === cell.column.id) === 0;
       return [
@@ -67,17 +68,17 @@ const useNestedRows = (hooks) => {
             marginRight:
               isFirstCell &&
               cell.row.depth > 0 &&
-              parseInt(props.style.width, 10) <= 32 * cell.row.depth + 18 + 50
+              parseInt(props.style.width, 10) <=
+                getIndentation(cell.row.depth) + 50
                 ? `${
-                    -32 * cell.row.depth -
-                    18 +
                     parseInt(props.style.width, 10) -
-                    50
+                    (getIndentation(cell.row.depth) + 50)
                   }px`
                 : '',
             width:
               isFirstCell && cell.row.depth > 0
-                ? parseInt(props.style.width, 10) + (-32 * cell.row.depth - 18)
+                ? parseInt(props.style.width, 10) -
+                  getIndentation(cell.row.depth)
                 : props.style.width,
           },
         },


### PR DESCRIPTION
Closes #4972 

made the width dynamically change, instead of giving margin-right = -50 to fix overlapping issue.
also if any cell is resized below 50px (minimum width), the difference is added to margin right to fix the layout of the row

#### What did you change?
packages/ibm-products/src/components/Datagrid/useNestedRows.js

#### How did you test and verify your work?
storybook