### PR TITLE
chore(v1): address mismatch stylelint config tag versions

### DIFF
--- a/config/stylelint-config-ibm-products/package.json
+++ b/config/stylelint-config-ibm-products/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stylelint-config-ibm-products",
   "private": true,
-  "version": "0.0.35",
+  "version": "0.0.36",
   "license": "Apache-2.0",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
v1 release failed because `stylelint-config-ibm-products` version was out of sync with the tag version published on github from an earlier v2 publish that bumped the package from `0.0.35` to `0.0.36`, we've since deleted this package in our `main` branch so it should only be an issue in v1.
#### What did you change?
```
config/stylelint-config-ibm-products/package.json
```
#### How did you test and verify your work?
Verified `0.0.36` already exists, https://github.com/carbon-design-system/ibm-products/releases/tag/stylelint-config-ibm-products%400.0.36