### PR TITLE
fix: main landmark role removed from components

### DIFF
--- a/packages/ibm-products/scripts/generate/templates/DISPLAY_NAME.test.js
+++ b/packages/ibm-products/scripts/generate/templates/DISPLAY_NAME.test.js
@@ -23,8 +23,8 @@ const dataTestId = uuidv4();
 
 describe(componentName, () => {
   it('renders a component DISPLAY_NAME', async () => {
-    render(<DISPLAY_NAME> </DISPLAY_NAME>);
-    expect(screen.getByRole('main')).toHaveClass(blockClass);
+    render(<DISPLAY_NAME data-testid={dataTestId}> </DISPLAY_NAME>);
+    expect(screen.getByTestId(dataTestId)).toHaveClass(blockClass);
   });
 
   it('has no accessibility violations', async () => {
@@ -39,8 +39,12 @@ describe(componentName, () => {
   });
 
   it('applies className to the containing node', async () => {
-    render(<DISPLAY_NAME className={className}> </DISPLAY_NAME>);
-    expect(screen.getByRole('main')).toHaveClass(className);
+    render(
+      <DISPLAY_NAME data-testid={dataTestId} className={className}>
+        {' '}
+      </DISPLAY_NAME>
+    );
+    expect(screen.getByTestId(dataTestId)).toHaveClass(className);
   });
 
   it('adds additional props to the containing node', async () => {

--- a/packages/ibm-products/scripts/generate/templates/DISPLAY_NAME.tsx
+++ b/packages/ibm-products/scripts/generate/templates/DISPLAY_NAME.tsx
@@ -79,7 +79,6 @@ export let DISPLAY_NAME = React.forwardRef(
           }
         )}
         ref={ref}
-        role="main"
         {...getDevtoolsProps(componentName)}
       >
         {children}

--- a/packages/ibm-products/src/components/Carousel/Carousel.test.js
+++ b/packages/ibm-products/src/components/Carousel/Carousel.test.js
@@ -31,8 +31,8 @@ describe(componentName, () => {
   });
 
   it('renders a component Carousel', () => {
-    render(<Carousel> </Carousel>);
-    expect(screen.getByRole('main')).toHaveClass(blockClass);
+    render(<Carousel data-testid={dataTestId}> </Carousel>);
+    expect(screen.getByTestId(dataTestId)).toHaveClass(blockClass);
   });
 
   // Skipping.
@@ -49,8 +49,12 @@ describe(componentName, () => {
   });
 
   it('applies className to the containing node', () => {
-    render(<Carousel className={className}> </Carousel>);
-    expect(screen.getByRole('main')).toHaveClass(className);
+    render(
+      <Carousel data-testid={dataTestId} className={className}>
+        {' '}
+      </Carousel>
+    );
+    expect(screen.getByTestId(dataTestId)).toHaveClass(className);
   });
 
   it('adds additional props to the containing node', () => {

--- a/packages/ibm-products/src/components/Carousel/Carousel.tsx
+++ b/packages/ibm-products/src/components/Carousel/Carousel.tsx
@@ -337,7 +337,6 @@ const Carousel = React.forwardRef<HTMLDivElement, CarouselProps>(
         tabIndex={-1}
         className={cx(blockClass, className)}
         ref={carouselRef}
-        role="main"
         {...getDevtoolsProps(componentName)}
       >
         <div className={cx(`${blockClass}__elements-container`)}>

--- a/packages/ibm-products/src/components/Coachmark/CoachmarkDragbar.tsx
+++ b/packages/ibm-products/src/components/Coachmark/CoachmarkDragbar.tsx
@@ -123,7 +123,6 @@ export let CoachmarkDragbar = React.forwardRef<
           }
         )}
         ref={ref}
-        // role="main"
         {...getDevtoolsProps(componentName)}
       >
         <button

--- a/packages/ibm-products/src/components/Coachmark/CoachmarkHeader.tsx
+++ b/packages/ibm-products/src/components/Coachmark/CoachmarkHeader.tsx
@@ -75,7 +75,6 @@ export let CoachmarkHeader = React.forwardRef<
         }
         className={cx(blockClass, `${blockClass}__${theme}`)}
         ref={ref}
-        // role="main"
         {...getDevtoolsProps(componentName)}
       >
         {showCloseButton && (

--- a/packages/ibm-products/src/components/CoachmarkOverlayElement/CoachmarkOverlayElement.tsx
+++ b/packages/ibm-products/src/components/CoachmarkOverlayElement/CoachmarkOverlayElement.tsx
@@ -75,7 +75,6 @@ export let CoachmarkOverlayElement = React.forwardRef<
           }
         )}
         ref={ref}
-        // role="main"
         {...getDevtoolsProps(componentName)}
       >
         <div className={`${blockClass}__content`}>

--- a/packages/ibm-products/src/components/CoachmarkOverlayElements/CoachmarkOverlayElements.tsx
+++ b/packages/ibm-products/src/components/CoachmarkOverlayElements/CoachmarkOverlayElements.tsx
@@ -170,7 +170,6 @@ export let CoachmarkOverlayElements = React.forwardRef<
           }
         )}
         ref={ref}
-        // role="main"
         {...getDevtoolsProps(componentName)}
       >
         {media &&

--- a/packages/ibm-products/src/components/CoachmarkStack/CoachmarkStackHome.tsx
+++ b/packages/ibm-products/src/components/CoachmarkStack/CoachmarkStackHome.tsx
@@ -180,7 +180,6 @@ export let CoachmarkStackHome = forwardRef<
             }
             className={cx(blockClass, className)}
             ref={ref}
