### PR TITLE
chore: update changelog script to ignore version bump commit 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - main
       - v1
       - 'release/v2*'
+      - 'chore/v2*'
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
       - main
       - v1
       - 'release/v2*'
-      - 'chore/v2*'
   merge_group:
     types: [checks_requested]
 

--- a/scripts/get-changelog.js
+++ b/scripts/get-changelog.js
@@ -53,6 +53,7 @@ const delimiter = '----DELIMITER----';
 const denyList = [
   'chore(release): publish [skip ci]',
   'chore(telemetry): update telemetry config',
+  'chore(release): v2.',
 ];
 
 /**


### PR DESCRIPTION
Closes #5967

Adjusting the release changelog script to ignore the version bump commit and not include it in the changelog.

example:
```
### Housekeeping :house:
- chore(Conditionbuilder): typescript migration (#5841)
- chore(release): v2.47.0 (#5866) <-------- do not want this to be included
```

#### What did you change?

- `scripts/get-changelog.js`

#### How did you test and verify your work?

ran changelog script locally
