### PR TITLE
fix(ExportModal): focus return to trigger button

### DIFF
--- a/packages/ibm-products/src/components/ExportModal/ExportModal.stories.jsx
+++ b/packages/ibm-products/src/components/ExportModal/ExportModal.stories.jsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { Button } from '@carbon/react';
 // import styles from './_storybook-styles.scss?inline'; // import index in case more files are added later.
 import { ExportModal } from '.';
@@ -98,6 +98,7 @@ const Template = ({ storyInitiallyOpen = false, ...args }, context) => {
   const [open, setOpen] = useState(
     context.viewMode !== 'docs' && storyInitiallyOpen
   );
+  const triggerButtonRef = useRef(null);
   const [loading, setLoading] = useState(false);
   const [successful, setSuccessful] = useState(false);
   const [error, setError] = useState(false);
@@ -118,9 +119,16 @@ const Template = ({ storyInitiallyOpen = false, ...args }, context) => {
     setSuccessful(false);
     setError(false);
   };
-
+  function RenderButton(triggerButtonRef) {
+    return (
+      <Button ref={triggerButtonRef} onClick={() => setOpen(true)}>
+        Launch modal
+      </Button>
+    );
+  }
   return (
     <>
+      {RenderButton(triggerButtonRef)}
       <ExportModal
         {...args}
         open={open}
@@ -132,8 +140,8 @@ const Template = ({ storyInitiallyOpen = false, ...args }, context) => {
         successMessage="The file has been exported."
         error={error}
         errorMessage="Server error 500"
+        triggerButtonRef={triggerButtonRef}
       />
-      <Button onClick={() => setOpen(true)}>Launch modal</Button>
     </>
   );
 };

--- a/packages/ibm-products/src/components/ExportModal/ExportModal.tsx
+++ b/packages/ibm-products/src/components/ExportModal/ExportModal.tsx
@@ -268,10 +268,6 @@ export let ExportModal = forwardRef(
       onBlur: onBlurHandler,
       ['data-modal-primary-focus']: true,
     };
-    const closeModal = () => {
-      onClose && onClose();
-      triggerButtonRef?.current.focus();
-    };
     return renderPortalUse(
       <FeatureFlags
         flags={{
@@ -284,8 +280,8 @@ export let ExportModal = forwardRef(
           aria-label={title}
           size="sm"
           preventCloseOnClickOutside
-          onClose={closeModal}
-          {...{ open, ref, ...getDevtoolsProps(componentName) }}
+          launcherButtonRef={triggerButtonRef}
+          {...{ open, ref, onClose, ...getDevtoolsProps(componentName) }}
         >
           <ModalHeader
             className={`${blockClass}__header`}

--- a/packages/ibm-products/src/components/ExportModal/ExportModal.tsx
+++ b/packages/ibm-products/src/components/ExportModal/ExportModal.tsx
@@ -25,6 +25,7 @@ import React, {
   forwardRef,
   useEffect,
   useRef,
+  RefObject,
   useState,
 } from 'react';
 
@@ -145,6 +146,10 @@ export interface ExportModalProps
    */
   title: string;
   /**
+   * Reference to trigger button
+   */
+  triggerButtonRef?: RefObject<any>;
+  /**
    * array of valid extensions the file can have
    */
   validExtensions: readonly any[];
@@ -181,6 +186,7 @@ export let ExportModal = forwardRef(
       successMessage,
       successful,
       title,
+      triggerButtonRef,
       validExtensions = defaults.validExtensions,
 
       // Collect any other property values passed in.
@@ -262,7 +268,10 @@ export let ExportModal = forwardRef(
       onBlur: onBlurHandler,
       ['data-modal-primary-focus']: true,
     };
-
+    const closeModal = () => {
+      onClose && onClose();
+      triggerButtonRef?.current.focus();
+    };
     return renderPortalUse(
       <FeatureFlags
         flags={{
@@ -275,7 +284,8 @@ export let ExportModal = forwardRef(
           aria-label={title}
           size="sm"
           preventCloseOnClickOutside
-          {...{ open, ref, onClose, ...getDevtoolsProps(componentName) }}
+          onClose={closeModal}
+          {...{ open, ref, ...getDevtoolsProps(componentName) }}
         >
           <ModalHeader
             className={`${blockClass}__header`}
@@ -478,6 +488,10 @@ ExportModal.propTypes = {
    * The text displayed at the top of the modal
    */
   title: PropTypes.string.isRequired,
+  /**
+   * Sets the trigger button ref
+   */
+  triggerButtonRef: PropTypes.any,
   /**
    * array of valid extensions the file can have
    */


### PR DESCRIPTION
Closes #6018

Export Modal, Focus not returning to triggering button

#### What did you change?

Passed the trigger button reference `triggerButtonRef ` as prop to `Export Modal` and added the logic focus on the button on closing the modal from there.

#### How did you test and verify your work?
Storybook
