### PR TITLE
fix(NotificationPanel): focus return to trigger on closing notification panel

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -181,7 +181,6 @@
     "unauthorizedemptystate",
     "userprofileimage",
     "uuidv",
-    "webfonts",
-    "triggerButtonref"
+    "webfonts"
   ]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -181,6 +181,7 @@
     "unauthorizedemptystate",
     "userprofileimage",
     "uuidv",
-    "webfonts"
+    "webfonts",
+    "triggerButtonref"
   ]
 }

--- a/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.stories.jsx
+++ b/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.stories.jsx
@@ -153,7 +153,7 @@ const Template = (args) => {
           tempData = tempData.filter((item) => item.id !== id);
           setNotificationsData(tempData);
         }}
-        triggerButtonref={notificationTriggerRef}
+        triggerButtonRef={notificationTriggerRef}
       />
     </div>
   );

--- a/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.stories.jsx
+++ b/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.stories.jsx
@@ -131,13 +131,6 @@ const Template = (args) => {
     return () => clearTimeout(unreadTimer);
   }, [open, notificationsData, hasUnreadNotifications]);
 
-  // Focus the dialog content and trigger button
-  useEffect(() => {
-    if (!open && notificationTriggerRef.current) {
-      notificationTriggerRef.current.focus();
-    }
-  }, [open]);
-
   return (
     <div className={`${storyBlockClass}--full-height`}>
       {renderUIShellHeader(
@@ -160,6 +153,7 @@ const Template = (args) => {
           tempData = tempData.filter((item) => item.id !== id);
           setNotificationsData(tempData);
         }}
+        triggerButtonref={notificationTriggerRef}
       />
     </div>
   );

--- a/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.tsx
+++ b/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.tsx
@@ -17,7 +17,13 @@ import {
   WarningAltFilled,
 } from '@carbon/react/icons';
 // Import portions of React that are needed.
-import React, { MutableRefObject, useEffect, useRef, useState } from 'react';
+import React, {
+  MutableRefObject,
+  RefObject,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import { NotificationsEmptyState } from '../EmptyStates';
 // Other standard imports.
@@ -228,6 +234,11 @@ export interface NotificationsPanelProps {
   todayLabel?: string;
 
   /**
+   * Reference to trigger button
+   */
+  triggerButtonref?: RefObject<any>;
+
+  /**
    * Sets the View all button text
    */
   viewAllLabel?: (value: number) => string;
@@ -298,7 +309,7 @@ export let NotificationsPanel = React.forwardRef(
       yesterdayAtText = defaults.yesterdayAtText,
       yesterdayLabel = defaults.yesterdayLabel,
       selectorsFloatingMenus,
-
+      triggerButtonref,
       // Collect any other property values passed in.
       ...rest
     }: NotificationsPanelProps,
@@ -316,7 +327,6 @@ export let NotificationsPanel = React.forwardRef(
 
     const reducedMotion = usePrefersReducedMotion();
     const carbonPrefix = usePrefix();
-
     useEffect(() => {
       // Set the notifications passed to the state within this component
       setAllNotifications(data);
@@ -324,6 +334,9 @@ export let NotificationsPanel = React.forwardRef(
 
     useClickOutside(ref || notificationPanelRef, () => {
       onClickOutside();
+      setTimeout(() => {
+        triggerButtonref?.current?.focus();
+      }, 0);
     });
 
     useEffect(() => {
@@ -390,6 +403,9 @@ export let NotificationsPanel = React.forwardRef(
       event.stopPropagation();
       if (event.key === 'Escape') {
         onClickOutside();
+        setTimeout(() => {
+          triggerButtonref?.current?.focus();
+        }, 0);
       }
     };
     useEffect(() => {
@@ -946,6 +962,11 @@ NotificationsPanel.propTypes = {
    * Sets the today label text
    */
   todayLabel: PropTypes.string,
+
+  /**
+   * Sets the today label text
+   */
+  triggerButtonref: PropTypes.any,
 
   /**
    * Sets the View all button text

--- a/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.tsx
+++ b/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.tsx
@@ -236,7 +236,7 @@ export interface NotificationsPanelProps {
   /**
    * Reference to trigger button
    */
-  triggerButtonref?: RefObject<any>;
+  triggerButtonRef?: RefObject<any>;
 
   /**
    * Sets the View all button text
@@ -309,7 +309,7 @@ export let NotificationsPanel = React.forwardRef(
       yesterdayAtText = defaults.yesterdayAtText,
       yesterdayLabel = defaults.yesterdayLabel,
       selectorsFloatingMenus,
-      triggerButtonref,
+      triggerButtonRef,
       // Collect any other property values passed in.
       ...rest
     }: NotificationsPanelProps,
@@ -335,7 +335,7 @@ export let NotificationsPanel = React.forwardRef(
     useClickOutside(ref || notificationPanelRef, () => {
       onClickOutside();
       setTimeout(() => {
-        triggerButtonref?.current?.focus();
+        triggerButtonRef?.current?.focus();
       }, 0);
     });
 
@@ -404,7 +404,7 @@ export let NotificationsPanel = React.forwardRef(
       if (event.key === 'Escape') {
         onClickOutside();
         setTimeout(() => {
-          triggerButtonref?.current?.focus();
+          triggerButtonRef?.current?.focus();
         }, 0);
       }
     };
@@ -966,7 +966,7 @@ NotificationsPanel.propTypes = {
   /**
    * Sets the today label text
    */
-  triggerButtonref: PropTypes.any,
+  triggerButtonRef: PropTypes.any,
 
   /**
    * Sets the View all button text


### PR DESCRIPTION
Closes #6089 

Focus return to the trigger button on closing the Notification panel should be handled in the component not in stories for better adapter experience.

#### What did you change?
Added option to pass trigger button reference `triggerButtonref` as prop to the `Notification Panel`component and focus being returned from the component itself instead of being done in the stories. 

#### How did you test and verify your work?
