### PR TITLE
fix: correct auto-generated guidelines links

### DIFF
--- a/packages/ibm-products/src/global/js/utils/story-helper.js
+++ b/packages/ibm-products/src/global/js/utils/story-helper.js
@@ -130,7 +130,7 @@ export const storyDocsPageInfo = (csfFile) => {
 
     result.section = a;
 
-    result.guidelinesHref = `https://pages.github.ibm.com/cdai-design/pal/${kind}s/${paramCase(
+    result.guidelinesHref = `https://pages.github.ibm.com/cdai-design/pal/${kind.toLowerCase()}/${paramCase(
       result.section
     )}/usage`;
   } else {


### PR DESCRIPTION
Addresses _most_ cases from https://github.com/carbon-design-system/ibm-products/issues/5837

Currently, all auto-generated guideline links for components and patterns are leading to 404 pages as they…:
- use an uppercase first characters instead of lowercase
- add an unwanted "s" suffix

Before
```
https://pages.github.ibm.com/cdai-design/pal/Componentss/side-panel/usage
```

After
```
https://pages.github.ibm.com/cdai-design/pal/components/side-panel/usage
```

#### What did you change?

- Transform kind (`Components | Patterns`) to lowercase
- Remove unwanted "s" suffix

#### How did you test and verify your work?
Local storybook
