### PR TITLE
build(playwright): remove playwright results from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,4 +71,3 @@ package-lock.json
 
 # Playwright
 .playwright/
-/packages/ibm-products/.playwright/


### PR DESCRIPTION
Addresses missing piece from https://github.com/carbon-design-system/ibm-products/issues/5576

Because the playwright results for `packages/ibm-products` are included in our `gitignore`, the results are never included in our published releases. This is problematic in that we won't be able to use up to date playwright avt coverage results in the website. I've removed it from our `gitignore` so that we can pull the results from our package instead of including it just as a local file for the website (see [here](https://github.com/carbon-design-system/carbon-for-products-website/blob/main/src/components/A11yStatus/test_avt_report.json)).

#### What did you change?
```
.gitignore
```
#### How did you test and verify your work?
Ran build locally