### PR TITLE
fix: add floating ui to tagset

### DIFF
--- a/packages/ibm-products/src/components/TagSet/TagSet.tsx
+++ b/packages/ibm-products/src/components/TagSet/TagSet.tsx
@@ -113,7 +113,7 @@ export interface TagSetProps extends PropsWithChildren {
   /**
    * Will auto-align the popover on first render if it is not visible. This prop is currently experimental and is subject to future changes.
    */
-  overFlowAutoAlign?: boolean;
+  overflowAutoAlign?: boolean;
   /**
    * overflowClassName for the tooltip popup
    */
@@ -147,7 +147,7 @@ export let TagSet = React.forwardRef<HTMLDivElement, TagSetProps>(
       className,
       maxVisible,
       multiline,
-      overFlowAutoAlign,
+      overflowAutoAlign,
       overflowAlign = 'bottom',
       overflowClassName,
       overflowType = 'default',
@@ -253,7 +253,7 @@ export let TagSet = React.forwardRef<HTMLDivElement, TagSetProps>(
       newDisplayedTags.push(
         <TagSetOverflow
           allTagsModalSearchThreshold={allTagsModalSearchThreshold}
-          overFlowAutoAlign={overFlowAutoAlign}
+          overflowAutoAlign={overflowAutoAlign}
           className={overflowClassName}
           onShowAllClick={handleShowAllClick}
           overflowTags={newOverflowTags}
@@ -279,7 +279,7 @@ export let TagSet = React.forwardRef<HTMLDivElement, TagSetProps>(
       onOverflowTagChange,
       popoverOpen,
       handleTagOnClose,
-      overFlowAutoAlign,
+      overflowAutoAlign,
     ]);
 
     const checkFullyVisibleTags = useCallback(() => {
@@ -489,10 +489,6 @@ TagSet.propTypes = {
    */
   onOverflowTagChange: PropTypes.func,
   /**
-   * Will auto-align the popover on first render if it is not visible. This prop is currently experimental and is subject to future changes.
-   */
-  overFlowAutoAlign: PropTypes.bool,
-  /**
    * overflowAlign from the standard tooltip. Default center.
    */
   overflowAlign: PropTypes.oneOf([
@@ -509,6 +505,10 @@ TagSet.propTypes = {
     'right-bottom',
     'right-top',
   ]),
+  /**
+   * Will auto-align the popover on first render if it is not visible. This prop is currently experimental and is subject to future changes.
+   */
+  overflowAutoAlign: PropTypes.bool,
   /**
    * overflowClassName for the tooltip popup
    */

--- a/packages/ibm-products/src/components/TagSet/TagSet.tsx
+++ b/packages/ibm-products/src/components/TagSet/TagSet.tsx
@@ -111,6 +111,10 @@ export interface TagSetProps extends PropsWithChildren {
    */
   overflowAlign?: OverflowAlign;
   /**
+   * Will auto-align the popover on first render if it is not visible. This prop is currently experimental and is subject to future changes.
+   */
+  overFlowAutoAlign?: boolean;
+  /**
    * overflowClassName for the tooltip popup
    */
   overflowClassName?: string;
@@ -143,6 +147,7 @@ export let TagSet = React.forwardRef<HTMLDivElement, TagSetProps>(
       className,
       maxVisible,
       multiline,
+      overFlowAutoAlign,
       overflowAlign = 'bottom',
       overflowClassName,
       overflowType = 'default',
@@ -248,6 +253,7 @@ export let TagSet = React.forwardRef<HTMLDivElement, TagSetProps>(
       newDisplayedTags.push(
         <TagSetOverflow
           allTagsModalSearchThreshold={allTagsModalSearchThreshold}
+          overFlowAutoAlign={overFlowAutoAlign}
           className={overflowClassName}
           onShowAllClick={handleShowAllClick}
           overflowTags={newOverflowTags}
@@ -273,6 +279,7 @@ export let TagSet = React.forwardRef<HTMLDivElement, TagSetProps>(
       onOverflowTagChange,
       popoverOpen,
       handleTagOnClose,
+      overFlowAutoAlign,
     ]);
 
     const checkFullyVisibleTags = useCallback(() => {
@@ -481,6 +488,10 @@ TagSet.propTypes = {
    * Handler to get overflow tags
    */
   onOverflowTagChange: PropTypes.func,
+  /**
+   * Will auto-align the popover on first render if it is not visible. This prop is currently experimental and is subject to future changes.
+   */
+  overFlowAutoAlign: PropTypes.bool,
   /**
    * overflowAlign from the standard tooltip. Default center.
    */

--- a/packages/ibm-products/src/components/TagSet/TagSetOverflow.tsx
+++ b/packages/ibm-products/src/components/TagSet/TagSetOverflow.tsx
@@ -68,6 +68,10 @@ interface TagSetOverflowProps {
    */
   overflowType?: OverflowType;
   /**
+   * Will auto-align the popover on first render if it is not visible. This prop is currently experimental and is subject to future changes.
+   */
+  overFlowAutoAlign?: boolean;
+  /**
    * Open state of the popover
    */
   popoverOpen?: boolean;
@@ -90,6 +94,7 @@ export const TagSetOverflow = React.forwardRef(
       className,
       onShowAllClick,
       overflowAlign = 'bottom',
+      overFlowAutoAlign,
       overflowTags,
       overflowType,
       showAllTagsLabel,
@@ -142,6 +147,7 @@ export const TagSetOverflow = React.forwardRef(
           highContrast
           onKeyDown={handleEscKeyPress}
           open={popoverOpen}
+          autoAlign={overFlowAutoAlign}
         >
           <Tag
             onClick={() => setPopoverOpen?.(!popoverOpen)}
@@ -217,6 +223,10 @@ TagSetOverflow.propTypes = {
    * function to execute on clicking show all
    */
   onShowAllClick: PropTypes.func.isRequired,
+  /**
+   * Will auto-align the popover on first render if it is not visible. This prop is currently experimental and is subject to future changes.
+   */
+  overFlowAutoAlign: PropTypes.bool,
   /**
    * overflowAlign from the standard tooltip
    */

--- a/packages/ibm-products/src/components/TagSet/TagSetOverflow.tsx
+++ b/packages/ibm-products/src/components/TagSet/TagSetOverflow.tsx
@@ -70,7 +70,7 @@ interface TagSetOverflowProps {
   /**
    * Will auto-align the popover on first render if it is not visible. This prop is currently experimental and is subject to future changes.
    */
-  overFlowAutoAlign?: boolean;
+  overflowAutoAlign?: boolean;
   /**
    * Open state of the popover
    */
@@ -94,7 +94,7 @@ export const TagSetOverflow = React.forwardRef(
       className,
       onShowAllClick,
       overflowAlign = 'bottom',
-      overFlowAutoAlign,
+      overflowAutoAlign,
       overflowTags,
       overflowType,
       showAllTagsLabel,
@@ -147,7 +147,7 @@ export const TagSetOverflow = React.forwardRef(
           highContrast
           onKeyDown={handleEscKeyPress}
           open={popoverOpen}
-          autoAlign={overFlowAutoAlign}
+          autoAlign={overflowAutoAlign}
         >
           <Tag
             onClick={() => setPopoverOpen?.(!popoverOpen)}
@@ -224,10 +224,6 @@ TagSetOverflow.propTypes = {
    */
   onShowAllClick: PropTypes.func.isRequired,
   /**
-   * Will auto-align the popover on first render if it is not visible. This prop is currently experimental and is subject to future changes.
-   */
-  overFlowAutoAlign: PropTypes.bool,
-  /**
    * overflowAlign from the standard tooltip
    */
   overflowAlign: PropTypes.oneOf([
@@ -244,6 +240,10 @@ TagSetOverflow.propTypes = {
     'right-bottom',
     'right-top',
   ]),
+  /**
+   * Will auto-align the popover on first render if it is not visible. This prop is currently experimental and is subject to future changes.
+   */
+  overflowAutoAlign: PropTypes.bool,
   /**
    * tags shown in overflow
    */


### PR DESCRIPTION
Closes #5407 and also #5354

i'm guessing something changed on the carbon side because using floating ui and `autoAlign` is now working with `TagSet`.

the results i'm seeing today are much different (working) compared to a previous attempt to implement. i just reused the same code from a previous PR https://github.com/carbon-design-system/ibm-products/pull/5406

verification of functionality inside the `TagSet` story

<img width="950" alt="Screenshot 2024-09-04 at 4 31 09 PM" src="https://github.com/user-attachments/assets/0285bf04-804e-4bea-9b53-3080d2a89a5f">

verification of functionality using the example code provided in the issue

<img width="1840" alt="Screenshot 2024-09-04 at 4 39 23 PM" src="https://github.com/user-attachments/assets/7ef9d4da-6bb5-45eb-94a4-f9ba49d9b240">

