### PR TITLE
fix(TagOverflow): use operational tag

### DIFF
--- a/packages/ibm-products-styles/src/components/TagOverflow/_tag-overflow.scss
+++ b/packages/ibm-products-styles/src/components/TagOverflow/_tag-overflow.scss
@@ -100,6 +100,8 @@ $block-class-modal: #{$block-class}-modal;
   }
 
   .#{$block-class-overflow}__trigger {
+    /* stylelint-disable-next-line declaration-no-important */
+    border: none !important;
     font-family: inherit;
   }
 

--- a/packages/ibm-products/src/components/TagOverflow/TagOverflowPopover.tsx
+++ b/packages/ibm-products/src/components/TagOverflow/TagOverflowPopover.tsx
@@ -8,12 +8,12 @@
 import React, { useRef, forwardRef, Ref } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-/**@ts-ignore */
 import {
   Link,
   Tag,
   Popover,
   PopoverContent,
+  /**@ts-ignore */
   OperationalTag,
 } from '@carbon/react';
 import { useClickOutside } from '../../global/js/hooks';

--- a/packages/ibm-products/src/components/TagOverflow/TagOverflowPopover.tsx
+++ b/packages/ibm-products/src/components/TagOverflow/TagOverflowPopover.tsx
@@ -8,7 +8,14 @@
 import React, { useRef, forwardRef, Ref } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { Link, Tag, Popover, PopoverContent } from '@carbon/react';
+/**@ts-ignore */
+import {
+  Link,
+  Tag,
+  Popover,
+  PopoverContent,
+  OperationalTag,
+} from '@carbon/react';
 import { useClickOutside } from '../../global/js/hooks';
 import { pkg } from '../../settings';
 import { TagOverflowItem } from './TagOverflow';
@@ -98,12 +105,11 @@ export const TagOverflowPopover = forwardRef(
           onKeyDown={handleEscKeyPress}
           open={popoverOpen}
         >
-          <Tag
+          <OperationalTag
             onClick={() => setPopoverOpen?.(!popoverOpen)}
             className={cx(`${blockClass}__trigger`)}
-          >
-            +{overflowTags?.length}
-          </Tag>
+            text={`+${overflowTags.length}`}
+          />
           <PopoverContent>
             <div ref={overflowTagContent} className={`${blockClass}__content`}>
               <ul className={`${blockClass}__tag-list`}>


### PR DESCRIPTION
Closes #6002

Update TagOverflow to use OperationalTag

#### What did you change?
Replaced `Tag` with `OperationalTag`  for tag with click action.

#### How did you test and verify your work?
Storybook
