### PR TITLE
chore(FullPageError): add docs and fix example

### DIFF
--- a/docs/guides/security-component-migration.md
+++ b/docs/guides/security-component-migration.md
@@ -60,7 +60,7 @@ v2 will receive weekly releases occurring every Tuesday morning.
 | `DelimitedList`                    | View changes [here](#delimitedlist)                                                                               | `@carbon/ibm-products` | Low    |
 | `Dropdown`                         | [Carbon v11 Migration guide][111]                                                                                 | `@carbon/react`        | Low    |
 | `DropdownSkeleton`                 | The deprecated prop `inline` has been removed                                                                     | `@carbon/react`        | Low    |
-| `ErrorPage`                        | **Deprecated:** [View replacement][4]                                                                             | `@carbon/ibm-products` | High   |
+| `ErrorPage`                        | **Deprecated:** [~~View replacement~~][4] [View replacement][9]                                                   | `@carbon/ibm-products` | High   |
 | `ExpandableTile`                   | [Carbon v11 Migration guide][112]                                                                                 | `@carbon/react`        | Low    |
 | `ExternalLink`                     | **Deprecated:** [View replacement][5]                                                                             | `@carbon/react`        | Medium |
 | `FileUploader`                     | [Carbon v11 Migration guide][113]                                                                                 | `@carbon/react`        | Low    |
@@ -84,6 +84,9 @@ v2 will receive weekly releases occurring every Tuesday morning.
 | `Header`                           | **Deprecated:** [View replacement][6]                                                                             | `@carbon/ibm-products` | Medium |
 | `HeaderMenu`                       | Updated from a class to functional component                                                                      | `@carbon/react`        | Low    |
 | `HeaderNavigation`                 | Updated from a class to functional component                                                                      | `@carbon/react`        | Low    |
+| `HTTPError403`                     | **Deprecated:** [View replacement][9]                                                                             | `@carbon/ibm-products` | Low    |
+| `HTTPError404`                     | **Deprecated:** [View replacement][9]                                                                             | `@carbon/ibm-products` | Low    |
+| `HTTPErrorOther`                   | **Deprecated:** [View replacement][9]                                                                             | `@carbon/ibm-products` | Low    |
 | `ICA`                              | **Renamed:** See [Big Numbers](#bignumbers)                                                                       | `@carbon/ibm-products` | Low    |
 | `Icon`                             | **Removed:** [View replacement][16]                                                                               | `@carbon/react`        | Medium |
 | `IconButton`                       | **Deprecated:** [View replacement][7]                                                                             | `@carbon/react`        | High   |

--- a/docs/guides/security-component-migration.md
+++ b/docs/guides/security-component-migration.md
@@ -60,7 +60,7 @@ v2 will receive weekly releases occurring every Tuesday morning.
 | `DelimitedList`                    | View changes [here](#delimitedlist)                                                                               | `@carbon/ibm-products` | Low    |
 | `Dropdown`                         | [Carbon v11 Migration guide][111]                                                                                 | `@carbon/react`        | Low    |
 | `DropdownSkeleton`                 | The deprecated prop `inline` has been removed                                                                     | `@carbon/react`        | Low    |
-| `ErrorPage`                        | **Deprecated:** [~~View replacement~~][4] [View replacement][9]                                                   | `@carbon/ibm-products` | High   |
+| `ErrorPage`                        | **Deprecated:** [View replacement][9]                                                                             | `@carbon/ibm-products` | Low    |
 | `ExpandableTile`                   | [Carbon v11 Migration guide][112]                                                                                 | `@carbon/react`        | Low    |
 | `ExternalLink`                     | **Deprecated:** [View replacement][5]                                                                             | `@carbon/react`        | Medium |
 | `FileUploader`                     | [Carbon v11 Migration guide][113]                                                                                 | `@carbon/react`        | Low    |

--- a/docs/guides/v2.md
+++ b/docs/guides/v2.md
@@ -15,56 +15,56 @@ v1 and v2 will both receive weekly releases occurring every Tuesday morning.
 
 ## List of component changes
 
-| Component                 | Changes                                |
-| ------------------------- | -------------------------------------- |
-| AboutModal                | View changes [here](#aboutmodal)       |
-| APIKeyModal               | No API changes.                        |
-| ActionBar                 | View changes [here](#actionbar)        |
-| Cascade                   | No API changes.                        |
-| CreateModal               | No API changes.                        |
-| CreateFullPage            | No API changes.                        |
-| CreateFullPageStep        | No API changes.                        |
-| CreateSidePanel           | No API changes.                        |
-| CreateTearsheetNarrow     | No API changes.                        |
-| CreateTearsheet           | No API changes.                        |
-| CreateTearsheetStep       | No API changes.                        |
-| DataSpreadsheet           | No API changes.                        |
-| Datagrid                  | View changes [here](#datagrid)         |
-| EditInPlace               | View changes [here](#editinplace)      |
-| EditSidePanel             | View changes [here](#editsidepanel)    |
-| EditTearsheet             | No API changes.                        |
-| EditTearsheetNarrow       | No API changes.                        |
-| EditFullPage              | No API changes.                        |
-| EditUpdateCards           | No API changes.                        |
-| EmptyState                | View changes [here](#emptystate)       |
-| ExportModal               | No API changes.                        |
-| ExpressiveCard            | View changes [here](#expressivecard)   |
-| HTTPError403              | View changes [here](#fullpageerror)    |
-| HTTPError404              | View changes [here](#fullpageerror)    |
-| HTTPErrorOther            | View changes [here](#fullpageerror)    |
-| ImportModal               | No API changes.                        |
-| InlineEdit                | View changes [here](#inlineedit)       |
-| ModifiedTabs              | This component is deprecated in v2     |
-| MultiAddSelect            | No API changes.                        |
-| NotificationsPanel        | No API changes.                        |
-| OptionsTile               | No API changes.                        |
-| PageHeader                | No API changes.                        |
-| ProductiveCard            | View changes [here](#productivecard)   |
-| RemoveModal               | No API changes.                        |
-| Saving                    | No API changes.                        |
-| SidePanel                 | View changes [here](#sidepanel)        |
-| SingleAddSelect           | No API changes.                        |
-| StatusIcon                | View changes [here](#statusicon)       |
-| TagSet                    | View changes [here](#tagset)           |
-| Tearsheet                 | No API changes.                        |
-| TearsheetNarrow           | No API changes.                        |
-| Toolbar                   | No API changes.                        |
-| ToolbarButton             | View changes [here](#toolbarbutton)    |
-| ToolbarGroup              | No API changes.                        |
-| UserProfileImage          | View changes [here](#userprofileimage) |
-| WebTerminal               | No API changes.                        |
-| WebTerminalContentWrapper | No API changes.                        |
-| WebTerminalProvider       | No API changes.                        |
+| Component                 | Changes                                            |
+| ------------------------- | -------------------------------------------------- |
+| AboutModal                | View changes [here](#aboutmodal)                   |
+| APIKeyModal               | No API changes.                                    |
+| ActionBar                 | View changes [here](#actionbar)                    |
+| Cascade                   | No API changes.                                    |
+| CreateModal               | No API changes.                                    |
+| CreateFullPage            | No API changes.                                    |
+| CreateFullPageStep        | No API changes.                                    |
+| CreateSidePanel           | No API changes.                                    |
+| CreateTearsheetNarrow     | No API changes.                                    |
+| CreateTearsheet           | No API changes.                                    |
+| CreateTearsheetStep       | No API changes.                                    |
+| DataSpreadsheet           | No API changes.                                    |
+| Datagrid                  | View changes [here](#datagrid)                     |
+| EditInPlace               | View changes [here](#editinplace)                  |
+| EditSidePanel             | View changes [here](#editsidepanel)                |
+| EditTearsheet             | No API changes.                                    |
+| EditTearsheetNarrow       | No API changes.                                    |
+| EditFullPage              | No API changes.                                    |
+| EditUpdateCards           | No API changes.                                    |
+| EmptyState                | View changes [here](#emptystate)                   |
+| ExportModal               | No API changes.                                    |
+| ExpressiveCard            | View changes [here](#expressivecard)               |
+| HTTPError403              | No API changes. New version [here](#fullpageerror) |
+| HTTPError404              | No API changes. New version [here](#fullpageerror) |
+| HTTPErrorOther            | No API changes. New version [here](#fullpageerror) |
+| ImportModal               | No API changes.                                    |
+| InlineEdit                | View changes [here](#inlineedit)                   |
+| ModifiedTabs              | This component is deprecated in v2                 |
+| MultiAddSelect            | No API changes.                                    |
+| NotificationsPanel        | No API changes.                                    |
+| OptionsTile               | No API changes.                                    |
+| PageHeader                | No API changes.                                    |
+| ProductiveCard            | View changes [here](#productivecard)               |
+| RemoveModal               | No API changes.                                    |
+| Saving                    | No API changes.                                    |
+| SidePanel                 | View changes [here](#sidepanel)                    |
+| SingleAddSelect           | No API changes.                                    |
+| StatusIcon                | View changes [here](#statusicon)                   |
+| TagSet                    | View changes [here](#tagset)                       |
+| Tearsheet                 | No API changes.                                    |
+| TearsheetNarrow           | No API changes.                                    |
+| Toolbar                   | No API changes.                                    |
+| ToolbarButton             | View changes [here](#toolbarbutton)                |
+| ToolbarGroup              | No API changes.                                    |
+| UserProfileImage          | View changes [here](#userprofileimage)             |
+| WebTerminal               | No API changes.                                    |
+| WebTerminalContentWrapper | No API changes.                                    |
+| WebTerminalProvider       | No API changes.                                    |
 
 ### AboutModal
 
@@ -110,13 +110,13 @@ v1 and v2 will both receive weekly releases occurring every Tuesday morning.
 
 ### FullPageError
 
-- `HTTPError403`,`HTTPError404`, `HTTPErrorOther` have been deprecated, and is
-  been replaced by `FullPageError`
+- `HTTPError403`,`HTTPError404`, `HTTPErrorOther` are deprecated and will be
+  removed in the next major version. Please migrate to `FullPageError`, view
+  [docs](https://ibm-products.carbondesignsystem.com/?path=/docs/ibm-products-patterns-full-page-error-fullpageerror--docs).
 
 - `errorCodeLabel` --> `label`
 
-- `links` prop is removed and they need to be passed as children instead of a
-  prop
+- `links` prop is removed; links can be passed as children instead
 
 - New `kind` prop: `'404', '403', 'custom'`
 

--- a/docs/guides/v2.md
+++ b/docs/guides/v2.md
@@ -39,9 +39,9 @@ v1 and v2 will both receive weekly releases occurring every Tuesday morning.
 | EmptyState                | View changes [here](#emptystate)       |
 | ExportModal               | No API changes.                        |
 | ExpressiveCard            | View changes [here](#expressivecard)   |
-| HTTPError403              | No API changes.                        |
-| HTTPError404              | No API changes.                        |
-| HTTPErrorOther            | No API changes.                        |
+| HTTPError403              | View changes [here](#fullpageerror)    |
+| HTTPError404              | View changes [here](#fullpageerror)    |
+| HTTPErrorOther            | View changes [here](#fullpageerror)    |
 | ImportModal               | No API changes.                        |
 | InlineEdit                | View changes [here](#inlineedit)       |
 | ModifiedTabs              | This component is deprecated in v2     |
@@ -107,6 +107,11 @@ v1 and v2 will both receive weekly releases occurring every Tuesday morning.
 ### ExpressiveCard
 
 - `pictogram` can now be either a function or object.
+
+### FullPageError
+
+- `HTTPError403`,`HTTPError404`, `HTTPErrorOther` have been deprecated, and is
+  been replaced by `FullPageError`
 
 ### IconButtonBar
 

--- a/docs/guides/v2.md
+++ b/docs/guides/v2.md
@@ -113,6 +113,13 @@ v1 and v2 will both receive weekly releases occurring every Tuesday morning.
 - `HTTPError403`,`HTTPError404`, `HTTPErrorOther` have been deprecated, and is
   been replaced by `FullPageError`
 
+- `errorCodeLabel` --> `label`
+
+- `links` prop is removed and they need to be passed as children instead of a
+  prop
+
+- New `kind` prop: `'404', '403', 'custom'`
+
 ### IconButtonBar
 
 - The IconButtonBar is removed in V2 as the existing ActionBar is a viable

--- a/examples/carbon-for-ibm-products/FullPageError/src/Example/Example.jsx
+++ b/examples/carbon-for-ibm-products/FullPageError/src/Example/Example.jsx
@@ -8,11 +8,8 @@ import React from 'react';
 // from the @carbon/ibm-products component library.
 // ----------------------------------------------------
 import { FullPageError } from '@carbon/ibm-products';
-// import { pkg } from '@carbon/ibm-products';
 import { Link } from '@carbon/react';
 import './_example.scss';
-
-// pkg.component.FullPageError = true;
 export const Example = () => (
   <FullPageError
     kind="custom"

--- a/examples/carbon-for-ibm-products/FullPageError/src/Example/Example.jsx
+++ b/examples/carbon-for-ibm-products/FullPageError/src/Example/Example.jsx
@@ -7,18 +7,25 @@ import React from 'react';
 // AboutModal component
 // from the @carbon/ibm-products component library.
 // ----------------------------------------------------
-
 import { FullPageError } from '@carbon/ibm-products';
 
 import './_example.scss';
 
 export const Example = () => (
-  <div className="example">
-    <CommonHeader className="header-area" />
-    <div className="content-area">
-      <FullPageError />
-    </div>
-  </div>
+  <FullPageError
+    kind="custom"
+    children={
+      <>
+        <Link href={'/'}>– Forwarding Link 1</Link>
+        <br />
+        <Link href={'/'}>– Forwarding Link 1</Link>
+      </>
+    }
+    title="[Error title]"
+    label="Error ###"
+    // cSpell:dictionaries lorem-ipsum
+    description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam."
+  />
 );
 
 export default Example;

--- a/examples/carbon-for-ibm-products/FullPageError/src/Example/Example.jsx
+++ b/examples/carbon-for-ibm-products/FullPageError/src/Example/Example.jsx
@@ -4,13 +4,15 @@ import React from 'react';
 
 // ----------------------------------------------------
 // This is an example showing use of the
-// AboutModal component
+// FullPageError component
 // from the @carbon/ibm-products component library.
 // ----------------------------------------------------
 import { FullPageError } from '@carbon/ibm-products';
-
+// import { pkg } from '@carbon/ibm-products';
+import { Link } from '@carbon/react';
 import './_example.scss';
 
+// pkg.component.FullPageError = true;
 export const Example = () => (
   <FullPageError
     kind="custom"

--- a/packages/ibm-products/src/components/FullPageError/FullPageError.mdx
+++ b/packages/ibm-products/src/components/FullPageError/FullPageError.mdx
@@ -23,7 +23,30 @@ level.
 
 ## Example usage
 
-{/* TODO: One example per designed use case. */}
+```jsx
+import { FullPageError } from "@carbon/ibm-products";
+import { Link } from "@carbon/react";
+
+export const Example = () => (
+  <FullPageError
+    kind="custom"
+    children={
+      <>
+        <Link href={"/"}>– Forwarding Link 1</Link>
+        <br />
+        <Link href={"/"}>– Forwarding Link 1</Link>
+      </>
+    }
+    title="[Error title]"
+    label="Error ###"
+    // cSpell:dictionaries lorem-ipsum
+    description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam."
+  />
+);
+
+export default Example;
+
+```
 
 ### Default
 
@@ -53,9 +76,9 @@ broken links.
   <Story of={stories.fullPageError404} />
 </Canvas>
 
-## Code sample
+{/* ## Code sample */}
 
-<CodesandboxLink exampleDirectory="FullPageError" />
+{/* <CodesandboxLink exampleDirectory="FullPageError" /> */}
 
 ## Component API
 

--- a/packages/ibm-products/src/components/FullPageError/FullPageError.mdx
+++ b/packages/ibm-products/src/components/FullPageError/FullPageError.mdx
@@ -1,5 +1,5 @@
 import { Story, Controls, Source, Canvas } from '@storybook/addon-docs';
-import { CodesandboxLink } from '../../global/js/utils/story-helper';
+import { CodesandboxLink, stackblitzHref } from '../../global/js/utils/story-helper';
 import { FullPageError } from '.';
 import * as stories from './FullPageError.stories';
 
@@ -12,6 +12,7 @@ import * as stories from './FullPageError.stories';
 - [Overview](#overview)
 - [Example usage](#example-usage)
 - [Component API](#component-api)
+  - [Migrating from HTTP errors](https://github.com/carbon-design-system/ibm-products/blob/main/docs/guides/v2.md#carbon-for-ibm-products-v2-migration-guide)
 
 ## Overview
 
@@ -76,9 +77,10 @@ broken links.
   <Story of={stories.fullPageError404} />
 </Canvas>
 
-{/* ## Code sample */}
+## Code sample
 
 {/* <CodesandboxLink exampleDirectory="FullPageError" /> */}
+<a href={stackblitzHref("FullPageError")}>Stackblitz example</a>
 
 ## Component API
 

--- a/packages/ibm-products/src/components/FullPageError/FullPageError.mdx
+++ b/packages/ibm-products/src/components/FullPageError/FullPageError.mdx
@@ -55,7 +55,7 @@ broken links.
 
 ## Code sample
 
-{/* <CodesandboxLink exampleDirectory="FullPageError" /> */}
+<CodesandboxLink exampleDirectory="FullPageError" />
 
 ## Component API
 

--- a/packages/ibm-products/src/components/HTTPErrors/HTTPError403/HTTPError403.stories.jsx
+++ b/packages/ibm-products/src/components/HTTPErrors/HTTPError403/HTTPError403.stories.jsx
@@ -36,7 +36,7 @@ const Template = (args) => {
         <div>
           This component is deprecated and will be removed in the next major
           version. Please migrate to{' '}
-          <a href="http://localhost:3000/?path=/docs/ibm-products-patterns-full-page-error-fullpageerror--docs">
+          <a href="https://ibm-products.carbondesignsystem.com/?path=/docs/ibm-products-patterns-full-page-error-fullpageerror--docs">
             FullPageError
           </a>
           .

--- a/packages/ibm-products/src/components/HTTPErrors/HTTPError404/HTTPError404.stories.jsx
+++ b/packages/ibm-products/src/components/HTTPErrors/HTTPError404/HTTPError404.stories.jsx
@@ -43,7 +43,7 @@ const Template = (args) => {
         <div>
           This component is deprecated and will be removed in the next major
           version. Please migrate to{' '}
-          <a href="http://localhost:3000/?path=/docs/ibm-products-patterns-full-page-error-fullpageerror--docs">
+          <a href="https://ibm-products.carbondesignsystem.com/?path=/docs/ibm-products-patterns-full-page-error-fullpageerror--docs">
             FullPageError
           </a>
           .

--- a/packages/ibm-products/src/components/HTTPErrors/HTTPErrorOther/HTTPErrorOther.stories.jsx
+++ b/packages/ibm-products/src/components/HTTPErrors/HTTPErrorOther/HTTPErrorOther.stories.jsx
@@ -43,7 +43,7 @@ const Template = (args) => {
         <div>
           This component is deprecated and will be removed in the next major
           version. Please migrate to{' '}
-          <a href="http://localhost:3000/?path=/docs/ibm-products-patterns-full-page-error-fullpageerror--docs">
+          <a href="https://ibm-products.carbondesignsystem.com/?path=/docs/ibm-products-patterns-full-page-error-fullpageerror--docs">
             FullPageError
           </a>
           .


### PR DESCRIPTION
Closes #4402 

adds documentation and fixes example for FullPageError

#### What did you change?
docs/guides/security-component-migration.md
docs/guides/v2.md
examples/carbon-for-ibm-products/FullPageError/src/Example/Example.jsx
packages/ibm-products/src/components/FullPageError/FullPageError.mdx

#### How did you test and verify your work?
storybook, markdown preview.