### PR TITLE
fix(EditTearsheet): prevent submit while processing and add indication if submitting

### DIFF
--- a/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.test.js
+++ b/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.test.js
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, waitFor } from '@testing-library/react';
 import { carbon, pkg } from '../../settings';
 import { EditTearsheet } from './EditTearsheet';
 import { EditTearsheetForm } from './EditTearsheetForm';
@@ -206,6 +206,29 @@ describe(componentName, () => {
 
     await act(() => click(submitButton));
     expect(onRequestSubmitFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables submit when submit button is clicked until onRequestSubmit processing completes', async () => {
+    const onRequestSubmitLong = async () => {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    };
+    render(
+      <EditTearsheet
+        {...{ ...defaultProps }}
+        onClose={onCloseReturnsTrue}
+        onRequestSubmit={onRequestSubmitLong}
+        open
+      />
+    );
+
+    const editTearsheet = document.querySelector(`.${carbon.prefix}--modal`);
+    expect(editTearsheet).toHaveClass('is-visible');
+    const submitButton = screen.getByText('Save');
+
+    await act(() => click(submitButton));
+    expect(submitButton.disabled).toBeTruthy();
+    //wait up to a sec until state expected to change
+    await waitFor(() => expect(submitButton.disabled).toEqual(false));
   });
 
   it('applies className to the root node', async () => {

--- a/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.test.js
+++ b/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.test.js
@@ -215,7 +215,6 @@ describe(componentName, () => {
     render(
       <EditTearsheet
         {...{ ...defaultProps }}
-        onClose={onCloseReturnsTrue}
         onRequestSubmit={onRequestSubmitLong}
         open
       />
@@ -224,6 +223,7 @@ describe(componentName, () => {
     const editTearsheet = document.querySelector(`.${carbon.prefix}--modal`);
     expect(editTearsheet).toHaveClass('is-visible');
     const submitButton = screen.getByText('Save');
+    expect(submitButton.disabled).toEqual(false);
 
     await act(() => click(submitButton));
     expect(submitButton.disabled).toBeTruthy();

--- a/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.tsx
+++ b/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.tsx
@@ -153,11 +153,23 @@ export let EditTearsheet = forwardRef(
     }: EditTearsheetProps,
     ref: ForwardedRef<HTMLDivElement>
   ) => {
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const handleOnRequestSubmit = async () => {
+      setIsSubmitting(true);
+      try {
+        await onRequestSubmit();
+      } catch (error) {
+        console.warn(`${componentName} submit error: ${error}`);
+      }
+      setIsSubmitting(false);
+    };
     const actions = [
       {
         key: 'edit-action-button-submit',
         label: submitButtonText,
-        onClick: onRequestSubmit,
+        onClick: () => handleOnRequestSubmit(),
+        loading: isSubmitting,
         kind: 'primary',
       },
       {

--- a/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.tsx
+++ b/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.tsx
@@ -92,7 +92,8 @@ interface EditTearsheetProps extends PropsWithChildren {
   onFormChange?: (formIndex: number) => number;
 
   /**
-   * Specify a handler for submitting the tearsheet.
+   * Specify a handler for submitting the tearsheet. Throughout its execution
+   * the submit button will be disabled and include a loading indicator.
    */
   onRequestSubmit: () => void;
 

--- a/packages/ibm-products/src/components/EditTearsheet/preview-components/MultiFormEditTearsheet.js
+++ b/packages/ibm-products/src/components/EditTearsheet/preview-components/MultiFormEditTearsheet.js
@@ -68,7 +68,9 @@ export const MultiFormEditTearsheet = ({
     action('onClose')();
   };
 
-  const onSubmit = () => {
+  const onSubmit = async () => {
+    //emulate submit processing time
+    await new Promise((resolve) => setTimeout(resolve, 1000));
     setOpen(false);
     action('onSubmit')();
   };


### PR DESCRIPTION
Closes #4520 

Provide indication and prevent consecutive submit button clicks as long as prev onRequestSubmit  is processing.

#### What did you change?
1. Following submit button click, submit button is disabled with loading indicator until the onRequestSubmit processing completes.
2. Modify story to emulate a 1 sec processing to see the change
3. Added unit test

#### How did you test and verify your work?
Manual tests via storyboard 
Added unit test

https://github.com/carbon-design-system/ibm-products/assets/147585390/d41f4d6b-f4a2-40c0-b8e9-b328ac041fdc


