### PR TITLE
fix(Datagrid): select all row count updated to exclude disabled rows

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
@@ -1735,8 +1735,7 @@ describe(componentName, () => {
         .getElementsByTagName('div')[0]
         .getElementsByTagName('div')[0]
         .getElementsByTagName('button')[0].textContent
-    ).toEqual('Select all (100)');
-    // ).toEqual('Select all (93)'); (7 rows are disabled in entire table) switch to this after #5937 issue fixes
+    ).toEqual('Select all (93)');
 
     // click select all button in toolbar
     fireEvent.click(

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.tsx
@@ -56,7 +56,7 @@ const DatagridBatchActionsToolbar = (
   useEffect(() => {
     const countDisabledRows =
       (rows.find((row) => row.getRowProps)?.getRowProps?.() as DatagridRowProps)
-        ?.nonselectablerows.length || 0;
+        ?.nonselectablerows?.length || 0;
     rows && setAvailableRowsCount(rows.length - countDisabledRows);
   }, [rows]);
 

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.tsx
@@ -18,7 +18,7 @@ import { useResizeObserver } from '../../../global/js/hooks/useResizeObserver';
 import { pkg, carbon } from '../../../settings';
 import cx from 'classnames';
 import { handleSelectAllRowData } from './addons/stateReducer';
-import { DataGridState } from '../types';
+import { DataGridState, DatagridRowProps } from '../types';
 
 const blockClass = `${pkg.prefix}--datagrid__table-toolbar`;
 
@@ -47,9 +47,18 @@ const DatagridBatchActionsToolbar = (
     batchActionMenuButtonLabel,
     translateWithIdBatchActions,
   } = datagridState;
+  const [availableRowsCount, setAvailableRowsCount] = useState(rows.length);
+
   const batchActionMenuButtonLabelText = batchActionMenuButtonLabel ?? 'More';
   const selectedKeys = Object.keys(selectedRowIds || {});
   const totalSelected = selectedKeys.length;
+
+  useEffect(() => {
+    const countDisabledRows =
+      (rows.find((row) => row.getRowProps)?.getRowProps?.() as DatagridRowProps)
+        ?.nonselectablerows.length || 0;
+    rows && setAvailableRowsCount(rows.length - countDisabledRows);
+  }, [rows]);
 
   // Get initial width of batch actions container,
   // used to measure when all items are put inside
@@ -183,7 +192,7 @@ const DatagridBatchActionsToolbar = (
       totalSelected={totalSelected}
       onCancel={onCancelHandler}
       onSelectAll={onSelectAllHandler}
-      totalCount={rows && rows.length}
+      totalCount={availableRowsCount}
       translateWithId={translateWithIdBatchActions}
     >
       {!displayAllInMenu &&

--- a/packages/ibm-products/src/components/Datagrid/types/index.ts
+++ b/packages/ibm-products/src/components/Datagrid/types/index.ts
@@ -11,6 +11,7 @@ import { RadioButtonProps } from '@carbon/react/lib/components/RadioButton/Radio
 import { RadioButtonGroupProps } from '@carbon/react/lib/components/RadioButtonGroup/RadioButtonGroup';
 import { CheckboxProps } from '@carbon/react/lib/components/Checkbox';
 import { NumberInputProps } from '@carbon/react/lib/components/NumberInput/NumberInput';
+import { TableRowProps } from 'react-table';
 
 import React, {
   CSSProperties,
@@ -372,4 +373,8 @@ export type NodeFuncType = (props) => ReactNode;
 export interface PropGetterMeta {
   instance?: DataGridTableInstance;
   row?: Partial<Row<any> & DatagridRow<any>>;
+}
+
+export interface DatagridRowProps extends TableRowProps {
+  nonselectablerows: Array<number>;
 }

--- a/packages/ibm-products/src/components/Datagrid/useDisableSelectRows.ts
+++ b/packages/ibm-products/src/components/Datagrid/useDisableSelectRows.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { Hooks, Row, RowPropGetter, TableRowProps } from 'react-table';
-import { DatagridRow, PropGetterMeta } from './types';
+import { DatagridRow, PropGetterMeta, DatagridRowProps } from './types';
 
 const nonselectablerowsList = (instance) => {
   const nonselectablerows: number[] =
@@ -39,7 +39,7 @@ const useDisableSelectRows = (hooks: Hooks) => {
         disabled: instance?.shouldDisableSelectRow?.(row),
         nonselectablerows,
       },
-    ] as Partial<TableRowProps>[];
+    ] as Partial<DatagridRowProps>[];
   };
   hooks.getRowProps.push(getRowProps);
 };


### PR DESCRIPTION
Closes #5937

Selectable row should not count disabled rows in select all button

#### What did you change?
Updated the `totalCount ` attribute being passed to `TableBatchActions` with only selectable rows count.

#### How did you test and verify your work?
Storybook
