### PR TITLE
chore: remove sb iframe scrollbars

### DIFF
--- a/packages/core/.storybook/manager-head.html
+++ b/packages/core/.storybook/manager-head.html
@@ -80,10 +80,4 @@
     width: 100%;
     z-index: 99999;
   }
-
-  /* This style removes scrollbars added to iframe after sb8 upgrade */
-  iframe[data-is-storybook="true"] {
-    width: calc(100% - 2px);
-    height: calc(100% - 2px);
-  }
 </style>

--- a/packages/core/.storybook/manager-head.html
+++ b/packages/core/.storybook/manager-head.html
@@ -80,4 +80,10 @@
     width: 100%;
     z-index: 99999;
   }
+
+  /* This style removes scrollbars added to iframe after sb8 upgrade */
+  iframe[data-is-storybook="true"] {
+    width: calc(100% - 2px);
+    height: calc(100% - 2px);
+  }
 </style>

--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -66,9 +66,9 @@ const makeViewport = (name, width, shadow) => ({
   styles: {
     border: '1px solid #1EA7FD',
     boxShadow: `0 0 50px 20px rgb(30 167 253 / ${shadow}%)`,
-    width,
+    width: width === '100%' ? 'calc(100% - 2px)' : width,
     // when width is fixed, leave room for a horizontal scroll bar
-    height: width === '100%' ? '100%' : 'calc(100% - 12px)',
+    height: width === '100%' ? 'calc(100% - 2px)' : 'calc(100% - 12px)',
   },
 });
 const carbonViewports = {


### PR DESCRIPTION
Ever since the SB8 upgrade, there have been scrollbars visible on the `iframe` that we didn't have before. I made some updates to storybook `preview.js` to remove them (they were being caused from the border that we apply to the story).

#### What did you change?
```
packages/core/.storybook/preview.js
```
#### How did you test and verify your work?
Storybook