### PR TITLE
refactor(useExpandedRow): add typescript types

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/types/index.ts
+++ b/packages/ibm-products/src/components/Datagrid/types/index.ts
@@ -266,7 +266,7 @@ export interface DataGridState<T extends object = any>
   loadMoreThreshold?: number;
   onRowClick?: (row, event) => void;
   onSort?: boolean;
-  expandedContentHeight?: boolean;
+  expandedContentHeight?: number;
   onRowExpand?: (
     row: DatagridRow,
     event: React.MouseEvent<HTMLElement>

--- a/packages/ibm-products/src/components/Datagrid/types/index.ts
+++ b/packages/ibm-products/src/components/Datagrid/types/index.ts
@@ -266,6 +266,12 @@ export interface DataGridState<T extends object = any>
   loadMoreThreshold?: number;
   onRowClick?: (row, event) => void;
   onSort?: boolean;
+  expandedContentHeight?: boolean;
+  onRowExpand?: (
+    row: DatagridRow,
+    event: React.MouseEvent<HTMLElement>
+  ) => void;
+  ExpandedRowContentComponent?: JSXElementConstructor<any>;
 }
 
 // DatagridHeaderRow related types

--- a/packages/ibm-products/src/components/Datagrid/useExpandedRow.ts
+++ b/packages/ibm-products/src/components/Datagrid/useExpandedRow.ts
@@ -8,16 +8,18 @@
 import { useState } from 'react';
 import DatagridExpandedRow from './Datagrid/DatagridExpandedRow';
 import useRowExpander from './useRowExpander';
+import { Hooks, TableInstance } from 'react-table';
+import { DataGridState, DatagridRow } from './types';
 
-const useExpandedRow = (hooks) => {
+const useExpandedRow = (hooks: Hooks) => {
   useRowExpander(hooks);
-  const useInstance = (instance) => {
+  const useInstance = (instance: TableInstance) => {
     const {
       rows,
       expandedContentHeight,
       ExpandedRowContentComponent,
       onRowExpand,
-    } = instance;
+    } = instance as DataGridState;
     const [expandedRowsHeight, setExpandedRowsHeight] = useState({});
     const setExpandedRowHeight = (rowIndex, height) =>
       setExpandedRowsHeight({ ...expandedRowsHeight, [rowIndex]: height });
@@ -26,8 +28,11 @@ const useExpandedRow = (hooks) => {
       canExpand: row.original && !row.original.notExpandable,
       expandedContentHeight:
         expandedRowsHeight[row.index] || expandedContentHeight,
-      RowExpansionRenderer: DatagridExpandedRow(ExpandedRowContentComponent),
-      onClick: (row, event) => onRowExpand?.(row, event),
+      RowExpansionRenderer:
+        ExpandedRowContentComponent &&
+        DatagridExpandedRow(ExpandedRowContentComponent),
+      onClick: (row: DatagridRow, event: React.MouseEvent<HTMLElement>) =>
+        onRowExpand?.(row, event),
     }));
     Object.assign(instance, {
       rows: rowsWithExpand,


### PR DESCRIPTION
Closes #5180 

Add Typescript types to useExpandedRow

#### What did you change?
Changed `packages/ibm-products/src/components/Datagrid/useExpandedRow.js `to `packages/ibm-products/src/components/Datagrid/useExpandedRow.ts`

#### How did you test and verify your work?

- Storybook
- Yarn test
