### PR TITLE
fix(TagSet): fix string formatting

### DIFF
--- a/packages/ibm-products/src/components/TagSet/TagSetOverflow.tsx
+++ b/packages/ibm-products/src/components/TagSet/TagSetOverflow.tsx
@@ -147,7 +147,7 @@ export const TagSetOverflow = React.forwardRef(
             onClick={() => setPopoverOpen?.(!popoverOpen)}
             className={cx(`${blockClass}__popover-trigger`)}
           >
-            +{overflowTags.length}
+            {'+' + overflowTags.length}
           </Tag>
           <PopoverContent>
             <div ref={overflowTagContent} className={`${blockClass}__content`}>

--- a/packages/ibm-products/src/components/TagSet/TagSetOverflow.tsx
+++ b/packages/ibm-products/src/components/TagSet/TagSetOverflow.tsx
@@ -147,7 +147,7 @@ export const TagSetOverflow = React.forwardRef(
             onClick={() => setPopoverOpen?.(!popoverOpen)}
             className={cx(`${blockClass}__popover-trigger`)}
           >
-            {'+' + overflowTags.length}
+            {`+${overflowTags.length}`}
           </Tag>
           <PopoverContent>
             <div ref={overflowTagContent} className={`${blockClass}__content`}>


### PR DESCRIPTION
Closes #5854 

fixes string format for the child of the `<Tag>` component, which fixes the title attribute.

#### What did you change?
packages/ibm-products/src/components/TagSet/TagSetOverflow.tsx

#### How did you test and verify your work?
storybook