### PR TITLE
refactor(useRowIsMouseOver): implement types

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useRowIsMouseOver.ts
+++ b/packages/ibm-products/src/components/Datagrid/useRowIsMouseOver.ts
@@ -8,17 +8,19 @@
 
 import { useState, useCallback } from 'react';
 import debounce from 'lodash/debounce';
+import { Hooks, RowPropGetter, TableInstance } from 'react-table';
+import { DataGridState } from './types';
 
-const useRowIsMouseOver = (hooks) => {
-  const useInstance = (instance) => {
-    const [mouseOverRowIndex, setMouseOverRowIndex] = useState();
+const useRowIsMouseOver = (hooks: Hooks) => {
+  const useInstance = (instance: TableInstance) => {
+    const [mouseOverRowIndex, setMouseOverRowIndex] = useState<number>();
 
-    const onMouseChange = useDebounce((datagridState) => {
+    const onMouseChange = useDebounce((datagridState: DataGridState) => {
       const { row } = datagridState;
-      setMouseOverRowIndex(row.index);
+      setMouseOverRowIndex(row?.index);
     }, 100);
 
-    const getRowProps = (props, datagridState) => {
+    const getRowProps = (props, datagridState: DataGridState) => {
       const onMouseOver = () => onMouseChange(datagridState);
       return [props, { onMouseOver }];
     };
@@ -34,13 +36,13 @@ const useRowIsMouseOver = (hooks) => {
       withMouseHover: true,
       setMouseOverRowIndex,
     });
-    hooks.getRowProps.push(getRowProps);
+    hooks.getRowProps.push(getRowProps as RowPropGetter<any>);
   };
 
   hooks.useInstance.push(useInstance);
 };
 
-const useDebounce = (fn, wait) =>
+const useDebounce = (fn: (state: DataGridState) => void, wait: number) =>
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useCallback(debounce(fn, wait), []);
 


### PR DESCRIPTION
Closes #5183 

#### What did you change?
`packages/ibm-products/src/components/Datagrid/useRowIsMouseOver.ts`

#### How did you test and verify your work?
Storybook