### PR TITLE
feat: use autoAlign prop for dropdown editable cell

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
     "@carbon/ibm-products-styles": "^2.41.0-rc.0",
     "@carbon/layout": "^11.21.0",
     "@carbon/motion": "^11.17.0",
-    "@carbon/react": "^1.60.3",
+    "@carbon/react": "^1.61.0",
     "@carbon/themes": "^11.37.1",
     "@carbon/type": "^11.26.0",
     "@storybook/addon-a11y": "^8.1.10",

--- a/packages/ibm-products-community/package.json
+++ b/packages/ibm-products-community/package.json
@@ -27,7 +27,7 @@
     "@carbon/grid": "^11.22.0",
     "@carbon/layout": "^11.21.0",
     "@carbon/motion": "^11.17.0",
-    "@carbon/react": "^1.60.3",
+    "@carbon/react": "^1.61.0",
     "@carbon/themes": "^11.37.1",
     "@carbon/type": "^11.26.0",
     "react": "^18.2.0",

--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -114,7 +114,7 @@
     "@carbon/grid": "^11.22.0",
     "@carbon/layout": "^11.21.0",
     "@carbon/motion": "^11.17.0",
-    "@carbon/react": "^1.60.3",
+    "@carbon/react": "^1.61.0",
     "@carbon/themes": "^11.37.1",
     "@carbon/type": "^11.26.0",
     "react": "^16.8.6 || ^17.0.1 || ^18.2.0",

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
@@ -331,8 +331,9 @@ export const InlineEditCell = ({
       <Dropdown
         id={cellId}
         label={cellLabel || 'Dropdown menu options'}
-        ariaLabel={cellLabel || 'Dropdown menu options'}
+        aria-label={cellLabel || 'Dropdown menu options'}
         {...inputProps}
+        autoAlign
         hideLabel
         style={{
           width: cell.column.totalWidth,

--- a/scripts/example-gallery-builder/update-example/templates-react-16/package.json
+++ b/scripts/example-gallery-builder/update-example/templates-react-16/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@carbon/ibm-products": "^2.21.0",
-    "@carbon/react": "^1.60.3",
+    "@carbon/react": "^1.61.0",
     "lodash": "^4.17.21",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",

--- a/scripts/example-gallery-builder/update-example/templates-react-17/package.json
+++ b/scripts/example-gallery-builder/update-example/templates-react-17/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@carbon/ibm-products": "^2.21.0",
-    "@carbon/react": "^1.60.3",
+    "@carbon/react": "^1.61.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/scripts/example-gallery-builder/update-example/templates/package.json
+++ b/scripts/example-gallery-builder/update-example/templates/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@carbon/ibm-products": "^2.21.0",
-    "@carbon/react": "^1.60.3",
+    "@carbon/react": "^1.61.0",
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -126,18 +126,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.23.6":
-  version: 7.24.7
-  resolution: "@babel/generator@npm:7.24.7"
-  dependencies:
-    "@babel/types": "npm:^7.24.7"
-    "@jridgewell/gen-mapping": "npm:^0.3.5"
-    "@jridgewell/trace-mapping": "npm:^0.3.25"
-    jsesc: "npm:^2.5.1"
-  checksum: c71d24a4b41b19c10d2f2eb819f27d4cf94220e2322f7c8fed8bfbbb115b2bebbdd6dc1f27dac78a175e90604def58d763af87e0fa81ce4ab1582858162cf768
-  languageName: node
-  linkType: hard
-
 "@babel/helper-annotate-as-pure@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-annotate-as-pure@npm:7.22.5"
@@ -351,24 +339,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-string-parser@npm:^7.24.7":
-  version: 7.24.7
-  resolution: "@babel/helper-string-parser@npm:7.24.7"
-  checksum: 603d8d962bbe89907aa99a8f19a006759ab7b2464615f20a6a22e3e2e8375af37ddd0e5175c9e622e1c4b2d83607ffb41055a59d0ce34404502af30fde573a5c
-  languageName: node
-  linkType: hard
-
 "@babel/helper-validator-identifier@npm:^7.22.20, @babel/helper-validator-identifier@npm:^7.24.5":
   version: 7.24.5
   resolution: "@babel/helper-validator-identifier@npm:7.24.5"
   checksum: 38aaf6a64a0ea2e84766165b461deda3c24fd2173dff18419a2cc9e1ea1d3e709039aee94db29433a07011492717c80900a5eb564cdca7d137757c3c69e26898
-  languageName: node
-  linkType: hard
-
-"@babel/helper-validator-identifier@npm:^7.24.7":
-  version: 7.24.7
-  resolution: "@babel/helper-validator-identifier@npm:7.24.7"
-  checksum: 86875063f57361471b531dbc2ea10bbf5406e12b06d249b03827d361db4cad2388c6f00936bcd9dc86479f7e2c69ea21412c2228d4b3672588b754b70a449d4b
   languageName: node
   linkType: hard
 
@@ -419,15 +393,6 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: f5ed1c5fd4b0045a364fb906f54fd30e2fff93a45069068b6d80d3ab2b64f5569c90fb41d39aff80fb7e925ca4d44917965a76776a3ca11924ec1fae3be5d1ea
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.23.6":
-  version: 7.24.7
-  resolution: "@babel/parser@npm:7.24.7"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: ef9ebce60e13db560ccc7af9235d460f6726bb7e23ae2d675098c1fc43d5249067be60d4118889dad33b1d4f85162cf66baf554719e1669f29bb20e71322568e
   languageName: node
   linkType: hard
 
@@ -1687,17 +1652,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.23.6, @babel/types@npm:^7.24.7":
-  version: 7.24.7
-  resolution: "@babel/types@npm:7.24.7"
-  dependencies:
-    "@babel/helper-string-parser": "npm:^7.24.7"
-    "@babel/helper-validator-identifier": "npm:^7.24.7"
-    to-fast-properties: "npm:^2.0.0"
-  checksum: ad3c8c0d6fb4acb0bb74bb5b4bb849b181bf6185677ef9c59c18856c81e43628d0858253cf232f0eca806f02e08eff85a1d3e636a3e94daea737597796b0b430
-  languageName: node
-  linkType: hard
-
 "@base2/pretty-print-object@npm:1.0.1":
   version: 1.0.1
   resolution: "@base2/pretty-print-object@npm:1.0.1"
@@ -1712,7 +1666,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/colors@npm:^11.23.1":
+"@carbon/colors@npm:^11.23.0, @carbon/colors@npm:^11.23.1":
   version: 11.23.1
   resolution: "@carbon/colors@npm:11.23.1"
   dependencies:
@@ -1740,7 +1694,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/grid@npm:^11.24.1":
+"@carbon/grid@npm:^11.24.0, @carbon/grid@npm:^11.24.1":
   version: 11.24.1
   resolution: "@carbon/grid@npm:11.24.1"
   dependencies:
@@ -1779,7 +1733,7 @@ __metadata:
     "@carbon/ibm-products-styles": "npm:^2.41.0-rc.0"
     "@carbon/layout": "npm:^11.21.0"
     "@carbon/motion": "npm:^11.17.0"
-    "@carbon/react": "npm:^1.60.3"
+    "@carbon/react": "npm:^1.61.0"
     "@carbon/themes": "npm:^11.37.1"
     "@carbon/type": "npm:^11.26.0"
     "@storybook/addon-a11y": "npm:^8.1.10"
@@ -1833,7 +1787,7 @@ __metadata:
     "@carbon/grid": ^11.22.0
     "@carbon/layout": ^11.21.0
     "@carbon/motion": ^11.17.0
-    "@carbon/react": ^1.60.3
+    "@carbon/react": ^1.61.0
     "@carbon/themes": ^11.37.1
     "@carbon/type": ^11.26.0
     react: ^18.2.0
@@ -1926,7 +1880,7 @@ __metadata:
     "@carbon/grid": ^11.22.0
     "@carbon/layout": ^11.21.0
     "@carbon/motion": ^11.17.0
-    "@carbon/react": ^1.60.3
+    "@carbon/react": ^1.61.0
     "@carbon/themes": ^11.37.1
     "@carbon/type": ^11.26.0
     react: ^16.8.6 || ^17.0.1 || ^18.2.0
@@ -1934,7 +1888,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/icon-helpers@npm:^10.49.1":
+"@carbon/icon-helpers@npm:^10.49.0":
   version: 10.49.1
   resolution: "@carbon/icon-helpers@npm:10.49.1"
   dependencies:
@@ -1943,16 +1897,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/icons-react@npm:^11.44.1":
-  version: 11.44.1
-  resolution: "@carbon/icons-react@npm:11.44.1"
+"@carbon/icons-react@npm:^11.45.0":
+  version: 11.45.0
+  resolution: "@carbon/icons-react@npm:11.45.0"
   dependencies:
-    "@carbon/icon-helpers": "npm:^10.49.1"
+    "@carbon/icon-helpers": "npm:^10.49.0"
     "@ibm/telemetry-js": "npm:^1.5.0"
     prop-types: "npm:^15.7.2"
   peerDependencies:
     react: ">=16"
-  checksum: a546db550789e72d4d5e3b8dcab96341d36a7f4005d49ebdbbd3bcf88fcbaa8b175792d6bfa78818b3d5fb3b05f16eb7241cccb0a69655bdbf13aac164321e97
+  checksum: dd367f2f53d0f489ffc324fbb55e7e99d09f121f189214be7494f0a39a2ce895d5300d17190d97da1edd8c02a26170c0125c6b220cb711c56dbbf03056762c6e
   languageName: node
   linkType: hard
 
@@ -1965,7 +1919,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/layout@npm:^11.23.1":
+"@carbon/layout@npm:^11.23.0, @carbon/layout@npm:^11.23.1":
   version: 11.23.1
   resolution: "@carbon/layout@npm:11.23.1"
   dependencies:
@@ -1983,7 +1937,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/motion@npm:^11.19.1":
+"@carbon/motion@npm:^11.19.0":
   version: 11.19.1
   resolution: "@carbon/motion@npm:11.19.1"
   dependencies:
@@ -1992,16 +1946,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/react@npm:^1.60.3":
-  version: 1.60.3
-  resolution: "@carbon/react@npm:1.60.3"
+"@carbon/react@npm:^1.61.0":
+  version: 1.61.0
+  resolution: "@carbon/react@npm:1.61.0"
   dependencies:
     "@babel/runtime": "npm:^7.18.3"
     "@carbon/feature-flags": "npm:^0.20.0"
-    "@carbon/icons-react": "npm:^11.44.1"
-    "@carbon/layout": "npm:^11.23.1"
-    "@carbon/styles": "npm:^1.60.1"
-    "@figma/code-connect": "npm:^0.1.2"
+    "@carbon/icons-react": "npm:^11.45.0"
+    "@carbon/layout": "npm:^11.23.0"
+    "@carbon/styles": "npm:^1.61.0"
     "@floating-ui/react": "npm:^0.26.0"
     "@ibm/telemetry-js": "npm:^1.5.0"
     classnames: "npm:2.5.1"
@@ -2018,13 +1971,12 @@ __metadata:
     react-is: "npm:^18.2.0"
     tabbable: "npm:^6.2.0"
     use-resize-observer: "npm:^6.0.0"
-    wicg-inert: "npm:^3.1.1"
     window-or-global: "npm:^1.0.1"
   peerDependencies:
     react: ^16.8.6 || ^17.0.1 || ^18.2.0
     react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0
     sass: ^1.33.0
-  checksum: 28ac63d264b8c9ce9f42a956cf897d40cd5ec15b89422dc5d3ba11715c9fe01ca7d9d76baa23e31cd34af95858d55c4cc98016e20df876d422868ebd7dd13c63
+  checksum: 7ff8f62788a2c681ce6b6bbe003550569e703c1703437ab9ed779d8e34acf8010a1389d26892e3428aff3176689cbd3dd960401a4093e508ed63224490dca994
   languageName: node
   linkType: hard
 
@@ -2054,17 +2006,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/styles@npm:^1.60.1":
-  version: 1.60.1
-  resolution: "@carbon/styles@npm:1.60.1"
+"@carbon/styles@npm:^1.61.0":
+  version: 1.61.0
+  resolution: "@carbon/styles@npm:1.61.0"
   dependencies:
-    "@carbon/colors": "npm:^11.23.1"
+    "@carbon/colors": "npm:^11.23.0"
     "@carbon/feature-flags": "npm:^0.20.0"
-    "@carbon/grid": "npm:^11.24.1"
-    "@carbon/layout": "npm:^11.23.1"
-    "@carbon/motion": "npm:^11.19.1"
-    "@carbon/themes": "npm:^11.37.1"
-    "@carbon/type": "npm:^11.28.1"
+    "@carbon/grid": "npm:^11.24.0"
+    "@carbon/layout": "npm:^11.23.0"
+    "@carbon/motion": "npm:^11.19.0"
+    "@carbon/themes": "npm:^11.37.0"
+    "@carbon/type": "npm:^11.28.0"
     "@ibm/plex": "npm:6.0.0-next.6"
     "@ibm/telemetry-js": "npm:^1.5.0"
   peerDependencies:
@@ -2072,7 +2024,7 @@ __metadata:
   peerDependenciesMeta:
     sass:
       optional: true
-  checksum: 3a166807ff91a58783f35d3dbf30172cc58c748d68f2c066d8001ee2de50951439aae0f97ec55a6c5ab4b6349848d7d1c4e6a5398a1d749c7900962e834441bf
+  checksum: ae474457472bfbd153c18a42f410f1492db825dc2dea0346bcb6c67961b0dc4b5f847a2febbd1b1b954d860efd0fe9cee70cc10b0e50bd1f9b51877eef93c431
   languageName: node
   linkType: hard
 
@@ -2085,7 +2037,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/themes@npm:^11.37.1":
+"@carbon/themes@npm:^11.37.0, @carbon/themes@npm:^11.37.1":
   version: 11.37.1
   resolution: "@carbon/themes@npm:11.37.1"
   dependencies:
@@ -2109,7 +2061,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/type@npm:^11.28.1":
+"@carbon/type@npm:^11.28.0, @carbon/type@npm:^11.28.1":
   version: 11.28.1
   resolution: "@carbon/type@npm:11.28.1"
   dependencies:
@@ -3177,30 +3129,6 @@ __metadata:
     lodash.isundefined: "npm:^3.0.1"
     lodash.uniq: "npm:^4.5.0"
   checksum: 12b338134de8801c895f50f8bb5315b67a6181d5b39d99445be80898633541b06be77a2b14a8395fc51c3f028138e9fb8a2b5bc5258f50c08bef22fd9dd07ee0
-  languageName: node
-  linkType: hard
-
-"@figma/code-connect@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "@figma/code-connect@npm:0.1.2"
-  dependencies:
-    "@babel/core": "npm:^7.23.6"
-    "@babel/generator": "npm:^7.23.6"
-    "@babel/parser": "npm:^7.23.6"
-    "@babel/types": "npm:^7.23.6"
-    "@storybook/csf-tools": "npm:^7.6.7"
-    axios: "npm:^1.6.0"
-    chalk: "npm:^4.1.2"
-    commander: "npm:^11.1.0"
-    dotenv: "npm:^16.3.1"
-    glob: "npm:^10.3.10"
-    lodash: "npm:^4.17.21"
-    minimatch: "npm:^9.0.3"
-    prettier: "npm:^3.2.4"
-    typescript: "npm:5.4.2"
-  bin:
-    figma: bin/figma
-  checksum: 730fd7b326629bdfb4fa1376690fc6cef43471e372b40ba9873dba560246986646601f9f7f854df09d639652177ce926ff335fd57e71ec9cbb1d241bfeb65f37
   languageName: node
   linkType: hard
 
@@ -5692,20 +5620,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/channels@npm:7.6.20":
-  version: 7.6.20
-  resolution: "@storybook/channels@npm:7.6.20"
-  dependencies:
-    "@storybook/client-logger": "npm:7.6.20"
-    "@storybook/core-events": "npm:7.6.20"
-    "@storybook/global": "npm:^5.0.0"
-    qs: "npm:^6.10.0"
-    telejson: "npm:^7.2.0"
-    tiny-invariant: "npm:^1.3.1"
-  checksum: 3dc827df9d0d0c0c68f10edbf5169e42c2cdb43832cb14ce3ac8149f295219f8bae6ed27300fd50e6a78080914cf142d1810fdbcf687dd313a7bfac41386cd95
-  languageName: node
-  linkType: hard
-
 "@storybook/channels@npm:8.0.9":
   version: 8.0.9
   resolution: "@storybook/channels@npm:8.0.9"
@@ -5782,15 +5696,6 @@ __metadata:
   dependencies:
     "@storybook/global": "npm:^5.0.0"
   checksum: 0df63fa013a17b882061f291458b4ffd9e21957b5bca4bbac85cd4b7195ada82a7fbe6a3505df190f9b89038681c38dd45c1eed62800c090930211ce0f08ffbc
-  languageName: node
-  linkType: hard
-
-"@storybook/client-logger@npm:7.6.20":
-  version: 7.6.20
-  resolution: "@storybook/client-logger@npm:7.6.20"
-  dependencies:
-    "@storybook/global": "npm:^5.0.0"
-  checksum: 0062c440c825ab460667d799b00d3ff87dcf4dabce05733c11ffbb1ea70e0a2e77fdc313ce9bdeccc4ac816101abe17572b96cc20c975874812f875828653704
   languageName: node
   linkType: hard
 
@@ -5912,15 +5817,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/core-events@npm:7.6.20":
-  version: 7.6.20
-  resolution: "@storybook/core-events@npm:7.6.20"
-  dependencies:
-    ts-dedent: "npm:^2.0.0"
-  checksum: bd72649a262017f244aa6311352c1b38f2b38478c19b9aee4851bfdff5b2b11565dd768fe144f1304f9f130b533ffa4ab3fd2eea1361d202a76ff920cc377601
-  languageName: node
-  linkType: hard
-
 "@storybook/core-events@npm:8.0.9, @storybook/core-events@npm:^8.0.9":
   version: 8.0.9
   resolution: "@storybook/core-events@npm:8.0.9"
@@ -6005,23 +5901,6 @@ __metadata:
     recast: "npm:^0.23.5"
     ts-dedent: "npm:^2.0.0"
   checksum: 09779c1786b9c23efd46a7233e83b4cce5c21b69be4608a5e34034484bed976a1d31e0f5cf000b54a4860dcc50fa25af59cf3956efd4a190b2b71130c5a52f48
-  languageName: node
-  linkType: hard
-
-"@storybook/csf-tools@npm:^7.6.7":
-  version: 7.6.20
-  resolution: "@storybook/csf-tools@npm:7.6.20"
-  dependencies:
-    "@babel/generator": "npm:^7.23.0"
-    "@babel/parser": "npm:^7.23.0"
-    "@babel/traverse": "npm:^7.23.2"
-    "@babel/types": "npm:^7.23.0"
-    "@storybook/csf": "npm:^0.1.2"
-    "@storybook/types": "npm:7.6.20"
-    fs-extra: "npm:^11.1.0"
-    recast: "npm:^0.23.1"
-    ts-dedent: "npm:^2.0.0"
-  checksum: f0ca4a7e7309548bf647fbbc175bccb56fe4df210e3e52f96a5cc553bc06253c8fd7fcceb00ee7192e09fd073fd67fdaacab0ba81c56d440116114355b5f0935
   languageName: node
   linkType: hard
 
@@ -6356,18 +6235,6 @@ __metadata:
     "@types/express": "npm:^4.7.0"
     file-system-cache: "npm:2.3.0"
   checksum: 521b2ba3e3938b5774d2bcc6eda5db0b8dc7b7759aea0ba217daf34f83c40ef29ff05d011585e426ae70a77391a8015d9a9a9ff94ff0dcbec0f773c14cf723b8
-  languageName: node
-  linkType: hard
-
-"@storybook/types@npm:7.6.20":
-  version: 7.6.20
-  resolution: "@storybook/types@npm:7.6.20"
-  dependencies:
-    "@storybook/channels": "npm:7.6.20"
-    "@types/babel__core": "npm:^7.0.0"
-    "@types/express": "npm:^4.7.0"
-    file-system-cache: "npm:2.3.0"
-  checksum: 8da9513f1f34f606b114026af5fad5a7658ce5e2fa7af3363d9f3d481e5e22ed9ae6343f28aa9d14208bff07f489cb7f5ae3adcad5a603f8181e952b2ee29f3f
   languageName: node
   linkType: hard
 
@@ -11083,7 +10950,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.0.0, dotenv@npm:^16.3.1":
+"dotenv@npm:^16.0.0":
   version: 16.4.5
   resolution: "dotenv@npm:16.4.5"
   checksum: 55a3134601115194ae0f924e54473459ed0d9fc340ae610b676e248cca45aa7c680d86365318ea964e6da4e2ea80c4514c1adab5adb43d6867fb57ff068f95c8
@@ -20499,19 +20366,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"recast@npm:^0.23.1":
-  version: 0.23.9
-  resolution: "recast@npm:0.23.9"
-  dependencies:
-    ast-types: "npm:^0.16.1"
-    esprima: "npm:~4.0.0"
-    source-map: "npm:~0.6.1"
-    tiny-invariant: "npm:^1.3.3"
-    tslib: "npm:^2.0.1"
-  checksum: d60584be179d81a82fbe58b5bbe009aa42831ee114a21a3e3a22bda91334e0b8a1a4610dca8ecb7f9ea1426da4febc08134d3003085ad6ecee478d1808eb8796
-  languageName: node
-  linkType: hard
-
 "recast@npm:^0.23.3, recast@npm:^0.23.5":
   version: 0.23.6
   resolution: "recast@npm:0.23.6"
@@ -23358,16 +23212,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.4.2":
-  version: 5.4.2
-  resolution: "typescript@npm:5.4.2"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: f8cfdc630ab1672f004e9561eb2916935b2d267792d07ce93e97fc601c7a65191af32033d5e9c0169b7dc37da7db9bf320f7432bc84527cb7697effaa4e4559d
-  languageName: node
-  linkType: hard
-
 "typescript@npm:>=3 < 6, typescript@npm:^5.3.3":
   version: 5.4.5
   resolution: "typescript@npm:5.4.5"
@@ -23385,16 +23229,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 458f7220ab11e0fc191514cc41be1707645ec9a8c2d609448a448e18c522cef9646f58728f6811185a4c35613dacdf6c98cf8965c88b3541d0288c47291e4300
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A5.4.2#optional!builtin<compat/typescript>":
-  version: 5.4.2
-  resolution: "typescript@patch:typescript@npm%3A5.4.2#optional!builtin<compat/typescript>::version=5.4.2&hash=e012d7"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: ef4fc2994cc0219dc9ada94c92106ba8d44cbfd7a0328ed6f8d730311caf66e114cdfa07fbc6f369bfc0fc182d9493851b3bf1644c06fc5818690b19ee960d72
   languageName: node
   linkType: hard
 
@@ -24274,13 +24108,6 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: f17e84c042592c21e23c8195108cff18c64050b9efb8459589116999ea9da6dd1509e6a1bac3aeebefd137be00fabbb61b5c2bc0aa0f8526f32b58ee2f545651
-  languageName: node
-  linkType: hard
-
-"wicg-inert@npm:^3.1.1":
-  version: 3.1.2
-  resolution: "wicg-inert@npm:3.1.2"
-  checksum: a726f5ca2d3535dba9a638ff60b720d9f81857cb9b51bcaf9c2a71ee50d784ff3be6c5d9f0acc35edd8fee92bb3587c0a9daabb70baa725a106d149ae0fd8584
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #5663 

Upgrades `@carbon/react` to `1.61.0` so that we can use the new `autoAlign` prop on the `Dropdown` for editable cell Datagrids and not have overflow/layout issues.

#### What did you change?
```
packages/core/package.json
packages/ibm-products-community/package.json
packages/ibm-products/package.json
packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
scripts/example-gallery-builder/update-example/templates-react-16/package.json
scripts/example-gallery-builder/update-example/templates-react-17/package.json
scripts/example-gallery-builder/update-example/templates/package.json
yarn.lock
```
#### How did you test and verify your work?
Storybook