### PR TITLE
fix(FeatureFlags): remove forced rerender, causing focus issues

### DIFF
--- a/packages/core/.storybook/WithFeatureFlags/index.js
+++ b/packages/core/.storybook/WithFeatureFlags/index.js
@@ -15,7 +15,6 @@ import { Annotation } from '../Annotation';
 
 export const WithFeatureFlags = ({ flags, children }) => {
   const [updatedFlags, setUpdatedFlags] = useState();
-  const [tempKey, setTempKey] = useState(0);
   const allFlagsEnabled = Object.fromEntries(
     Array.from(FeatureFlagScope.flags.keys()).map((k) => [k, true])
   );
@@ -28,12 +27,11 @@ export const WithFeatureFlags = ({ flags, children }) => {
         FeatureFlagScope.flags.set(key, value);
       }
       setUpdatedFlags(FeatureFlagScope.flags);
-      setTempKey((prev) => prev + 1);
     }
   }, [flags]);
 
   return (
-    <FeatureFlags flags={flags ? updatedFlags : allFlagsEnabled} key={tempKey}>
+    <FeatureFlags flags={flags ? updatedFlags : allFlagsEnabled}>
       <Annotation
         type="feature-flags"
         text={


### PR DESCRIPTION
After the feature flag PR was merged, I noticed in the editable cell Datagrid stories that the focus was lost after attempting to edit a cell. This appears to be from the forced rerender that I added which we actually do not need, everything works as expected after removing that piece from the `WithFeatureFlags` component.

#### What did you change?
```
packages/core/.storybook/WithFeatureFlags/index.js
```
#### How did you test and verify your work?
Storybook