### PR TITLE
fix(InlineTip): added optional ? flag on media

### DIFF
--- a/packages/ibm-products/src/components/InlineTip/InlineTip.tsx
+++ b/packages/ibm-products/src/components/InlineTip/InlineTip.tsx
@@ -94,7 +94,7 @@ export interface InlineTipProps {
    *
    * Enabling `media` disables the `collapsible` feature.
    */
-  media: MediaType;
+  media?: MediaType;
   /**
    * Set to `true` to arrange the information in a format
    * that is easier to read in a limited space.


### PR DESCRIPTION
Closes #6099 

adds optional `?` flag on media prop for InlineTip

#### What did you change?
packages/ibm-products/src/components/InlineTip/InlineTip.tsx

#### How did you test and verify your work?
vs code intellisense, local.