### PR TITLE
fix(EditInPlace): removes focus when pressing esc or enter key

### DIFF
--- a/packages/ibm-products/src/components/EditInPlace/EditInPlace.tsx
+++ b/packages/ibm-products/src/components/EditInPlace/EditInPlace.tsx
@@ -248,16 +248,21 @@ export let EditInPlace = forwardRef<HTMLDivElement, EditInplaceProps>(
       onCancelHandler();
     };
 
+    const removeFocus = () => {
+      inputRef.current?.blur();
+      setFocused(false);
+    };
+
     const onKeyHandler = (e) => {
       // to prevent blur handler from being called twice add additional state to check if escape is being used
       escaping.current = true;
       switch (e.key) {
         case 'Escape':
-          inputRef.current?.blur();
+          removeFocus();
           escapeHandler();
           break;
         case 'Enter':
-          inputRef.current?.blur();
+          removeFocus();
           returnHandler();
           break;
         default:

--- a/packages/ibm-products/src/components/EditInPlace/EditInPlace.tsx
+++ b/packages/ibm-products/src/components/EditInPlace/EditInPlace.tsx
@@ -207,13 +207,11 @@ export let EditInPlace = forwardRef<HTMLDivElement, EditInplaceProps>(
 
     const onSaveHandler = () => {
       setInitialValue(value);
-      setFocused(false);
       setDirtyInput(false);
       onSave();
     };
 
     const onCancelHandler = () => {
-      setFocused(false);
       setDirtyInput(false);
       onCancel(initialValue);
     };


### PR DESCRIPTION
Closes #5852 

This PR removes the focus of the EditInPlace after pressing Enter or the Escape key.

#### What did you change?
`packages/ibm-products/src/components/EditInPlace/EditInPlace.tsx`

#### How did you test and verify your work?
Modified storybook story to reflect the code sandbox props

https://github.com/user-attachments/assets/29621692-3efc-4c88-9293-6b49327c1fb5



