### PR TITLE
fix(EditInPlace): focus and style issue

### DIFF
--- a/packages/ibm-products-styles/src/components/EditInPlace/_edit-in-place.scss
+++ b/packages/ibm-products-styles/src/components/EditInPlace/_edit-in-place.scss
@@ -59,8 +59,8 @@ $carbon-input: #{$carbon-prefix}--text-input;
 }
 
 .#{$block-class}--focused {
-  border: 2px solid $focus;
   background: $field-01;
+  outline: 2px solid $focus;
 }
 
 .#{$block-class}__text-input {

--- a/packages/ibm-products/src/components/EditInPlace/EditInPlace.tsx
+++ b/packages/ibm-products/src/components/EditInPlace/EditInPlace.tsx
@@ -209,6 +209,7 @@ export let EditInPlace = forwardRef<HTMLDivElement, EditInplaceProps>(
       setInitialValue(value);
       setDirtyInput(false);
       onSave();
+      setFocused(false);
     };
 
     const onCancelHandler = () => {


### PR DESCRIPTION
Closes #6050

Different scenarios in edit in place :

1. Click on the input box, input box is focused, clicking outside removes focus from input box.

2. Clicking on the input box, adding some extra text, by clicking on close icon I can remove the extra characters added, focus lost and I can see the initial state with pencil icon

3. Fix => Clicking on the input box, adding some extra text, by clicking on save icon I can save the new value - now its not looks like value is saved and focus is also not removed. Even if i click outside focus is not changing from input box 
Expected behaviour - value saved, focus lost and should be able to see the new value with pencil icon ( fix done)

Also addressed height issue

#### What did you change? 
packages/ibm-products-styles/src/components/EditInPlace/_edit-in-place.scss
packages/ibm-products/src/components/EditInPlace/EditInPlace.tsx

#### How did you test and verify your work? storybook
