### PR TITLE
fix(datagrid): filter tooltip causes horizontal scroll

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
@@ -33,11 +33,13 @@ const defaults = {
   title: 'Filter',
   primaryActionLabel: 'Apply',
   secondaryActionLabel: 'Cancel',
+  align: 'bottom',
 };
 
 const FilterFlyout = ({
   updateMethod,
   flyoutIconDescription = defaults.flyoutIconDescription,
+  align = defaults.align,
   filters = [],
   title = defaults.title,
   primaryActionLabel = defaults.primaryActionLabel,
@@ -239,7 +241,7 @@ const FilterFlyout = ({
       <IconButton
         label={flyoutIconDescription}
         kind="ghost"
-        align="bottom"
+        align={align}
         onClick={open ? closeFlyout : openFlyout}
         className={cx(`${componentClass}__trigger`, {
           [`${componentClass}__trigger--open`]: open,
@@ -274,6 +276,10 @@ const FilterFlyout = ({
 };
 
 FilterFlyout.propTypes = {
+  /**
+   * Tooltip alignment for the filter button
+   */
+  align: PropTypes.string,
   /**
    * All data rows in the table
    */

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.jsx
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.jsx
@@ -194,6 +194,7 @@ FlyoutInstant.args = {
     primaryActionLabel: 'Apply',
     secondaryActionLabel: 'Cancel',
     flyoutIconDescription: 'Open filters',
+    align: 'bottom',
     onFlyoutOpen: action('onFlyoutOpen'),
     onFlyoutClose: action('onFlyoutClose'),
     filters,

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.jsx
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Flyout.stories.jsx
@@ -165,6 +165,7 @@ FlyoutBatch.args = {
     primaryActionLabel: 'Apply',
     secondaryActionLabel: 'Cancel',
     flyoutIconDescription: 'Open filters',
+    align: 'bottom',
     onFlyoutOpen: action('onFlyoutOpen'),
     onFlyoutClose: action('onFlyoutClose'),
     filters,

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.jsx
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.jsx
@@ -79,6 +79,7 @@ export const getFilterProps = (id = 'id') => ({
   secondaryActionLabel: 'Cancel',
   panelIconDescription: `Open filters`,
   closeIconDescription: 'Close panel',
+  align: 'bottom',
   sections: [
     {
       categoryTitle: 'Category title',
@@ -260,6 +261,7 @@ PanelInstant.args = {
     secondaryActionLabel: 'Cancel',
     panelIconDescription: `Open filters`,
     closeIconDescription: 'Close panel',
+    align: 'bottom',
     sections: [
       {
         categoryTitle: 'Category title',
@@ -454,6 +456,7 @@ PanelWithInitialFilters.args = {
     secondaryActionLabel: 'Cancel',
     panelIconDescription: `Open filters`,
     closeIconDescription: 'Close panel',
+    align: 'bottom',
     sections: [
       {
         categoryTitle: 'Category title',
@@ -615,6 +618,7 @@ PanelOnlyAccordions.args = {
     secondaryActionLabel: 'Cancel',
     panelIconDescription: `Open filters`,
     closeIconDescription: 'Close panel',
+    align: 'bottom',
     sections: [
       {
         categoryTitle: 'Category title',
@@ -777,6 +781,7 @@ PanelNoAccordions.args = {
     secondaryActionLabel: 'Cancel',
     panelIconDescription: `Open filters`,
     closeIconDescription: 'Close panel',
+    align: 'bottom',
     sections: [
       {
         categoryTitle: 'Category title',
@@ -939,6 +944,7 @@ PanelNoData.args = {
     secondaryActionLabel: 'Cancel',
     panelIconDescription: `Open filters`,
     closeIconDescription: 'Close panel',
+    align: 'bottom',
     sections: [
       {
         categoryTitle: 'Category title',
@@ -1101,6 +1107,7 @@ PanelManyCheckboxes.args = {
     secondaryActionLabel: 'Cancel',
     panelIconDescription: `Open filters`,
     closeIconDescription: 'Close panel',
+    align: 'bottom',
     sections: [
       {
         categoryTitle: 'Category title',

--- a/packages/ibm-products/src/components/Datagrid/utils/DatagridActions.js
+++ b/packages/ibm-products/src/components/Datagrid/utils/DatagridActions.js
@@ -72,7 +72,7 @@ export const DatagridActions = (datagridState) => {
     filterProps?.variation === 'panel' && (
       <IconButton
         kind="ghost"
-        align="bottom"
+        align={filterProps.align}
         label={filterProps.panelIconDescription}
         className={`${blockClass}-filter-panel-open-button`}
         onClick={() => setPanelOpen((open) => !open)}


### PR DESCRIPTION
Closes #5000

Datagrid filter icon at the right most end of the screen causes scroll bar on hover. 
Issue caused by the tooltip

#### What did you change?
Added `align` prop in `filter flyout` and `filter panel` as part of `filter props`. 

#### How did you test and verify your work?
Storybook