### PR TITLE
fix(CreateFullPageStep): hasFieldset and fieldsetLegendText types

### DIFF
--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPageStep.tsx
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPageStep.tsx
@@ -97,13 +97,24 @@ interface CreateFullPageStepBaseProps extends PropsWithChildren {
   title: ReactNode;
 }
 
+// Try to specify the hasFieldset and fieldsetLegendText Typescript requirements.
+// Basically, fieldsetLegendText should only be specified when hasFieldset is true.
+// And usually, hasFieldset won't be specified at all unless it's being set to true.
 type CreateFullPageStepFieldsetProps =
   | {
-      hasFieldset: false;
+      // fieldsetLegendText should not be specified unless hasFieldset is true, but
+      // not sure how to do that in Typescript.
       fieldsetLegendText?: string;
     }
   | {
-      hasFieldset?: true;
+      hasFieldset: false;
+
+      // fieldsetLegendText should not be specified unless hasFieldset is true, but
+      // not sure how to do that in Typescript.
+      fieldsetLegendText?: string;
+    }
+  | {
+      hasFieldset: true;
       fieldsetLegendText: string;
     };
 
@@ -271,7 +282,6 @@ CreateFullPageStep.propTypes = {
   /**
    * This will conditionally disable the submit button in the multi step CreateFullPage
    */
-  /**@ts-ignore */
   disableSubmit: PropTypes.bool,
 
   /**
@@ -285,7 +295,6 @@ CreateFullPageStep.propTypes = {
   /**
    * This optional prop will render your form content inside of a fieldset html element
    */
-  /**@ts-ignore */
   hasFieldset: PropTypes.bool,
 
   /**


### PR DESCRIPTION

Refs #4512.

`fieldsetLegendText` should not be required when `hasFieldset` is not specified.

Basically, not specifying `hasFieldset` is the same thing as setting it to `false`.

#### What did you change?

When `hasFieldset` is not specified, make `fieldsetLegendText` optional.

#### How did you test and verify your work?

Test locally.
