### PR TITLE
fix(Datagrid): column customization negative selection value and disabled column deselection

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
@@ -35,7 +35,9 @@ const CustomizeColumnsTearsheet = ({
   const [totalColumns, setTotalColumns] = useState('');
   const [searchText, setSearchText] = useState('');
   const [columnObjects, setColumnObjects] = useState(
-    columnDefinitions.filter((col) => col.id !== 'spacer')
+    columnDefinitions.filter(
+      (col) => col.id !== 'spacer' && col.id !== 'actions'
+    )
   );
   const [isDirty, setIsDirty] = useState(false);
 
@@ -61,6 +63,7 @@ const CustomizeColumnsTearsheet = ({
       ) {
         return { ...definition, isVisible: value };
       }
+      console.log('64', definition);
       return definition;
     });
 
@@ -82,6 +85,7 @@ const CustomizeColumnsTearsheet = ({
 
   useEffect(() => {
     const notFilterableCount = columnObjects.filter((col) => !col.canFilter);
+    console.log('86', columnObjects);
     setVisibleColumnsCount(
       getVisibleColumnsCount() - notFilterableCount.length
     );

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
@@ -42,7 +42,11 @@ const CustomizeColumnsTearsheet = ({
   const [isDirty, setIsDirty] = useState(false);
 
   const onRequestClose = () => {
-    setColumnObjects(columnDefinitions);
+    setColumnObjects(
+      columnDefinitions.filter(
+        (col) => col.id !== 'spacer' && col.id !== 'actions'
+      )
+    );
     setIsTearsheetOpen(false);
   };
 
@@ -58,12 +62,13 @@ const CustomizeColumnsTearsheet = ({
   const onCheckboxCheck = (col, value) => {
     const changedDefinitions = columnObjects.map((definition) => {
       if (
-        (Array.isArray(col) && col.indexOf(definition) != -1) ||
+        (definition.disabled !== true &&
+          Array.isArray(col) &&
+          col.indexOf(definition) != -1) ||
         definition.id === col.id
       ) {
         return { ...definition, isVisible: value };
       }
-      console.log('64', definition);
       return definition;
     });
 
@@ -85,7 +90,7 @@ const CustomizeColumnsTearsheet = ({
 
   useEffect(() => {
     const notFilterableCount = columnObjects.filter((col) => !col.canFilter);
-    console.log('86', columnObjects);
+    // console.log('86', columnObjects);
     setVisibleColumnsCount(
       getVisibleColumnsCount() - notFilterableCount.length
     );

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
@@ -34,19 +34,11 @@ const CustomizeColumnsTearsheet = ({
   const [visibleColumnsCount, setVisibleColumnsCount] = useState('');
   const [totalColumns, setTotalColumns] = useState('');
   const [searchText, setSearchText] = useState('');
-  const [columnObjects, setColumnObjects] = useState(
-    columnDefinitions.filter(
-      (col) => col.id !== 'spacer' && col.id !== 'actions'
-    )
-  );
+  const [columnObjects, setColumnObjects] = useState(columnDefinitions);
   const [isDirty, setIsDirty] = useState(false);
 
   const onRequestClose = () => {
-    setColumnObjects(
-      columnDefinitions.filter(
-        (col) => col.id !== 'spacer' && col.id !== 'actions'
-      )
-    );
+    setColumnObjects(columnDefinitions);
     setIsTearsheetOpen(false);
   };
 
@@ -62,10 +54,10 @@ const CustomizeColumnsTearsheet = ({
   const onCheckboxCheck = (col, value) => {
     const changedDefinitions = columnObjects.map((definition) => {
       if (
-        (definition.disabled !== true &&
-          Array.isArray(col) &&
-          col.indexOf(definition) != -1) ||
-        definition.id === col.id
+        ((Array.isArray(col) && col.indexOf(definition) != -1) ||
+          definition.id === col.id) &&
+        definition.canFilter &&
+        !definition.disabled
       ) {
         return { ...definition, isVisible: value };
       }
@@ -89,12 +81,17 @@ const CustomizeColumnsTearsheet = ({
   const string = searchText.trim().toLowerCase();
 
   useEffect(() => {
-    const notFilterableCount = columnObjects.filter((col) => !col.canFilter);
+    const notFilterableCount = columnObjects.filter(
+      (col) => !col.canFilter
+    ).length;
+    const actionCount = columnObjects.filter(
+      (col) => col.id === 'actions'
+    ).length;
     // console.log('86', columnObjects);
     setVisibleColumnsCount(
-      getVisibleColumnsCount() - notFilterableCount.length
+      getVisibleColumnsCount() - notFilterableCount - actionCount
     );
-    setTotalColumns(columnObjects.length - notFilterableCount.length);
+    setTotalColumns(columnObjects.length - notFilterableCount - actionCount);
   }, [getVisibleColumnsCount, columnObjects]);
 
   return (

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
@@ -87,7 +87,6 @@ const CustomizeColumnsTearsheet = ({
     const actionCount = columnObjects.filter(
       (col) => col.id === 'actions'
     ).length;
-    // console.log('86', columnObjects);
     setVisibleColumnsCount(
       getVisibleColumnsCount() - notFilterableCount - actionCount
     );

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
@@ -34,7 +34,9 @@ const CustomizeColumnsTearsheet = ({
   const [visibleColumnsCount, setVisibleColumnsCount] = useState('');
   const [totalColumns, setTotalColumns] = useState('');
   const [searchText, setSearchText] = useState('');
-  const [columnObjects, setColumnObjects] = useState(columnDefinitions);
+  const [columnObjects, setColumnObjects] = useState(
+    columnDefinitions.filter((col) => col.id !== 'spacer')
+  );
   const [isDirty, setIsDirty] = useState(false);
 
   const onRequestClose = () => {


### PR DESCRIPTION
Closes #5402 
Closes #5428 
Closes #5433 

fixes the negative value in datagrid column customization tearsheet heading.
fixes disabled column being deselected (when deselect all checkbox is clicked)
fixes selectable column coming from `useSelectRows` being removed if deselect all is clicked from column customization 

#### What did you change?
packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js

#### How did you test and verify your work?
visually through storybook
for third issue i have imported and added `useSelectRows` to Column Customization Usage Story and verified in storybook