### PR TITLE
chore: updated doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Carbon for IBM Products
 
 > Carbon for IBM Products is an open source implementation of the closed source
-> [IBM Software pattern asset library (PAL)](https://pages.github.ibm.com/cdai-design/pal/).
+> [IBM Software pattern asset library (PAL)](https://pages.github.ibm.com/carbon/ibm-products/).
 > These PAL designs build on the foundation of IBM’s open source Carbon Design
 > System and React implementation to offer components and patterns beyond the
 > typical component library. Carbon for IBM Products was previously known as

--- a/docs/guides/VARIANT_COMPONENT_GUIDELINES.md
+++ b/docs/guides/VARIANT_COMPONENT_GUIDELINES.md
@@ -1,7 +1,7 @@
 # Variant Component Guidelines
 
 If you are creating a component with variant or themed modes such as the
-[Card](https://pages.github.ibm.com/cdai-design/pal/components/card/overview)
+[Card](https://pages.github.ibm.com/carbon/ibm-products/components/card/overview)
 you'll want to follow these guidelines. Please note that this pattern may not be
 applicable for every scenario, so please use your best judgment.
 

--- a/packages/ibm-products/README.md
+++ b/packages/ibm-products/README.md
@@ -1,7 +1,7 @@
 # @carbon/ibm-products
 
 > Carbon for IBM Products is an open source implementation of the closed source
-> [pattern asset library (PAL)](https://pages.github.ibm.com/cdai-design/pal/).
+> [pattern asset library (PAL)](https://pages.github.ibm.com/carbon/ibm-products/).
 > These PAL designs build on the foundation of IBM’s open source Carbon Design
 > System and React implementation to offer components and patterns beyond the
 > typical component library. Carbon for IBM Products was previously known as

--- a/packages/ibm-products/src/components/AboutModal/AboutModal.docs-page.js
+++ b/packages/ibm-products/src/components/AboutModal/AboutModal.docs-page.js
@@ -12,7 +12,7 @@ import * as stories from './AboutModal.stories';
 
 const DocsPage = () => (
   <StoryDocsPage
-    guidelinesHref="https://pages.github.ibm.com/cdai-design/pal/patterns/about-modal/usage"
+    guidelinesHref="https://pages.github.ibm.com/carbon/ibm-products/components/about-modal/usage/"
     blocks={[
       {
         story: stories.aboutModal,

--- a/packages/ibm-products/src/components/Coachmark/Coachmark.mdx
+++ b/packages/ibm-products/src/components/Coachmark/Coachmark.mdx
@@ -21,7 +21,7 @@ import * as CoachmarkStories from './Coachmark.stories';
 
 ## Overview
 
-[Coachmarks](https://pages.github.ibm.com/cdai-design/pal/components/onboarding/coachmark/usage)
+[Coachmarks](https://pages.github.ibm.com/carbon/ibm-products/components/onboarding/coachmark/usage)
 are just-in-time messages used to draw a user’s attention to a particular spot,
 and explain new functionality or concepts they might not otherwise notice or
 understand.

--- a/packages/ibm-products/src/components/CoachmarkBeacon/CoachmarkBeacon.mdx
+++ b/packages/ibm-products/src/components/CoachmarkBeacon/CoachmarkBeacon.mdx
@@ -16,7 +16,7 @@ import * as CoachmarkBeaconStories from './CoachmarkBeacon.stories';
 
 ## Overview
 
-[Beacons](https://pages.github.ibm.com/cdai-design/pal/components/onboarding/coachmark/usage#tooltip)
+[Beacons](https://pages.github.ibm.com/carbon/ibm-products/components/onboarding/coachmark/usage#tooltip)
 use a pulsing action to call a user’s attention to a specific area in the UI.
 
 The `target` prop of the Coachmark should always be either a CoachmarkBeacon or

--- a/packages/ibm-products/src/components/CoachmarkButton/CoachmarkButton.mdx
+++ b/packages/ibm-products/src/components/CoachmarkButton/CoachmarkButton.mdx
@@ -15,7 +15,7 @@ import * as CoachmarkButtonStories from './CoachmarkButton.stories';
 
 CoachmarkButton components use a ghost variant Carbon button specifically
 designed to be used in the target prop of a Coachmark component
-[floating](https://pages.github.ibm.com/cdai-design/pal/components/onboarding/coachmark/usage#floating)
+[floating](https://pages.github.ibm.com/carbon/ibm-products/components/onboarding/coachmark/usage#floating)
 variant.
 
 ## Example usage

--- a/packages/ibm-products/src/components/CoachmarkFixed/CoachmarkFixed.mdx
+++ b/packages/ibm-products/src/components/CoachmarkFixed/CoachmarkFixed.mdx
@@ -15,7 +15,7 @@ import * as CoachmarkFixedStories from './CoachmarkFixed.stories';
 
 ## Overview
 
-[CoachmarkFixed](https://pages.github.ibm.com/cdai-design/pal/components/onboarding/coachmark/usage#fixed)
+[CoachmarkFixed](https://pages.github.ibm.com/carbon/ibm-products/components/onboarding/coachmark/usage#fixed)
 appears fixed at the bottom right corner of the browser window when the page
 loads. It starts in a minimized state, to cover as little of the UI as possible;
 when shown in tests as expanded by default, users immediately closed it without

--- a/packages/ibm-products/src/components/CoachmarkStack/CoachmarkStack.mdx
+++ b/packages/ibm-products/src/components/CoachmarkStack/CoachmarkStack.mdx
@@ -15,13 +15,13 @@ import * as CoachmarkStackStories from './CoachmarkStack.stories';
 
 ## Overview
 
-[CoachmarkStacked](https://pages.github.ibm.com/cdai-design/pal/components/onboarding/coachmark/usage#stacked)
+[CoachmarkStacked](https://pages.github.ibm.com/carbon/ibm-products/components/onboarding/coachmark/usage#stacked)
 appears fixed at the bottom right corner of the browser window when the page
 loads. It starts in a minimized state, to cover as little of the UI as possible;
 when shown in tests as expanded by default, users immediately closed it without
 reading, to get it out of the way. CoachmarkStacked can include ghost buttons to
 trigger another layer to slide up to stack on top of it, much like the
-[stacked Tearsheet](https://pages.github.ibm.com/cdai-design/pal/components/tearsheet/usage/#navigation).
+[stacked Tearsheet](https://pages.github.ibm.com/carbon/ibm-products/components/tearsheet/usage/#navigation).
 When dismissed, the stacked layer exits by sliding back down, revealing the main
 layer. When the main layer is dismissed, it slides down off the page. Only one
 layer can be stacked on the main layer.

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.docs-page.js
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.docs-page.js
@@ -12,7 +12,7 @@ import * as stories from './CreateFullPage.stories';
 const DocsPage = () => {
   return (
     <StoryDocsPage
-      altGuidelinesHref="https://pages.github.ibm.com/cdai-design/pal/patterns/creation-flows/usage#full-page"
+      altGuidelinesHref="https://pages.github.ibm.com/carbon/ibm-products/patterns/create-flows/usage/#full-page"
       blocks={[
         {
           description: `There are **2** components that make up a Create Full Page component, which can

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.stories.jsx
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.stories.jsx
@@ -609,7 +609,7 @@ const TemplateWithGlobalHeader = ({ ...args }) => {
         >
           <SideNavItems>
             <SideNavLink
-              href="https://pages.github.ibm.com/cdai-design/pal/"
+              href="https://pages.github.ibm.com/carbon/ibm-products/"
               target="_blank"
             >
               Sample link: Carbon for IBM Products

--- a/packages/ibm-products/src/components/CreateModal/CreateModal.docs-page.js
+++ b/packages/ibm-products/src/components/CreateModal/CreateModal.docs-page.js
@@ -12,7 +12,7 @@ import * as stories from './CreateModal.stories';
 const DocsPage = () => {
   return (
     <StoryDocsPage
-      altGuidelinesHref="https://pages.github.ibm.com/cdai-design/pal/patterns/creation-flows/usage#modal"
+      altGuidelinesHref="https://pages.github.ibm.com/carbon/ibm-products/patterns/create-flows/usage#modal"
       blocks={[
         {
           story: stories.Default,

--- a/packages/ibm-products/src/components/CreateSidePanel/CreateSidePanel.docs-page.js
+++ b/packages/ibm-products/src/components/CreateSidePanel/CreateSidePanel.docs-page.js
@@ -14,7 +14,7 @@ const DocsPage = () => {
     <StoryDocsPage
       altGuidelinesHref={[
         {
-          href: 'https://pages.github.ibm.com/cdai-design/pal/patterns/creation-flows/usage#side-panel',
+          href: 'https://pages.github.ibm.com/carbon/ibm-products/patterns/create-flows/usage/#side-panel',
           label: 'Carbon create flows side panel usage guidelines',
         },
       ]}

--- a/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.docs-page.js
+++ b/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.docs-page.js
@@ -12,7 +12,7 @@ import * as stories from './CreateTearsheet.stories';
 const DocsPage = () => {
   return (
     <StoryDocsPage
-      altGuidelinesHref="https://pages.github.ibm.com/cdai-design/pal/patterns/creation-flows/usage#wide-tearsheet"
+      altGuidelinesHref="https://pages.github.ibm.com/carbon/ibm-products/patterns/create-flows/usage/#wide-tearsheet"
       blocks={[
         {
           story: stories.multiStepTearsheet,

--- a/packages/ibm-products/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.stories.jsx
+++ b/packages/ibm-products/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.stories.jsx
@@ -33,7 +33,7 @@ export default {
     styles,
     docs: {
       page: () => (
-        <StoryDocsPage altGuidelinesHref="https://pages.github.ibm.com/cdai-design/pal/patterns/creation-flows/usage#narrow-tearsheet" />
+        <StoryDocsPage altGuidelinesHref="https://pages.github.ibm.com/carbon/ibm-products/patterns/create-flows/usage/#narrow-tearsheet" />
       ),
     },
   },

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.mdx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.mdx
@@ -44,7 +44,7 @@ The `Datagrid` component is an extension of Carbon's DataTable component. At the
 most basic level, the `Datagrid` component takes in columns and rows and renders
 a data table. There is a set of data table extensions which this component
 provides support for, these can be found
-[here](https://pages.github.ibm.com/cdai-design/pal/components/data-table/overview/).
+[here](https://pages.github.ibm.com/carbon/ibm-products/components/datagrid/overview/).
 This component is data driven and allows you to choose what pieces will be
 included based on the hooks/plugins that are provided.
 
@@ -248,7 +248,7 @@ const App = () => {
 
 The default column alignment in the `Datagrid` is left, however there is support
 for center and right aligned as well. See
-[design guidance](https://pages.github.ibm.com/cdai-design/pal/components/data-table/column-alignment/usage)
+[design guidance](https://pages.github.ibm.com/carbon/ibm-products/components/datagrid/column-alignment/usage/)
 for details around when to change default column alignment.
 
 To utilize center or right aligned columns refer to the steps below:
@@ -478,7 +478,7 @@ data that might not be displayed in the columns available in the table. Filter
 options can be displayed in many form components, including dropdowns, text
 inputs, checkboxes, radio buttons, and date range pickers.
 
-[Check out the Guidance here.](https://pages.github.ibm.com/cdai-design/pal/components/data-table/filters/)
+[Check out the Guidance here.](https://pages.github.ibm.com/carbon/ibm-products/components/datagrid/filtering/usage/)
 
 ### Preparing your column headers
 

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/Datagrid.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/Datagrid.tsx
@@ -33,7 +33,7 @@ export interface DatagridProps {
 }
 
 /**
- * The `Datagrid` component is an extension of Carbon's DataTable component. At the most basic level, the `Datagrid` component takes in columns and rows and renders a data table. There is a set of data table extensions which this component provides support for, these can be found [here](https://pages.github.ibm.com/cdai-design/pal/components/data-table/overview/). This component is data driven and allows you to choose what pieces will be included based on the hooks/plugins that are provided.
+ * The `Datagrid` component is an extension of Carbon's DataTable component. At the most basic level, the `Datagrid` component takes in columns and rows and renders a data table. There is a set of data table extensions which this component provides support for, these can be found [here](https://pages.github.ibm.com/carbon/ibm-products/components/datagrid/overview/). This component is data driven and allows you to choose what pieces will be included based on the hooks/plugins that are provided.
  */
 export let Datagrid = React.forwardRef(
   (

--- a/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Filtering.docs-page.js
+++ b/packages/ibm-products/src/components/Datagrid/Extensions/Filtering/Filtering.docs-page.js
@@ -24,7 +24,7 @@ export const DocsPage = () => (
         description: `Applied filters can affect both the data that is visible in the table and also data that might not be displayed in the columns available in the table. Filter options can be displayed in many form components, including dropdowns, text inputs, checkboxes, radio buttons, and date range pickers.`,
       },
       {
-        description: `[Check out the Guidance here.](https://pages.github.ibm.com/cdai-design/pal/components/data-table/filters/)`,
+        description: `[Check out the Guidance here.](https://pages.github.ibm.com/carbon/ibm-products/components/datagrid/filtering/usage/)`,
       },
       {
         subTitle: 'Preparing your column headers',

--- a/packages/ibm-products/src/components/Datagrid/utils/makeData.js
+++ b/packages/ibm-products/src/components/Datagrid/utils/makeData.js
@@ -68,7 +68,7 @@ const renderDocLink = () => {
       chance > 0.66
         ? 'https://carbondesignsystem.com/'
         : chance > 0.33
-        ? 'https://pages.github.ibm.com/cdai-design/pal/'
+        ? 'https://pages.github.ibm.com/carbon/ibm-products/'
         : 'https://ibm-products.carbondesignsystem.com/',
     text:
       chance > 0.66

--- a/packages/ibm-products/src/components/DragAndDrop/DragAndDrop.mdx
+++ b/packages/ibm-products/src/components/DragAndDrop/DragAndDrop.mdx
@@ -12,7 +12,7 @@ import * as stories from './DragAndDrop.stories';
 ## Overview
 
 The following are drag and drop examples building upon the examples on the
-[PAL site](https://pages.github.ibm.com/cdai-design/pal/patterns/drag-and-drop/usage).
+[PAL site](https://pages.github.ibm.com/carbon/ibm-products/patterns/drag-and-drop/usage).
 While we are currently not providing these as exported components to use
 directly, they can be used as references for drag and drop interactions. The
 examples provided use `@dnd-kit`, also used in `@carbon/ibm-products` for

--- a/packages/ibm-products/src/components/EditFullPage/EditFullPage.docs-page.js
+++ b/packages/ibm-products/src/components/EditFullPage/EditFullPage.docs-page.js
@@ -12,7 +12,7 @@ import * as stories from './EditFullPage.stories';
 const DocsPage = () => {
   return (
     <StoryDocsPage
-      altGuidelinesHref="https://pages.github.ibm.com/cdai-design/pal/patterns/edit/usage#full-page-edit"
+      altGuidelinesHref="https://pages.github.ibm.com/carbon/ibm-products/patterns/edit-and-update/usage/#full-page-edit"
       blocks={[
         {
           description: `There are **2** components that make up a Create Full Page component, which can

--- a/packages/ibm-products/src/components/EditInPlace/EditInPlace.stories.jsx
+++ b/packages/ibm-products/src/components/EditInPlace/EditInPlace.stories.jsx
@@ -55,7 +55,7 @@ export default {
     styles,
     docs: {
       page: () => (
-        <StoryDocsPage altGuidelinesHref="https://pages.github.ibm.com/cdai-design/pal/patterns/edit/usage#inline-edit" />
+        <StoryDocsPage altGuidelinesHref="https://pages.github.ibm.com/carbon/ibm-products/patterns/edit-and-update/usage/#inline-edit" />
       ),
     },
   },

--- a/packages/ibm-products/src/components/EditSidePanel/EditSidePanel.stories.jsx
+++ b/packages/ibm-products/src/components/EditSidePanel/EditSidePanel.stories.jsx
@@ -100,7 +100,7 @@ export default {
     styles,
     docs: {
       page: () => (
-        <StoryDocsPage altGuidelinesHref="https://pages.github.ibm.com/cdai-design/pal/patterns/edit/usage#side-panel-edit" />
+        <StoryDocsPage altGuidelinesHref="https://pages.github.ibm.com/carbon/ibm-products/patterns/edit-and-update/usage/#side-panel-edit" />
       ),
     },
   },

--- a/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.docs-page.js
+++ b/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.docs-page.js
@@ -12,7 +12,7 @@ import * as stories from './EditTearsheet.stories';
 const DocsPage = () => {
   return (
     <StoryDocsPage
-      altGuidelinesHref="https://pages.github.ibm.com/cdai-design/pal/patterns/edit/usage#tearsheet-edit"
+      altGuidelinesHref="https://pages.github.ibm.com/carbon/ibm-products/patterns/edit-and-update/usage/#tearsheet-edit"
       blocks={[
         {
           story: stories.multiFormEditTearsheet,

--- a/packages/ibm-products/src/components/EditTearsheetNarrow/EditTearsheetNarrow.stories.jsx
+++ b/packages/ibm-products/src/components/EditTearsheetNarrow/EditTearsheetNarrow.stories.jsx
@@ -31,7 +31,7 @@ export default {
     styles,
     docs: {
       page: () => (
-        <StoryDocsPage altGuidelinesHref="https://pages.github.ibm.com/cdai-design/pal/patterns/edit/usage#tearsheet-edit" />
+        <StoryDocsPage altGuidelinesHref="https://pages.github.ibm.com/carbon/ibm-products/patterns/edit-and-update/usage/#tearsheet-edit" />
       ),
     },
   },

--- a/packages/ibm-products/src/components/EditUpdateCards/EditUpdateCards.stories.jsx
+++ b/packages/ibm-products/src/components/EditUpdateCards/EditUpdateCards.stories.jsx
@@ -41,7 +41,7 @@ export default {
     styles,
     docs: {
       page: () => (
-        <StoryDocsPage altGuidelinesHref="https://pages.github.ibm.com/cdai-design/pal/patterns/edit/usage#other-edit-behaviors" />
+        <StoryDocsPage altGuidelinesHref="https://pages.github.ibm.com/carbon/ibm-products/patterns/edit-and-update/usage/#other-edit-behaviors" />
       ),
     },
   },

--- a/packages/ibm-products/src/components/EmptyStates/EmptyStateV2.stories.jsx
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyStateV2.stories.jsx
@@ -22,7 +22,7 @@ export default {
         <StoryDocsPage
           altGuidelinesHref={[
             {
-              href: 'https://pages.github.ibm.com/cdai-design/pal/patterns/empty-state/usage',
+              href: 'https://carbondesignsystem.com/patterns/empty-states-pattern/',
               label: 'Error pattern usage guidelines',
             },
             {

--- a/packages/ibm-products/src/components/EmptyStates/EmptyStates.stories.jsx
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyStates.stories.jsx
@@ -27,7 +27,7 @@ export default {
         <StoryDocsPage
           altGuidelinesHref={[
             {
-              href: 'https://pages.github.ibm.com/cdai-design/pal/patterns/empty-state/usage',
+              href: 'https://carbondesignsystem.com/patterns/empty-states-pattern/',
               label: 'Error pattern usage guidelines',
             },
             {

--- a/packages/ibm-products/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.stories.jsx
+++ b/packages/ibm-products/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.stories.jsx
@@ -26,7 +26,7 @@ export default {
         <StoryDocsPage
           altGuidelinesHref={[
             {
-              href: 'https://pages.github.ibm.com/cdai-design/pal/patterns/empty-state/usage',
+              href: 'https://carbondesignsystem.com/patterns/empty-states-pattern/',
               label: 'Error pattern usage guidelines',
             },
             {

--- a/packages/ibm-products/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.stories.jsx
+++ b/packages/ibm-products/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.stories.jsx
@@ -26,7 +26,7 @@ export default {
         <StoryDocsPage
           altGuidelinesHref={[
             {
-              href: 'https://pages.github.ibm.com/cdai-design/pal/patterns/empty-state/usage',
+              href: 'https://carbondesignsystem.com/patterns/empty-states-pattern/',
               label: 'Error pattern usage guidelines',
             },
             {

--- a/packages/ibm-products/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.stories.jsx
+++ b/packages/ibm-products/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.stories.jsx
@@ -26,7 +26,7 @@ export default {
         <StoryDocsPage
           altGuidelinesHref={[
             {
-              href: 'https://pages.github.ibm.com/cdai-design/pal/patterns/empty-state/usage',
+              href: 'https://carbondesignsystem.com/patterns/empty-states-pattern/',
               label: 'Error pattern usage guidelines',
             },
             {

--- a/packages/ibm-products/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.stories.jsx
+++ b/packages/ibm-products/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.stories.jsx
@@ -25,7 +25,7 @@ export default {
         <StoryDocsPage
           altGuidelinesHref={[
             {
-              href: 'https://pages.github.ibm.com/cdai-design/pal/patterns/empty-state/usage',
+              href: 'https://carbondesignsystem.com/patterns/empty-states-pattern/',
               label: 'Error pattern usage guidelines',
             },
             {

--- a/packages/ibm-products/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.stories.jsx
+++ b/packages/ibm-products/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.stories.jsx
@@ -25,7 +25,7 @@ export default {
         <StoryDocsPage
           altGuidelinesHref={[
             {
-              href: 'https://pages.github.ibm.com/cdai-design/pal/patterns/empty-state/usage',
+              href: 'https://carbondesignsystem.com/patterns/empty-states-pattern/',
               label: 'Error pattern usage guidelines',
             },
             {

--- a/packages/ibm-products/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.stories.jsx
+++ b/packages/ibm-products/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.stories.jsx
@@ -25,7 +25,7 @@ export default {
         <StoryDocsPage
           altGuidelinesHref={[
             {
-              href: 'https://pages.github.ibm.com/cdai-design/pal/patterns/empty-state/usage',
+              href: 'https://carbondesignsystem.com/patterns/empty-states-pattern/',
               label: 'Error pattern usage guidelines',
             },
             {

--- a/packages/ibm-products/src/components/ExportModal/ExportModal.stories.jsx
+++ b/packages/ibm-products/src/components/ExportModal/ExportModal.stories.jsx
@@ -24,7 +24,7 @@ export default {
         <StoryDocsPage
           altGuidelinesHref={[
             {
-              href: 'https://pages.github.ibm.com/cdai-design/pal/patterns/exporting/usage',
+              href: 'https://pages.github.ibm.com/carbon/ibm-products/components/export/usage/',
               label: 'Export guidelines',
             },
             {

--- a/packages/ibm-products/src/components/FullPageError/FullPageError.mdx
+++ b/packages/ibm-products/src/components/FullPageError/FullPageError.mdx
@@ -5,7 +5,7 @@ import * as stories from './FullPageError.stories';
 
 # FullPageError
 
-[Usage guidelines](https://pages.github.ibm.com/cdai-design/pal/patterns/full-page-errors/usage/)
+[Usage guidelines](https://pages.github.ibm.com/carbon/ibm-products/components/full-page-error/usage/)
 
 ## Table of Contents
 

--- a/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreen.mdx
+++ b/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreen.mdx
@@ -13,7 +13,7 @@ import { InterstitialScreen } from '.';
 
 ## Overview
 
-[Interstitial screen](https://pages.github.ibm.com/cdai-design/pal/components/onboarding/interstitial/usage)
+[Interstitial screen](https://pages.github.ibm.com/carbon/ibm-products/components/onboarding/interstitial-screen/usage)
 can be a full page or an overlay, and are shown on the first time a user
 accesses a new experience (e.g. upon first login or first time opening a page
 where a newly purchased capability is presented).

--- a/packages/ibm-products/src/components/MultiAddSelect/MultiAddSelect.docs-page.js
+++ b/packages/ibm-products/src/components/MultiAddSelect/MultiAddSelect.docs-page.js
@@ -11,7 +11,7 @@ import { StoryDocsPage } from '../../global/js/utils/StoryDocsPage';
 const DocsPage = () => {
   return (
     <StoryDocsPage
-      altGuidelinesHref="https://pages.github.ibm.com/cdai-design/pal/patterns/add-and-select/usage"
+      altGuidelinesHref="https://pages.github.ibm.com/carbon/ibm-products/patterns/add-and-select/usage"
       blocks={[
         {
           title: 'Structuring items',

--- a/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.mdx
+++ b/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.mdx
@@ -5,7 +5,7 @@ import * as stories from './NotificationsPanel.stories';
 
 # NotificationsPanel
 
-[CD&AI Notifications panel usage guidelines](https://pages.github.ibm.com/cdai-design/pal/patterns/notifications/)
+[CD&AI Notifications panel usage guidelines](https://pages.github.ibm.com/carbon/ibm-products/patterns/notifications/usage/)
 
 ## Overview
 

--- a/packages/ibm-products/src/components/OptionsTile/OptionsTile-unused-v1.mdx
+++ b/packages/ibm-products/src/components/OptionsTile/OptionsTile-unused-v1.mdx
@@ -20,7 +20,7 @@ likely not interested in all available options, but only a subset.
 An options tile can also be paired with a toggle to enable or disable an entire
 set of features with ease.
 
-[Options Tile guidelines](https://pages.github.ibm.com/cdai-design/pal/components/options-tile/usage)
+[Options Tile guidelines](https://pages.github.ibm.com/carbon/ibm-products/components/options-tile/usage)
 (IBM internal)
 
 ## Example usage

--- a/packages/ibm-products/src/components/PageHeader/PageHeader.stories.jsx
+++ b/packages/ibm-products/src/components/PageHeader/PageHeader.stories.jsx
@@ -848,7 +848,7 @@ const TemplateDemo = ({
         >
           <SideNavItems>
             <SideNavLink
-              href="https://pages.github.ibm.com/cdai-design/pal/"
+              href="https://pages.github.ibm.com/carbon/ibm-products/"
               target="_blank"
             >
               Sample link: Carbon for IBM Products

--- a/packages/ibm-products/src/components/Saving/Saving.mdx
+++ b/packages/ibm-products/src/components/Saving/Saving.mdx
@@ -7,7 +7,7 @@ import * as stories from './Saving.stories';
 
 # Saving
 
-[Usage guidelines](https://pages.github.ibm.com/cdai-design/pal/patterns/saving/usage/)
+[Usage guidelines](https://pages.github.ibm.com/carbon/ibm-products/patterns/saving/usage/)
 
 ## Manual type
 

--- a/packages/ibm-products/src/components/SidePanel/SidePanel.mdx
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.mdx
@@ -5,7 +5,7 @@ import * as stories from './SidePanel.stories';
 
 # Side Panel
 
-[CD&AI Side Panel usage guidelines](https://pages.github.ibm.com/cdai-design/pal/components/side-panel/usage)
+[CD&AI Side Panel usage guidelines](https://pages.github.ibm.com/carbon/ibm-products/components/side-panel/usage)
 
 ## Overview
 

--- a/packages/ibm-products/src/components/SingleAddSelect/SingleAddSelect.docs-page.js
+++ b/packages/ibm-products/src/components/SingleAddSelect/SingleAddSelect.docs-page.js
@@ -11,7 +11,7 @@ import { StoryDocsPage } from '../../global/js/utils/StoryDocsPage';
 const DocsPage = () => {
   return (
     <StoryDocsPage
-      altGuidelinesHref="https://pages.github.ibm.com/cdai-design/pal/patterns/add-and-select/usage"
+      altGuidelinesHref="https://pages.github.ibm.com/carbon/ibm-products/patterns/add-and-select/usage"
       blocks={[
         {
           title: 'Structuring items',

--- a/packages/ibm-products/src/components/TagSet/TagSet.mdx
+++ b/packages/ibm-products/src/components/TagSet/TagSet.mdx
@@ -5,7 +5,7 @@ import * as stories from './TagSet.stories';
 
 # TagSet
 
-[TagSet usage guidelines](https://pages.github.ibm.com/cdai-design/pal/components/tag-set)
+[TagSet usage guidelines](https://pages.github.ibm.com/carbon/ibm-products/components/tag-set/usage/)
 
 ## Table of Contents
 

--- a/packages/ibm-products/src/components/UserProfileImage/UserProfileImage.tsx
+++ b/packages/ibm-products/src/components/UserProfileImage/UserProfileImage.tsx
@@ -55,7 +55,7 @@ type imageProps =
 type UserProfileImageBaseProps = {
   /**
    * The background color passed should match one of the background colors in the library documentation:
-   * https://pages.github.ibm.com/cdai-design/pal/patterns/user-profile-images/
+   * https://pages.github.ibm.com/carbon/ibm-products/patterns/user-profile-images/
    */
   backgroundColor?: string;
 
@@ -242,7 +242,7 @@ UserProfileImage.displayName = componentName;
 UserProfileImage.propTypes = {
   /**
    * The background color passed should match one of the background colors in the library documentation:
-   * https://pages.github.ibm.com/cdai-design/pal/patterns/user-profile-images/
+   * https://pages.github.ibm.com/carbon/ibm-products/patterns/user-profile-images/
    */
   backgroundColor: PropTypes.oneOf([
     'light-cyan',

--- a/packages/ibm-products/src/global/js/utils/story-helper.js
+++ b/packages/ibm-products/src/global/js/utils/story-helper.js
@@ -72,7 +72,7 @@ export const palUsageHref = (csfFile) => {
   const [_pkg, kind, section] = title.split('/');
 
   if (/components|patterns/i.test(kind) && name) {
-    return `https://pages.github.ibm.com/cdai-design/pal/${kind}s/${paramCase(
+    return `https://pages.github.ibm.com/carbon/ibm-products/${kind}s/${paramCase(
       section
     )}/usage`;
   }
@@ -130,7 +130,7 @@ export const storyDocsPageInfo = (csfFile) => {
 
     result.section = a;
 
-    result.guidelinesHref = `https://pages.github.ibm.com/cdai-design/pal/${kind.toLowerCase()}/${paramCase(
+    result.guidelinesHref = `https://pages.github.ibm.com/carbon/ibm-products/${kind.toLowerCase()}/${paramCase(
       result.section
     )}/usage`;
   } else {


### PR DESCRIPTION
Closes #5936 

Updated the docs links to new site.
github.ibm.com/cdai-design/pal ➡ https://pages.github.ibm.com/carbon/ibm-products

Also some paths are incorrect so corrected those url by comparing old site and new site 
example :  /save ➡  /saving , /data-table ➡ /datagrid etc.

#### What did you change? doc urls

#### How did you test and verify your work? storybook
