### PR TITLE
fix(Datagrid): return null for older react versions

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
+++ b/packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
@@ -75,27 +75,25 @@ const useNestedRowExpander = (hooks) => {
         const expanderTitle = row.isExpanded
           ? expanderButtonTitleExpanded
           : expanderButtonTitleCollapsed;
-        return (
-          (row.canExpand || getAsyncSubRows) && (
-            <button
-              type="button"
-              aria-label={expanderTitle}
-              className={cx(
-                `${blockClass}__row-expander`,
-                `${carbon.prefix}--btn`,
-                `${carbon.prefix}--btn--ghost`
-              )}
-              {...expanderButtonProps}
-            >
-              <ChevronRight
-                className={cx(`${blockClass}__expander-icon`, {
-                  [`${blockClass}__expander-icon--not-open`]: !row.isExpanded,
-                  [`${blockClass}__expander-icon--open`]: row.isExpanded,
-                })}
-              />
-            </button>
-          )
-        );
+        return row.canExpand || getAsyncSubRows ? (
+          <button
+            type="button"
+            aria-label={expanderTitle}
+            className={cx(
+              `${blockClass}__row-expander`,
+              `${carbon.prefix}--btn`,
+              `${carbon.prefix}--btn--ghost`
+            )}
+            {...expanderButtonProps}
+          >
+            <ChevronRight
+              className={cx(`${blockClass}__expander-icon`, {
+                [`${blockClass}__expander-icon--not-open`]: !row.isExpanded,
+                [`${blockClass}__expander-icon--open`]: row.isExpanded,
+              })}
+            />
+          </button>
+        ) : null;
       },
       width: 48,
       disableResizing: true,


### PR DESCRIPTION
Closes #5986

This bug stems from the recent support for dynamic nested rows, returning `null` fixes this problem.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
```
#### How did you test and verify your work?
Tested storybook locally by using react 17.x.x.