### PR TITLE
fix(FeatureFlags): add missing imports and update build script

### DIFF
--- a/packages/ibm-products/scripts/build.js
+++ b/packages/ibm-products/scripts/build.js
@@ -142,6 +142,17 @@ function getRollupConfig(input, rootDir, outDir) {
       }),
       babel(babelConfig),
       stripBanner(),
+      {
+        transform(_code, id) {
+          // Make sure to mark feature-flags.js as having side-effects to make
+          // sure it gets included in the final bundle
+          if (id === path.join(__dirname, '..', 'src', 'feature-flags.js')) {
+            return {
+              moduleSideEffects: true,
+            };
+          }
+        },
+      },
     ],
   };
 }

--- a/packages/ibm-products/src/index.js
+++ b/packages/ibm-products/src/index.js
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import './feature-flags';
+
 export { pkg } from './settings';
 export { usePrefix } from './global/js/hooks';
 export * from './components';

--- a/packages/ibm-products/src/index.ts
+++ b/packages/ibm-products/src/index.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import './feature-flags';
+
 export { pkg } from './settings';
 export { usePrefix } from './global/js/hooks';
 export * from './components';


### PR DESCRIPTION
Closes #5468 

Adds missing imports of `feature-flags` file as well as an update in build script to mark `feature-flags.js` as a side effect, in order for it to be included in our build output.

#### What did you change?
```
packages/ibm-products/scripts/build.js
packages/ibm-products/src/index.js
packages/ibm-products/src/index.ts
```
#### How did you test and verify your work?
Confirmed that `feature-flags.js` was included in `es` and `lib` after running build script.