-            role="main"
             {...getDevtoolsProps(componentName)}
           >
             <CoachmarkHeader

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.test.js
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.test.js
@@ -100,11 +100,11 @@ const getOptions = async (conditionState, { property }) => {
 };
 describe(componentName, () => {
   it('renders a component ConditionBuilder', async () => {
-    render(<ConditionBuilder {...defaultProps} />);
-    expect(screen.getByRole('main')).toHaveClass(cx(blockClass));
+    render(<ConditionBuilder data-testid={dataTestId} {...defaultProps} />);
+    expect(screen.getByTestId(dataTestId)).toHaveClass(cx(blockClass));
   });
 
-   it('has no accessibility violations', async () => {
+  it('has no accessibility violations', async () => {
     const { container } = render(<ConditionBuilder {...defaultProps} />);
     try {
       await expect(container).toBeAccessible(componentName);
@@ -115,8 +115,14 @@ describe(componentName, () => {
   });
 
   it('applies className to the containing node', async () => {
-    render(<ConditionBuilder className={className} {...defaultProps} />);
-    expect(screen.getByRole('main')).toHaveClass(className);
+    render(
+      <ConditionBuilder
+        data-testid={dataTestId}
+        className={className}
+        {...defaultProps}
+      />
+    );
+    expect(screen.getByTestId(dataTestId)).toHaveClass(className);
   });
 
   it('adds additional props to the containing node', async () => {

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.tsx
@@ -99,7 +99,6 @@ export let ConditionBuilder = React.forwardRef(
               // example: [`${blockClass}__here-if-small`]: size === 'sm',
             }
           )}
-          role="main"
           ref={conditionBuilderRef}
           {...getDevtoolsProps(componentName)}
         >
@@ -214,7 +213,7 @@ ConditionBuilder.propTypes = {
 
   /**
    * This is a mandatory prop that defines the input to the condition builder.
-   
+
    */
   /**@ts-ignore */
   inputConfig: PropTypes.shape({

--- a/packages/ibm-products/src/components/EditUpdateCards/EditUpdateCards.test.js
+++ b/packages/ibm-products/src/components/EditUpdateCards/EditUpdateCards.test.js
@@ -23,8 +23,8 @@ const dataTestId = uuidv4();
 
 describe(componentName, () => {
   it('renders a component EditUpdateCards', async () => {
-    render(<EditUpdateCards> </EditUpdateCards>);
-    expect(screen.getByRole('main')).toHaveClass(blockClass);
+    render(<EditUpdateCards data-testid={dataTestId}> </EditUpdateCards>);
+    expect(screen.getByTestId(dataTestId)).toHaveClass(blockClass);
   });
 
   it('has no accessibility violations', async () => {
@@ -39,8 +39,12 @@ describe(componentName, () => {
   // });
 
   it('applies className to the containing node', async () => {
-    render(<EditUpdateCards className={className}> </EditUpdateCards>);
-    expect(screen.getByRole('main')).toHaveClass(className);
+    render(
+      <EditUpdateCards className={className} data-testid={dataTestId}>
+        {' '}
+      </EditUpdateCards>
+    );
+    expect(screen.getByTestId(dataTestId)).toHaveClass(className);
   });
 
   it('adds additional props to the containing node', async () => {

--- a/packages/ibm-products/src/components/EditUpdateCards/EditUpdateCards.tsx
+++ b/packages/ibm-products/src/components/EditUpdateCards/EditUpdateCards.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2024
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -200,7 +200,6 @@ export let EditUpdateCards = React.forwardRef(
           }
         )}
         ref={ref}
-        role="main"
         {...getDevtoolsProps(componentName)}
       >
         <ProductiveCard

--- a/packages/ibm-products/src/components/TagOverflow/TagOverflow.test.js
+++ b/packages/ibm-products/src/components/TagOverflow/TagOverflow.test.js
@@ -49,8 +49,8 @@ describe(componentName, () => {
   });
 
   it('renders a component TagOverflow', async () => {
-    render(<TagOverflow />);
-    expect(screen.getByRole('main')).toHaveClass(blockClass);
+    render(<TagOverflow data-testid={dataTestId} />);
+    expect(screen.getByTestId(dataTestId)).toHaveClass(blockClass);
   });
 
   it('has no accessibility violations', async () => {
@@ -60,8 +60,8 @@ describe(componentName, () => {
   });
 
   it('applies className to the containing node', async () => {
-    render(<TagOverflow className={className} />);
-    expect(screen.getByRole('main')).toHaveClass(className);
+    render(<TagOverflow className={className} data-testid={dataTestId} />);
+    expect(screen.getByTestId(dataTestId)).toHaveClass(className);
   });
 
   it('adds additional props to the containing node', async () => {

--- a/packages/ibm-products/src/components/TagOverflow/TagOverflow.tsx
+++ b/packages/ibm-products/src/components/TagOverflow/TagOverflow.tsx
@@ -263,7 +263,6 @@ export let TagOverflow = forwardRef(
           [`${blockClass}--multiline`]: multiline,
         })}
         ref={containerRef}
-        role="main"
         {...getDevtoolsProps(componentName)}
       >
         {visibleItems?.length > 0 &&


### PR DESCRIPTION
Closes #5964 

The main landmark role is  removed from components as it is used to indicate the primary content of a document.

#### What did you change?
Removed role="main" attribute from component level and updated unit tests with data-testid attribute instead of role.

#### How did you test and verify your work?

- unit test
- storybook
- `yarn generate ComponentName`