### PR TITLE
fix(OptionsTile): onToggle should not be required

### DIFF
--- a/packages/ibm-products/src/components/OptionsTile/OptionsTile.tsx
+++ b/packages/ibm-products/src/components/OptionsTile/OptionsTile.tsx
@@ -76,7 +76,7 @@ export interface OptionsTileProps {
    * Provide a function which will be called each time the user
    * interacts with the toggle.
    */
-  onToggle: (value: boolean) => void;
+  onToggle?: (value: boolean) => void;
 
   /**
    * Whether the OptionsTile is in open state.
@@ -444,7 +444,6 @@ OptionsTile.propTypes = {
    * Provide a function which will be called each time the user
    * interacts with the toggle.
    */
-  /**@ts-ignore*/
   onToggle: PropTypes.func,
 
   /**


### PR DESCRIPTION
Refs #4281.

Fix Typescript declaration of OptionsTile.onToggle.

#### What did you change?

Made onToggle optional in Typescript.  It was already optional in PropTypes.

#### How did you test and verify your work?

Building locally.
