### PR TITLE
fix(dataGrid): focus loss on radio select

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useSelectRows.tsx
+++ b/packages/ibm-products/src/components/Datagrid/useSelectRows.tsx
@@ -122,7 +122,7 @@ const SelectRow = (datagridState) => {
     // focus the radio / checkbox if lost
     const activeElement = document?.activeElement?.id ?? '';
     await undefined;
-    document.getElementById(activeElement)?.focus();
+    document?.getElementById(activeElement)?.focus();
   };
 
   const selectDisabled = isFetching || row.getRowProps().disabled;

--- a/packages/ibm-products/src/components/Datagrid/useSelectRows.tsx
+++ b/packages/ibm-products/src/components/Datagrid/useSelectRows.tsx
@@ -120,7 +120,7 @@ const SelectRow = (datagridState) => {
       selectAll: null,
     });
     // focus the radio / checkbox if lost
-    const activeElement = document.activeElement?.id ?? '';
+    const activeElement = document?.activeElement?.id ?? '';
     await undefined;
     document.getElementById(activeElement)?.focus();
   };

--- a/packages/ibm-products/src/components/Datagrid/useSelectRows.tsx
+++ b/packages/ibm-products/src/components/Datagrid/useSelectRows.tsx
@@ -102,7 +102,7 @@ const SelectRow = (datagridState) => {
     return () => window.removeEventListener('resize', updateSize);
   }, []);
 
-  const onSelectHandler = (event) => {
+  const onSelectHandler = async (event) => {
     event.stopPropagation(); // avoid triggering onRowClick
     if (radio) {
       toggleAllRowsSelected(false);
@@ -119,6 +119,10 @@ const SelectRow = (datagridState) => {
       getRowId,
       selectAll: null,
     });
+    // focus the radio / checkbox if lost
+    const activeElement = document.activeElement?.id ?? '';
+    await undefined;
+    document.getElementById(activeElement)?.focus();
   };
 
   const selectDisabled = isFetching || row.getRowProps().disabled;


### PR DESCRIPTION
Closes #5683 

returns the radio select focus, if it's lost.

#### What did you change?
packages/ibm-products/src/components/Datagrid/useSelectRows.tsx

#### How did you test and verify your work?
storybook, screen reader for mac, jaws for win 11