### PR TITLE
fix: v1 version mismatch

### DIFF
--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -97,8 +97,5 @@
     "carbon-icons": "^7.0.7",
     "react": "^16.8.6 || ^17.0.1",
     "react-dom": "^16.8.6 || ^17.0.1"
-  },
-  "resolutions": {
-    "carbon-components-react": "^7.60.0"
   }
 }

--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ibm-products",
   "description": "Carbon for IBM Products",
-  "version": "1.73.5",
+  "version": "1.73.2",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -93,7 +93,7 @@
     "@carbon/themes": "^10.55.5",
     "@carbon/type": "^10.45.5",
     "carbon-components": "^10.59.0",
-    "carbon-components-react": "^7.70.0",
+    "carbon-components-react": "^7.60.0",
     "carbon-icons": "^7.0.7",
     "react": "^16.8.6 || ^17.0.1",
     "react-dom": "^16.8.6 || ^17.0.1"

--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ibm-products",
   "description": "Carbon for IBM Products",
-  "version": "1.73.2",
+  "version": "1.73.5",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -97,5 +97,8 @@
     "carbon-icons": "^7.0.7",
     "react": "^16.8.6 || ^17.0.1",
     "react-dom": "^16.8.6 || ^17.0.1"
+  },
+  "resolutions": {
+    "carbon-components-react": "^7.60.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3058,7 +3058,7 @@ __metadata:
     "@carbon/themes": ^10.55.5
     "@carbon/type": ^10.45.5
     carbon-components: ^10.59.0
-    carbon-components-react: ^7.70.0
+    carbon-components-react: ^7.60.0
     carbon-icons: ^7.0.7
     react: ^16.8.6 || ^17.0.1
     react-dom: ^16.8.6 || ^17.0.1


### PR DESCRIPTION
Closes #6255

`carbon-components-react` lists `7.70.0` instead of `7.60.0` in one spot, which is leading to incorrect peer dependencies. Likely a typo while updating to latest versions.

#### What did you change?
Downgrade to a the latest version that exists.

#### How did you test and verify your work?
CI