### PR TITLE
test(SearchBar): add default avt testing

### DIFF
--- a/e2e/components/SearchBar/SearchBar-test.avt.e2e.js
+++ b/e2e/components/SearchBar/SearchBar-test.avt.e2e.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../test-utils/storybook';
+
+test.describe('SearchBar @avt', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'SearchBar',
+      id: 'ibm-products-components-search-bar-searchbar--default',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('SearchBar @avt-default-state');
+  });
+});


### PR DESCRIPTION
Closes [#5217](https://github.com/carbon-design-system/ibm-products/issues/5217)

#### What did you change?
Added avt test file for SearchBar component

#### How did you test and verify your work?
`yarn avt`