### PR TITLE
fix(datagrid): screen reader misreads datagrid table headers

### DIFF
--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -3715,6 +3715,7 @@ p.c4p--about-modal__copyright-text:first-child {
 
 .c4p--datagrid__head-hidden-select-all {
   padding-right: 3rem;
+  min-width: 3rem;
 }
 .c4p--datagrid__head-hidden-select-all.c4p--datagrid__select-all-sticky-left {
   position: sticky;
@@ -5833,6 +5834,113 @@ th.c4p--datagrid__select-all-toggle-on.button {
   font-weight: var(--cds-heading-03-font-weight, 400);
   line-height: var(--cds-heading-03-line-height, 1.4);
   letter-spacing: var(--cds-heading-03-letter-spacing, 0);
+}
+
+.c4p--full-page-error {
+  height: inherit;
+}
+
+.c4p--full-page-error__container {
+  height: 100%;
+  margin: 0 1.5rem;
+}
+@media (max-width: 41.98rem) {
+  .c4p--full-page-error__container {
+    margin: 0 0.5rem;
+  }
+}
+
+.c4p--full-page-error__grid {
+  height: 100%;
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+
+.c4p--full-page-error__column {
+  padding: 0;
+}
+@media (min-width: 66rem) {
+  .c4p--full-page-error__column {
+    padding: 0 2rem 0 0;
+  }
+}
+
+.c4p--full-page-error__svg-container {
+  display: flex;
+  height: 100%;
+  padding: 0.5rem 0.5rem 5rem 0.5rem;
+}
+@media (min-width: 42rem) {
+  .c4p--full-page-error__svg-container {
+    padding: auto 0.5rem 5rem 0.5rem;
+  }
+}
+
+.c4p--full-page-error__label,
+.c4p--full-page-error__title {
+  font-size: 2rem;
+  font-weight: 400;
+  line-height: 1.25;
+  letter-spacing: 0;
+  font-size: calc(2rem + 0.25 * (100vw - 20rem) / 22);
+}
+@media (min-width: 42rem) {
+  .c4p--full-page-error__label,
+  .c4p--full-page-error__title {
+    font-size: 2.25rem;
+    font-weight: 300;
+    line-height: 1.22;
+    font-size: calc(2.25rem + 0.375 * (100vw - 42rem) / 24);
+  }
+}
+@media (min-width: 66rem) {
+  .c4p--full-page-error__label,
+  .c4p--full-page-error__title {
+    font-size: 2.625rem;
+    line-height: 1.19;
+    font-size: calc(2.625rem + 0.375 * (100vw - 66rem) / 16);
+  }
+}
+@media (min-width: 82rem) {
+  .c4p--full-page-error__label,
+  .c4p--full-page-error__title {
+    font-size: 3rem;
+    line-height: 1.17;
+    font-size: calc(3rem + 0.75 * (100vw - 82rem) / 17);
+  }
+}
+@media (min-width: 99rem) {
+  .c4p--full-page-error__label,
+  .c4p--full-page-error__title {
+    font-size: 3.75rem;
+    font-size: 3.75rem;
+  }
+}
+
+.c4p--full-page-error__label {
+  display: block;
+  color: var(--cds-text-error, #da1e28);
+}
+
+.c4p--full-page-error__title {
+  margin-bottom: 3rem;
+}
+
+.c4p--full-page-error__description {
+  font-size: var(--cds-body-02-font-size, 1rem);
+  font-weight: var(--cds-body-02-font-weight, 400);
+  line-height: var(--cds-body-02-line-height, 1.5);
+  letter-spacing: var(--cds-body-02-letter-spacing, 0);
+  margin-bottom: 2rem;
+}
+
+.c4p--full-page-error__svg-container svg.c4p--full-page-error__svg {
+  width: 100%;
+}
+
+.c4p--full-page-error__svg-container svg.c4p--full-page-error__svg path {
+  fill: var(--cds-background, #ffffff);
+  stroke: var(--cds-border-inverse, #161616);
 }
 
 .c4p--http-errors .c4p--http-errors__content {

--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -3714,8 +3714,8 @@ p.c4p--about-modal__copyright-text:first-child {
 }
 
 .c4p--datagrid__head-hidden-select-all {
-  padding-right: 3rem;
   min-width: 3rem;
+  padding-right: 3rem;
 }
 .c4p--datagrid__head-hidden-select-all.c4p--datagrid__select-all-sticky-left {
   position: sticky;

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_datagrid.scss
@@ -479,6 +479,7 @@
 }
 
 .#{$block-class}__head-hidden-select-all {
+  min-width: $spacing-09;
   padding-right: $spacing-09;
 
   &.#{$block-class}__select-all-sticky-left {

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
@@ -987,7 +987,6 @@ describe(componentName, () => {
         .getByRole('table')
         .getElementsByTagName('thead')[0]
         .getElementsByTagName('tr')[0]
-        .getElementsByTagName('div')[0]
         .getElementsByTagName('th')[0]
         .getElementsByTagName('div')[0]
         .getElementsByTagName('input')[0]
@@ -1009,7 +1008,6 @@ describe(componentName, () => {
         .getByRole('table')
         .getElementsByTagName('thead')[0]
         .getElementsByTagName('tr')[0]
-        .getElementsByTagName('div')[0]
         .getElementsByTagName('th')[0]
         .getElementsByTagName('div')[0]
         .getElementsByTagName('input')[0]
@@ -1994,7 +1992,6 @@ describe(componentName, () => {
         .getByRole('table')
         .getElementsByTagName('thead')[0]
         .getElementsByTagName('tr')[0]
-        .getElementsByTagName('div')[0]
         .getElementsByTagName('th')[0]
         .getElementsByTagName('div')[0]
         .getElementsByTagName('label')[0]
@@ -2017,7 +2014,6 @@ describe(componentName, () => {
         .getByRole('table')
         .getElementsByTagName('thead')[0]
         .getElementsByTagName('tr')[0]
-        .getElementsByTagName('div')[0]
         .getElementsByTagName('th')[0]
         .getElementsByTagName('div')[0]
         .getElementsByTagName('label')[0]

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSelectAll.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSelectAll.tsx
@@ -48,7 +48,7 @@ const SelectAll = (datagridState: DataGridState) => {
     columns[0]?.sticky === 'left' && withStickyColumn;
   if (hideSelectAll || radio) {
     return (
-      <div
+      <th
         className={cx(`${blockClass}__head-hidden-select-all`, {
           [`${blockClass}__select-all-sticky-left`]:
             /* istanbul ignore next */

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSelectAll.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSelectAll.tsx
@@ -91,7 +91,8 @@ const SelectAll = (datagridState: DataGridState) => {
   };
 
   return (
-    <div
+    <TableSelectAll
+      {...selectProps}
       className={cx(
         `${blockClass}__head-select-all`,
         `${blockClass}__checkbox-cell`,
@@ -101,15 +102,11 @@ const SelectAll = (datagridState: DataGridState) => {
             isFirstColumnStickyLeft && Number(windowSize) > 671,
         }
       )}
-    >
-      <TableSelectAll
-        {...selectProps}
-        name={`${tableId}-select-all-checkbox-name`}
-        onSelect={handleSelectAllChange}
-        disabled={isFetching || selectProps?.disabled}
-        id={`${tableId}-select-all-checkbox-id`}
-      />
-    </div>
+      name={`${tableId}-select-all-checkbox-name`}
+      onSelect={handleSelectAllChange}
+      disabled={isFetching || selectProps?.disabled}
+      id={`${tableId}-select-all-checkbox-id`}
+    />
   );
 };
 


### PR DESCRIPTION
Closes #5682 

due to the presence of `div` instead of `th` at coordinates (1,1) in the table for all the mentioned variants in the issue, the screen reader reads the header ahead by 1.
also below format is inconsistent across browsers (chrome has no issues, but firefox reads header ahead by 1)
```
<div>
    <th>
    </th>
</div>
```

this pr fixes them.

#### What did you change?
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridSelectAll.tsx
packages/ibm-products-styles/src/components/Datagrid/styles/_datagrid.scss
packages/ibm-products/src/components/Datagrid/Datagrid.test.js

#### How did you test and verify your work?
voiceover in storybook, mozilla, chrome