### PR TITLE
fix(datagrid): fixes multiselect for instant update bug

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.jsx
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.jsx
@@ -294,15 +294,11 @@ PanelInstant.args = {
           {
             filterLabel: 'Status',
             filter: {
-              type: 'dropdown',
+              type: 'multiSelect',
               column: 'status',
               props: {
-                Dropdown: {
-                  id: 'marital-status-dropdown',
-                  ['aria-label']: 'Marital status dropdown',
-                  items: ['relationship', 'complicated', 'single'],
-                  label: 'Marital status',
-                  titleText: 'Marital status',
+                MultiSelect: {
+                  ...multiSelectProps,
                 },
               },
             },

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.jsx
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.jsx
@@ -485,15 +485,11 @@ PanelWithInitialFilters.args = {
           {
             filterLabel: 'Status',
             filter: {
-              type: 'dropdown',
+              type: 'multiSelect',
               column: 'status',
               props: {
-                Dropdown: {
-                  id: 'marital-status-dropdown',
-                  ['aria-label']: 'Marital status dropdown',
-                  items: ['relationship', 'complicated', 'single'],
-                  label: 'Marital status',
-                  titleText: 'Marital status',
+                MultiSelect: {
+                  ...multiSelectProps,
                 },
               },
             },
@@ -647,15 +643,11 @@ PanelOnlyAccordions.args = {
           {
             filterLabel: 'Status',
             filter: {
-              type: 'dropdown',
+              type: 'multiSelect',
               column: 'status',
               props: {
-                Dropdown: {
-                  id: 'marital-status-dropdown',
-                  ['aria-label']: 'Marital status dropdown',
-                  items: ['relationship', 'complicated', 'single'],
-                  label: 'Marital status',
-                  titleText: 'Marital status',
+                MultiSelect: {
+                  ...multiSelectProps,
                 },
               },
             },
@@ -810,15 +802,11 @@ PanelNoAccordions.args = {
           {
             filterLabel: 'Status',
             filter: {
-              type: 'dropdown',
+              type: 'multiSelect',
               column: 'status',
               props: {
-                Dropdown: {
-                  id: 'marital-status-dropdown',
-                  ['aria-label']: 'Marital status dropdown',
-                  items: ['relationship', 'complicated', 'single'],
-                  label: 'Marital status',
-                  titleText: 'Marital status',
+                MultiSelect: {
+                  ...multiSelectProps,
                 },
               },
             },
@@ -973,15 +961,11 @@ PanelNoData.args = {
           {
             filterLabel: 'Status',
             filter: {
-              type: 'dropdown',
+              type: 'multiSelect',
               column: 'status',
               props: {
-                Dropdown: {
-                  id: 'marital-status-dropdown',
-                  ['aria-label']: 'Marital status dropdown',
-                  items: ['relationship', 'complicated', 'single'],
-                  label: 'Marital status',
-                  titleText: 'Marital status',
+                MultiSelect: {
+                  ...multiSelectProps,
                 },
               },
             },
@@ -1136,15 +1120,11 @@ PanelManyCheckboxes.args = {
           {
             filterLabel: 'Status',
             filter: {
-              type: 'dropdown',
+              type: 'multiSelect',
               column: 'status',
               props: {
-                Dropdown: {
-                  id: 'marital-status-dropdown',
-                  ['aria-label']: 'Marital status dropdown',
-                  items: ['relationship', 'complicated', 'single'],
-                  label: 'Marital status',
-                  titleText: 'Marital status',
+                MultiSelect: {
+                  ...multiSelectProps,
                 },
               },
             },


### PR DESCRIPTION
Closes #5935 

This PR fixes the error `a.filter is not a function`. Replaced the dropdown filter with multiselect

#### What did you change?
`packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Panel.stories.jsx`

#### How did you test and verify your work?
Storybook
