### PR TITLE
fix(Datagrid): address issue when id and value of filter are different

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterProvider.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterProvider.js
@@ -67,7 +67,7 @@ export const clearSingleFilter = ({ key, value }, setAllFilters, state) => {
           When all checkboxes of a group are all unselected the value still exists in the filtersObjectArray
           This checks if all the checkboxes are selected = false and removes it from the array
         */
-        const valueIndex = filterValues.findIndex((val) => val.id === value);
+        const valueIndex = filterValues.findIndex((val) => val.value === value);
         filterValues[valueIndex].selected = false;
         const updatedFilterObject = {
           ...f,


### PR DESCRIPTION
Closes #5594

This fixes an issue where if the `id` and `value` for checkbox or multiselect filters are different an error gets thrown if you attempt to remove the filter tag via the close icon.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterProvider.js
```
#### How did you test and verify your work?
Updated filter props in `Flyout.stories.jsx` to locally reproduce and check that this change fixes the issue