### PR TITLE
fix(PageHeader): silence warnings from enabling ActionBar

### DIFF
--- a/packages/ibm-products/src/components/PageHeader/PageHeader.tsx
+++ b/packages/ibm-products/src/components/PageHeader/PageHeader.tsx
@@ -49,6 +49,7 @@ import {
 } from './PageHeaderUtils';
 import { PageHeaderTitle } from './PageHeaderTitle';
 
+pkg._silenceWarnings(true);
 pkg.component.ActionBar = true;
 
 // Default values for props


### PR DESCRIPTION
Closes #5499 

This PR removes the console warning when using the `PageHeader`. This happens because now that the `ActionBar` is a canary component we have to enable it which normally emits a console warning, in this case we want to opt out of receiving warnings.

#### What did you change?
```
packages/ibm-products/src/components/PageHeader/PageHeader.tsx
```
#### How did you test and verify your work?
Storybook