### PR TITLE
fix(OptionTile): animation flicker when collapsing options tile

### DIFF
--- a/packages/ibm-products/src/components/OptionsTile/OptionsTile.tsx
+++ b/packages/ibm-products/src/components/OptionsTile/OptionsTile.tsx
@@ -221,6 +221,9 @@ export let OptionsTile = React.forwardRef(
           contentRef.current
         );
 
+        const animationDuration = Number(
+          carbonMotion.moderate01.replace('ms', '')
+        );
         const animation = contentRef.current.animate(
           [
             {
@@ -237,7 +240,7 @@ export let OptionsTile = React.forwardRef(
             },
           ],
           {
-            duration: Number(carbonMotion.moderate01.replace('ms', '')),
+            duration: animationDuration,
             easing: carbonMotion.easings.entrance.productive,
           }
         );
@@ -247,7 +250,14 @@ export let OptionsTile = React.forwardRef(
           setClosing(false);
         };
 
-        animation.onfinish = callback;
+        //This is to fix the flicking issue while collapsing.
+        //root cause : after the animation is finished , isOpen is still true until onFinish callback is triggered.For that minute duration , collapsed content will again show.
+        // To avoid this , isOpen is set to false after the 90% of animation duration.
+        setTimeout(() => {
+          callback();
+        }, animationDuration * 0.9);
+
+        // animation.onfinish = callback;
         animation.oncancel = callback;
       } else {
         // in case the ref is not set or the user prefers reduced motion, skip the animation


### PR DESCRIPTION
Closes #5410 

[OptionsTile]: animation flicker when collapsing options tile

#### What did you change?
root cause : after the animation is finished , isOpen is still true until onFinish callback is triggered.For that minute duration , collapsed content will again show causing the flickering.
To avoid this , isOpen is set to false after the 90% of animation completion.

#### How did you test and verify your work?
Local storybook