### PR TITLE
fix(Datagrid): sortable column focus issue

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useSortableColumns.tsx
+++ b/packages/ibm-products/src/components/Datagrid/useSortableColumns.tsx
@@ -126,6 +126,14 @@ const useSortableColumns = (hooks: Hooks) => {
         }
         return <ArrowsVertical {...iconProps} />;
       };
+
+      const handleKey = (e, columnId) => {
+        const { key } = e;
+        if (key === 'Enter') {
+          setTimeout(() => document.getElementById(columnId)?.focus(), 0);
+        }
+      };
+
       const Header = (headerProp) =>
         column.disableSortBy === true ||
         column.id === 'datagridSelection' ||
@@ -153,6 +161,7 @@ const useSortableColumns = (hooks: Hooks) => {
                 </>
               );
             }}
+            id={column?.id}
             className={cx(
               `${carbon.prefix}--table-sort ${blockClass}--table-sort`,
               {
@@ -162,6 +171,7 @@ const useSortableColumns = (hooks: Hooks) => {
                   headerProp?.column.isSortedDesc === false,
               }
             )}
+            onKeyDown={(event) => handleKey(event, column.id)}
           >
             {column.Header}
           </Button>


### PR DESCRIPTION
Closes #5079 

Instead of losing the column header focus after sorting, now user will be able to sort in opposite direction without pressing the Tab again ( just needs to press Enter to sort in opposite direction).

#### What did you change? packages/ibm-products/src/components/Datagrid/useSortableColumns.tsx

#### How did you test and verify your work? storybook
