### PR TITLE
fix(telemetry): updating URL in `v1`

### DIFF
--- a/packages/cdai/telemetry.yml
+++ b/packages/cdai/telemetry.yml
@@ -2,7 +2,7 @@
 
 version: 1
 projectId: 3fd2b152-b3b0-4651-90b2-246d49c6307d
-endpoint: https://www-api.ibm.com/ibm-telemetry/v1/telemetry
+endpoint: https://www-api.ibm.com/ibm-telemetry/v1/metrics
 collect:
   jsx:
     elements:

--- a/packages/ibm-products/telemetry.yml
+++ b/packages/ibm-products/telemetry.yml
@@ -2,7 +2,7 @@
 
 version: 1
 projectId: 495342db-5046-4ecf-85ea-9ffceb6f8cdf
-endpoint: https://www-api.ibm.com/ibm-telemetry/v1/telemetry
+endpoint: https://www-api.ibm.com/ibm-telemetry/v1/metrics
 collect:
   jsx:
     elements:

--- a/packages/security/telemetry.yml
+++ b/packages/security/telemetry.yml
@@ -2,7 +2,7 @@
 
 version: 1
 projectId: cf5d7614-1602-40ba-baac-1f813cf09915
-endpoint: https://www-api.ibm.com/ibm-telemetry/v1/telemetry
+endpoint: https://www-api.ibm.com/ibm-telemetry/v1/metrics
 collect:
   jsx:
     elements:


### PR DESCRIPTION
#### What did you change?
Changed `https://www-api.ibm.com/ibm-telemetry/v1/telemetry` to `https://www-api.ibm.com/ibm-telemetry/v1/metrics`

#### How did you test and verify your work?
N/A
