### PR TITLE
feat: expose onChange and onPrevious for CreateFullPage

### DIFF
--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.stories.jsx
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.stories.jsx
@@ -85,6 +85,7 @@ const defaultFullPageProps = {
     "If you cancel, the information you have entered won't be saved.",
   modalDangerButtonText: 'Cancel partition',
   modalSecondaryButtonText: 'Return to form',
+  onClickInfluencerStep: (step) => console.log('Step: ', step),
   onRequestSubmit: action('Submit handler called'),
   onClose: action('Close handler called'),
 };

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.stories.jsx
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.stories.jsx
@@ -195,17 +195,20 @@ const Template = ({ ...args }) => {
           title="Dynamic step"
           description="Example dynamic step"
           includeStep={shouldIncludeAdditionalStep}
+          onPrevious={() => console.log('custom onPrevious handler')}
         />
         <CreateFullPageStep
           title="Empty"
           secondaryLabel="Optional"
           description="Empty step for demonstration purposes"
+          onPrevious={() => console.log('custom onPrevious handler')}
         />
         <CreateFullPageStep
           className={`${storyClass}__step-fieldset--no-label`}
           title="Core configuration"
           description="Here is an example description for the 'Core configuration' step."
           secondaryLabel="Optional"
+          onPrevious={() => console.log('custom onPrevious handler')}
         >
           <Grid>
             <Column xlg={5} lg={5} md={4} sm={4}>
@@ -260,6 +263,7 @@ const Template = ({ ...args }) => {
           title="Message retention"
           subtitle="This is how many copies of a topic will be made for high availability"
           description="The partitions of each topic can be replicated across a configurable number of brokers"
+          onPrevious={() => console.log('custom onPrevious handler')}
         >
           <Grid>
             <Column span={100}>

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.test.js
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.test.js
@@ -212,6 +212,17 @@ describe(componentName, () => {
     expect(container.querySelector(`.${blockClass}`)).toBeTruthy();
   });
 
+  it('should call onClickInfluencerStep when expected', async () => {
+    const onChange = jest.fn();
+    renderCreateFullPage({
+      ...defaultFullPageProps,
+      onClickInfluencerStep: onChange,
+    });
+
+    await userEvent.click(screen.getByTitle('Title 2'));
+    expect(onChange).toHaveBeenCalled();
+  });
+
   it('should render the CreateFullPage on the specified initialStep prop provided', () => {
     const { container } = renderCreateFullPage({
       ...defaultFullPageProps,

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.test.js
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.test.js
@@ -42,6 +42,7 @@ const onRequestSubmitRejectFn = jest.fn(() =>
   Promise.reject(rejectionErrorMessage)
 );
 const onNextStepFn = jest.fn(() => Promise.resolve());
+const onPreviousStepFn = jest.fn();
 const onNextStepNonPromiseFn = jest.fn();
 const onNextStepRejectionFn = jest.fn(() =>
   Promise.reject(rejectionErrorMessage)
@@ -96,6 +97,7 @@ const renderCreateFullPage = ({
   rejectOnNext = false,
   submitFn = onRequestSubmitFn,
   onNext = onNextStepFn,
+  onPrevious = onPreviousStepFn,
   finalOnNextFn = finalStepOnNext,
   rejectOnSubmitNext = false,
   ...rest
@@ -121,6 +123,7 @@ const renderCreateFullPage = ({
         description="2"
         fieldsetLegendText="2"
         invalid={false}
+        onPrevious={onPrevious}
       >
         {stepFormField}
       </CreateFullPageStep>
@@ -312,6 +315,28 @@ describe(componentName, () => {
     await waitFor(() => {
       expect(onNextStepFn).toHaveBeenCalled();
     });
+  });
+
+  it('calls the onPrevious function prop as expected', async () => {
+    const { click } = userEvent;
+    const { container } = renderCreateFullPage(defaultFullPageProps);
+    const nextButtonElement = screen.getByText(nextButtonText);
+    const backButtonElement = screen.getByText(backButtonText);
+    await act(() => click(nextButtonElement));
+    const createFullPageSteps = container.querySelector(
+      `.${blockClass}__content`
+    ).children;
+    expect(
+      createFullPageSteps[0].classList.contains(
+        `.${blockClass}__step__step--visible-step`
+      )
+    );
+
+    await waitFor(() => {
+      expect(onNextStepFn).toHaveBeenCalled();
+    });
+    click(backButtonElement);
+    await waitFor(() => expect(onPreviousStepFn).toHaveBeenCalledTimes(1));
   });
 
   it('renders a modal when cancel button has been clicked and recognizes primary and secondary button clicks in modal', async () => {

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.tsx
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.tsx
@@ -260,6 +260,7 @@ export let CreateFullPage = React.forwardRef(
     // eslint-disable-next-line ssr-friendly/no-dom-globals-in-react-fc
     const previousState = usePreviousValue({ currentStep, open });
     const [isDisabled, setIsDisabled] = useState(false);
+    const [onPrevious, setOnPrevious] = useState();
     const [onNext, setOnNext] = useState();
     const [onMount, setOnMount] = useState();
     const [stepData, setStepData] = useState<Step[]>([]);
@@ -316,6 +317,7 @@ export let CreateFullPage = React.forwardRef(
       firstIncludedStep,
       lastIncludedStep,
       stepData,
+      onPrevious,
       onNext,
       isSubmitDisabled: isDisabled,
       setCurrentStep,
@@ -374,6 +376,7 @@ export let CreateFullPage = React.forwardRef(
                       {
                         currentStep,
                         setIsDisabled,
+                        setOnPrevious: (fn) => setOnPrevious(() => fn),
                         setOnNext: (fn) => setOnNext(() => fn),
                         setOnMount: (fn) => setOnMount(() => fn),
                         setStepData,

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.tsx
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.tsx
@@ -162,6 +162,12 @@ type CreateFullPageBaseProps = {
   noTrailingSlash?: boolean;
 
   /**
+   * onChange event for Progress Indicator in the Influencer
+   * @param data step index
+   */
+  onClickInfluencerStep?: (data: number) => void;
+
+  /**
    * An optional handler that is called when the user closes the full page (by
    * clicking the secondary button, located in the modal, which triggers after
    * clicking the ghost button in the modal
@@ -233,6 +239,7 @@ export let CreateFullPage = React.forwardRef(
       modalSecondaryButtonText,
       modalTitle,
       nextButtonText,
+      onClickInfluencerStep,
       onClose,
       onRequestSubmit,
       firstFocusElement,
@@ -355,6 +362,7 @@ export let CreateFullPage = React.forwardRef(
               stepData={stepData}
               currentStep={currentStep}
               title={secondaryTitle}
+              onClickStep={onClickInfluencerStep}
             />
           </div>
           <div className={`${blockClass}__body`}>
@@ -526,6 +534,11 @@ CreateFullPage.propTypes = {
    * A prop to omit the trailing slash for the breadcrumbs
    */
   noTrailingSlash: PropTypes.bool,
+
+  /**
+   * onChange event for Progress Indicator in the Influencer
+   */
+  onClickInfluencerStep: PropTypes.func,
 
   /**
    * An optional handler that is called when the user closes the full page (by

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPageStep.tsx
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPageStep.tsx
@@ -82,6 +82,11 @@ interface CreateFullPageStepBaseProps extends PropsWithChildren {
   onNext?: () => void | Promise<any>;
 
   /**
+   * Optional function to be called when you move to the previous step.
+   */
+  onPrevious?: () => void;
+
+  /**
    * Sets the optional secondary label on the progress step component
    */
   secondaryLabel?: string;
@@ -138,6 +143,7 @@ export let CreateFullPageStep = forwardRef(
       hasFieldset,
       fieldsetLegendText,
       onNext,
+      onPrevious,
       onMount,
       secondaryLabel,
 
@@ -184,8 +190,9 @@ export let CreateFullPageStep = forwardRef(
       if (stepNumber === stepsContext?.currentStep) {
         stepsContext.setIsDisabled(disableSubmit as boolean);
         stepsContext?.setOnNext(onNext); // needs to be updated here otherwise there could be stale state values from only initially setting onNext
+        stepsContext?.setOnPrevious(onPrevious);
       }
-    }, [stepsContext, stepNumber, disableSubmit, onNext]);
+    }, [stepsContext, stepNumber, disableSubmit, onNext, onPrevious]);
 
     const span = { span: 50 }; // Half.
 
@@ -325,6 +332,11 @@ CreateFullPageStep.propTypes = {
    * This function can _optionally_ return a promise that is either resolved or rejected and the CreateFullPage will handle the submitting state of the next button.
    */
   onNext: PropTypes.func,
+
+  /**
+   * Optional function to be called when you move to the previous step.
+   */
+  onPrevious: PropTypes.func,
 
   /**
    * Sets the optional secondary label on the progress step component

--- a/packages/ibm-products/src/components/CreateInfluencer/CreateInfluencer.tsx
+++ b/packages/ibm-products/src/components/CreateInfluencer/CreateInfluencer.tsx
@@ -34,6 +34,10 @@ interface CreateInfluencerProps {
    */
   currentStep: number;
   /**
+   * onChange event for Progress Indicator
+   */
+  onClickStep?: (step: number) => void;
+  /**
    * Provide the Set Data.
    */
   stepData: Step[];
@@ -46,6 +50,7 @@ interface CreateInfluencerProps {
 export const CreateInfluencer = ({
   className,
   currentStep,
+  onClickStep,
   stepData,
   title,
 }: PropsWithChildren<CreateInfluencerProps>) => {
@@ -86,6 +91,7 @@ export const CreateInfluencer = ({
             spaceEqually
             vertical
             className={cx(`${blockClass}__progress-indicator`)}
+            onChange={onClickStep}
           >
             {progressSteps.map((step, stepIndex) => {
               return (
@@ -121,6 +127,11 @@ CreateInfluencer.propTypes = {
    * Used to mark the current step on the ProgressIndicator component
    */
   currentStep: PropTypes.number.isRequired,
+
+  /**
+   * onChange event for Progress Indicator
+   */
+  onClickStep: PropTypes.func,
 
   /**
    * The step data that renders the progress items


### PR DESCRIPTION
Closes #6030

Expose the `onChange` property of `ProgressIndicator` in the `CreateInfluencer` component.
Expose the `onPrevious` property for the `CreateFullPageStep` component.

#### What did you change?
Props updated
<table>
<thead>
<th>Component</th>
<th>Prop</th>
<th>Description</th>
</thead>
<tr>
<td>CreateFullPage</td>
<td>onClickInfluencerStep</td>
<td>Pass <i>onClickInfluencerStep</i> prop through the <i>CreateFullPage</i> component.</td>
</tr>
<tr>
<td>CreateInfluencer</td>
<td>onClickStep</td>
<td>Receiving the <i>onClickStep</i> prop and passing it into the <i>ProgressIndicator</i>'s <i>onChange</i></td>
</tr>
<tr>
<td>CreateFullPageStep</td>
<td>onPrevious</td>
<td>New prop exposed</td>
</tr>
</table>

#### How did you test and verify your work?
Storybook
`yarn test`