### PR TITLE
fix(CreateFullPage): breadcrumbs should be array

### DIFF
--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.tsx
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.tsx
@@ -57,7 +57,7 @@ export const StepsContext = createContext<StepsContextType | null>(null);
 // to let it know what number it is in the sequence of steps
 export const StepNumberContext = createContext(-1);
 
-interface HeaderBreadcrumbs {
+interface HeaderBreadcrumb {
   /** breadcrumb item key */
   key: string;
   /** breadcrumb item label */
@@ -82,7 +82,7 @@ type CreateFullPageBreadcrumbsProps =
     }
   | {
       /** The header breadcrumbs */
-      breadcrumbs: HeaderBreadcrumbs;
+      breadcrumbs: HeaderBreadcrumb[];
 
       /**
        * Label for open/close overflow button used for breadcrumb items that do not fit


### PR DESCRIPTION
Closes #5707.

Fix type of CreateFullPage.breadcrumbs

#### What did you change?

Made it an array rather than a single breadcrumb.

#### How did you test and verify your work?

Tested locally.
