### PR TITLE
fix: createTearsheet height fix

### DIFF
--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -3303,7 +3303,7 @@ p.c4p--about-modal__copyright-text:first-child {
   }
 }
 .c4p--tearsheet-create .c4p--tearsheet-create__content {
-  height: 100%;
+  min-height: 100%;
   padding-top: 1.5rem;
   padding-bottom: 1.5rem;
   overflow-x: hidden;

--- a/packages/ibm-products-styles/src/components/CreateTearsheet/_create-tearsheet.scss
+++ b/packages/ibm-products-styles/src/components/CreateTearsheet/_create-tearsheet.scss
@@ -81,7 +81,7 @@ $tearsheet-fieldset-class: #{c4p-settings.$pkg-prefix}--tearsheet-create__step--
 }
 
 .#{$create-tearsheet-block-class} .#{$create-tearsheet-block-class}__content {
-  height: 100%;
+  min-height: 100%;
   padding-top: $spacing-06;
   padding-bottom: $spacing-06;
   overflow-x: hidden;


### PR DESCRIPTION
Closes #5613 

fixes small visual bug where `height: 100%` was preventing padding from being applied inside `.dev-prefix--c4p--tearsheet-create__content`