### PR TITLE
refactor(FeatureFlags): convert to typescript

### DIFF
--- a/packages/ibm-products/src/components/FeatureFlags/index.tsx
+++ b/packages/ibm-products/src/components/FeatureFlags/index.tsx
@@ -80,9 +80,17 @@ FeatureFlags.propTypes = {
  * @param {Function} compare
  * @param {Function} callback
  */
-function useChangedValue(value, compare, callback) {
+function useChangedValue(
+  value: { [key: string]: boolean },
+  compare: (
+    prevValue: { [key: string]: boolean },
+    value: { [key: string]: boolean }
+  ) => boolean,
+  callback: (changedFlags) => void
+) {
   const initialRender = useRef(false);
-  const savedCallback = useRef(callback);
+  const savedCallback =
+    useRef<(prevValue: { [key: string]: boolean }) => void>(callback);
   const [prevValue, setPrevValue] = useState(value);
 
   if (!compare(prevValue, value)) {
@@ -106,21 +114,15 @@ function useChangedValue(value, compare, callback) {
 }
 
 /**
- * Access whether a given flag is enabled or disabled in a given
- * FeatureFlagContext
- *
- * @returns {boolean}
+ * Access whether a given flag is enabled or disabled in a given FeatureFlagContext
  */
-function useFeatureFlag(flag) {
+function useFeatureFlag(flag: string): boolean {
   const scope = useContext(FeatureFlagContext);
-  // console.log(scope);
   return scope.enabled(flag);
 }
 
 /**
  * Access all feature flag information for the given FeatureFlagContext
- *
- * @returns {FeatureFlagScope}
  */
 function useFeatureFlags() {
   return useContext(FeatureFlagContext);
@@ -131,11 +133,8 @@ function useFeatureFlags() {
  * comparison since the objects we are comparing are objects with boolean flags
  * from the flags prop in the `FeatureFlags` component
  *
- * @param {object} a
- * @param {object} b
- * @returns {boolean}
  */
-function isEqual(a, b) {
+function isEqual(a: object, b: object): boolean {
   if (a === b) {
     return true;
   }


### PR DESCRIPTION
Closes #5671 

Converts `FeatureFlags` to TypeScript, also realized we didn't _have_ to do this one because it's released currently as unstable. But it didn't require too many changes 😄 

#### What did you change?
```
packages/ibm-products/src/components/FeatureFlags/index.tsx
```
#### How did you test and verify your work?
Component and hooks still function as expected in storybook, no type errors