### PR TITLE
fix(DataGrid): disable save button on customise column

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
@@ -499,7 +499,10 @@ const RowSizeDropdown = ({ ...rest } = {}) => {
 };
 
 const CustomizingColumns = ({ ...rest } = {}) => {
-  const columns = React.useMemo(() => defaultHeader, []);
+  const columns = React.useMemo(
+    () => (rest.columns ? rest.columns : defaultHeader),
+    [rest.columns]
+  );
   const [data] = useState(makeData(10));
   const datagridState = useDatagrid(
     {
@@ -1980,6 +1983,41 @@ describe(componentName, () => {
         'none'
       );
     });
+  });
+  it('Customizing Columns disable save button when un-select all columns', async () => {
+    const columnsWithoutSticky = [
+      {
+        Header: 'Row Index',
+        accessor: (row, i) => i,
+        id: 'rowIndex', // id is required when accessor is a function.
+      },
+      {
+        Header: 'First Name',
+        accessor: 'firstName',
+      },
+    ];
+    const columns = [...columnsWithoutSticky, ...defaultHeader.slice(2)];
+    render(
+      <CustomizingColumns
+        data-testid={dataTestId}
+        columns={columns}
+      ></CustomizingColumns>
+    );
+
+    const customizeColumnsButton = screen.getByLabelText('Customize columns');
+    fireEvent.click(customizeColumnsButton);
+    screen.getByRole('heading', { name: /Customize columns/ });
+
+    const selectAllCheckBox = screen.getByRole('checkbox', {
+      name: 'Column name',
+    });
+    fireEvent.click(selectAllCheckBox);
+    expect(selectAllCheckBox.checked).toEqual(true);
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+
+    fireEvent.click(selectAllCheckBox);
+    expect(selectAllCheckBox.checked).toEqual(false);
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
   });
 
   it('Customizing Columns', async () => {

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
@@ -91,11 +91,17 @@ const CustomizeColumnsTearsheet = ({
     });
 
     setColumnObjects(finalDefinitions);
-    setDirty();
+    if (selectedColumnsCount === 0) {
+      setDirty(false);
+    } else {
+      setDirty();
+    }
   };
 
-  const setDirty = () => {
-    if (!isDirty) {
+  const setDirty = (dirty) => {
+    if (dirty !== undefined) {
+      setIsDirty(dirty);
+    } else if (!isDirty) {
       setIsDirty(true);
     }
   };
@@ -172,7 +178,11 @@ const CustomizeColumnsTearsheet = ({
           onSelectColumn={onCheckboxCheck}
           setColumnsObject={(cols) => {
             setColumnObjects(cols);
-            setDirty();
+            if (getVisibleColumnsCount() === 0) {
+              setDirty(false);
+            } else {
+              setDirty();
+            }
           }}
           selectAllLabel={selectAllLabel}
           customizeTearsheetHeadingLabel={customizeTearsheetHeadingLabel}

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
@@ -91,16 +91,7 @@ const CustomizeColumnsTearsheet = ({
     });
 
     setColumnObjects(finalDefinitions);
-    if (selectedColumnsCount === 0) {
-      setDirty(false);
-    } else {
-      setDirty(true);
-    }
-  };
-  const setDirty = (dirty) => {
-    if (dirty !== isDirty) {
-      setIsDirty(dirty);
-    }
+    setIsDirty(selectedColumnsCount !== 0);
   };
 
   const getVisibleColumnsCount = useCallback(() => {
@@ -157,7 +148,7 @@ const CustomizeColumnsTearsheet = ({
         searchText={searchText}
         setColumnsObject={(cols) => {
           setColumnObjects(cols);
-          setDirty(true);
+          setIsDirty(true);
         }}
         setSearchText={setSearchText}
         findColumnPlaceholderLabel={findColumnPlaceholderLabel}
@@ -175,11 +166,7 @@ const CustomizeColumnsTearsheet = ({
           onSelectColumn={onCheckboxCheck}
           setColumnsObject={(cols) => {
             setColumnObjects(cols);
-            if (getVisibleColumnsCount() === 0) {
-              setDirty(false);
-            } else {
-              setDirty(true);
-            }
+            setIsDirty(getVisibleColumnsCount() !== 0);
           }}
           selectAllLabel={selectAllLabel}
           customizeTearsheetHeadingLabel={customizeTearsheetHeadingLabel}

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
@@ -94,15 +94,12 @@ const CustomizeColumnsTearsheet = ({
     if (selectedColumnsCount === 0) {
       setDirty(false);
     } else {
-      setDirty();
+      setDirty(true);
     }
   };
-
   const setDirty = (dirty) => {
-    if (dirty !== undefined) {
+    if (dirty !== isDirty) {
       setIsDirty(dirty);
-    } else if (!isDirty) {
-      setIsDirty(true);
     }
   };
 
@@ -160,7 +157,7 @@ const CustomizeColumnsTearsheet = ({
         searchText={searchText}
         setColumnsObject={(cols) => {
           setColumnObjects(cols);
-          setDirty();
+          setDirty(true);
         }}
         setSearchText={setSearchText}
         findColumnPlaceholderLabel={findColumnPlaceholderLabel}
@@ -181,7 +178,7 @@ const CustomizeColumnsTearsheet = ({
             if (getVisibleColumnsCount() === 0) {
               setDirty(false);
             } else {
-              setDirty();
+              setDirty(true);
             }
           }}
           selectAllLabel={selectAllLabel}


### PR DESCRIPTION
Closes #5843 

 If all the columns are unchecked, Save button should not be enabled in Datagrid customise columns


#### How did you test and verify your work?
storybook