### PR TITLE
fix(Toolbar): avt check failing in PRs

### DIFF
--- a/packages/ibm-products-styles/src/components/Toolbar/_toolbar.scss
+++ b/packages/ibm-products-styles/src/components/Toolbar/_toolbar.scss
@@ -52,7 +52,8 @@ $toolbar-dimensions: $spacing-08;
   border-bottom-width: 0;
 }
 
-.#{$block-class}__button--caret {
+.#{$block-class}__button--caret,
+.#{$block-class}__button__iconButtonWrapper {
   position: relative;
 }
 

--- a/packages/ibm-products/src/components/Toolbar/ToolbarButton.tsx
+++ b/packages/ibm-products/src/components/Toolbar/ToolbarButton.tsx
@@ -49,22 +49,23 @@ export let ToolbarButton = forwardRef(
   ) => {
     const Icon = renderIcon;
     return (
-      <IconButton
-        align={useContext(ToolbarContext)?.vertical ? 'right' : 'top'}
-        {...rest}
-        label={label ?? deprecated_iconDescription}
-        ref={ref}
-        className={cx(className, { [`${blockClass}--caret`]: caret })}
-        kind="ghost"
-        size="md"
-      >
-        <>
-          {Icon ? <Icon /> : null}
-          {children}
-
-          {caret && <span className={`${blockClass}__caret`} />}
-        </>
-      </IconButton>
+      <span className={`${blockClass}__iconButtonWrapper`}>
+        <IconButton
+          align={useContext(ToolbarContext)?.vertical ? 'right' : 'top'}
+          {...rest}
+          label={label ?? deprecated_iconDescription}
+          ref={ref}
+          className={cx(className, { [`${blockClass}--caret`]: caret })}
+          kind="ghost"
+          size="md"
+        >
+          <>
+            {Icon ? <Icon /> : null}
+            {children}
+          </>
+        </IconButton>
+        {caret && <span className={`${blockClass}__caret`} />}
+      </span>
     );
   }
 );


### PR DESCRIPTION
Closes #6160

avt checks are failing for any new PR raised and throwing accessibility violations from Toolbar component.

Message: Undersized target "span" does not have sufficient spacing of 12 CSS pixels from another target "button"
Level: violation
XPath: /html[1]/body[1]/div[5]/div[1]/div[1]/div[5]/span[1]/div[1]/button[1]/span[1]
Snippet:
Help: https://able.ibm.com/rules/archives/2024.10.01/doc/en-US/target_spacing_sufficient.html#%7B%22message%22%3A%22Undersized%20target%20%5C%22span%5C%22%20does%20not%20have%20sufficient%20spacing%20of%2012%20CSS%20pixels%20from%20another%20target%20%5C%22button%5C%22%22%2C%22snippet%22%3A%22%3Cspan%20class%3D%5C%22c4p--toolbar__button__caret%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22FAIL%22%5D%2C%22reasonId%22%3A%22violation_spacing%22%2C%22ruleId%22%3A%22target_spacing_sufficient%22%2C%22msgArgs%22%3A%5B%22span%22%2C%22button%22%5D%7D

#### What did you change?
Added a wrapper for icon button and moved caret icon outside of the icon button

#### How did you test and verify your work?
yarn avt