### PR TITLE
docs(storybook): remove storybook doc and codesandbox example

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.mdx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.mdx
@@ -937,11 +937,6 @@ according to their persistent strategy.
     - Callback function when 'Save' button clicked on the narrow tearsheet. It
       allows consumer to preserve the updated column preference. This output can
       also be used to compute the `hiddenColumns` and `columnOrder`
-- Reset to default (optional)
-  - There is a reset to default button on the modal. It will use the
-    `options.columns` as the default. If there are columns should be hidden by
-    default, denote them with property: `isVisible: false` (undefined will be
-    treated as `true`)
 
 ```jsx
 const columns = React.useMemo(() => defaultHeader, []);

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories/CustomizeColumnStory.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories/CustomizeColumnStory.js
@@ -21,8 +21,6 @@ const notes = `
     - \`options.customizeColumnsProps.onSaveColumnPrefs\`
       - type: \`Function(Columns: Array<{ColumnId: String, isVisible: Boolean}>) => void\`
       - It's a callback function when 'Save' button clicked on the modal. It allows consumer to preserve the updated column preference. This output can also be used to compute the \`hiddenColumns\` and \`columnOrder\`
-  - (optional) Reset to default
-    - There is a reset to default button on the modal. It will use the \`options.columns\` as the default. If there are columns should be hidden by default, denote them with property: \`isVisible: false\` (undefined will be treated as \`true\`)
 
   code snippet:
 
@@ -60,7 +58,7 @@ const notes = `
       <IntlProvider locale="en">
         <Datagrid {...datagridState} />
         <div>
