### PR TITLE
fix(Datagrid): useflexresize infinite redraw

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useFlexResize.js
+++ b/packages/ibm-products/src/components/Datagrid/useFlexResize.js
@@ -14,7 +14,7 @@ const useFlexResize = (hooks) => {
     const { enableSpacerColumn } = instance;
     useEffect(() => {
       setSpacerColumn(enableSpacerColumn);
-    });
+    }, [enableSpacerColumn]);
   };
   const spacer = {
     id: 'spacer',


### PR DESCRIPTION
Refs #5920, #5646.

Fix regression from 9bd307e4836d986383a0464e799834712f3904e0 where Datagrid keeps redrawing.  On our unit tests we get the exception:

> Too many re-renders. React limits the number of renders to prevent an infinite loop.


#### What did you change?

Added correct dependencies to useEffect().

#### How did you test and verify your work?

Tested locally.