### PR TITLE
fix: csp errors on 2 illustrations

### DIFF
--- a/packages/ibm-products/src/components/EmptyStates/assets/NoDataIllustration.js
+++ b/packages/ibm-products/src/components/EmptyStates/assets/NoDataIllustration.js
@@ -149,7 +149,6 @@ export const NoDataIllustration = ({ theme, size, alt, ...rest }) => {
               <stop offset={0} stopColor="#f4f4f4" />
               <stop offset={1} stopColor="#e0e0e0" />
             </linearGradient>
-            <style>{`.prefix__g_${svgId}{fill:#fff}`}</style>
           </defs>
           <path fill="none" d="M0 0h80v80H0z" />
           <path
@@ -173,7 +172,7 @@ export const NoDataIllustration = ({ theme, size, alt, ...rest }) => {
             d="M25.97 26.67l28.67-16.55-.42-.24-28.68 16.56.43.23z"
           />
           <path
-            className={`prefix__g_${svgId}`}
+            fill="#fff"
             d="M40 35.24L11.13 18.57v-.24l.21-.12 28.87 16.67-.21.11v.25zM21.49 33.33l-8.2-4.73.01-5.69 8.19 4.74v5.68z"
           />
         </>

--- a/packages/ibm-products/src/components/EmptyStates/assets/NotificationsIllustration.js
+++ b/packages/ibm-products/src/components/EmptyStates/assets/NotificationsIllustration.js
@@ -87,7 +87,6 @@ export const NotificationsIllustration = ({ theme, size, alt, ...rest }) => {
               <stop offset={0.93} stopColor="#404040" stopOpacity={0.35} />
               <stop offset={0.97} stopColor="#262626" stopOpacity={0} />
             </linearGradient>
-            <style>{`.prefix__f_dark_${svgId}{fill:#525252}`}</style>
           </defs>
           <path fill="none" d="M0 0h80v80H0z" />
           <path
@@ -107,7 +106,7 @@ export const NotificationsIllustration = ({ theme, size, alt, ...rest }) => {
             fill={`url(#prefix__c_dark_${svgId})`}
           />
           <path
-            className={`prefix__f_dark_${svgId}`}
+            fill="#525252"
             d="M57.99 37.07l-.01 3.9L18.03 17.9l.01-3.9 39.95 23.07zM57.99 45.11l-.01 3.91-39.95-23.07.01-3.9 39.95 23.06zM44.62 45.04l-.01 3.9L18.03 33.6l.01-3.9 26.58 15.34z"
           />
           <path
@@ -232,7 +231,6 @@ export const NotificationsIllustration = ({ theme, size, alt, ...rest }) => {
               <stop offset={0.95} stopColor="#d7d7d7" stopOpacity={0.14} />
               <stop offset={0.97} stopColor="#d0d0d0" stopOpacity={0} />
             </linearGradient>
-            <style>{`.prefix__f_${svgId}{fill:url(#prefix__e_${svgId})}`}</style>
           </defs>
           <path fill="none" d="M0 0h80v80H0z" />
           <path
@@ -252,7 +250,7 @@ export const NotificationsIllustration = ({ theme, size, alt, ...rest }) => {
             fill={`url(#prefix__d_${svgId})`}
           />
           <path
-            className={`prefix__f_${svgId}`}
+            fill={`url(#prefix__e_${svgId})`}
             d="M59.48 28.88a3.17 3.17 0 011.42 2.47l-.1 36.08c0 .9-.65 1.26-1.42.81l-26.7-15.4-2.26 4.22a.9.9 0 01-1.33.28 3.07 3.07 0 01-1.22-1.53l-2.33-7.09-9-5.2a3.15 3.15 0 01-1.43-2.46L15.23 5c0-.9.64-1.27 1.43-.81z"
           />
           <path
@@ -260,7 +258,7 @@ export const NotificationsIllustration = ({ theme, size, alt, ...rest }) => {
             fill={`url(#prefix__f_${svgId})`}
           />
           <path
-            className={`prefix__f_${svgId}`}
+            fill={`url(#prefix__e_${svgId})`}
             d="M59.48 28.88a3.17 3.17 0 011.42 2.47l-.1 36.08c0 .9-.65 1.26-1.42.81l-26.7-15.4-2.26 4.22a.9.9 0 01-1.33.28 3.07 3.07 0 01-1.22-1.53l-2.33-7.09-9-5.2a3.15 3.15 0 01-1.43-2.46L15.23 5c0-.9.64-1.27 1.43-.81z"
           />
           <path


### PR DESCRIPTION
Closes #6178

moved internal fill css to fill attribute on paths in svg

#### What did you change?
packages/ibm-products/src/components/EmptyStates/assets/NotificationsIllustration.js
packages/ibm-products/src/components/EmptyStates/assets/NoDataIllustration.js

#### How did you test and verify your work?
as u can see in repro if we remove the style tag from dom, the error is gone.
we are removing the style tag in this pr, which would solve the issue.

https://github.com/user-attachments/assets/c3ef37a8-41f2-4ba1-b2aa-3e017a94557d

