### PR TITLE
fix(Tearsheet): fix behavior of `selectorPrimaryFocus` for stacked tearsheets

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
@@ -337,10 +337,20 @@ export const TearsheetShell = React.forwardRef(
     useEffect(() => {
       if (open && position !== depth) {
         setTimeout(() => {
+          if (selectorPrimaryFocus) {
+            return specifiedElement?.focus();
+          }
           firstElement?.focus();
         }, 0);
       }
-    }, [position, depth, firstElement, open]);
+    }, [
+      position,
+      depth,
+      firstElement,
+      open,
+      specifiedElement,
+      selectorPrimaryFocus,
+    ]);
 
     useEffect(() => {
       const notify = () =>
@@ -561,8 +571,8 @@ TearsheetShell.displayName = componentName;
 export const portalType =
   typeof Element === 'undefined'
     ? PropTypes.object
-    // eslint-disable-next-line ssr-friendly/no-dom-globals-in-module-scope
-    : PropTypes.instanceOf(Element);
+    : // eslint-disable-next-line ssr-friendly/no-dom-globals-in-module-scope
+      PropTypes.instanceOf(Element);
 
 export const deprecatedProps = {
   /**


### PR DESCRIPTION
Closes #5624 

This addresses the issues described in #5624. It adds the same functionality added in [this PR](https://github.com/carbon-design-system/ibm-products/pull/5264), which fixed the `selectorPrimaryFocus` behavior but for stacked tearsheets.

#### What did you change?
```
packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
```
#### How did you test and verify your work?
Storybook