### PR TITLE
fix(tearsheet): slug spacing

### DIFF
--- a/packages/ibm-products-styles/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/ibm-products-styles/src/components/Tearsheet/_tearsheet.scss
@@ -426,5 +426,7 @@ $motion-duration: $duration-moderate-02;
   &.#{$block-class}--has-slug:not(.#{$block-class}--has-close)
     .#{$carbon-prefix}--slug {
     inset-inline-end: 0;
+    margin-block: 0.5rem;
+    margin-inline-end: 1rem;
   }
 }


### PR DESCRIPTION
Closes #5870 

This PR fixes the spacing for the AI Slug when there is no close icon. 

**Before**:
<img width="875" alt="Screenshot 2024-09-06 at 3 41 18 PM" src="https://github.com/user-attachments/assets/eb770ce5-a529-49ac-a6b1-9331d64d8c42">

**After**: 
<img width="933" alt="Screenshot 2024-09-06 at 3 41 32 PM" src="https://github.com/user-attachments/assets/84841e4a-891f-4bbc-991e-3178453e091a">

**Design concerns:**
I do have a concern, the spacing when the close icon is present is different with the slug to be inline with the close icon. Can we get design input on this?

https://github.com/user-attachments/assets/49ffcab6-9aaf-40af-a0c0-3e50580ae812

#### What did you change?
* packages/ibm-products-styles/src/components/Tearsheet/_tearsheet.scss

#### How did you test and verify your work?
Storybook