### PR TITLE
chore: add wc storybook scripts to root package.json for netlify setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "storybook:build": "run-s -s 'storybook:build:*'",
     "storybook:build:storybook": "cd packages/core && yarn build",
     "storybook:start": "cd packages/core && yarn start",
+    "storybook-wc": "cd packages/ibm-products-web-components && yarn storybook",
+    "storybook-wc:build": "cd packages/ibm-products-web-components && run-s build build:storybook",
     "sync": "carbon-cli sync",
     "update-gallery-config": "node scripts/example-gallery-builder/index.js; prettier examples/carbon-for-ibm-products/**/src/**/*.{js,jsx,md,mdx,scss,json} --write --loglevel=silent",
     "//upgrade:dependencies:top": "# don't upgrade carbon (done globally), react/react-dom (not tested)",

--- a/packages/ibm-products-web-components/netlify.toml
+++ b/packages/ibm-products-web-components/netlify.toml
@@ -1,0 +1,9 @@
+# Netlify build and deploy settings - https://docs.netlify.com/configure-builds/file-based-configuration/#sample-file
+[build]
+ignore = "sh ./scripts/ignore_dependabot.sh"
+command = "yarn build:storybook"
+publish = "packages/ibm-products-web-components/storybook-static"
+
+[build.environment]
+YARN_ENABLE_GLOBAL_CACHE = "true"
+YARN_GLOBAL_FOLDER = "/opt/buildhome/.yarn_cache"

--- a/packages/ibm-products-web-components/netlify.toml
+++ b/packages/ibm-products-web-components/netlify.toml
@@ -1,6 +1,5 @@
 # Netlify build and deploy settings - https://docs.netlify.com/configure-builds/file-based-configuration/#sample-file
 [build]
-ignore = "sh ./scripts/ignore_dependabot.sh"
 command = "yarn build:storybook"
 publish = "packages/ibm-products-web-components/storybook-static"
 

--- a/packages/ibm-products-web-components/package.json
+++ b/packages/ibm-products-web-components/package.json
@@ -40,7 +40,7 @@
   ],
   "scripts": {
     "build": "yarn clean && node tasks/build.js && yarn wca",
-    "build:storybook": "storybook build",
+    "build:storybook": "yarn wca && storybook build",
     "clean": "rimraf es lib scss dist storybook-static",
     "preview": "vite preview",
     "storybook": "storybook dev -p 3000",

--- a/packages/ibm-products-web-components/package.json
+++ b/packages/ibm-products-web-components/package.json
@@ -39,7 +39,6 @@
     "web components"
   ],
   "scripts": {
-    "dev": "vite",
     "build": "yarn clean && node tasks/build.js && yarn wca",
     "build:storybook": "storybook build",
     "clean": "rimraf es lib scss dist storybook-static",


### PR DESCRIPTION
Addresses part of #6130 

Adds storybook build scripts for web component storybook to root package.json to help with Netlify setup. I also removed the `dev` script in the web components package which was no longer being used.

#### What did you change?
```
package.json
packages/ibm-products-web-components/package.json
```
#### How did you test and verify your work?
Setting up similar to how we have our React storybook