### PR TITLE
fix(useFocus): variable name changed

### DIFF
--- a/packages/ibm-products/src/global/js/hooks/useFocus.js
+++ b/packages/ibm-products/src/global/js/hooks/useFocus.js
@@ -44,13 +44,13 @@ export const useFocus = (modalRef, selectorPrimaryFocus) => {
     const first = focusableElements?.[0];
     const last = focusableElements?.[focusableElements?.length - 1];
     const all = focusableElements;
-    const specifiedElement = getSpecificElement(modalEl, selectorPrimaryFocus);
+    const specified = getSpecificElement(modalEl, selectorPrimaryFocus);
 
     return {
       first,
       last,
       all,
-      specifiedElement,
+      specified,
     };
   }, [modalEl, query, selectorPrimaryFocus]);
 
@@ -84,6 +84,8 @@ export const useFocus = (modalRef, selectorPrimaryFocus) => {
       }, 0);
     }
   };
+
+  console.log();
 
   return {
     firstElement: getFocusable().first,


### PR DESCRIPTION
Closes #5811 

{{short description}}

#### What did you change?
`packages/ibm-products/src/global/js/hooks/useFocus.js`
Line 47: Variable name changed to `specified`.
Line 53: Property name changed to `specified`.

#### How did you test and verify your work?
Storybook
`yarn avt`
