### PR TITLE
chore: add version to web component package

### DIFF
--- a/packages/ibm-products-web-components/package.json
+++ b/packages/ibm-products-web-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ibm-products-web-components",
   "description": "Carbon for IBM Products Web Components",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "Apache-2.0",
   "main": "es/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
It looks that if the web component package version is `0.0.0` lerna will not publish it, this PR just sets the version manually to `0.0.1` so that it will be published during our next code freeze.

#### What did you change?
```
packages/ibm-products-web-components/package.json
```
