### PR TITLE
fix(Tearsheet): add missing declaration for headerActions prop

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/Tearsheet.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/Tearsheet.tsx
@@ -88,6 +88,14 @@ export interface TearsheetProps extends PropsWithChildren {
   hasCloseIcon?: boolean;
 
   /**
+   * The content for the header actions area, displayed alongside the title in
+   * the header area of the tearsheet. This is typically a drop-down, or a set
+   * of small buttons, or similar. NB the headerActions is only applicable for
+   * wide tearsheets.
+   */
+  headerActions?: ReactNode;
+
+  /**
    * The content for the influencer section of the tearsheet, displayed
    * alongside the main content. This is typically a menu, or filter, or
    * progress indicator, or similar.
@@ -296,6 +304,14 @@ Tearsheet.propTypes = {
    */
   /**@ts-ignore */
   hasCloseIcon: PropTypes.bool,
+
+  /**
+   * The content for the header actions area, displayed alongside the title in
+   * the header area of the tearsheet. This is typically a drop-down, or a set
+   * of small buttons, or similar. NB the headerActions is only applicable for
+   * wide tearsheets.
+   */
+  headerActions: PropTypes.element,
 
   /**
    * The content for the influencer section of the tearsheet, displayed


### PR DESCRIPTION
Refs #546.

`headerActions` was defined for `TearsheetShell` but not for `Tearsheet`.

This caused Typescript errors, and you were also missing `PropTypes` validation for any plain Javascript code using `headerActions`.

Note that ideally, Tearsheet.tsx and TearsheetNarrow.tsx would not repeat the type declarations from TearsheetShell.tsx.  But that's no addressed in this PR.

#### What did you change?

Added Tearsheet `headerActions` Typescript declaration, and also added it to the `PropTypes`.

#### How did you test and verify your work?

Built locally.
