### PR TITLE
fix(Datagrid): EditableCell shifting focus to the below cell after edit

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
@@ -229,7 +229,9 @@ export const InlineEditCell = ({
     const newCellId =
       key === 'Enter'
         ? `column-${columnIndex}-row-${
-            cell.row.index < totalRows - 1 ? cell.row.index + 1 : cell.row.index
+            cell.row.index < totalRows - 1 && type === 'checkbox'
+              ? cell.row.index + 1
+              : cell.row.index
           }`
         : `column-${
             columnIndex < instance.columns.length - 1


### PR DESCRIPTION
Closes #5649 

fixes the focus going to below cell after we hit enter to save the cell

#### What did you change?
packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js

#### How did you test and verify your work?
storybook
