### PR TITLE
fix(create-full-page-step): update `hasFieldSet` type and export `CreateFullPageStepProps`

### DIFF
--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPageStep.tsx
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPageStep.tsx
@@ -50,7 +50,7 @@ interface CreateFullPageStepBaseProps extends PropsWithChildren {
   /**
    * This optional prop will render your form content inside of a fieldset html element
    */
-  hasFieldset: boolean;
+  hasFieldset?: boolean;
 
   /**
    * This prop is used to help track dynamic steps. If this value is `false` then the step is not included in the visible steps or the ProgressIndicator
@@ -107,7 +107,7 @@ type CreateFullPageStepFieldsetProps =
       fieldsetLegendText: string;
     };
 
-type CreateFullPageStepProps = CreateFullPageStepBaseProps &
+export type CreateFullPageStepProps = CreateFullPageStepBaseProps &
   CreateFullPageStepFieldsetProps;
 
 export let CreateFullPageStep = forwardRef(

--- a/packages/ibm-products/src/components/CreateFullPage/index.ts
+++ b/packages/ibm-products/src/components/CreateFullPage/index.ts
@@ -8,3 +8,4 @@
 export { CreateFullPage } from './CreateFullPage';
 export { CreateFullPageStep } from './CreateFullPageStep';
 export type { CreateFullPageProps } from './CreateFullPage';
+export type { CreateFullPageStepProps } from './CreateFullPageStep';


### PR DESCRIPTION
Closes #5701 

This PR changes the `hasFieldSet` prop to optional and exports `CreateFullPageStepProps`

#### What did you change?

- packages/ibm-products/src/components/CreateFullPage/CreateFullPageStep.tsx
- packages/ibm-products/src/components/CreateFullPage/index.ts

