### PR TITLE
fix(PageHeader): correct conditional for non zero offsets

### DIFF
--- a/packages/ibm-products/src/components/PageHeader/PageHeaderUtils.js
+++ b/packages/ibm-products/src/components/PageHeader/PageHeaderUtils.js
@@ -86,7 +86,7 @@ export const utilCheckUpdateVerticalSpace = (
     // The header offset calculation is either going to work out at 0 if we have no gap between scrolling container
     // top and the measuring ref top, or the difference between.
     update.headerOffset =
-      offsetMeasuringTop === 0
+      offsetMeasuringTop !== 0
         ? offsetMeasuringTop - scrollableContainerTop
         : 0;
 


### PR DESCRIPTION
Closes #4427

`headerOffset` is used to ensure the PageHeader works correctly if the component is not at the top of the viewport. The conditional for calculating a header offset was incorrect.

#### What did you change?

Previously it checked whether the offset value was zero. This could only be true if the header was already at the top of the viewport or it could not obtain a reference to the `offsetTopMeasuringRef`. In either case there would be no need to calculate the offset anyway.

By inverting the conditional, headerOffset will now be calculated (i.e. set to non-zero) if the offset component used to identify the PageHeader's position within the viewport if actually offset from the top.