### PR TITLE
fix(options-tile): fix styling of summary and chevron when nesting OptionsTile

### DIFF
--- a/packages/ibm-products-styles/src/components/OptionsTile/_options-tile.scss
+++ b/packages/ibm-products-styles/src/components/OptionsTile/_options-tile.scss
@@ -163,20 +163,17 @@ $block-class: #{c4p-settings.$pkg-prefix}--options-tile;
   overflow: hidden;
 }
 
-.#{$block-class}:not(.#{$block-class}--closing)
-  > details[open]
-  .#{$block-class}__summary,
+.#{$block-class}__summary.#{$block-class}__summary--open:not(.#{$block-class}__summary--closing),
 .#{$block-class}__summary--hidden {
   height: 0;
   margin-top: 0;
   opacity: 0;
 }
 
-.#{$block-class}:not(.#{$block-class}--closing)
-  > details[open]
-  .#{$block-class}__chevron {
+.#{$block-class}__chevron.#{$block-class}__chevron--open:not(.#{$block-class}__chevron--closing) {
   transform: rotate(180deg);
 }
+
 
 .#{$block-class} > details[open] .#{$block-class}__content {
   padding-top: $spacing-03;

--- a/packages/ibm-products/src/components/OptionsTile/OptionsTile.tsx
+++ b/packages/ibm-products/src/components/OptionsTile/OptionsTile.tsx
@@ -279,6 +279,12 @@ export let OptionsTile = React.forwardRef(
       let Icon: CarbonIconType | null = null;
       let text = summary;
       const summaryClasses = [`${blockClass}__summary`];
+      if (closing) {
+        summaryClasses.push(`${blockClass}__summary--closing`)
+      }
+      if (isOpen) {
+        summaryClasses.push(`${blockClass}__summary--open`)
+      }
 
       if (invalid) {
         Icon = WarningFilled;
@@ -351,7 +357,10 @@ export let OptionsTile = React.forwardRef(
                */
               /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
               <summary className={`${blockClass}__header`} onClick={toggle}>
-                <ChevronDown size={16} className={`${blockClass}__chevron`} />
+                <ChevronDown size={16} className={cx(`${blockClass}__chevron`, {
+                  [`${blockClass}__chevron--open`]: isOpen,
+                  [`${blockClass}__chevron--closing`]: closing
+                })} />
                 {renderTitle()}
               </summary>
             }


### PR DESCRIPTION
Closes #5560

#### What did you change?

change the selectors for the CSS rules applicable to summary and chevron to use BEM modifiers, instead of looking at parent elements to determine the open and closing states.

#### How did you test and verify your work?

The effects of the fix are visual, so (manually) compared how the chevron looks like and behaves during opening/closing, verified that the summary is visible on a nested options tile when it is collapsed.