### PR TITLE
feat(ConditionBuilder): option to default enable with initial state

### DIFF
--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.stories.jsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.stories.jsx
@@ -240,7 +240,10 @@ export const conditionBuilderWithInitialState = ConditionBuilderTemplate.bind(
 );
 conditionBuilderWithInitialState.storyName = 'With initial state';
 conditionBuilderWithInitialState.args = {
-  initialState: sampleDataStructure_nonHierarchical,
+  initialState: {
+    state: sampleDataStructure_nonHierarchical,
+    enabledDefault: true,
+  },
   inputConfig: inputData,
   variant: NON_HIERARCHICAL_VARIANT,
   translateWithId: translateWithId,
@@ -268,7 +271,10 @@ export const conditionBuilderWithInitialStateHierarchical =
 conditionBuilderWithInitialStateHierarchical.storyName =
   'With initial state (Hierarchical)';
 conditionBuilderWithInitialStateHierarchical.args = {
-  initialState: sampleDataStructure_Hierarchical,
+  initialState: {
+    state: sampleDataStructure_Hierarchical,
+    enabledDefault: false,
+  },
   inputConfig: inputData,
   variant: HIERARCHICAL_VARIANT,
 };

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.test.js
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.test.js
@@ -104,7 +104,7 @@ describe(componentName, () => {
     expect(screen.getByRole('main')).toHaveClass(cx(blockClass));
   });
 
-   it('has no accessibility violations', async () => {
+  it('has no accessibility violations', async () => {
     const { container } = render(<ConditionBuilder {...defaultProps} />);
     try {
       await expect(container).toBeAccessible(componentName);
@@ -377,7 +377,7 @@ describe(componentName, () => {
       <ConditionBuilder
         {...defaultProps}
         inputConfig={inputData}
-        initialState={sampleDataStructure_nonHierarchical}
+        initialState={{ state: sampleDataStructure_nonHierarchical }}
       />
     );
     //start builder
@@ -607,7 +607,7 @@ describe(componentName, () => {
       <ConditionBuilder
         {...defaultProps}
         inputConfig={inputData}
-        initialState={sampleDataStructure_nonHierarchical}
+        initialState={{ state: sampleDataStructure_nonHierarchical }}
         translateWithId={translateWithId}
       />
     );
@@ -846,7 +846,7 @@ describe(componentName, () => {
       <ConditionBuilder
         {...defaultProps}
         inputConfig={inputData}
-        initialState={sampleDataStructure_nonHierarchical}
+        initialState={{ state: sampleDataStructure_nonHierarchical }}
       />
     );
 
@@ -940,7 +940,7 @@ describe(componentName, () => {
         {...defaultProps}
         inputConfig={inputData}
         variant={HIERARCHICAL_VARIANT}
-        initialState={sampleDataStructure}
+        initialState={{ state: sampleDataStructure }}
       />
     );
 
@@ -1016,7 +1016,7 @@ describe(componentName, () => {
         {...defaultProps}
         inputConfig={inputData}
         actions={actions}
-        initialState={sampleDataStructure}
+        initialState={{ state: sampleDataStructure }}
       />
     );
 
@@ -1210,7 +1210,7 @@ describe(componentName, () => {
         {...defaultProps}
         variant={HIERARCHICAL_VARIANT}
         inputConfig={inputData}
-        initialState={sampleDataStructure}
+        initialState={{ state: sampleDataStructure }}
       />
     );
 
@@ -1521,7 +1521,7 @@ describe(componentName, () => {
         {...defaultProps}
         variant={HIERARCHICAL_VARIANT}
         inputConfig={inputData}
-        initialState={sampleDataStructure_Hierarchical}
+        initialState={{ state: sampleDataStructure_Hierarchical }}
       />
     );
 

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.tsx
@@ -56,7 +56,7 @@ export let ConditionBuilder = React.forwardRef(
     {
       className,
       inputConfig,
-      startConditionLabel,
+      startConditionLabel = 'Add Condition',
       popOverSearchThreshold,
       getOptions,
       initialState,
@@ -176,40 +176,45 @@ ConditionBuilder.propTypes = {
    */
   getOptions: PropTypes.func,
   /**
-   * Optional prop if you want to pass a saved condition state.
-   *  This object should respect the structure of condition state that is available in getConditionState callback
+   * Optional prop if you want to pass a saved condition state, pass as "initialState.state".
+   * "initialState.enabledDefault" will populate the builder with the provided initial state before clicking Add Condition button.
+   *
+   *  This state should respect the structure of condition state that is available in getConditionState callback
    */
   /**@ts-ignore */
   initialState: PropTypes.shape({
-    groups: PropTypes.arrayOf(
-      PropTypes.shape({
-        groupOperator: PropTypes.string,
-        statement: PropTypes.string,
-        conditions: PropTypes.arrayOf(
-          PropTypes.oneOfType([
-            PropTypes.shape({
-              property: PropTypes.string,
-              operator: PropTypes.string,
-              value: PropTypes.oneOfType([
-                PropTypes.string,
-                PropTypes.arrayOf(
+    state: PropTypes.shape({
+      groups: PropTypes.arrayOf(
+        PropTypes.shape({
+          groupOperator: PropTypes.string,
+          statement: PropTypes.string,
+          conditions: PropTypes.arrayOf(
+            PropTypes.oneOfType([
+              PropTypes.shape({
+                property: PropTypes.string,
+                operator: PropTypes.string,
+                value: PropTypes.oneOfType([
+                  PropTypes.string,
+                  PropTypes.arrayOf(
+                    PropTypes.shape({
+                      id: PropTypes.string,
+                      label: PropTypes.string,
+                    })
+                  ),
                   PropTypes.shape({
                     id: PropTypes.string,
                     label: PropTypes.string,
-                  })
-                ),
-                PropTypes.shape({
-                  id: PropTypes.string,
-                  label: PropTypes.string,
-                }),
-              ]),
-            }),
-            PropTypes.object,
-          ])
-        ),
-      })
-    ),
-    operator: PropTypes.string,
+                  }),
+                ]),
+              }),
+              PropTypes.object,
+            ])
+          ),
+        })
+      ),
+      operator: PropTypes.string,
+    }),
+    enabledDefault: PropTypes.bool,
   }),
 
   /**
@@ -260,7 +265,7 @@ ConditionBuilder.propTypes = {
   /**
    * Provide a label to the button that starts condition builder
    */
-  startConditionLabel: PropTypes.string.isRequired,
+  startConditionLabel: PropTypes.string,
   /**
    * Optional prop, if you need to pass translations to the texts on the component instead of the defined defaults.
    * This callback function will receive the message id and you need to return the corresponding text for that id.

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.types.ts
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.types.ts
@@ -172,7 +172,7 @@ export type variantsType = 'Non-Hierarchical' | 'Hierarchical';
 
 export type ConditionBuilderProps = {
   inputConfig: inputConfig;
-  initialState?: ConditionBuilderState;
+  initialState?: InitialState;
   getActionsState?: (state: Action[] | undefined) => void;
   getConditionState: (state: ConditionBuilderState | undefined) => void;
   getOptions?: (
@@ -182,9 +182,14 @@ export type ConditionBuilderProps = {
   actions?: Action[];
   className?: string;
   popOverSearchThreshold: number;
-  startConditionLabel: string;
+  startConditionLabel?: string;
   variant?: 'Non-Hierarchical' | 'Hierarchical';
   translateWithId: (id: string) => string;
+};
+
+export type InitialState = {
+  state: ConditionBuilderState;
+  enabledDefault?: boolean;
 };
 
 export interface ConditionBuilderContextInputProps extends PropsWithChildren {


### PR DESCRIPTION
Closes #5874

This will add an option to start the condition builder by default when initial state is provided. Currently initial state populates when _Add Condition_ button is clicked. 
`initialState` prop will now accept a initial state as well as boolean that decides whether to default populate the state.



#### How did you test and verify your work?
Storybook