### PR TITLE
fix(options-tile): size prop optional

### DIFF
--- a/packages/ibm-products/src/components/OptionsTile/OptionsTile.tsx
+++ b/packages/ibm-products/src/components/OptionsTile/OptionsTile.tsx
@@ -454,7 +454,6 @@ OptionsTile.propTypes = {
   /**
    * Define the size of the OptionsTile.
    */
-  /**@ts-ignore*/
   size: PropTypes.oneOf(['lg', 'xl']),
 
   /**

--- a/packages/ibm-products/src/components/OptionsTile/OptionsTile.tsx
+++ b/packages/ibm-products/src/components/OptionsTile/OptionsTile.tsx
@@ -85,7 +85,7 @@ interface OptionsTileProps {
   /**
    * Define the size of the OptionsTile.
    */
-  size: 'lg' | 'xl';
+  size?: 'lg' | 'xl';
 
   /**
    * Optionally provide a text summarizing the current state of the content.


### PR DESCRIPTION
Closes #5702 

Changes size prop to optional on ts prop declarations

#### What did you change?
- packages/ibm-products/src/components/OptionsTile/OptionsTile.tsx


