### PR TITLE
fix(datagrid): adds missing header hover styles in v2

### DIFF
--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_datagrid.scss
@@ -446,6 +446,8 @@
 }
 
 .#{$block-class}__resizableColumn:hover {
+  background-color: $background-selected-hover;
+
   .#{$block-class}__resizer {
     border-right: $spacing-01 solid $border-strong-01;
     background-color: $background-selected-hover;


### PR DESCRIPTION
Closes #6254

adds missing header hover background style from v1 to v2. this was removed around 2 years ago.
i tried to find any relevant history if it was removed intentionally, but couldn't find any, so i am guessing it was an error.

#### What did you change?
packages/ibm-products-styles/src/components/Datagrid/styles/_datagrid.scss
<img width="2056" alt="Screenshot 2024-10-22 at 4 43 59 PM" src="https://github.com/user-attachments/assets/b91e910a-9521-4814-a4a7-b8b2f4415a0d">

#### How did you test and verify your work?
storybook