### PR TITLE
fix(Datagrid): datagrid sort reset

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useInitialColumnSort.js
+++ b/packages/ibm-products/src/components/Datagrid/useInitialColumnSort.js
@@ -20,6 +20,10 @@ export const useInitialColumnSort = (instance) => {
 
     if (sortableColumn) {
       const { id: columnId, order } = sortableColumn;
+      // prevents edge case where initial sort state of none actually starts out as ascending
+      if (order !== 'ASC' && order !== 'DESC') {
+        return;
+      }
       const { newSortDesc, newOrder } = getNewSortOrder(order);
       onSort?.(columnId, newOrder);
       instance.toggleSortBy(columnId, newSortDesc, false);

--- a/packages/ibm-products/src/components/Datagrid/useSortableColumns.tsx
+++ b/packages/ibm-products/src/components/Datagrid/useSortableColumns.tsx
@@ -15,26 +15,35 @@ import { DatagridSlug } from './Datagrid/addons/Slug/DatagridSlug';
 import { Hooks, TableInstance } from 'react-table';
 import { DataGridState } from './types';
 
+interface Order {
+  newOrder: 'ASC' | 'DESC' | 'NONE';
+  newSortDesc: undefined | boolean;
+}
+
 const blockClass = `${pkg.prefix}--datagrid`;
 
-const ordering = {
-  ASC: 'ASC',
-  DESC: 'DESC',
-  NONE: 'NONE',
-};
-
-export const getNewSortOrder = (sortOrder?: boolean | string) => {
-  const order = {
-    newSortDesc: false,
-    newOrder: ordering.NONE,
+export const getNewSortOrder = (currentOrder?: boolean | string) => {
+  const order: Order = {
+    newOrder: 'NONE',
+    newSortDesc: undefined,
   };
-  if (sortOrder === false || sortOrder === ordering.DESC) {
-    order.newOrder = ordering.DESC;
+
+  // NONE => ASC
+  if (currentOrder === undefined) {
+    order.newOrder = 'ASC';
+    order.newSortDesc = false;
+  }
+
+  // ACS => DESC
+  if (currentOrder === false || currentOrder === 'DESC') {
+    order.newOrder = 'DESC';
     order.newSortDesc = true;
   }
-  if (sortOrder === undefined || sortOrder === ordering.ASC) {
-    order.newOrder = ordering.ASC;
-    order.newSortDesc = false;
+
+  // DESC => NONE
+  if (currentOrder === true || currentOrder === 'ASC') {
+    order.newOrder = 'NONE';
+    order.newSortDesc = undefined;
   }
   return order;
 };


### PR DESCRIPTION
Closes #5569

fixes bug where cycling through the column sort options on datagrid wouldn't allow you to go back to no sort