### PR TITLE
fix(DataGrid): column headers vertically misaligned when some are sortable

### DIFF
--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_useSortableColumns.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_useSortableColumns.scss
@@ -64,6 +64,7 @@
 
   .#{c4p-settings.$carbon-prefix}--table-sort.#{$block-class}--table-sort {
     width: calc(100% + #{$spacing-07}); // offset due to inner label
+    align-items: inherit;
     margin: 0 calc(-1 * #{$spacing-05}); // fill width of parent table column header
   }
 }


### PR DESCRIPTION
Closes #5940



#### What did you change?
Inherited the alignment from parent for sortable columns

#### How did you test and verify your work?
Storybook