### PR TITLE
fix(datagrid): selectall selects disabled rows

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -120,6 +120,7 @@
     "namor",
     "nodataemptystate",
     "nonlinearreading",
+    "nonselectablerows",
     "noreply",
     "overridable",
     "overscan",

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.jsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.jsx
@@ -285,6 +285,29 @@ export const Pagination = () => {
   return <Datagrid datagridState={{ ...datagridState }} />;
 };
 
+export const PaginationWithSelectableRow = () => {
+  const [data] = useState(makeData(100));
+  const columns = React.useMemo(() => getColumns(data), []);
+  const datagridState = useDatagrid(
+    {
+      columns,
+      data,
+      DatagridActions,
+      batchActions: true,
+      toolbarBatchActions: getBatchActions(),
+      initialState: {
+        pageSize: 10,
+        pageSizes: [5, 10, 25, 50],
+      },
+      endPlugins: [useDisableSelectRows],
+      shouldDisableSelectRow: (row) => row.id % 5 === 0,
+      DatagridPagination,
+    },
+    useSelectRows
+  );
+  return <Datagrid datagridState={{ ...datagridState }} />;
+};
+
 export const SelectableRow = () => {
   const [data] = useState(makeData(10));
   const columns = React.useMemo(() => getColumns(data), []);

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.stories.jsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.stories.jsx
@@ -285,29 +285,6 @@ export const Pagination = () => {
   return <Datagrid datagridState={{ ...datagridState }} />;
 };
 
-export const PaginationWithSelectableRow = () => {
-  const [data] = useState(makeData(100));
-  const columns = React.useMemo(() => getColumns(data), []);
-  const datagridState = useDatagrid(
-    {
-      columns,
-      data,
-      DatagridActions,
-      batchActions: true,
-      toolbarBatchActions: getBatchActions(),
-      initialState: {
-        pageSize: 10,
-        pageSizes: [5, 10, 25, 50],
-      },
-      endPlugins: [useDisableSelectRows],
-      shouldDisableSelectRow: (row) => row.id % 5 === 0,
-      DatagridPagination,
-    },
-    useSelectRows
-  );
-  return <Datagrid datagridState={{ ...datagridState }} />;
-};
-
 export const SelectableRow = () => {
   const [data] = useState(makeData(10));
   const columns = React.useMemo(() => getColumns(data), []);

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
@@ -1715,8 +1715,7 @@ describe(componentName, () => {
         .getElementsByTagName('div')[0]
         .getElementsByTagName('p')[0]
         .getElementsByTagName('span')[0].textContent
-      // ).toEqual('99 items selected');
-    ).toEqual('93 items selected'); //(7 rows are disabled in entire table) switch to this after #5972 issue fixes
+    ).toEqual('93 items selected');
 
     // check for cancel button in batch actions and click
     expect(

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
@@ -1715,8 +1715,8 @@ describe(componentName, () => {
         .getElementsByTagName('div')[0]
         .getElementsByTagName('p')[0]
         .getElementsByTagName('span')[0].textContent
-    ).toEqual('99 items selected');
-    // ).toEqual('93 items selected'); (7 rows are disabled in entire table) switch to this after #5972 issue fixes
+      // ).toEqual('99 items selected');
+    ).toEqual('93 items selected'); //(7 rows are disabled in entire table) switch to this after #5972 issue fixes
 
     // check for cancel button in batch actions and click
     expect(

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -122,11 +122,7 @@ export const stateReducer = (newState, action) => {
           rows.find((row) => row.getRowProps)?.getRowProps?.()
             ?.nonselectablerows || [];
         rows.forEach((row) => {
-          const props = row.getRowProps?.();
-          if (props && props.disabled) {
-            return;
-          } else if (
-            !props &&
+          if (
             nonSelectableRows.length > 0 &&
             nonSelectableRows.includes(row.id)
           ) {

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -119,7 +119,8 @@ export const stateReducer = (newState, action) => {
       if (rows) {
         const newSelectedRowData = {};
         const nonSelectableRows =
-          rows[0]?.getRowProps?.()?.nonselectablerows || [];
+          rows.find((row) => row.getRowProps)?.getRowProps?.()
+            ?.nonselectablerows || [];
         rows.forEach((row) => {
           const props = row.getRowProps?.();
           if (props && props.disabled) {

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -127,7 +127,7 @@ export const stateReducer = (newState, action) => {
           } else if (
             !props &&
             nonSelectableRows.length > 0 &&
-            nonSelectableRows.includes(row)
+            nonSelectableRows.includes(row.id)
           ) {
             return;
           }

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/stateReducer.js
@@ -118,9 +118,17 @@ export const stateReducer = (newState, action) => {
       const newSelectedRowIds = {};
       if (rows) {
         const newSelectedRowData = {};
+        const nonSelectableRows =
+          rows[0]?.getRowProps?.()?.nonselectablerows || [];
         rows.forEach((row) => {
           const props = row.getRowProps?.();
           if (props && props.disabled) {
+            return;
+          } else if (
+            !props &&
+            nonSelectableRows.length > 0 &&
+            nonSelectableRows.includes(row)
+          ) {
             return;
           }
           newSelectedRowIds[getRowId(row.original, row.index)] = true;

--- a/packages/ibm-products/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.jsx
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.jsx
@@ -14,6 +14,7 @@ import {
   useDatagrid,
   useStickyColumn,
   useActionsColumn,
+  useDisableSelectRows,
   useSelectRows,
 } from '../../index';
 import styles from '../../_storybook-styles.scss?inline';
@@ -280,7 +281,7 @@ const RowActionButtonsBatchActions = ({ ...args }) => {
     ],
     []
   );
-  const [data] = useState(makeData(10));
+  const [data] = useState(makeData(50));
   const rows = React.useMemo(() => data, [data]);
 
   const datagridState = useDatagrid(
@@ -293,6 +294,8 @@ const RowActionButtonsBatchActions = ({ ...args }) => {
       },
       DatagridActions,
       DatagridPagination,
+      endPlugins: [useDisableSelectRows],
+      shouldDisableSelectRow: (row) => row.id % 5 === 0,
       ...args.defaultGridProps,
     },
     useStickyColumn,

--- a/packages/ibm-products/src/components/Datagrid/useDisableSelectRows.ts
+++ b/packages/ibm-products/src/components/Datagrid/useDisableSelectRows.ts
@@ -15,14 +15,21 @@ const useDisableSelectRows = (hooks: Hooks) => {
   const getRowProps: RowPropGetter<any> = (
     props: Partial<TableRowProps>,
     { row, instance }: PropGetterMeta
-  ) =>
-    [
+  ) => {
+    const nonselectablerows: Row<any>[] =
+      instance?.rows?.filter(
+        (row) =>
+          instance.shouldDisableSelectRow &&
+          instance.shouldDisableSelectRow(row)
+      ) || [];
+    return [
       props,
       {
         disabled: instance?.shouldDisableSelectRow?.(row),
+        nonselectablerows,
       },
     ] as Partial<TableRowProps>[];
-
+  };
   hooks.getRowProps.push(getRowProps);
 };
 

--- a/packages/ibm-products/src/components/Datagrid/useDisableSelectRows.ts
+++ b/packages/ibm-products/src/components/Datagrid/useDisableSelectRows.ts
@@ -4,29 +4,41 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
+import { useRef } from 'react';
 import { Hooks, Row, RowPropGetter, TableRowProps } from 'react-table';
 import { DatagridRow, PropGetterMeta } from './types';
+const nonselectablerowsList = (instance) => {
+  const nonselectablerows: number[] =
+    instance?.rows
+      ?.filter(
+        (row) =>
+          instance.shouldDisableSelectRow &&
+          instance.shouldDisableSelectRow(row)
+      )
+      .map((row) => {
+        return row.id;
+      }) || [];
+  return nonselectablerows;
+};
 
 const useDisableSelectRows = (hooks: Hooks) => {
   updateSelectAll(hooks);
   updatePageSelectAll(hooks);
-
+  const funcCalled = useRef(false);
+  const funcResult = useRef<number[]>([]);
   const getRowProps: RowPropGetter<any> = (
     props: Partial<TableRowProps>,
     { row, instance }: PropGetterMeta
   ) => {
-    const nonselectablerows: Row<any>[] =
-      instance?.rows?.filter(
-        (row) =>
-          instance.shouldDisableSelectRow &&
-          instance.shouldDisableSelectRow(row)
-      ) || [];
+    if (!funcCalled.current) {
+      funcResult.current = nonselectablerowsList(instance);
+      funcCalled.current = true;
+    }
     return [
       props,
       {
         disabled: instance?.shouldDisableSelectRow?.(row),
-        nonselectablerows,
+        nonselectablerows: funcResult.current,
       },
     ] as Partial<TableRowProps>[];
   };

--- a/packages/ibm-products/src/components/Datagrid/useDisableSelectRows.ts
+++ b/packages/ibm-products/src/components/Datagrid/useDisableSelectRows.ts
@@ -15,9 +15,7 @@ const nonselectablerowsList = (instance) => {
           instance.shouldDisableSelectRow &&
           instance.shouldDisableSelectRow(row)
       )
-      .map((row) => {
-        return row.id;
-      }) || [];
+      .map((row) => row.id) || [];
   return nonselectablerows;
 };
 

--- a/packages/ibm-products/src/components/Datagrid/useDisableSelectRows.ts
+++ b/packages/ibm-products/src/components/Datagrid/useDisableSelectRows.ts
@@ -4,9 +4,9 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { useRef } from 'react';
 import { Hooks, Row, RowPropGetter, TableRowProps } from 'react-table';
 import { DatagridRow, PropGetterMeta } from './types';
+
 const nonselectablerowsList = (instance) => {
   const nonselectablerows: number[] =
     instance?.rows
@@ -22,21 +22,22 @@ const nonselectablerowsList = (instance) => {
 const useDisableSelectRows = (hooks: Hooks) => {
   updateSelectAll(hooks);
   updatePageSelectAll(hooks);
-  const funcCalled = useRef(false);
-  const funcResult = useRef<number[]>([]);
+
+  let nonselectablerows: number[] = [];
+  const useInstance = (instance) => {
+    nonselectablerows = nonselectablerowsList(instance);
+  };
+  hooks.useInstance.push(useInstance);
+
   const getRowProps: RowPropGetter<any> = (
     props: Partial<TableRowProps>,
     { row, instance }: PropGetterMeta
   ) => {
-    if (!funcCalled.current) {
-      funcResult.current = nonselectablerowsList(instance);
-      funcCalled.current = true;
-    }
     return [
       props,
       {
         disabled: instance?.shouldDisableSelectRow?.(row),
-        nonselectablerows: funcResult.current,
+        nonselectablerows: nonselectablerows,
       },
     ] as Partial<TableRowProps>[];
   };

--- a/packages/ibm-products/src/components/Datagrid/useDisableSelectRows.ts
+++ b/packages/ibm-products/src/components/Datagrid/useDisableSelectRows.ts
@@ -37,7 +37,7 @@ const useDisableSelectRows = (hooks: Hooks) => {
       props,
       {
         disabled: instance?.shouldDisableSelectRow?.(row),
-        nonselectablerows: nonselectablerows,
+        nonselectablerows,
       },
     ] as Partial<TableRowProps>[];
   };


### PR DESCRIPTION
Closes #5972

Select all button in batch actions, selects disabled rows on other pages. 
The issue is React table only provides `getRowProps` for rows that are visible for performance improvement.
And this function is needed to determine whether a row is disabled or not.

#### What did you change?
As a workaround added a new  field `nonselectablerows` to the returned props value for each row - which holds the list of disabled rows .

#### How did you test and verify your work?
Storybook (Story: `Row Action Buttons Batch Actions Usage Story`)
