### PR TITLE
fix: enable autoAlign prop in popover

### DIFF
--- a/packages/ibm-products/src/components/TagSet/TagSet.tsx
+++ b/packages/ibm-products/src/components/TagSet/TagSet.tsx
@@ -116,6 +116,10 @@ interface TagSetProps extends PropsWithChildren {
    */
   onOverflowTagChange?: (value: ReactNode) => void;
   /**
+   * Will auto-align the popover on first render if it is not visible. This prop is currently experimental and is subject to future changes.
+   */
+  overFlowAutoAlign?: boolean;
+  /**
    * overflowAlign from the standard tooltip. Default center.
    */
   overflowAlign?: OverflowAlign;
@@ -154,6 +158,7 @@ export let TagSet = React.forwardRef<HTMLDivElement, TagSetProps>(
       className,
       maxVisible,
       multiline,
+      overFlowAutoAlign,
       overflowAlign = 'bottom',
       overflowClassName,
       overflowType = 'default',
@@ -259,6 +264,7 @@ export let TagSet = React.forwardRef<HTMLDivElement, TagSetProps>(
       newDisplayedTags.push(
         <TagSetOverflow
           allTagsModalSearchThreshold={allTagsModalSearchThreshold}
+          overFlowAutoAlign={overFlowAutoAlign}
           className={overflowClassName}
           onShowAllClick={handleShowAllClick}
           overflowTags={newOverflowTags}
@@ -284,6 +290,7 @@ export let TagSet = React.forwardRef<HTMLDivElement, TagSetProps>(
       onOverflowTagChange,
       popoverOpen,
       handleTagOnClose,
+      overFlowAutoAlign,
     ]);
 
     const checkFullyVisibleTags = useCallback(() => {
@@ -492,6 +499,10 @@ TagSet.propTypes = {
    * Handler to get overflow tags
    */
   onOverflowTagChange: PropTypes.func,
+  /**
+   * Will auto-align the popover on first render if it is not visible. This prop is currently experimental and is subject to future changes.
+   */
+  overFlowAutoAlign: PropTypes.bool,
   /**
    * overflowAlign from the standard tooltip. Default center.
    */

--- a/packages/ibm-products/src/components/TagSet/TagSetOverflow.tsx
+++ b/packages/ibm-products/src/components/TagSet/TagSetOverflow.tsx
@@ -48,6 +48,10 @@ interface TagSetOverflowProps {
    */
   allTagsModalSearchThreshold?: number;
   /**
+   * Will auto-align the popover on first render if it is not visible. This prop is currently experimental and is subject to future changes.
+   */
+  overFlowAutoAlign?: boolean;
+  /**
    * className
    */
   className?: string;
@@ -89,6 +93,7 @@ export const TagSetOverflow = React.forwardRef(
       allTagsModalSearchThreshold = defaults.allTagsModalSearchThreshold,
       className,
       onShowAllClick,
+      overFlowAutoAlign,
       overflowAlign = 'bottom',
       overflowTags,
       overflowType,
@@ -142,6 +147,7 @@ export const TagSetOverflow = React.forwardRef(
           highContrast
           onKeyDown={handleEscKeyPress}
           open={popoverOpen}
+          autoAlign={overFlowAutoAlign}
         >
           <Tag
             onClick={() => setPopoverOpen?.(!popoverOpen)}
@@ -217,6 +223,10 @@ TagSetOverflow.propTypes = {
    * function to execute on clicking show all
    */
   onShowAllClick: PropTypes.func.isRequired,
+  /**
+   * Will auto-align the popover on first render if it is not visible. This prop is currently experimental and is subject to future changes.
+   */
+  overFlowAutoAlign: PropTypes.bool,
   /**
    * overflowAlign from the standard tooltip
    */


### PR DESCRIPTION
Closes #5354 

enables floating ui prop in tagset overflow for popover. whether or not it's working as intended is another question 😅 
![Screenshot 2024-06-04 at 11 31 04 AM](https://github.com/carbon-design-system/ibm-products/assets/6370760/a90aecbd-ffa8-40c7-9608-5186aa141844)

this also confirms that popover within datagrid is still not working as intended
![Screenshot 2024-06-04 at 11 32 18 AM](https://github.com/carbon-design-system/ibm-products/assets/6370760/42d96b0a-1ba3-4d86-a487-86c153802312)
