### PR TITLE
refactor(Datagrid): fixes the resizer overflow scorllbar on last column

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.tsx
@@ -223,13 +223,16 @@ const HeaderRow = (
           const resizerProps = header?.getResizerProps?.({ role: undefined });
           const headerStyle = headerProps?.style;
           const lastVisibleIndex = withActionsColumn ? 2 : 1;
-          const lastVisibleFlexStyle =
-            index === visibleColumns.length - lastVisibleIndex
-              ? '1 1 0'
-              : '0 0 auto';
+          const isLastVisibleColumn =
+            index === visibleColumns.length - lastVisibleIndex;
+
           if (headerStyle) {
-            headerStyle.flex = lastVisibleFlexStyle;
+            Object.assign(headerStyle, {
+              flex: isLastVisibleColumn ? '1 1 0' : '0 0 auto',
+              overflow: isLastVisibleColumn ? 'hidden' : headerStyle.overflow,
+            });
           }
+
           return (
             <TableHeader
               {...headerProps}


### PR DESCRIPTION
Closes #6208 

The last column has a resizer that overflows on the right end, causing a horizontal scrollbar to appear. Previously, we used a non-resizable spacer column, which prevented this issue. Now that the spacer column is optional, disabling it allows the resizer in the last column to overflow, resulting in a horizontal scrollbar on the table. now we hide the overflow on last column.

#### What did you change?
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.tsx

#### How did you test and verify your work?
storybook