### PR TITLE
fix: datagrid hidden virtual body width

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridVirtualBody.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridVirtualBody.tsx
@@ -47,7 +47,9 @@ const DatagridVirtualBody = (datagridState: DataGridState) => {
   /* istanbul ignore next */
   const handleVirtualGridResize = () => {
     const gridRefElement = gridRef?.current;
-    if (gridRefElement) {
+    // isHidden checks for an edge case where if the table is hidden by something like a Tab that the width can't be calculated to 0
+    const isHidden = gridRefElement?.offsetParent === null;
+    if (gridRefElement && !isHidden) {
       gridRefElement.style.width = gridRefElement?.clientWidth?.toString();
     }
   };


### PR DESCRIPTION
Closes #4579 

fixes a bug where a datagrid using infinite scrolling when hidden by something like a carbon `Tab` the width was getting set to 0. this fix simply checks to make sure the datagrid is on screen before applying a new width
