### PR TITLE
fix(SidePanel): remove default slide-in focus trap

### DIFF
--- a/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
@@ -49,7 +49,7 @@ type SidePanelBaseProps = {
   /**
    * Sets the action toolbar buttons
    */
-  actionToolbarButtons?: ButtonProps[];
+  actionToolbarButtons?: ButtonProps<any>[];
 
   /**
    * The primary actions to be shown in the side panel. Each action is
@@ -59,7 +59,7 @@ type SidePanelBaseProps = {
    *
    * See https://react.carbondesignsystem.com/?path=/docs/components-button--default#component-api
    */
-  actions?: ButtonProps[];
+  actions?: ButtonProps<any>[];
 
   /**
    * Determines if the title will animate on scroll
@@ -623,12 +623,12 @@ export let SidePanel = React.forwardRef(
             if (primeFocusEl) {
               (primeFocusEl as HTMLElement)?.focus();
             }
-          } else {
+          } else if (!slideIn) {
             firstElement?.focus();
           }
         }, 0);
       }
-    }, [animationComplete, firstElement, open, selectorPrimaryFocus]);
+    }, [animationComplete, firstElement, open, selectorPrimaryFocus, slideIn]);
 
     const primaryActionContainerClassNames = cx([
       `${blockClass}__actions-container`,
@@ -838,7 +838,7 @@ export let SidePanel = React.forwardRef(
               animate="visible"
               exit="exit"
               custom={{ placement, shouldReduceMotion }}
-              onKeyDown={keyDownListener}
+              onKeyDown={slideIn ? undefined : keyDownListener}
             >
               <>
                 {/* header */}
@@ -883,6 +883,7 @@ SidePanel.propTypes = {
   /**
    * Sets the action toolbar buttons
    */
+  /**@ts-ignore */
   actionToolbarButtons: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string,
@@ -916,6 +917,7 @@ SidePanel.propTypes = {
     ActionSet.validateActions(),
     PropTypes.arrayOf(
       PropTypes.shape({
+        /**@ts-ignore */
         ...Button.propTypes,
         kind: PropTypes.oneOf([
           'ghost',
@@ -929,6 +931,7 @@ SidePanel.propTypes = {
         label: PropTypes.string,
         loading: PropTypes.bool,
         // we duplicate this Button prop to improve the DocGen here
+        /**@ts-ignore */
         onClick: Button.propTypes.onClick,
       })
     ),


### PR DESCRIPTION
Closes #5400

#### What did you change?
`packages/ibm-products/src/components/SidePanel/SidePanel.tsx`
![image](https://github.com/carbon-design-system/ibm-products/assets/9197089/da7161af-0514-4b30-8fc8-82e512853b98)

![image](https://github.com/carbon-design-system/ibm-products/assets/9197089/dd54e791-2658-4559-a35a-e6db32f00fb4)


#### How did you test and verify your work?
Storybook