### PR TITLE
chore(telemetry): update endpoint and README

### DIFF
--- a/config/storybook-addon-carbon-theme/README.md
+++ b/config/storybook-addon-carbon-theme/README.md
@@ -148,3 +148,12 @@ $feature-flags: (
   );
 }
 ```
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect de-identified and anonymized metrics
+data. By installing this package as a dependency you are agreeing to telemetry
+collection. To opt out, see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/config/storybook-addon-carbon-theme/telemetry.yml
+++ b/config/storybook-addon-carbon-theme/telemetry.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
 version: 1
 projectId: '55e814ff-85db-406f-9e37-2d0c92a753b0'
-endpoint: 'https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics'
+endpoint: 'https://www-api.ibm.com/ibm-telemetry/v1/metrics'
 collect:
   npm:
     dependencies: null

--- a/packages/ibm-products-styles/README.md
+++ b/packages/ibm-products-styles/README.md
@@ -27,3 +27,12 @@ $ npm install @carbon/ibm-products-styles
 Follow the in the ibm-products README to change the prefix.
 
 [Prefix setting instructions](https://github.com/carbon-design-system/ibm-products/blob/main/packages/ibm-products/README.md#package-prefix)
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect de-identified and anonymized metrics
+data. By installing this package as a dependency you are agreeing to telemetry
+collection. To opt out, see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/ibm-products-styles/telemetry.yml
+++ b/packages/ibm-products-styles/telemetry.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
 version: 1
 projectId: '178994d9-2db9-4965-8155-4b10d588faa6'
-endpoint: 'https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics'
+endpoint: 'https://www-api.ibm.com/ibm-telemetry/v1/metrics'
 collect:
   npm:
     dependencies: null

--- a/packages/ibm-products/README.md
+++ b/packages/ibm-products/README.md
@@ -245,9 +245,9 @@ and
 
 ## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
 
-This package uses IBM Telemetry to collect metrics data. By installing this
-package as a dependency you are agreeing to telemetry collection. To opt out,
-see
+This package uses IBM Telemetry to collect de-identified and anonymized metrics
+data. By installing this package as a dependency you are agreeing to telemetry
+collection. To opt out, see
 [Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
 For more information on the data being collected, please see the
 [IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/ibm-products/telemetry.yml
+++ b/packages/ibm-products/telemetry.yml
@@ -2,7 +2,7 @@
 
 version: 1
 projectId: 495342db-5046-4ecf-85ea-9ffceb6f8cdf
-endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+endpoint: https://www-api.ibm.com/ibm-telemetry/v1/metrics
 collect:
   jsx:
     elements:


### PR DESCRIPTION
This PR updates the endpoint within each package's `telemetry.yml` file with the new stable endpoint for the collector. Also, this updates the wording used in the telemetry notice under each README.

For the following packages:
- IBM Products
- IBM Products Styles
- Storybook Addon Carbon Theme

#### What did you change?
Changed `telemetry.yml` endpoint to new stable endpoint, and updated wording under telemetry notice in each README

#### How did you test and verify your work?
N/A