### PR TITLE
fix: remove ellipsis from EditInPlace

### DIFF
--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -5450,16 +5450,6 @@ th.c4p--datagrid__select-all-toggle-on.button {
   line-height: inherit;
 }
 
-.c4p--edit-in-place__ellipsis {
-  position: relative;
-  margin-left: -1rem;
-  opacity: 0;
-}
-
-.c4p--edit-in-place--overflows:not(.c4p--edit-in-place--focused) .c4p--edit-in-place__ellipsis {
-  opacity: 1;
-}
-
 .c4p--edit-in-place__text-input-label {
   display: none;
 }
@@ -8881,8 +8871,9 @@ button.c4p--add-select__global-filter-toggle--open {
   text-align: left;
 }
 .c4p--tag-set-overflow__tagset-popover .c4p--tag-set-overflow__popover-trigger {
-  font-family: inherit;
+  /* stylelint-disable-next-line declaration-no-important */
   border: none !important;
+  font-family: inherit;
 }
 .c4p--tag-set-overflow__tagset-popover .c4p--tag-set-overflow__show-all-tags-link.cds--link:visited {
   display: inline-block;

--- a/packages/ibm-products-styles/src/components/EditInPlace/_edit-in-place.scss
+++ b/packages/ibm-products-styles/src/components/EditInPlace/_edit-in-place.scss
@@ -75,17 +75,6 @@ $carbon-input: #{$carbon-prefix}--text-input;
   line-height: inherit;
 }
 
-.#{$block-class}__ellipsis {
-  position: relative;
-  margin-left: calc(-1 * $spacing-05);
-  opacity: 0;
-}
-
-.#{$block-class}--overflows:not(.#{$block-class}--focused)
-  .#{$block-class}__ellipsis {
-  opacity: 1;
-}
-
 .#{$block-class}__text-input-label {
   display: none;
 }

--- a/packages/ibm-products/src/components/EditInPlace/EditInPlace.tsx
+++ b/packages/ibm-products/src/components/EditInPlace/EditInPlace.tsx
@@ -301,9 +301,6 @@ export let EditInPlace = forwardRef<HTMLDivElement, EditInplaceProps>(
             aria-label={labelText}
             aria-invalid={invalid}
           />
-          <div className={`${blockClass}__ellipsis`} aria-hidden={!focused}>
-            &hellip;
-          </div>
           <div className={`${blockClass}__toolbar`}>
             {invalid && (
               <WarningFilled


### PR DESCRIPTION
Closes #6082 

removes the ellipsis in `EditInPlace` to alleviate an accessibility and functional issue where you are unable to focus on the input