### PR TITLE
fix: address bug in update gallery script

### DIFF
--- a/scripts/example-gallery-builder/update-example/index.js
+++ b/scripts/example-gallery-builder/update-example/index.js
@@ -118,7 +118,7 @@ const updateExample = (name, config) => {
 
     const example_node_modules = join(rootPath, examplePath, 'node_modules');
     if (fs.existsSync(example_node_modules)) {
-      fs.fmSync(example_node_modules, { recursive: true, force: true });
+      fs.rmSync(example_node_modules, { recursive: true, force: true });
     }
 
     sync(resolve(rootPath, examplePath, '**/*')).forEach((file) => {


### PR DESCRIPTION
Closes #5423 

This change fixes a bug in the example gallery update script. It previously attempted to call `fs.fmSync` which does not exist rather than `fs.rmSync` as intended.

#### What did you change?
```
scripts/example-gallery-builder/update-example/index.js
```
#### How did you test and verify your work?
Applied this change and was able to successfully run `yarn update-gallery-config` which failed previously