### PR TITLE
test(BigNumbers): add default avt test

### DIFF
--- a/e2e/components/BigNumbers/BigNumbers-test.avt.e2e.js
+++ b/e2e/components/BigNumbers/BigNumbers-test.avt.e2e.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../test-utils/storybook';
+
+test.describe('Cascade @avt', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'BigNumbers',
+      id: 'ibm-products-components-big-numbers-bignumbers--big-numbers',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('BigNumbers @avt-default-state');
+  });
+});


### PR DESCRIPTION
Closes #5206

#### What did you change?
Added default avt test for BigNumbers

#### How did you test and verify your work?
Ran `yarn avt`