### PR TITLE
fix(Datagrid): add support for autoAlign in row resize popover

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/RowSize/RowSizeDropdown.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/RowSize/RowSizeDropdown.js
@@ -18,6 +18,7 @@ const blockClass = `${pkg.prefix}--datagrid__row-size`;
 const RowSizeDropdown = ({
   align = 'bottom-right',
   legendText = 'Row settings',
+  autoAlign,
   ...props
 }) => {
   const radioGroupRef = useRef(undefined);
@@ -63,6 +64,7 @@ const RowSizeDropdown = ({
       className={`${blockClass}-options-container`}
       onKeyDown={onKeyHandler}
       onBlur={onBlurHandler}
+      autoAlign={autoAlign}
     >
       <IconButton
         align={align}
@@ -90,6 +92,7 @@ const RowSizeDropdown = ({
 
 RowSizeDropdown.propTypes = {
   align: IconButton.propTypes.align,
+  autoAlign: PropTypes.bool,
   datagridName: PropTypes.string,
   legendText: PropTypes.string,
   light: PropTypes.bool,


### PR DESCRIPTION
Closes #5925 

Add support for `autoAlign` in RowResize popover in datagrid batch actions.
Pass `autoAlign ={true} `to `<RowSizeDropdown` component from DatagridAction.

#### What did you change?
<RowSizeDropdown will now accept autoAlign prop and passdown to popover

#### How did you test and verify your work?
local