### PR TITLE
fix(CreateFullPage): full viewport height

### DIFF
--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -2124,7 +2124,8 @@ p.c4p--about-modal__copyright-text:first-child {
 
 .c4p--create-full-page {
   display: grid;
-  height: 100%;
+  overflow: hidden;
+  height: 100vh;
   color: var(--cds-text-primary, #161616);
   grid-template-rows: minmax(auto, 100%);
 }
@@ -4064,13 +4065,12 @@ p.c4p--about-modal__copyright-text:first-child {
   width: 1rem;
 }
 
-/*
-* Licensed Materials - Property of IBM
-* 5724-Q36
-* (c) Copyright IBM Corp. 2020 - 2022
-* US Government Users Restricted Rights - Use, duplication or disclosure
-* restricted by GSA ADP Schedule Contract with IBM Corp.
-*/
+/**
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 .cds--data-table tr.c4p--datagrid__carbon-nested-row {
   border-left: 1px solid transparent;
 }
@@ -4121,7 +4121,7 @@ p.c4p--about-modal__copyright-text:first-child {
 }
 
 .cds--data-table td.c4p--datagrid__expandable-row-cell.c4p--datagrid__expandable-row-cell--is-expanded + td::before,
-.cds--data-table .c4p--datagrid__carbon-nested-row:not(.c4p--datagrid__carbon-row-expandable) td.c4p--datagrid__cell:nth-of-type(2)::before,
+.cds--data-table .c4p--datagrid__carbon-nested-row:not(.c4p--datagrid__carbon-row-expandable):not(.c4p--datagrid__carbon-row-expandable--async) td.c4p--datagrid__cell:nth-of-type(2)::before,
 .cds--data-table .c4p--datagrid__carbon-nested-row td.c4p--datagrid__expandable-row-cell + td::before {
   position: absolute;
   /* stylelint-disable-next-line carbon/layout-token-use */
@@ -4145,13 +4145,12 @@ p.c4p--about-modal__copyright-text:first-child {
   border-bottom: none;
 }
 
-/*
-* Licensed Materials - Property of IBM
-* 5724-Q36
-* (c) Copyright IBM Corp. 2020
-* US Government Users Restricted Rights - Use, duplication or disclosure
-* restricted by GSA ADP Schedule Contract with IBM Corp.
-*/
+/**
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 .c4p--datagrid__expanded-row .cds--data-table-container {
   width: calc(100% - 2rem);
   border-left: 2px solid var(--cds-background-brand, #0f62fe);
@@ -4229,13 +4228,12 @@ p.c4p--about-modal__copyright-text:first-child {
   visibility: visible;
 }
 
-/*
-* Licensed Materials - Property of IBM
-* 5724-Q36
-* (c) Copyright IBM Corp. 2020
-* US Government Users Restricted Rights - Use, duplication or disclosure
-* restricted by GSA ADP Schedule Contract with IBM Corp.
-*/
+/**
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 .c4p--datagrid__right-align-header {
   width: 100%;
   text-align: right;
@@ -4267,13 +4265,12 @@ p.c4p--about-modal__copyright-text:first-child {
   margin-left: auto;
 }
 
-/*
-* Licensed Materials - Property of IBM
-* 5724-Q36
-* (c) Copyright IBM Corp. 2021
-* US Government Users Restricted Rights - Use, duplication or disclosure
-* restricted by GSA ADP Schedule Contract with IBM Corp.
-*/
+/**
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 .c4p--datagrid__right-sticky-column-cell {
   /* stylelint-disable-next-line declaration-no-important */
   position: sticky !important;
@@ -4334,13 +4331,12 @@ p.c4p--about-modal__copyright-text:first-child {
   left: 0;
 }
 
-/*
-* Licensed Materials - Property of IBM
-* 5724-Q36
-* (c) Copyright IBM Corp. 2021
-* US Government Users Restricted Rights - Use, duplication or disclosure
-* restricted by GSA ADP Schedule Contract with IBM Corp.
-*/
+/**
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 .c4p--datagrid__actions-column-cell {
   display: flex;
   flex-flow: column;
@@ -4428,13 +4424,12 @@ p.c4p--about-modal__copyright-text:first-child {
   background-color: var(--cds-layer-selected);
 }
 
-/*
-* Licensed Materials - Property of IBM
-* 5724-Q36
-* (c) Copyright IBM Corp. 2021
-* US Government Users Restricted Rights - Use, duplication or disclosure
-* restricted by GSA ADP Schedule Contract with IBM Corp.
-*/
+/**
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 .c4p--datagrid .c4p--datagrid__row-size-toggle-tip-content {
   background-color: var(--cds-layer-02, #ffffff);
   box-shadow: 1px 4px 8px -3px var(--cds-overlay, rgba(22, 22, 22, 0.5)), -1px 6px 8px -5px var(--cds-overlay, rgba(22, 22, 22, 0.5));
@@ -4725,13 +4720,12 @@ th.c4p--datagrid__select-all-toggle-on.button {
   width: 10rem;
 }
 
-/*
-* Licensed Materials - Property of IBM
-* 5724-Q36
-* (c) Copyright IBM Corp. 2022
-* US Government Users Restricted Rights - Use, duplication or disclosure
-* restricted by GSA ADP Schedule Contract with IBM Corp.
-*/
+/**
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 .c4p--datagrid .c4p--datagrid__expanded-row-content {
   position: relative;
   padding: 1rem 1rem 1.5rem 4rem;
@@ -4899,13 +4893,12 @@ th.c4p--datagrid__select-all-toggle-on.button {
   white-space: nowrap;
 }
 
-/*
-* Licensed Materials - Property of IBM
-* 5724-Q36
-* (c) Copyright IBM Corp. 2021
-* US Government Users Restricted Rights - Use, duplication or disclosure
-* restricted by GSA ADP Schedule Contract with IBM Corp.
-*/
+/**
+ * Copyright IBM Corp. 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 .c4p--datagrid .c4p--datagrid__inline-edit--outer-cell-button--xs .cds--text-input,
 .c4p--datagrid .c4p--datagrid__inline-edit--outer-cell-button--xs .cds--number input[type=number],
 .c4p--datagrid .c4p--datagrid__inline-edit--outer-cell-button--xs .c4p--datagrid__inline-edit--select .cds--list-box.cds--dropdown,

--- a/packages/ibm-products-styles/src/components/CreateFullPage/_create-full-page.scss
+++ b/packages/ibm-products-styles/src/components/CreateFullPage/_create-full-page.scss
@@ -23,10 +23,10 @@ $step-block-class: #{c4p-settings.$pkg-prefix}--create-full-page__step;
 
 .#{$block-class} {
   display: grid;
-  height: 100%;
+  overflow: hidden;
+  height: 100vh;
   color: $text-primary;
   grid-template-rows: minmax(auto, 100%);
-
   &:has(.#{$block-class}__header) {
     grid-template-rows: auto minmax(auto, 100%);
   }

--- a/packages/ibm-products/src/components/CreateFullPage/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/CreateFullPage/_storybook-styles.scss
@@ -65,11 +65,6 @@ $block-class: #{c4p-settings.$pkg-prefix}--create-full-page;
   padding-left: 0;
 }
 
-.#{$story-class}__viewport {
-  overflow: hidden;
-  height: 100vh;
-}
-
 .#{$story-class}__viewport .#{$story-class}__content-container {
   height: 100%;
   overflow-y: auto;


### PR DESCRIPTION
Closes #5573 

CreateFullPage is not using the full viewport height anymore, it was working on earlier versions. 
[4794](https://github.com/carbon-design-system/ibm-products/pull/4794) this change introduced current issue

#### What did you change? 
packages/ibm-products-styles/src/components/CreateFullPage/_create-full-page.scss
packages/ibm-products/src/components/CreateFullPage/_storybook-styles.scss

#### How did you test and verify your work? storybook
