### PR TITLE
fix(Tearsheet): changed actions prop to optional

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/Tearsheet.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/Tearsheet.tsx
@@ -59,7 +59,7 @@ export interface TearsheetProps extends PropsWithChildren {
    *
    * See https://react.carbondesignsystem.com/?path=/docs/components-button--default#component-api
    */
-  actions: ButtonProps<'button'>[];
+  actions?: ButtonProps<'button'>[];
 
   /**
    * The aria-label for the tearsheet, which is optional.

--- a/packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.tsx
@@ -38,7 +38,7 @@ interface TearsheetNarrowBaseProps extends PropsWithChildren {
    *
    * See https://react.carbondesignsystem.com/?path=/docs/components-button--default#component-api
    */
-  actions?: ButtonProps[];
+  actions?: ButtonProps<'button'>[];
 
   /**
    * The aria-label for the tearsheet, which is optional.

--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
@@ -49,7 +49,7 @@ const componentName = 'TearsheetShell';
 const maxDepth = 3;
 
 interface TearsheetShellProps extends PropsWithChildren {
-  actions?: ButtonProps<any>[];
+  actions?: ButtonProps<'button'>[];
 
   ariaLabel?: string;
 


### PR DESCRIPTION
Closes #5704 

changes the actions prop to optional in Tearsheet.
actions prop in TearhseetNarrow, and TearsheetShell are optional already. made the typings consistent.

#### What did you change?
packages/ibm-products/src/components/Tearsheet/Tearsheet.tsx
packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.tsx
packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx

#### How did you test and verify your work?
vs code IntelliSense