### PR TITLE
fix: import feature flags to prevent them from being tree shook away for webpack builds

### DIFF
--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -18,9 +18,7 @@
     "**/global/js/utils/props-helper.js",
     "**/*.css",
     "**/*.scss",
-    "es/feature-flags.js",
-    "lib/feature-flags.js",
-    "src/feature-flags.js"
+    "**/feature-flags.js"
   ],
   "files": [
     "css",

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.tsx
@@ -4,7 +4,7 @@
 //  * This source code is licensed under the Apache-2.0 license found in the
 //  * LICENSE file in the root directory of this source tree.
 //  */
-
+import '../../../feature-flags';
 import { FilterContext, FilterPanel } from './addons/Filtering';
 import React, { useContext, ForwardedRef, useRef, useEffect } from 'react';
 import { Table, TableContainer } from '@carbon/react';

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/TearsheetWrapper.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/TearsheetWrapper.js
@@ -3,7 +3,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
+import '../../../../../feature-flags';
 import React, { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import CustomizeColumnsTearsheet from './CustomizeColumnsTearsheet';

--- a/packages/ibm-products/src/global/js/hooks/usePortalTarget.js
+++ b/packages/ibm-products/src/global/js/hooks/usePortalTarget.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import '../../../feature-flags';
 import { useState, useEffect, useCallback } from 'react';
 import { pkg } from '../../../settings';
 import { createPortal } from 'react-dom';


### PR DESCRIPTION
Closes #5468

This PR resolves issues with feature flags specifically for webpack builds. https://github.com/carbon-design-system/ibm-products/pull/5469 fixed most of the issues however, the `feature-flags.js` file was still being tree shook by webpack even though it is listed in our `package.json`.

I tested through some trial and error by publishing our package separately under my own npm account and then created a test app using webpack. I discovered that importing the `feature-flags.js` file from the file that uses it prevents webpack from tree shaking the file so this resolves the issue.

#### What did you change?
```
packages/ibm-products/package.json
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.tsx
packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/TearsheetWrapper.js
packages/ibm-products/src/global/js/hooks/usePortalTarget.js
```
#### How did you test and verify your work?
Published package outside of `@carbon/ibm-products` to be able to test and confirm that these changes worked as expected