### PR TITLE
fix(Dataspreadsheets): don't append new line when we hit enter

### DIFF
--- a/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheet.tsx
+++ b/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheet.tsx
@@ -916,9 +916,11 @@ export let DataSpreadsheet = React.forwardRef(
               updateData,
             })}
             onChange={(event) => {
-              setCellEditorValue(event.target.value);
-              if (cellEditorRulerRef?.current) {
-                cellEditorRulerRef.current.textContent = event.target.value;
+              if (previousState.isEditing) {
+                setCellEditorValue(event.target.value);
+                if (cellEditorRulerRef?.current) {
+                  cellEditorRulerRef.current.textContent = event.target.value;
+                }
               }
             }}
             ref={cellEditorRef as LegacyRef<HTMLTextAreaElement>}


### PR DESCRIPTION
Closes #

https://github.com/carbon-design-system/ibm-products/issues/5330

#### What did you change?

If previous state wasn't in edit mode, then don't append the new line. I checked the storybook before this change and there wasn't a way to do new line through any commands that I found. So this doesn't regress anything. Thanks!

#### How did you test and verify your work?

Storybook


https://github.com/carbon-design-system/ibm-products/assets/10100397/62512d95-c05b-4839-8a5b-9444de88cc40

