### PR TITLE
fix: datagrid typescript declarations

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/index.ts
+++ b/packages/ibm-products/src/components/Datagrid/index.ts
@@ -27,3 +27,7 @@ export { default as useEditableCell } from './useEditableCell';
 export { default as useFiltering } from './useFiltering';
 export { getAutoSizedColumnWidth } from './utils/getAutoSizedColumnWidth';
 export { useFilterContext } from './Datagrid/addons/Filtering/hooks';
+
+// types/index.ts defines a lot of types.  Unclear which ones should be exported,
+// but presumably not all of them because some have generic names like "Size".
+export type { DataGridState } from './types';

--- a/packages/ibm-products/src/components/Datagrid/types/index.ts
+++ b/packages/ibm-products/src/components/Datagrid/types/index.ts
@@ -11,7 +11,6 @@ import { RadioButtonProps } from '@carbon/react/lib/components/RadioButton/Radio
 import { RadioButtonGroupProps } from '@carbon/react/lib/components/RadioButtonGroup/RadioButtonGroup';
 import { CheckboxProps } from '@carbon/react/lib/components/Checkbox';
 import { NumberInputProps } from '@carbon/react/lib/components/NumberInput/NumberInput';
-import { TableRowProps } from 'react-table';
 
 import React, {
   CSSProperties,
@@ -34,6 +33,7 @@ import {
   TableCommonProps,
   TableDispatch,
   TableInstance,
+  TableRowProps,
   TableState,
   TableToggleAllRowsSelectedProps,
   UseExpandedRowProps,
@@ -235,11 +235,10 @@ export interface RowAction {
 }
 export interface DataGridState<T extends object = any>
   extends TableCommonProps,
-    UsePaginationInstanceProps<T>,
+    Partial<UsePaginationInstanceProps<T>>,
     Omit<TableInstance<T>, 'state' | 'headers' | 'rows' | 'columns'>,
-    Omit<UseFiltersInstanceProps<T>, 'rows'>,
-    UseRowSelectInstanceProps<T>,
-    Pick<UseRowSelectInstanceProps<T>, 'toggleAllRowsSelected'> {
+    Partial<Pick<UseFiltersInstanceProps<T>, 'setFilter' | 'setAllFilters'>>,
+    UseRowSelectInstanceProps<T> {
   withVirtualScroll?: boolean;
   DatagridPagination?: JSXElementConstructor<any>;
   isFetching?: boolean;
@@ -278,7 +277,7 @@ export interface DataGridState<T extends object = any>
   emptyStateSize?: 'lg' | 'sm';
   emptyStateType?: string;
   illustrationTheme?: 'light' | 'dark';
-  emptyStateAction: {
+  emptyStateAction?: {
     kind?: 'primary' | 'secondary' | 'tertiary';
     renderIcon?: CarbonIconType;
     onClick?: ButtonProps<any>['onClick'];
@@ -297,13 +296,13 @@ export interface DataGridState<T extends object = any>
   setMouseOverRowIndex?: (arg: any) => void;
   hideSelectAll?: boolean;
   radio?: boolean;
-  onAllRowSelect: (rows: DatagridRow[], evt: any) => void;
+  onAllRowSelect?: (rows: DatagridRow[], evt: any) => void;
   selectAllToggle?: {
     onSelectAllRows?: (args) => void;
     labels?: Labels;
   };
   allPageRowsLabel?: string | object;
-  allRowsLabel: string | object;
+  allRowsLabel?: string | object;
   onSelectAllRows?: (val?: boolean) => void;
   toolbarBatchActions?: ButtonProps<any>[];
   setGlobalFilter?: (filterValue: FilterValue) => void;


### PR DESCRIPTION

Refs #5257, #6115.

This fixes some (but not all) of the Typescript issues with Datagrid.

Specifically:

1. Export DataGridState type.  Maybe other types should be exported too. Note that in other places the G is not capitalized, but it is for the type.

2. onAllRowSelect() is (and should be) optional.

3. Presumably you aren't required to have a button on your empty state screens, so "emptyStateAction" should be optional.

4. "allRowsLabel" should be optional because you only need it if your table has a "Select all" checkbox.  And also because it's optional in PropTypes.

5. Properties like "page" are only necessary if your table has pagination, so make UsePaginationInstanceProps props optional.

6. UseFiltersInstanceProps defines a bunch of weird and required properties like "preFilteredRows", "preFilteredFlatRows", "preFilteredRowsById".  AFAICT none of those are valid for DataGridState except for setFilter() and setAllFilters(), and even those should be optional.

7. The original DataGridState class extended both UseRowSelectInstanceProps and Pick<UseRowSelectInstanceProps<T>, 'toggleAllRowsSelected'>.  Obviously that doesn't make sense because of the redundancy.  But I'm not sure what does make sense.  AFAIK users don't directly defined functions like toggleRowSelected() or toggleAllRowsSelected()... but there is code that calls them.

This PR doesn't address the main issues with the types, where useDatagrid() returns a TableInstance but Datagrid.datagridState is a DataGridState.

Further, I think maybe DataGridState needs to be split into two types. Consider that:

1. The object passed to Datagrid.datagridState does not contain "row".
2. DataGridRow's props DO include "row".
3. Both Datagrid.datagridState and DataGridRow's props are defined as DataGridState.


#### What did you change?

Typescript declarations for Datagrid.

#### How did you test and verify your work?

Tested locally with my own app.