### PR TITLE
fix(SidePanel): acton toolbar style issue

### DIFF
--- a/packages/ibm-products/src/components/SidePanel/SidePanel.stories.jsx
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.stories.jsx
@@ -605,19 +605,23 @@ WithStaticTitleAndActionToolbar.args = {
   includeOverlay: true,
   actionToolbarButtons: [
     {
+      leading: true,
       label: 'Copy',
       icon: (props) => <Copy size={16} {...props} />,
       onClick: action('Action toolbar button clicked: Copy'),
+      kind: 'primary',
     },
     {
       label: 'Settings',
       icon: (props) => <Settings size={16} {...props} />,
       onClick: action('Action toolbar button clicked: Settings'),
+      hasIconOnly: true,
     },
     {
       label: 'Delete',
       icon: (props) => <TrashCan size={16} {...props} />,
       onClick: action('Action toolbar button clicked: Delete'),
+      hasIconOnly: true,
     },
   ],
 };


### PR DESCRIPTION
Closes #5437 

Fixed the style of story With static title and action toolbar. Now the style is similar to With action toolbar story

#### What did you change? packages/ibm-products/src/components/SidePanel/SidePanel.stories.jsx

#### How did you test and verify your work? storybook
