### PR TITLE
fix(SidePanel): style issue with multi select

### DIFF
--- a/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
+++ b/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
@@ -413,6 +413,7 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
 .#{$block-class} .#{c4p-settings.$carbon-prefix}--text-area,
 .#{$block-class} .#{c4p-settings.$carbon-prefix}--search-input,
 .#{$block-class} .#{c4p-settings.$carbon-prefix}--select-input,
+.#{$block-class} .#{c4p-settings.$carbon-prefix}--multi-select,
 .#{$block-class} .#{c4p-settings.$carbon-prefix}--dropdown,
 .#{$block-class} .#{c4p-settings.$carbon-prefix}--dropdown-list,
 .#{$block-class} .#{c4p-settings.$carbon-prefix}--number input[type='number'],

--- a/packages/ibm-products/src/components/SidePanel/SidePanel.stories.jsx
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.stories.jsx
@@ -14,6 +14,7 @@ import {
   Column,
   TextArea,
   TextInput,
+  MultiSelect,
   DataTable,
   Table,
   TableHeader,
@@ -266,6 +267,21 @@ const ChildrenContent = () => {
           labelText="Input D"
           id="side-panel-story-text-input-d"
           className={`${prefix}text-input`}
+        />
+      </div>
+      <div className={`${prefix}multi-select-container`}>
+        <MultiSelect
+          data-testid="alert--subtype--transfer--secondary-zones"
+          id="multiselectA"
+          titleText="Multiselect A"
+          label="Select an item"
+          items={[
+            {
+              value: 'all',
+              label: 'Multiselect A',
+            },
+          ]}
+          selectionFeedback="top-after-reopen"
         />
       </div>
       <div className={`${prefix}text-area-container`}>

--- a/packages/ibm-products/src/components/SidePanel/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/SidePanel/_storybook-styles.scss
@@ -28,6 +28,10 @@ $story-prefix: side-panel-stories__;
   .#{$story-prefix}text-area-container {
     position: relative;
   }
+  .#{$story-prefix}multi-select-container {
+    position: relative;
+    margin: $spacing-05 0;
+  }
   .#{$story-prefix}text-area-container .#{$story-prefix}allowed-characters {
     @include type.type-style('label-01');
 


### PR DESCRIPTION
Closes #5922

Background color for `Multiselect` doesn't match with other fields in  `Side Panel`

#### What did you change?
Updated the style file to set `Multiselect` the same style as the rest of the fields and added a `Multi select` field in the storybook stories for `Side panel`

#### How did you test and verify your work?
Storybook
