### PR TITLE
fix: adds typescript to coverage report

### DIFF
--- a/config/jest-config-ibm-cloud-cognitive/index.js
+++ b/config/jest-config-ibm-cloud-cognitive/index.js
@@ -8,43 +8,7 @@
 'use strict';
 
 module.exports = {
-  collectCoverageFrom: ['src/**/*.js', '!**/*.stories.js'],
-  coverageReporters: [
-    [
-      'html',
-      {
-        skipEmpty: true,
-        // this next part doesn't actually seem to work
-        // see https://github.com/facebook/jest/issues/9734
-        watermark: {
-          statements: [80, 100],
-          lines: [80, 100],
-          functions: [80, 100],
-          branches: [80, 100],
-        },
-      },
-    ],
-    'text',
-    'text-summary',
-  ],
-  // set the global coverage threshold, because that supplies the default for
-  // the upper watermark, then nullify the global coverage threshold so it
-  // doesn't actually cause jest to fail whenever anything falls short of 100%!
-  // This can be removed if/when there's a way to set reporter watermarks directly.
-  coverageThreshold: {
-    global: {
-      branches: 100,
-      functions: 100,
-      lines: 100,
-      statements: 100,
-    },
-    '**/*.js': {
-      branches: 0,
-      functions: 0,
-      lines: 0,
-      statements: 0,
-    },
-  },
+  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!**/*.stories.{js,jsx}'],
   resolver: require.resolve('./setup/resolver.js'),
   moduleFileExtensions: ['tsx', 'ts', 'jsx', 'js', 'json', 'node'],
   moduleNameMapper: {


### PR DESCRIPTION
Closes #6139 

adds `{ts,tsx}` extensions to the test coverage analysis and cleans up some of the jest config by removing old unnecessary coverage options. this bug was originally noticed when `UserAvatar` wasn't being picked up in the reporter. in the below screen shot you can see it's included after running the updated script.

<img width="1840" alt="Screenshot 2024-09-30 at 12 23 26 PM" src="https://github.com/user-attachments/assets/2468f05f-0e16-4449-84a8-16957cedaf44">
