### PR TITLE
chore(Datagrid): add skeletonRowCount example

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid.docs-page.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.docs-page.js
@@ -572,6 +572,23 @@ return <Datagrid datagridState={datagridState} />;
           `,
         },
       },
+      {
+        title: 'Skeleton',
+        description: `By default, \`isFetching: true\` will render 3 skeleton rows. Use \`skeletonRowCount: Number\` to change the number of skeleton rows.`,
+      },
+      {
+        source: {
+          code: `
+const datagridState = useDatagrid(
+  {
+    columns,
+    data,
+    isFetching: true,
+    skeletonRowCount: 5,
+  }
+);`,
+        },
+      },
     ]}
   />
 );


### PR DESCRIPTION
Closes #6206 

adds skeletonRowCount snippet in story docs

#### What did you change?
packages/ibm-products/src/components/Datagrid/Datagrid.docs-page.js

#### How did you test and verify your work?
storybook