### PR TITLE
fix(tagoverflow): incorrect type for filter prop

### DIFF
--- a/packages/ibm-products/src/components/TagOverflow/TagOverflow.tsx
+++ b/packages/ibm-products/src/components/TagOverflow/TagOverflow.tsx
@@ -30,7 +30,7 @@ import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 
 export interface TagOverflowItem {
   className?: string;
-  filter?: string;
+  filter?: boolean;
   id: string;
   label: string;
   onClose: () => void;


### PR DESCRIPTION
Closes #5985 

Updated the type value of _filter_ prop as _boolean_

#### What did you change?

packages/ibm-products/src/components/TagOverflow/TagOverflow.tsx

#### How did you test and verify your work?
storybook
