### PR TITLE
refactor(useColumnCenterAlign): add typescript types

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/types/index.ts
+++ b/packages/ibm-products/src/components/Datagrid/types/index.ts
@@ -14,10 +14,12 @@ import {
 } from 'react';
 import {
   Cell,
+  Column,
   ColumnInstance,
   FilterValue,
   Filters,
   HeaderGroup,
+  Meta,
   Row,
   TableCommonProps,
   TableDispatch,
@@ -295,3 +297,9 @@ export interface ResizeHeaderProps {
   resizerAriaLabel?: string;
   isFetching?: boolean;
 }
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type VisibleColumns<T extends object = {}> = (
+  allColumns: Array<ColumnInstance<T>>,
+  meta: Meta<T>
+) => Array<Column<T>>;

--- a/packages/ibm-products/src/components/Datagrid/types/index.ts
+++ b/packages/ibm-products/src/components/Datagrid/types/index.ts
@@ -134,6 +134,10 @@ export interface DatagridColumn<T extends object = any>
   extends ColumnInstance<T> {
   sticky?: 'left' | 'right';
   className?: string;
+  disableSortBy?: boolean;
+  centerAlignedColumn?: boolean;
+  Cell?: (props: any) => ReactNode;
+  Header?: (props: any) => ReactNode | any;
 }
 
 export interface DataGridCell<T extends object = any>
@@ -266,6 +270,7 @@ export interface DataGridState<T extends object = any>
   loadMoreThreshold?: number;
   onRowClick?: (row, event) => void;
   onSort?: boolean;
+  column?: DatagridColumn;
 }
 
 // DatagridHeaderRow related types

--- a/packages/ibm-products/src/components/Datagrid/useColumnCenterAlign.tsx
+++ b/packages/ibm-products/src/components/Datagrid/useColumnCenterAlign.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,7 +9,12 @@ import React from 'react';
 import cx from 'classnames';
 import { pkg } from '../../settings';
 import { Hooks } from 'react-table';
-import { DataGridHeader, DataGridState, DatagridColumn } from './types';
+import {
+  DataGridHeader,
+  DataGridState,
+  DatagridColumn,
+  VisibleColumns,
+} from './types';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
@@ -44,16 +49,16 @@ const useColumnCenterAlign = (hooks: Hooks) => {
     const columnsWithDefaultCells = columns.map((column) => ({
       ...column,
       Cell: column.centerAlignedColumn
-        ? (tableProp) => centerAlignRenderer(tableProp, column)
+        ? (tableProp: DataGridState) => centerAlignRenderer(tableProp, column)
         : column.Cell,
       Header: column.centerAlignedColumn
-        ? (headerProp) => centerAlignHeader(headerProp, column)
+        ? (headerProp: DataGridHeader) => centerAlignHeader(headerProp, column)
         : column.Header,
     }));
     return [...columnsWithDefaultCells];
   };
 
-  hooks.visibleColumns.push(centerAlignedColumns);
+  hooks.visibleColumns.push(centerAlignedColumns as VisibleColumns);
 };
 
 export default useColumnCenterAlign;

--- a/packages/ibm-products/src/components/Datagrid/useColumnCenterAlign.tsx
+++ b/packages/ibm-products/src/components/Datagrid/useColumnCenterAlign.tsx
@@ -8,23 +8,31 @@
 import React from 'react';
 import cx from 'classnames';
 import { pkg } from '../../settings';
+import { Hooks } from 'react-table';
+import { DataGridHeader, DataGridState, DatagridColumn } from './types';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
-const useColumnCenterAlign = (hooks) => {
-  const centerAlignRenderer = (tableProps, column) => (
+const useColumnCenterAlign = (hooks: Hooks) => {
+  const centerAlignRenderer = (
+    tableProps: DataGridState,
+    column: DatagridColumn
+  ) => (
     <div
       className={cx(`${blockClass}__center-align-cell-renderer`, {
         sortDisabled:
           !tableProps.isTableSortable ||
-          tableProps.column.disableSortBy === true,
+          (tableProps.column && tableProps.column.disableSortBy === true),
       })}
     >
-      {column.Cell(tableProps)}
+      {column.Cell && column.Cell(tableProps)}
     </div>
   );
 
-  const centerAlignHeader = (headerProp, column) => (
+  const centerAlignHeader = (
+    headerProp: DataGridHeader,
+    column: DatagridColumn
+  ) => (
     <div className={`${blockClass}__center-align-header`}>
       {typeof column.Header === 'function'
         ? column.Header(headerProp)
@@ -32,7 +40,7 @@ const useColumnCenterAlign = (hooks) => {
     </div>
   );
 
-  const centerAlignedColumns = (columns) => {
+  const centerAlignedColumns = (columns: DatagridColumn[]) => {
     const columnsWithDefaultCells = columns.map((column) => ({
       ...column,
       Cell: column.centerAlignedColumn


### PR DESCRIPTION
Closes #5184 

Add Typescript types to useColumnCenterAlign Datagrid hook

#### What did you change?
Changed `packages/ibm-products/src/components/Datagrid/useColumnCenterAlign.js` to `packages/ibm-products/src/components/Datagrid/useColumnCenterAlign.tsx`

#### How did you test and verify your work?
Storybook
