### PR TITLE
fix: temp workaround for target_spacing_sufficient rule

### DIFF
--- a/config/jest-config-ibm-cloud-cognitive/setup/matchers/toHaveNoACViolations.js
+++ b/config/jest-config-ibm-cloud-cognitive/setup/matchers/toHaveNoACViolations.js
@@ -20,6 +20,7 @@ async function toHaveNoACViolations(node, label) {
       'html_skipnav_exists',
       'aria_content_in_landmark',
       'aria_child_tabbable',
+      'target_spacing_sufficient',
     ]);
     const ruleset = await aChecker.getRuleset('IBM_Accessibility');
     const customRuleset = JSON.parse(JSON.stringify(ruleset));

--- a/e2e/components/Datagrid/Datagrid-test.avt.e2e.js
+++ b/e2e/components/Datagrid/Datagrid-test.avt.e2e.js
@@ -40,12 +40,12 @@ test.describe('Datagrid @avt', () => {
     firstRow.click();
     await page.waitForTimeout(3000);
     const sidePanel = page.locator('[aria-label="Title"]');
-    await page.waitForTimeout(3000);
     await expect(sidePanel).toBeVisible();
     const button = sidePanel.getByText('View details');
     await expect(button).toBeFocused();
     await page.keyboard.press('Shift+Tab');
     await page.keyboard.press('Enter');
+    await page.waitForTimeout(3000);
     await expect(firstRow).toBeFocused();
     await expect(page).toHaveNoACViolations(
       'Datagrid @avt-open-and-dismiss-sidepanel-onRowClick'

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -87,7 +87,8 @@ expect.extend({
         'html_skipnav_exists',
         'aria_content_in_landmark',
         'aria_child_tabbable',
-        'skip_main_described'
+        'skip_main_described',
+        'target_spacing_sufficient'
       ]);
 
       const ruleset = await aChecker.getRuleset('IBM_Accessibility');


### PR DESCRIPTION
Adds a temporary workaround for the `target_spacing_sufficient` rule that changed to flag certain areas as violations. We can revisit this rule as there are updates in the issue. There was also a Datagrid avt test where I found that the timeout needed to be moved to account for the side panel exit animation before checking focus returning to the row.

#### What did you change?
```
config/jest-config-ibm-cloud-cognitive/setup/matchers/toHaveNoACViolations.js
e2e/components/Datagrid/Datagrid-test.avt.e2e.js
playwright.config.js
```
#### How did you test and verify your work?
AVT tests from PR checks