-          Hidden column ids: 
+          Hidden column ids:
           <pre>{JSON.stringify(datagridState.state.hiddenColumns, null, 2)}</pre>
         </div>
       </IntlProvider>

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.jsx
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.jsx
@@ -38,6 +38,7 @@ export default {
     docs: {
       page: () => (
         <StoryDocsPage
+          omitCodedExample
           blocks={[
             {
               title: 'Row click',

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.docs-page.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.docs-page.js
@@ -10,6 +10,7 @@ import { StoryDocsPage } from '../../../../global/js/utils/StoryDocsPage';
 
 export const DocsPage = () => (
   <StoryDocsPage
+    omitCodedExample
     blocks={[
       {
         title: 'Customizing columns',

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.docs-page.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.docs-page.js
@@ -29,8 +29,6 @@ export const DocsPage = () => (
   - \`options.customizeColumnsProps.onSaveColumnPrefs\`
     - type: \`Function(Columns: Array<{ColumnId: String, isVisible: Boolean}>) => void\`
     - Callback function when 'Save' button clicked on the narrow tearsheet. It allows consumer to preserve the updated column preference. This output can also be used to compute the \`hiddenColumns\` and \`columnOrder\`
-  - Reset to default (optional)
-    - There is a reset to default button on the modal. It will use the \`options.columns\` as the default. If there are columns should be hidden by default, denote them with property: \`isVisible: false\` (undefined will be treated as \`true\`).
         `,
         source: {
           code: `

--- a/packages/ibm-products/src/components/Datagrid/Extensions/EditableCell/EditableCell.docs-page.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/EditableCell/EditableCell.docs-page.js
@@ -7,6 +7,7 @@ import {
 
 export const DocsPage = () => (
   <StoryDocsPage
+    omitCodedExample
     blocks={[
       {
         description: `The \`Datagrid\` supports inline editing when used with the \`useEditableCell\` hook (previously named \`useInlineEdit\` in v1) and columns are provided the required configuration. The four data types supported are strings, numbers, dates, and
@@ -14,7 +15,7 @@ export const DocsPage = () => (
       },
       {
         description: `Below are example column configurations for the supported inline edit data types:
-        
+
 Default/string:
         `,
         source: {

--- a/packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.docs-page.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.docs-page.js
@@ -3,6 +3,7 @@ import { StoryDocsPage } from '../../../../global/js/utils/StoryDocsPage';
 
 export const DocsPage = () => (
   <StoryDocsPage
+    omitCodedExample
     blocks={[
       {
         description: `The \`Datagrid\` supports expandable rows with the use of the \`useExpandedRow\` hook.`,
@@ -25,7 +26,7 @@ const App = () => {
       data,
       ExpandedRowContentComponent: expansionRenderer,
       expanderButtonTitleExpanded: 'Collapse row',
-      expanderButtonTitleCollapsed: 'Expand row', 
+      expanderButtonTitleCollapsed: 'Expand row',
     },
     useExpandedRow
   );

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Filtering.docs-page.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Filtering.docs-page.js
@@ -10,6 +10,7 @@ import { StoryDocsPage } from '../../../../global/js/utils/StoryDocsPage';
 
 export const DocsPage = () => (
   <StoryDocsPage
+    omitCodedExample
     blocks={[
       {
         title: 'Filtering',

--- a/packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.jsx
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.jsx
@@ -30,6 +30,7 @@ export default {
     docs: {
       page: () => (
         <StoryDocsPage
+          omitCodedExample
           blocks={[
             {
               title: 'Nested rows',

--- a/packages/ibm-products/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.docs-page.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.docs-page.js
@@ -3,6 +3,7 @@ import { StoryDocsPage } from '../../../../global/js/utils/StoryDocsPage';
 
 export const DocsPage = () => (
   <StoryDocsPage
+    omitCodedExample
     blocks={[
       {
         title: 'Actions column',

--- a/packages/ibm-products/src/components/Datagrid/Extensions/RowHeightSettings/RowHeightSettings.stories.jsx
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/RowHeightSettings/RowHeightSettings.stories.jsx
@@ -16,6 +16,7 @@ import { DatagridActions } from '../../utils/DatagridActions';
 import { DatagridPagination } from '../../utils/DatagridPagination';
 import { makeData } from '../../utils/makeData';
 import { ARG_TYPES } from '../../utils/getArgTypes';
+import { StoryDocsPage } from '../../../../global/js/utils/StoryDocsPage';
 
 export default {
   title: 'IBM Products/Components/Datagrid/RowHeightSettings',
@@ -23,6 +24,9 @@ export default {
   tags: ['autodocs'],
   parameters: {
     styles,
+    docs: {
+      page: () => <StoryDocsPage omitCodedExample />,
+    },
     layout: 'fullscreen',
     // docs: { page: mdx },
   },

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Slug/Slug.stories.jsx
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Slug/Slug.stories.jsx
@@ -34,6 +34,7 @@ export default {
     docs: {
       page: () => (
         <StoryDocsPage
+          omitCodedExample
           blocks={[
             {
               description:


### PR DESCRIPTION
Closes #5273 
Contributes to #5016 

Remove the "reset to default" documentation from Storybook as we do not have any design documentation around that feature and it has not been implemented.

Also remove the codesandbox/stackblitz links for non-existent Datagrid extension stories

#### What did you change?

- Remove "reset to default" documentation from 
```
- packages/ibm-products/src/components/Datagrid/Datagrid.mdx
- packages/ibm-products/src/components/Datagrid/Datagrid.stories/CustomizeColumnStory.js
- packages/ibm-products/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.docs-page.js
```

- Add `omitCodedExample` prop to the `StoryDocsPage` component for
```
components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.jsx
components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.docs-page.js
components/Datagrid/Extensions/EditableCell/EditableCell.docs-page.js
components/Datagrid/Extensions/ExpandableRow/ExpandableRow.docs-page.js
components/Datagrid/Extensions/Filtering/Filtering.docs-page.js
components/Datagrid/Extensions/NestedRows/NestedRows.stories.jsx
components/Datagrid/Extensions/RowActionButtons/RowActionButtons.docs-page.js
components/Datagrid/Extensions/RowHeightSettings/RowHeightSettings.stories.jsx
components/Datagrid/Extensions/Slug/Slug.stories.jsx
```

#### How did you test and verify your work?

storybook
