### PR TITLE
fix(WebTerminal): fixes exit animation glitchy behaviour

### DIFF
--- a/packages/ibm-products/src/components/WebTerminal/WebTerminal.tsx
+++ b/packages/ibm-products/src/components/WebTerminal/WebTerminal.tsx
@@ -118,7 +118,7 @@ export let WebTerminal = React.forwardRef(
         : { matches: true };
 
     const webTerminalAnimationName = `${
-      open ? 'web-terminal-entrance' : 'web-terminal-exit'
+      open ? 'web-terminal-entrance' : 'web-terminal-exit forwards'
     } ${moderate02}`;
 
     const showDocumentationLinks = useMemo(


### PR DESCRIPTION
Closes #5416

added `forwards` to the exit animation, to prevent animation reset upon completion.

#### What did you change?
packages/ibm-products/src/components/WebTerminal/WebTerminal.tsx

#### How did you test and verify your work?
storybook