### PR TITLE
chore(stylelint): use version for stylelint config package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - v1
+      - 'release/v2*'
   merge_group:
     types: [checks_requested]
 

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "react-dom": "^18.2.0",
     "rimraf": "^5.0.5",
     "stylelint": "^15.11.0",
-    "stylelint-config-ibm-products": "*",
+    "stylelint-config-ibm-products": "^0.0.45",
     "webpack": "^5.90.0"
   },
   "//resolutions:http-signature": "package 'request' deprecated but still used, asks for http-signature ~1.2.0 which indirectly has vulnerabilities",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13852,7 +13852,7 @@ __metadata:
     react-dom: "npm:^18.2.0"
     rimraf: "npm:^5.0.5"
     stylelint: "npm:^15.11.0"
-    stylelint-config-ibm-products: "npm:*"
+    stylelint-config-ibm-products: "npm:^0.0.45"
     stylelint-plugin-carbon-tokens: "npm:2.8.0"
     webpack: "npm:^5.90.0"
   languageName: unknown
@@ -22237,7 +22237,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylelint-config-ibm-products@npm:*, stylelint-config-ibm-products@workspace:config/stylelint-config-ibm-products":
+"stylelint-config-ibm-products@npm:^0.0.45, stylelint-config-ibm-products@workspace:config/stylelint-config-ibm-products":
   version: 0.0.0-use.local
   resolution: "stylelint-config-ibm-products@workspace:config/stylelint-config-ibm-products"
   dependencies:


### PR DESCRIPTION
[Running into an issue in the release](https://github.com/carbon-design-system/ibm-products/actions/runs/10455189263/job/28950754349) where lerna is trying to find the `stylelint-config-ibm-products@npm: *` and is failing. The other private packages are referenced directly with their package versions, so changing to the same for the `stylelint-config-ibm-products` package as well to see if that will work.

<img width="1146" alt="Screenshot 2024-08-19 at 10 42 22 AM" src="https://github.com/user-attachments/assets/d5cc7488-6332-44eb-b3f5-d5ee7feb768e">

Will keep an eye out to see if lerna updates the `stylelint-config-ibm-products` version in root `package.json` as the reason why it was changed to `*` was because it was not getting updated by lerna.|

Also add the release branch to the `ci.yml` workflow so we can get ci-checks running on PRs based against the release branch

#### What did you change?

- `package.json`
- `ci.yml`
- `yarn.lock`
