### PR TITLE
fix: install playwright browsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,8 +133,6 @@ jobs:
             test-c4p-wc-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install
         run: yarn
-      - name: Install browsers
-        run: yarn playwright install --with-deps
       - name: CI tests for products web components
         run: yarn ci-check:test:c4p-wc
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test:c4p:snapshot": "yarn test:c4p-styles styles -u",
     "test:c4p-styles": "lerna run --stream --scope @carbon/ibm-products-styles test --",
     "test:community": "lerna run --stream --scope @carbon/ibm-products-community test --",
-    "test:c4p-wc": "lerna run --stream --scope @carbon/ibm-products-web-components test --",
+    "test:c4p-wc": "yarn playwright install && lerna run --stream --scope @carbon/ibm-products-web-components test --",
     "spellcheck": "cspell '**' -e './examples' --gitignore --quiet --no-must-find-files",
     "storybook": "yarn storybook:start",
     "storybook:build": "run-s -s 'storybook:build:*'",


### PR DESCRIPTION
I noticed that there were ci issues in the new web component package when the canary release action runs because playwright browsers haven't been installed. I made a change to do this before running the web component tests, so it will work in `ci.yml` and `release-canary.yml`.

#### What did you change?
```
.github/workflows/ci.yml
package.json
```
#### How did you test and verify your work?
Verifying all checks in this PR still pass