### PR TITLE
feat(datagrid): adds radio filter

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useFiltering.ts
+++ b/packages/ibm-products/src/components/Datagrid/useFiltering.ts
@@ -13,9 +13,22 @@ import {
   DATE,
   MULTISELECT,
   NUMBER,
+  RADIO,
 } from './Datagrid/addons/Filtering/constants';
 import { Hooks, TableInstance } from 'react-table';
 import { DataGridState } from './types';
+
+// This function was taken from https://github.com/TanStack/table/blob/v7/src/filterTypes.js
+export const exactText = (rows, ids, filterValue) => {
+  return rows.filter((row) => {
+    return ids.some((id) => {
+      const rowValue = row.values[id];
+      return rowValue !== undefined
+        ? String(rowValue).toLowerCase() === String(filterValue).toLowerCase()
+        : true;
+    });
+  });
+};
 
 const handleMultiFilter = (rows, id, value) => {
   // gets all the items that are selected and returns their value
@@ -72,6 +85,7 @@ const useFiltering = (hooks: Hooks) => {
       },
       [CHECKBOX]: (rows, id, value) => handleMultiFilter(rows, id, value),
       [MULTISELECT]: (rows, id, value) => handleMultiFilter(rows, id, value),
+      [RADIO]: (rows, id, value) => exactText(rows, id, value),
     }),
     []
   );

--- a/packages/ibm-products/src/components/Datagrid/utils/FilteringUsage.js
+++ b/packages/ibm-products/src/components/Datagrid/utils/FilteringUsage.js
@@ -96,6 +96,7 @@ export const FilteringUsage = ({ defaultGridProps }) => {
     {
       Header: 'Role',
       accessor: 'role',
+      filter: 'radio',
     },
   ];
 


### PR DESCRIPTION
Closes #5742 

This PR adds a new filter type to Radio buttons. The radio button will now search for the `exactText` react-table function when filtering rather than using `.includes()`

#### What did you change?
- packages/ibm-products/src/components/Datagrid/useFiltering.ts
- packages/ibm-products/src/components/Datagrid/utils/FilteringUsage.js

#### How did you test and verify your work?
Ran the same scenario as the issue and got it to work.

https://github.com/user-attachments/assets/8e92393e-5f71-49a5-8357-c007204f1426


