### PR TITLE
fix(Datagrid): dynamic nested rows skeleton always showing regardless of dynamic prop being set

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
+++ b/packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
@@ -56,7 +56,9 @@ const useNestedRowExpander = (hooks) => {
                   depth: row.depth,
                   index: row.index,
                 });
-                await getAsyncSubRows?.(row);
+               if(getAsyncSubRows){
+                  await getAsyncSubRows?.(row);
+                }
                 handleDynamicRowCheck({
                   dispatch,
                   status: 'finish',


### PR DESCRIPTION


Closes #5983 

Dynamic nested rows skeleton always showing regardless of dynamic prop being set

#### What did you change?
skip await getAsyncSubRows when not defined

#### How did you test and verify your work?
local storybook