### PR TITLE
fix: move netlify config to `packages/core` to follow monorepo docs w/ multiple sites

### DIFF
--- a/packages/core/netlify.toml
+++ b/packages/core/netlify.toml
@@ -1,8 +1,8 @@
 # Netlify build and deploy settings - https://docs.netlify.com/configure-builds/file-based-configuration/#sample-file
 [build]
-ignore = "sh ./scripts/ignore_dependabot.sh"
-command = "yarn storybook:build"
-publish = "packages/core/storybook-static"
+ignore = "sh ../../scripts/ignore_dependabot.sh"
+command = "yarn build"
+publish = "storybook-static"
 
 [build.environment]
 YARN_ENABLE_GLOBAL_CACHE = "true"

--- a/packages/ibm-products-web-components/netlify.toml
+++ b/packages/ibm-products-web-components/netlify.toml
@@ -1,7 +1,7 @@
 # Netlify build and deploy settings - https://docs.netlify.com/configure-builds/file-based-configuration/#sample-file
 [build]
 command = "yarn build:storybook"
-publish = "packages/ibm-products-web-components/storybook-static"
+publish = "storybook-static"
 
 [build.environment]
 YARN_ENABLE_GLOBAL_CACHE = "true"


### PR DESCRIPTION
Part of #6130 

Moved `netlify.toml` from root to `packages/core` to follow Netlify docs on monorepo setup with multiple sites. Since we currently have a `netlify.toml` at our project root, it'll always take precedence over the one in `packages/ibm-products-web-components`.

#### What did you change?
```
netlify.toml --> packages/core/netlify.toml
packages/ibm-products-web-components/netlify.toml
```
#### How did you test and verify your work?
I checked against the docs Netlify has for configuring monorepos with multiple sites
https://docs.netlify.com/configure-builds/monorepos/#example-monorepo-setup