### PR TITLE
feat(RemoveModal): update body to use ReactNode

### DIFF
--- a/packages/ibm-products/src/components/RemoveModal/RemoveModal.stories.jsx
+++ b/packages/ibm-products/src/components/RemoveModal/RemoveModal.stories.jsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState } from 'react';
-import { Button } from '@carbon/react';
+import { Button, Link } from '@carbon/react';
 // import styles from './_storybook-styles.scss?inline'; // import index in case more files are added later.
 import { RemoveModal } from '.';
 import DocsPage from './RemoveModal.docs-page';
@@ -82,4 +82,18 @@ export const DeletePattern = Template.bind({});
 DeletePattern.args = {
   ...defaultProps,
   textConfirmation: true,
+};
+
+export const ComponentInBodyPattern = Template.bind({});
+ComponentInBodyPattern.args = {
+  ...defaultProps,
+  body: (
+    <React.Fragment>
+      {`Before removing ${resourceName}, you can find out more information on the `}
+      <Link href={'https://www.carbondesignsystem.com'}>
+        Carbon Design System
+      </Link>
+      {' website.'}
+    </React.Fragment>
+  ),
 };

--- a/packages/ibm-products/src/components/RemoveModal/RemoveModal.test.js
+++ b/packages/ibm-products/src/components/RemoveModal/RemoveModal.test.js
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -8,6 +8,7 @@
 import { fireEvent, render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { Link } from '@carbon/react';
 
 import { RemoveModal } from '.';
 
@@ -28,6 +29,19 @@ const defaultProps = {
   secondaryButtonText: 'secondary button text',
   textConfirmation: false,
   title: 'test title',
+};
+
+const bodyWithReactNodeProps = {
+  ...defaultProps,
+  body: (
+    <React.Fragment>
+      {`Before removing ${resourceName}, you can find out more information on the `}
+      <Link href={'https://www.carbondesignsystem.com'}>
+        {'Carbon Design System'}
+      </Link>
+      {' website.'}
+    </React.Fragment>
+  ),
 };
 
 describe(componentName, () => {
@@ -149,5 +163,12 @@ describe(componentName, () => {
     expect(screen.getByTestId(dataTestId)).toHaveDevtoolsAttribute(
       componentName
     );
+  });
+
+  it('use react component in the body to render link', async () => {
+    render(
+      <RemoveModal {...bodyWithReactNodeProps} data-testid={dataTestId} />
+    );
+    screen.getByRole('link', { name: 'Carbon Design System' });
   });
 });

--- a/packages/ibm-products/src/components/RemoveModal/RemoveModal.tsx
+++ b/packages/ibm-products/src/components/RemoveModal/RemoveModal.tsx
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2024
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -34,7 +34,7 @@ interface RemoveModalProps extends React.ComponentProps<typeof ComposedModal> {
   /**
    * The content to be displayed in the body of the modal
    */
-  body: string;
+  body: ReactNode;
   /**
    * Optional classname
    */
@@ -192,7 +192,11 @@ export let RemoveModal = forwardRef(
           iconDescription={iconDescription}
         />
         <ModalBody>
-          <p className={`${blockClass}__body`}>{body}</p>
+          {typeof body === 'string' ? (
+            <p className={`${blockClass}__body`}>{body}</p>
+          ) : (
+            body
+          )}
           {textConfirmation && (
             <TextInput
               id={`${idRef.current}-confirmation-input`}
@@ -237,7 +241,7 @@ RemoveModal.propTypes = {
   /**
    * The content to be displayed in the body of the modal
    */
-  body: PropTypes.string.isRequired,
+  body: PropTypes.node.isRequired,
   /**
    * Optional classname
    */


### PR DESCRIPTION
Closes #2289 

Update the Remove Modal to use ReactNode

#### What did you change?
Changed the typing for the body from `string` to `ReactNode`. 

#### How did you test and verify your work?
- Added a test to check that a `Link` react node exists in the modal when added. 
- Added a new story in storybook which includes a `Link` react node in the body of text, linking to the carbon design homepage. Note: the naming of the story might want some work, and for my use case, I am looking at using Links, but are there other potential components that should be tested here? 

