### PR TITLE
fix(Datagrid): minWidth logic for useSortableColumns vs useActionsColumn

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useSortableColumns.tsx
+++ b/packages/ibm-products/src/components/Datagrid/useSortableColumns.tsx
@@ -179,12 +179,9 @@ const useSortableColumns = (hooks: Hooks) => {
       return {
         ...column,
         Header,
-        minWidth:
-          column.disableSortBy === true
-            ? 0
-            : column.minWidth
-            ? column.minWidth
-            : 90,
+        minWidth: column.disableSortBy
+          ? 0
+          : column.minWidth ?? (column.isAction ? 50 : 90),
       };
     });
     return instance.customizeColumnsProps?.isTearsheetOpen


### PR DESCRIPTION
Closes #5578

fixes the logic to apply column minWidth as 90, only to the sortable columns.

#### What did you change?
packages/ibm-products/src/components/Datagrid/useSortableColumns.tsx

#### How did you test and verify your work?
storybook