### PR TITLE
test(ConditionBuilder): add default state AVT for Condition Builder

### DIFF
--- a/e2e/components/ConditionBuilder/ConditionBuilder-test.avt.e2e.js
+++ b/e2e/components/ConditionBuilder/ConditionBuilder-test.avt.e2e.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const { expect, test } = require('@playwright/test');
+const { visitStory } = require('../../test-utils/storybook');
+
+test.describe('ConditionBuilder @avt', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'ConditionBuilder',
+      id: 'experimental-components-conditionbuilder--condition-builder',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations(
+      'ConditionBuilder @avt-default-state'
+    );
+  });
+});


### PR DESCRIPTION
Closes #5932

Add default state AVT check for Condition Builder

#### What did you change?
added `e2e/components/ConditionBuilder/ConditionBuilder-test.avt.e2e.js`
#### How did you test and verify your work?
yarn avt