### PR TITLE
fix(Datagrid): remove redundant aria disabled

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.tsx
@@ -45,7 +45,6 @@ const DraggableElement = ({
     disabled,
     id,
   });
-
   const content = (
     <>
       <div
@@ -66,7 +65,7 @@ const DraggableElement = ({
     transform: !disabled ? CSS.Transform.toString(transform) : undefined,
     transition,
   };
-
+  const { 'aria-disabled': _, ...attributesUpdated } = attributes;
   return (
     <li
       className={cx(classList, `${blockClass}__draggable-handleHolder`, {
@@ -77,7 +76,7 @@ const DraggableElement = ({
       id={id}
       ref={setNodeRef}
       style={style}
-      {...attributes}
+      {...attributesUpdated}
       {...listeners}
       aria-selected={selected}
       role="option"

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.tsx
@@ -65,7 +65,6 @@ const DraggableElement = ({
     transform: !disabled ? CSS.Transform.toString(transform) : undefined,
     transition,
   };
-  const { 'aria-disabled': _, ...attributesUpdated } = attributes;
   return (
     <li
       className={cx(classList, `${blockClass}__draggable-handleHolder`, {
@@ -76,8 +75,9 @@ const DraggableElement = ({
       id={id}
       ref={setNodeRef}
       style={style}
-      {...attributesUpdated}
+      {...attributes}
       {...listeners}
+      aria-disabled={undefined}
       aria-selected={selected}
       role="option"
     >


### PR DESCRIPTION
Closes #4797

Remove redundant `aria-disabled` in customize columns items

#### What did you change?
`aria-disabled` is set to `undefined` for `li` element.

#### How did you test and verify your work?
Storybook
