### PR TITLE
fix(tagset): updates props

### DIFF
--- a/e2e/components/ConditionBuilder/ConditionBuilder-test.avt.e2e.js
+++ b/e2e/components/ConditionBuilder/ConditionBuilder-test.avt.e2e.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const { expect, test } = require('@playwright/test');
+const { visitStory } = require('../../test-utils/storybook');
+
+test.describe('ConditionBuilder @avt', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'ConditionBuilder',
+      id: 'experimental-components-conditionbuilder--condition-builder',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations(
+      'ConditionBuilder @avt-default-state'
+    );
+  });
+});

--- a/packages/ibm-products/src/components/TagSet/TagSet.test.js
+++ b/packages/ibm-products/src/components/TagSet/TagSet.test.js
@@ -14,11 +14,7 @@ import { TagSetModal } from './TagSetModal';
 
 import { TYPES as tagTypes } from './constants';
 
-import {
-  expectMultipleError,
-  mockHTMLElement,
-  required,
-} from '../../global/js/utils/test-helper';
+import { mockHTMLElement } from '../../global/js/utils/test-helper';
 import uuidv4 from '../../global/js/utils/uuidv4';
 
 const { prefix } = pkg;
@@ -196,22 +192,6 @@ describe(TagSet.displayName, () => {
     await act(() => userEvent.click(closeButton));
     expect(modal).not.toHaveClass('is-visible');
   });
