### PR TITLE
fix(tearsheet): Firefox focuses Tearsheet content div with scroll

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
@@ -550,9 +550,7 @@ export const TearsheetShell = React.forwardRef(
                     alwaysRender={
                       !!(influencer && influencerPosition === 'right')
                     }
-                    {...{
-                      tabIndex: -1,
-                    }}
+                    tabIndex={-1}
                   >
                     {children}
                   </Wrap>

--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
@@ -550,6 +550,9 @@ export const TearsheetShell = React.forwardRef(
                     alwaysRender={
                       !!(influencer && influencerPosition === 'right')
                     }
+                    {...{
+                      tabIndex: -1,
+                    }}
                   >
                     {children}
                   </Wrap>

--- a/packages/ibm-products/src/global/js/utils/Wrap.tsx
+++ b/packages/ibm-products/src/global/js/utils/Wrap.tsx
@@ -54,6 +54,11 @@ interface WrapProps extends PropsWithChildren {
   neverRender?: boolean;
 
   className?: string;
+
+  /**
+   * Tab index for the wrapper div
+   */
+  tabIndex?: number;
 }
 
 /**


### PR DESCRIPTION
Closes #5745 

#### What did you change?
`tabIndex: -1` for `div.c4p--tearsheet__content` element

#### How did you test and verify your work?
`yarn avt`
Storybook