### PR TITLE
fix: include avt report in release workflow

### DIFF
--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -47,8 +47,32 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install
+      - name: Install browsers
+        run: yarn playwright install --with-deps
       - name: Continuous integration check (includes build)
         run: yarn ci-check
+      - name: Run storybook
+        id: storybook
+        run: |
+          npx serve -l 3000 packages/core/storybook-static &
+          pid=$!
+          echo "pid=$pid" >> $GITHUB_OUTPUT
+      - uses: ./actions/wait-for-it
+        with:
+          URL: 'http://localhost:3000'
+        timeout-minutes: 3
+      - name: Run AVT
+        if: github.repository == 'carbon-design-system/ibm-products'
+        run: |
+          yarn playwright test --project chromium --grep @avt --shard="${{ matrix.shard }}/4"
+      - name: Stop storybook
+        run: kill ${{ steps.storybook.outputs.pid }}
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: playwright-avt-report
+          path: .playwright
       - name: Set NPM token
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.CARBON_BOT_NPM_TOKEN }}" >> .npmrc

--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -26,7 +26,8 @@
     "lib",
     "scss",
     "flags.js",
-    "telemetry.yml"
+    "telemetry.yml",
+    ".playwright/INTERNAL_AVT_REPORT_DO_NOT_USE.json"
   ],
   "keywords": [
     "carbon",


### PR DESCRIPTION
Closes #5576

This change will update avt reports during release workflows so that we have up to date reports that can be imported from `@carbon/ibm-products/.playwright/report.json` and used to track accessibility status from our website ([work in progress here](https://github.com/carbon-design-system/carbon-for-products-website/pull/24)).

#### What did you change?
```
.github/workflows/release-base.yml
packages/ibm-products/package.json
```
#### How did you test and verify your work?
This should match a similar process as seen in `@carbon/react`.