### PR TITLE
refactor(useInlineEdit): add typescript types

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useInlineEdit.tsx
+++ b/packages/ibm-products/src/components/Datagrid/useInlineEdit.tsx
@@ -9,10 +9,12 @@ import React from 'react';
 import { pkg } from '../../settings';
 import cx from 'classnames';
 import { InlineEditCell } from './Datagrid/addons/InlineEdit/InlineEditCell';
+import { Hooks, TableInstance } from 'react-table';
+import { DataGridState } from './types';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
-const useInlineEdit = (hooks) => {
+const useInlineEdit = (hooks: Hooks) => {
   const addInlineEdit = (props, { cell, instance }) => {
     const columnInlineEditConfig = cell.column.inlineEdit;
     const inlineEditType = cell.column?.inlineEdit?.type;
@@ -24,7 +26,7 @@ const useInlineEdit = (hooks) => {
         tabIndex={-1}
         value={cell.value}
         cell={cell}
-        isDisabled={isDisabled}
+        disabledCell={isDisabled}
         instance={instance}
         type={type}
       />
@@ -73,8 +75,8 @@ const useInlineEdit = (hooks) => {
     ];
   };
   hooks.getCellProps.push(addInlineEdit);
-  hooks.useInstance.push((instance) => {
-    Object.assign(instance, {
+  hooks.useInstance.push((instance: TableInstance) => {
+    Object.assign(instance as DataGridState, {
       withInlineEdit: true,
     });
   });


### PR DESCRIPTION
Closes #5192 

Converted packages/ibm-products/src/components/Datagrid/useInlineEdit.js to packages/ibm-products/src/components/Datagrid/useInlineEdit.tsx

#### What did you change? packages/ibm-products/src/components/Datagrid/useInlineEdit.tsx

#### How did you test and verify your work? storybook
