### PR TITLE
fix(Datagrid): sticky header column

### DIFF
--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -2553,6 +2553,11 @@ p.c4p--about-modal__copyright-text:first-child {
   width: 40rem;
   max-width: 100%;
 }
+.c4p--side-panel.c4p--side-panel--xl {
+  /* any value is single value list */
+  width: 65rem;
+  max-width: 100%;
+}
 .c4p--side-panel.c4p--side-panel--2xl {
   /* any value is single value list */
   width: 40rem;
@@ -4270,7 +4275,7 @@ p.c4p--about-modal__copyright-text:first-child {
   right: 0;
   display: flex;
   align-items: center;
-  border-left: 1px solid var(--cds-layer-active-02, #c6c6c6);
+  border-left: 1px solid var(--cds-border-subtle);
 }
 
 .c4p--datagrid__right-sticky-column-header {
@@ -4285,7 +4290,7 @@ p.c4p--about-modal__copyright-text:first-child {
   left: 0;
   display: flex;
   align-items: center;
-  border-right: 1px solid var(--cds-layer-active-02, #c6c6c6);
+  border-right: 1px solid var(--cds-border-subtle);
 }
 
 .c4p--datagrid__left-sticky-column-header {
@@ -4293,11 +4298,11 @@ p.c4p--about-modal__copyright-text:first-child {
   position: sticky !important;
   z-index: 1;
   left: 0;
-  border-right: 1px solid var(--cds-layer-active-02, #c6c6c6);
+  border-right: 1px solid var(--cds-border-subtle);
 }
 
 .c4p--datagrid__right-sticky-column-header {
-  border-left: 1px solid var(--cds-layer-active-02, #c6c6c6);
+  border-left: 1px solid var(--cds-border-subtle);
 }
 
 .c4p--datagrid__left-sticky-column-cell.c4p--datagrid__left-sticky-column-cell--with-extra-select-column,
@@ -4988,6 +4993,12 @@ th.c4p--datagrid__select-all-toggle-on.button {
 
 .c4p--datagrid .c4p--inline-edit__after-input-elements {
   display: flex;
+  align-items: center;
+}
+
+.c4p--datagrid__static--outer-cell {
+  display: flex;
+  height: -webkit-fill-available;
   align-items: center;
 }
 

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.tsx
@@ -234,7 +234,7 @@ const HeaderRow = (
                   [`${blockClass}__with-slug`]:
                     header.slug && React.isValidElement(header?.slug),
                 },
-                header.getHeaderProps().className
+                headerProps.className
               )}
               key={header.id}
               aria-hidden={header.id === 'spacer' && 'true'}

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.tsx
@@ -222,16 +222,20 @@ const HeaderRow = (
           return (
             <TableHeader
               {...headerProps}
-              className={cx(header?.className, {
-                [`${blockClass}__resizableColumn`]: resizerProps,
-                [`${blockClass}__isResizing`]: header?.isResizing,
-                [`${blockClass}__sortableColumn`]:
-                  datagridState.isTableSortable && header.id !== 'spacer',
-                [`${blockClass}__isSorted`]: header?.isSorted,
-                [`${blockClass}__header-actions-column`]: header?.isAction,
-                [`${blockClass}__with-slug`]:
-                  header.slug && React.isValidElement(header?.slug),
-              })}
+              className={cx(
+                header?.className,
+                {
+                  [`${blockClass}__resizableColumn`]: resizerProps,
+                  [`${blockClass}__isResizing`]: header?.isResizing,
+                  [`${blockClass}__sortableColumn`]:
+                    datagridState.isTableSortable && header.id !== 'spacer',
+                  [`${blockClass}__isSorted`]: header?.isSorted,
+                  [`${blockClass}__header-actions-column`]: header?.isAction,
+                  [`${blockClass}__with-slug`]:
+                    header.slug && React.isValidElement(header?.slug),
+                },
+                header.getHeaderProps().className
+              )}
               key={header.id}
               aria-hidden={header.id === 'spacer' && 'true'}
               {...getAccessibilityProps(header)}

--- a/packages/ibm-products/src/components/Datagrid/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/Datagrid/_storybook-styles.scss
@@ -155,7 +155,3 @@ div[data-story-title*='#{$story-anchor}']
   cursor: pointer;
   text-align: start;
 }
-
-.test-column {
-  z-index: 10;
-}


### PR DESCRIPTION
Closes #5431 

fixes the sticky header (not sticking) issue, by bringing back this line `header.getHeaderProps().className` as `headerProps.className` from this pr #3957 

also removed 
```
.test-column {
  z-index: 10;
}
```
from packages/ibm-products/src/components/Datagrid/_storybook-styles.scss
which was added in #4967 
as i observed this

https://github.com/carbon-design-system/ibm-products/assets/47176249/3bc3b968-8416-46e7-8412-ba70c16f13d0


#### What did you change?
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.tsx

#### How did you test and verify your work?
storybook