### PR TITLE
fix(DataSpreadsheet): address issue with active cell value

### DIFF
--- a/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheet.tsx
+++ b/packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheet.tsx
@@ -641,12 +641,9 @@ export let DataSpreadsheet = React.forwardRef(
             ]
           : null;
 
-      let activeCellValue;
-      if (activeCellFullData && activeCellCoordinates?.column) {
-        activeCellValue = activeCellFullData
-          ? activeCellFullData.row.cells?.[activeCellCoordinates?.column]?.value
-          : null;
-      }
+      const activeCellValue =
+        activeCellFullData?.row?.cells?.[Number(activeCellCoordinates?.column)]
+          ?.value;
 
       setCellEditorValue(activeCellValue || '');
       if (cellEditorRulerRef?.current) {


### PR DESCRIPTION
Closes #5617

This change properly sets the cell editor value so that when entering edit mode for cells within the first column (index 0) the correct value is applied.

#### What did you change?
```
packages/ibm-products/src/components/DataSpreadsheet/DataSpreadsheet.tsx
```
#### How did you test and verify your work?
Storybook