### PR TITLE
fix: update toHaveNoAxeViolations and remove skips

### DIFF
--- a/config/jest-config-ibm-cloud-cognitive/setup/matchers/toHaveNoAxeViolations.js
+++ b/config/jest-config-ibm-cloud-cognitive/setup/matchers/toHaveNoAxeViolations.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2020
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -29,33 +29,24 @@ const defaultOptions = {
   },
 };
 
-function toHaveNoAxeViolations(node, options = {}) {
-  return new Promise((resolve) => {
-    axe.run(
-      node,
-      {
-        ...defaultOptions,
-        ...options,
-      },
-      (error, result) => {
-        if (error) {
-          throw error;
-        }
+async function toHaveNoAxeViolations(node, options = {}) {
+  await axe.run();
 
-        if (result.violations.length > 0) {
-          resolve({
-            message: () => formatOutput(result.violations),
-            pass: false,
-          });
-          return;
-        }
-
-        resolve({
-          pass: true,
-        });
-      }
-    );
+  const result = await axe.run(node, {
+    ...defaultOptions,
+    ...options,
   });
+
+  if (result.violations.length > 0) {
+    return {
+      message: () => formatOutput(result.violations),
+      pass: false,
+    };
+  }
+
+  return {
+    pass: true,
+  };
 }
 
 function formatOutput(violations) {

--- a/config/jest-config-ibm-cloud-cognitive/setup/matchers/toHaveNoAxeViolations.js
+++ b/config/jest-config-ibm-cloud-cognitive/setup/matchers/toHaveNoAxeViolations.js
@@ -30,8 +30,6 @@ const defaultOptions = {
 };
 
 async function toHaveNoAxeViolations(node, options = {}) {
-  await axe.run();
-
   const result = await axe.run(node, {
     ...defaultOptions,
     ...options,

--- a/packages/ibm-products/src/components/AboutModal/AboutModal.test.js
+++ b/packages/ibm-products/src/components/AboutModal/AboutModal.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -93,17 +93,16 @@ describe(componentName, () => {
     expect(screen.getByRole('presentation')).toHaveClass(blockClass);
   });
 
-  // Currently fails due to https://github.com/carbon-design-system/carbon/issues/14135 regarding focusable button
-  it.skip('has no accessibility violations when closed', async () => {
+  it('has no accessibility violations when closed', async () => {
     const { container } = renderComponent({ open: false });
-    expect(container).toBeAccessible(`${componentName} closed`);
-    expect(container).toHaveNoAxeViolations();
+    await expect(container).toBeAccessible(`${componentName} closed`);
+    await expect(container).toHaveNoAxeViolations();
   });
 
   it('has no accessibility violations', async () => {
     const { container } = renderComponent({ open: true });
-    expect(container).toBeAccessible(componentName);
-    expect(container).toHaveNoAxeViolations();
+    await expect(container).toBeAccessible(componentName);
+    await expect(container).toHaveNoAxeViolations();
   });
 
   it('renders closeIconDescription, title, logo, and version', async () => {

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.test.js
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -185,8 +185,7 @@ describe(componentName, () => {
     window.ResizeObserver = ResizeObserver;
   });
 
-  // Currently fails due to https://github.com/carbon-design-system/carbon/issues/14135 regarding focusable button
-  it.skip('has no accessibility violations', async () => {
+  it('has no accessibility violations', async () => {
     const { container } = renderComponent({ ...defaultFullPageProps });
 
     expect(container).toBeAccessible(componentName);

--- a/packages/ibm-products/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.test.js
+++ b/packages/ibm-products/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -76,17 +76,16 @@ describe(componentName, () => {
     expect(screen.getByText(defaultProps.primaryButtonText)).toBeVisible();
   });
 
-  it.skip('has no accessibility violations when closed', async () => {
-    // Currently fails due to https://github.com/carbon-design-system/carbon/issues/14135 regarding focusable button
+  it('has no accessibility violations when closed', async () => {
     const { container } = renderComponent({ open: false });
-    expect(container).toBeAccessible(componentName);
-    expect(container).toHaveNoAxeViolations();
+    await expect(container).toBeAccessible(componentName);
+    await expect(container).toHaveNoAxeViolations();
   });
 
   it('has no accessibility violations', async () => {
     const { container } = renderComponent();
-    expect(container).toBeAccessible(componentName);
-    expect(container).toHaveNoAxeViolations();
+    await expect(container).toBeAccessible(componentName);
+    await expect(container).toHaveNoAxeViolations();
   });
 
   it(`renders children`, async () => {

--- a/packages/ibm-products/src/components/Tearsheet/Tearsheet.test.js
+++ b/packages/ibm-products/src/components/Tearsheet/Tearsheet.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -106,8 +106,7 @@ const commonTests = (Ts, name, props, testActions) => {
     });
   });
 
-  // Currently fails due to https://github.com/carbon-design-system/carbon/issues/14135 regarding focusable button
-  it.skip('has no accessibility violations when closed', async () => {
+  it('has no accessibility violations when closed', async () => {
     const { container } = render(
       <Ts {...{ ...props, closeIconDescription, label, title }} />
     );


### PR DESCRIPTION
Updates toHaveNoAxeViolations and fixes a small number of use cases.

#### What did you change?

The function was creating a new Promise which is not necessary, refactored.

Not entirely sure the async/await is doing much in the tests that were refactored, but with async tests the accessible checks need to be waited for when there are multiple uses of the accessible matchers.

#### How did you test and verify your work?

Ran the tests.