-
-  it('it requires strings for overflow and modal when more than ten tags supplied.', async () =>
-    expectMultipleError(
-      [
-        required('allTagsModalSearchLabel', 'TagSet'),
-        required('allTagsModalSearchPlaceholderText', 'TagSet'),
-        required('allTagsModalTitle', 'TagSet'),
-        required('showAllTagsLabel', 'TagSet'),
-      ],
-      () => {
-        const visibleTags = 5;
-        window.innerWidth = tagWidth * (visibleTags + 1) + 1; // + 1 for overflow
-
-        render(<TagSet tags={tags} />);
-      }
-    ));
 
   it('Obeys max visible', async () => {
     window.innerWidth = tagWidth * 10 + 1;

--- a/packages/ibm-products/src/components/TagSet/TagSet.tsx
+++ b/packages/ibm-products/src/components/TagSet/TagSet.tsx
@@ -55,13 +55,6 @@ type OverflowAlign =
   | 'right-top';
 type OverflowType = 'default' | 'tag';
 
-// interface TagType extends TagBaseProps
-// {
-//   label: string;
-//   // we duplicate this prop to improve the DocGen
-//   type?: typeof tagTypes[number];
-// }
-
 type TagType = {
   label: string;
   type?: keyof typeof tagTypes;
@@ -72,11 +65,11 @@ export interface TagSetProps extends PropsWithChildren {
    */
   align?: Align;
   /**
-   * label text for the show all search. **Note: Required if more than 10 tags**
+   * label text for the show all search.
    */
   allTagsModalSearchLabel?: string;
   /**
-   * placeholder text for the show all search. **Note: Required if more than 10 tags**
+   * placeholder text for the show all search.
    */
   allTagsModalSearchPlaceholderText?: string;
   /**
@@ -84,7 +77,7 @@ export interface TagSetProps extends PropsWithChildren {
    */
   allTagsModalTarget?: ReactNode;
   /**
-   * title for the show all modal. **Note: Required if more than 10 tags**
+   * title for the show all modal.
    */
   allTagsModalTitle?: string;
   /**
@@ -127,10 +120,8 @@ export interface TagSetProps extends PropsWithChildren {
   overflowType?: OverflowType;
   /**
    * label for the overflow show all tags link.
-   *
-   * **Note:** Required if more than 10 tags
    */
-  showAllTagsLabel: string;
+  showAllTagsLabel?: string;
   /**
    * The tags to be shown in the TagSet. Each tag is specified as an object
    * with properties: **label**\* (required) to supply the tag content, and
@@ -155,11 +146,11 @@ export let TagSet = React.forwardRef<HTMLDivElement, TagSetProps>(
       overflowAlign = 'bottom',
       overflowClassName,
       overflowType = 'default',
-      allTagsModalTitle,
-      allTagsModalSearchLabel,
-      allTagsModalSearchPlaceholderText,
-      showAllTagsLabel,
-      tags,
+      allTagsModalTitle = 'All tags',
+      allTagsModalSearchLabel = 'Search all tags',
+      allTagsModalSearchPlaceholderText = 'Search all tags',
+      showAllTagsLabel = 'View all tags',
+      tags = [],
       containingElementRef,
       measurementOffset = defaults.measurementOffset,
       onOverflowTagChange = defaults.onOverflowTagChange,
@@ -448,21 +439,21 @@ TagSet.propTypes = {
    */
   align: PropTypes.oneOf(['start', 'center', 'end']),
   /**
-   * label text for the show all search. **Note: Required if more than 10 tags**
+   * label text for the show all search.
    */
-  allTagsModalSearchLabel: string_required_if_more_than_10_tags,
+  allTagsModalSearchLabel: PropTypes.string,
   /**
-   * placeholder text for the show all search. **Note: Required if more than 10 tags**
+   * placeholder text for the show all search.
    */
-  allTagsModalSearchPlaceholderText: string_required_if_more_than_10_tags,
+  allTagsModalSearchPlaceholderText: PropTypes.string,
   /**
    * portal target for the all tags modal
    */
   allTagsModalTarget: PropTypes.node,
   /**
-   * title for the show all modal. **Note: Required if more than 10 tags**
+   * title for the show all modal.
    */
-  allTagsModalTitle: string_required_if_more_than_10_tags,
+  allTagsModalTitle: PropTypes.string,
   /**
    * className
    */
@@ -517,10 +508,8 @@ TagSet.propTypes = {
   overflowType: PropTypes.oneOf(['default', 'tag']),
   /**
    * label for the overflow show all tags link.
-   *
-   * **Note:** Required if more than 10 tags
    */
-  showAllTagsLabel: string_required_if_more_than_10_tags,
+  showAllTagsLabel: PropTypes.string,
   /**
    * The tags to be shown in the TagSet. Each tag is specified as an object
    * with properties: **label**\* (required) to supply the tag content, and

--- a/packages/ibm-products/src/components/TagSet/TagSet.tsx
+++ b/packages/ibm-products/src/components/TagSet/TagSet.tsx
@@ -148,10 +148,10 @@ export let TagSet = React.forwardRef<HTMLDivElement, TagSetProps>(
       overflowAlign = 'bottom',
       overflowClassName,
       overflowType = 'default',
-      allTagsModalTitle,
-      allTagsModalSearchLabel,
-      allTagsModalSearchPlaceholderText,
-      showAllTagsLabel,
+      allTagsModalTitle = 'All tags',
+      allTagsModalSearchLabel = 'Search all tags',
+      allTagsModalSearchPlaceholderText = 'Search all tags',
+      showAllTagsLabel = 'View all tags',
       tags,
       containingElementRef,
       measurementOffset = defaults.measurementOffset,
@@ -441,21 +441,21 @@ TagSet.propTypes = {
    */
   align: PropTypes.oneOf(['start', 'center', 'end']),
   /**
-   * label text for the show all search. **Note: Required if more than 10 tags**
+   * label text for the show all search.
    */
-  allTagsModalSearchLabel: string_required_if_more_than_10_tags,
+  allTagsModalSearchLabel: PropTypes.string,
   /**
-   * placeholder text for the show all search. **Note: Required if more than 10 tags**
+   * placeholder text for the show all search.
    */
-  allTagsModalSearchPlaceholderText: string_required_if_more_than_10_tags,
+  allTagsModalSearchPlaceholderText: PropTypes.string,
   /**
    * portal target for the all tags modal
    */
   allTagsModalTarget: PropTypes.node,
   /**
-   * title for the show all modal. **Note: Required if more than 10 tags**
+   * title for the show all modal.
    */
-  allTagsModalTitle: string_required_if_more_than_10_tags,
+  allTagsModalTitle: PropTypes.string,
   /**
    * className
    */
@@ -510,10 +510,8 @@ TagSet.propTypes = {
   overflowType: PropTypes.oneOf(['default', 'tag']),
   /**
    * label for the overflow show all tags link.
-   *
-   * **Note: Required if more than 10 tags**
    */
-  showAllTagsLabel: string_required_if_more_than_10_tags,
+  showAllTagsLabel: PropTypes.string,
   /**
    * The tags to be shown in the TagSet. Each tag is specified as an object
    * with properties: **label**\* (required) to supply the tag content, and

--- a/packages/ibm-products/src/components/TagSet/TagSet.tsx
+++ b/packages/ibm-products/src/components/TagSet/TagSet.tsx
@@ -65,11 +65,11 @@ export interface TagSetProps extends PropsWithChildren {
    */
   align?: Align;
   /**
-   * label text for the show all search. **Note: Required if more than 10 tags**
+   * label text for the show all search.
    */
   allTagsModalSearchLabel?: string;
   /**
-   * placeholder text for the show all search. **Note: Required if more than 10 tags**
+   * placeholder text for the show all search.
    */
   allTagsModalSearchPlaceholderText?: string;
   /**
@@ -77,7 +77,7 @@ export interface TagSetProps extends PropsWithChildren {
    */
   allTagsModalTarget?: ReactNode;
   /**
-   * title for the show all modal. **Note: Required if more than 10 tags**
+   * title for the show all modal.
    */
   allTagsModalTitle?: string;
   /**
@@ -120,8 +120,6 @@ export interface TagSetProps extends PropsWithChildren {
   overflowType?: OverflowType;
   /**
    * label for the overflow show all tags link.
-   *
-   *  **Note: Required if more than 10 tags**
    */
   showAllTagsLabel?: string;
   /**

--- a/packages/ibm-products/src/components/TagSet/TagSet.tsx
+++ b/packages/ibm-products/src/components/TagSet/TagSet.tsx
@@ -65,11 +65,11 @@ export interface TagSetProps extends PropsWithChildren {
    */
   align?: Align;
   /**
-   * label text for the show all search.
+   * label text for the show all search. **Note: Required if more than 10 tags**
    */
   allTagsModalSearchLabel?: string;
   /**
-   * placeholder text for the show all search.
+   * placeholder text for the show all search. **Note: Required if more than 10 tags**
    */
   allTagsModalSearchPlaceholderText?: string;
   /**
@@ -77,7 +77,7 @@ export interface TagSetProps extends PropsWithChildren {
    */
   allTagsModalTarget?: ReactNode;
   /**
-   * title for the show all modal.
+   * title for the show all modal. **Note: Required if more than 10 tags**
    */
   allTagsModalTitle?: string;
   /**
@@ -120,6 +120,8 @@ export interface TagSetProps extends PropsWithChildren {
   overflowType?: OverflowType;
   /**
    * label for the overflow show all tags link.
+   *
+   *  **Note: Required if more than 10 tags**
    */
   showAllTagsLabel?: string;
   /**
@@ -146,11 +148,11 @@ export let TagSet = React.forwardRef<HTMLDivElement, TagSetProps>(
       overflowAlign = 'bottom',
       overflowClassName,
       overflowType = 'default',
-      allTagsModalTitle = 'All tags',
-      allTagsModalSearchLabel = 'Search all tags',
-      allTagsModalSearchPlaceholderText = 'Search all tags',
-      showAllTagsLabel = 'View all tags',
-      tags = [],
+      allTagsModalTitle,
+      allTagsModalSearchLabel,
+      allTagsModalSearchPlaceholderText,
+      showAllTagsLabel,
+      tags,
       containingElementRef,
       measurementOffset = defaults.measurementOffset,
       onOverflowTagChange = defaults.onOverflowTagChange,
@@ -439,21 +441,21 @@ TagSet.propTypes = {
    */
   align: PropTypes.oneOf(['start', 'center', 'end']),
   /**
-   * label text for the show all search.
+   * label text for the show all search. **Note: Required if more than 10 tags**
    */
-  allTagsModalSearchLabel: PropTypes.string,
+  allTagsModalSearchLabel: string_required_if_more_than_10_tags,
   /**
-   * placeholder text for the show all search.
+   * placeholder text for the show all search. **Note: Required if more than 10 tags**
    */
-  allTagsModalSearchPlaceholderText: PropTypes.string,
+  allTagsModalSearchPlaceholderText: string_required_if_more_than_10_tags,
   /**
    * portal target for the all tags modal
    */
   allTagsModalTarget: PropTypes.node,
   /**
-   * title for the show all modal.
+   * title for the show all modal. **Note: Required if more than 10 tags**
    */
-  allTagsModalTitle: PropTypes.string,
+  allTagsModalTitle: string_required_if_more_than_10_tags,
   /**
    * className
    */
@@ -508,8 +510,10 @@ TagSet.propTypes = {
   overflowType: PropTypes.oneOf(['default', 'tag']),
   /**
    * label for the overflow show all tags link.
+   *
+   * **Note: Required if more than 10 tags**
    */
-  showAllTagsLabel: PropTypes.string,
+  showAllTagsLabel: string_required_if_more_than_10_tags,
   /**
    * The tags to be shown in the TagSet. Each tag is specified as an object
    * with properties: **label**\* (required) to supply the tag content, and


### PR DESCRIPTION
Closes #5703 

This PR updates the tagset props. The initial issue is to update the typescript prop but after investigating I realized that it's better to not force the user to add a prop after 10 tags but have defaults and give the user the option to update them if they want to change the text for the labels. 

#### What did you change?
- packages/ibm-products/src/components/TagSet/TagSet.tsx

#### How did you test and verify your work?
Storybook

