### PR TITLE
fix: reword props in card stories

### DIFF
--- a/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.stories.jsx
+++ b/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.stories.jsx
@@ -111,7 +111,7 @@ const defaultProps = {
       action on the card.
     </p>
   ),
-  primaryButtonText: 'Primary',
+  primaryButtonText: 'Read more',
 };
 
 const Template = (opts) => {
@@ -205,7 +205,7 @@ WithPictogram.args = {
 export const WithSecondaryAction = Template.bind({});
 WithSecondaryAction.args = {
   ...defaultProps,
-  secondaryButtonText: 'Secondary',
+  secondaryButtonText: 'Remove',
   secondaryButtonKind: 'ghost',
   mediaRatio: null,
 };
@@ -224,7 +224,7 @@ WithButtonHref.args = {
   ...defaultProps,
   primaryButtonHref: '#',
   secondaryButtonHref: '#',
-  secondaryButtonText: 'Secondary',
+  secondaryButtonText: 'Remove',
   secondaryButtonKind: 'ghost',
 };
 

--- a/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.stories.jsx
+++ b/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.stories.jsx
@@ -156,7 +156,7 @@ LabelOnly.args = {
   title: '',
   label: 'Label',
   actionsPlacement: 'bottom',
-  primaryButtonText: 'Ghost button',
+  primaryButtonText: 'Read more',
 };
 
 export const WithOverflow = Template.bind({});
@@ -183,16 +183,16 @@ WithOverflow.args = {
 export const SupplementalBottomBar = Template.bind({});
 SupplementalBottomBar.args = {
   ...defaultProps,
-  primaryButtonText: 'Ghost button',
+  primaryButtonText: 'Read more',
 };
 
 export const ComplexBottomBar = Template.bind({});
 ComplexBottomBar.args = {
   ...defaultProps,
-  primaryButtonText: 'Ghost button',
+  primaryButtonText: 'Read more',
   actionsPlacement: 'bottom',
   title: '',
-  label: 'label',
+  label: 'Label',
 };
 
 export const Clickable = Template.bind({});
@@ -200,14 +200,14 @@ Clickable.args = {
   ...defaultProps,
   onClick: action('on click'),
   onKeyDown: action('on keydown'),
-  primaryButtonText: 'Ghost button',
+  primaryButtonText: 'Read more',
   actionIcons: [],
 };
 
 export const WithButtonHref = Template.bind({});
 WithButtonHref.args = {
   ...defaultProps,
-  primaryButtonText: 'Ghost button',
+  primaryButtonText: 'Read more',
   primaryButtonHref: '#',
 };
 
@@ -215,7 +215,7 @@ export const WithActionGhostButton = Template.bind({});
 WithActionGhostButton.args = {
   ...defaultProps,
   primaryButtonPlacement: 'top',
-  primaryButtonText: 'Ghost button',
+  primaryButtonText: 'Read more',
   primaryButtonIcon: (props) => <TrashCan size={16} {...props} />,
   primaryButtonDisabled: true,
 };


### PR DESCRIPTION
Closes #5863 

this helps to alleviate some issues Raghu was experiencing while testing cards. when the button is focused with VO in the link button example VO was reading like `link. ghost button.` which made it unclear as to what the element being focused was. a button or a link? this just rewords some of the props so they look like more real world examples to make our examples more clear to assistive technology.