### PR TITLE
fix(Datagrid): remove unused span with `inputProps`

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
@@ -397,10 +397,6 @@ export const InlineEditCell = ({
     }
   };
 
-  const renderRegularCell = () => {
-    return <span {...inputProps} id={cellId}></span>;
-  };
-
   const renderDateCell = () => {
     const datePickerPreparedProps = prepareProps(config.inputProps, [
       'datePickerInputProps',
@@ -584,10 +580,6 @@ export const InlineEditCell = ({
         [`${blockClass}__static--outer-cell`]: !disabledCell,
       })}
     >
-      {!nonEditCell &&
-        !disabledCell &&
-        type !== 'checkbox' &&
-        renderRegularCell()}
       {(!inEditMode || disabledCell) && type !== 'checkbox' && (
         <InlineEditButton
           isActiveCell={cellId === activeCellId}


### PR DESCRIPTION
Closes #5912 

This PR removes the `renderRegularCell` function that was spreading `inputProps` onto a `span` element, resulting in the bug described in #5912. That element isn't serving any purpose so we can safely remove it.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
```
#### How did you test and verify your work?
Storybook