### PR TITLE
fix: export status indicator step component

### DIFF
--- a/packages/ibm-products/src/components/index.js
+++ b/packages/ibm-products/src/components/index.js
@@ -123,7 +123,7 @@ export { Nav } from './Nav';
 export { StringFormatter } from './StringFormatter';
 export { UserAvatar } from './UserAvatar';
 export { ScrollGradient } from './ScrollGradient';
-export { StatusIndicator } from './StatusIndicator';
+export { StatusIndicator, StatusIndicatorStep } from './StatusIndicator';
 export { TagOverflow } from './TagOverflow';
 export { ActionBar } from './ActionBar';
 export {


### PR DESCRIPTION
Closes #5579

Properly exports StatusIndicatorStep.

#### What did you change?
```
packages/ibm-products/src/components/index.js
```
#### How did you test and verify your work?
Exported with all other components 😄 