### PR TITLE
fix: adds html output for coverage reporting

### DIFF
--- a/config/jest-config-ibm-cloud-cognitive/index.js
+++ b/config/jest-config-ibm-cloud-cognitive/index.js
@@ -8,7 +8,12 @@
 'use strict';
 
 module.exports = {
-  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!**/*.stories.{js,jsx}'],
+  coverageReporters: ['json', 'html'],
+  collectCoverageFrom: [
+    'src/**/*.{js,jsx,ts,tsx}',
+    '!**/*.stories.{js,jsx}',
+    '!**/*.story.{js,jsx}',
+  ],
   resolver: require.resolve('./setup/resolver.js'),
   moduleFileExtensions: ['tsx', 'ts', 'jsx', 'js', 'json', 'node'],
   moduleNameMapper: {


### PR DESCRIPTION
fixes small mistake i made when cleaning up the jest config. also includes skipping `.story` files, which apparently exist...
