### PR TITLE
fix: notification panel keyboard close focus

### DIFF
--- a/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.tsx
+++ b/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.tsx
@@ -405,7 +405,7 @@ export let NotificationsPanel = React.forwardRef(
         onClickOutside();
         setTimeout(() => {
           triggerButtonRef?.current?.focus();
-        }, 0);
+        }, 100);
       }
     };
     useEffect(() => {


### PR DESCRIPTION
Closes #6010 

fixes a small timing issue that was preventing the notification panel from regaining focus after closing via keyboard.

you can verify the fix by following the `Steps to reproduce the issue (if applicable)` and verifying that the focus is regained.
