### PR TITLE
chore: remove cron schedule for v1 release action

### DIFF
--- a/.github/workflows/release-v1.yml
+++ b/.github/workflows/release-v1.yml
@@ -2,8 +2,6 @@ name: v1 release # Builds and releases @carbon/v10 supported version of @carbon/
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '30 4 * * TUE' # Release every Tuesday at 4:30am EST
 
 jobs:
   Release_v1:


### PR DESCRIPTION
Latest v1 release action passed and published `1.73.2` after the latest changes to our `v1` branch. This PR removes the cron schedule for running our v1 releases.

#### What did you change?
```
.github/workflows/release-v1.yml
```
