### PR TITLE
fix(Tearsheet): update `portalTarget` type

### DIFF
--- a/packages/ibm-products/src/components/APIKeyModal/APIKeyModal.types.ts
+++ b/packages/ibm-products/src/components/APIKeyModal/APIKeyModal.types.ts
@@ -146,7 +146,7 @@ interface APIKeyModalCommonProps {
   /**
    * The DOM node the tearsheet should be rendered within. Defaults to document.body.
    */
-  portalTarget: ReactNode;
+  portalTarget?: ReactNode;
   /**
    * label text that's displayed when hovering over visibility toggler to show key
    */

--- a/packages/ibm-products/src/components/Tearsheet/Tearsheet.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/Tearsheet.tsx
@@ -59,7 +59,7 @@ export interface TearsheetProps extends PropsWithChildren {
    *
    * See https://react.carbondesignsystem.com/?path=/docs/components-button--default#component-api
    */
-  actions: ButtonProps[];
+  actions: ButtonProps<'button'>[];
 
   /**
    * The aria-label for the tearsheet, which is optional.
@@ -133,7 +133,7 @@ export interface TearsheetProps extends PropsWithChildren {
   /**
    * The DOM element that the tearsheet should be rendered within. Defaults to document.body.
    */
-  portalTarget: ReactNode;
+  portalTarget?: ReactNode;
 
   /**
    * Specify a CSS selector that matches the DOM element that should be


### PR DESCRIPTION
Closes #5700 

Makes the `portalTarget` property optional, as expected. I also found it was marked as required in `APIKeyModal` which I fixed in this PR as well.

#### What did you change?
```
packages/ibm-products/src/components/APIKeyModal/APIKeyModal.types.ts
packages/ibm-products/src/components/Tearsheet/Tearsheet.tsx
```
#### How did you test and verify your work?
Locally, verified within vscode