### PR TITLE
fix: use plex cdn to load custom font in wc storybook

### DIFF
--- a/packages/ibm-products-web-components/.storybook/preview-head.html
+++ b/packages/ibm-products-web-components/.storybook/preview-head.html
@@ -1,3 +1,7 @@
 <script>
   window.global = window;
 </script>
+
+<link
+  rel="stylesheet"
+  href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />


### PR DESCRIPTION
Includes plex via cdn within preview-head in storybook config, without this plex doesn't get loaded and is not used.

#### What did you change?
```
packages/ibm-products-web-components/.storybook/preview-head.html
```
#### How did you test and verify your work?
Web component preview deploy