### PR TITLE
fix: dynamically importing lottie web package

### DIFF
--- a/packages/ibm-products/src/components/CoachmarkOverlayElements/CoachmarkOverlayElements.tsx
+++ b/packages/ibm-products/src/components/CoachmarkOverlayElements/CoachmarkOverlayElements.tsx
@@ -10,10 +10,8 @@ import { Button, ButtonProps } from '@carbon/react';
 // Import portions of React that are needed.
 import React, {
   Children,
-  lazy,
   ReactNode,
   RefObject,
-  Suspense,
   useEffect,
   useRef,
   useState,
@@ -25,19 +23,13 @@ import { CarouselProps } from '../Carousel/Carousel';
 // Other standard imports.
 import PropTypes from 'prop-types';
 //TODO THIS PATH WILL NEED TO BE UPDATED ONCE IN IBM PRODUCTS
-//import { SteppedAnimatedMedia } from '../SteppedAnimatedMedia';
+import { SteppedAnimatedMedia } from '../SteppedAnimatedMedia';
 import { clamp } from 'lodash';
 import cx from 'classnames';
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import pconsole from '../../global/js/utils/pconsole';
 import { pkg } from '../../settings';
 import { useCoachmark } from '../Coachmark';
-
-const SteppedAnimatedMedia = lazy(() =>
-  import('../SteppedAnimatedMedia').then((module) => ({
-    default: module.SteppedAnimatedMedia,
-  }))
-);
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 const blockClass = `${pkg.prefix}--coachmark-overlay-elements`;
@@ -127,8 +119,6 @@ export let CoachmarkOverlayElements = React.forwardRef<
     const [currentProgStep, _setCurrentProgStep] = useState(0);
     const coachmark = useCoachmark();
 
-    console.log('media', media);
-
     const setCurrentProgStep = (value) => {
       if (currentProgStep > 0 && value === 0 && buttonFocusRef.current) {
         setTimeout(() => {
@@ -186,22 +176,11 @@ export let CoachmarkOverlayElements = React.forwardRef<
           (media.render ? (
             media.render()
           ) : (
-            <div>
-              {
-                <Suspense fallback={<div>Loading...</div>}>
-                  <SteppedAnimatedMedia
-                    className={`${blockClass}__element-stepped-media`}
-                    filePaths={media.filePaths}
-                    playStep={currentProgStep}
-                  />
-                </Suspense>
-                // <SteppedAnimatedMedia
-                //              className={`${blockClass}__element-stepped-media`}
-                //              filePaths={media.filePaths}
-                //              playStep={currentProgStep}
-                //            />
-              }
-            </div>
+            <SteppedAnimatedMedia
+              className={`${blockClass}__element-stepped-media`}
+              filePaths={media.filePaths}
+              playStep={currentProgStep}
+            />
           ))}
 
         {numProgSteps === 1 ? (

--- a/packages/ibm-products/src/components/CoachmarkOverlayElements/CoachmarkOverlayElements.tsx
+++ b/packages/ibm-products/src/components/CoachmarkOverlayElements/CoachmarkOverlayElements.tsx
@@ -10,8 +10,10 @@ import { Button, ButtonProps } from '@carbon/react';
 // Import portions of React that are needed.
 import React, {
   Children,
+  lazy,
   ReactNode,
   RefObject,
+  Suspense,
   useEffect,
   useRef,
   useState,
@@ -23,13 +25,19 @@ import { CarouselProps } from '../Carousel/Carousel';
 // Other standard imports.
 import PropTypes from 'prop-types';
 //TODO THIS PATH WILL NEED TO BE UPDATED ONCE IN IBM PRODUCTS
-import { SteppedAnimatedMedia } from '../SteppedAnimatedMedia';
+//import { SteppedAnimatedMedia } from '../SteppedAnimatedMedia';
 import { clamp } from 'lodash';
 import cx from 'classnames';
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import pconsole from '../../global/js/utils/pconsole';
 import { pkg } from '../../settings';
 import { useCoachmark } from '../Coachmark';
+
+const SteppedAnimatedMedia = lazy(() =>
+  import('../SteppedAnimatedMedia').then((module) => ({
+    default: module.SteppedAnimatedMedia,
+  }))
+);
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 const blockClass = `${pkg.prefix}--coachmark-overlay-elements`;
@@ -119,6 +127,8 @@ export let CoachmarkOverlayElements = React.forwardRef<
     const [currentProgStep, _setCurrentProgStep] = useState(0);
     const coachmark = useCoachmark();
 
+    console.log('media', media);
+
     const setCurrentProgStep = (value) => {
       if (currentProgStep > 0 && value === 0 && buttonFocusRef.current) {
         setTimeout(() => {
@@ -176,11 +186,22 @@ export let CoachmarkOverlayElements = React.forwardRef<
           (media.render ? (
             media.render()
           ) : (
-            <SteppedAnimatedMedia
-              className={`${blockClass}__element-stepped-media`}
-              filePaths={media.filePaths}
-              playStep={currentProgStep}
-            />
+            <div>
+              {
+                <Suspense fallback={<div>Loading...</div>}>
+                  <SteppedAnimatedMedia
+                    className={`${blockClass}__element-stepped-media`}
+                    filePaths={media.filePaths}
+                    playStep={currentProgStep}
+                  />
+                </Suspense>
+                // <SteppedAnimatedMedia
+                //              className={`${blockClass}__element-stepped-media`}
+                //              filePaths={media.filePaths}
+                //              playStep={currentProgStep}
+                //            />
+              }
+            </div>
           ))}
 
         {numProgSteps === 1 ? (

--- a/packages/ibm-products/src/components/SteppedAnimatedMedia/SteppedAnimatedMedia.tsx
+++ b/packages/ibm-products/src/components/SteppedAnimatedMedia/SteppedAnimatedMedia.tsx
@@ -13,7 +13,7 @@ import React, {
   useState,
   MutableRefObject,
 } from 'react';
-import lottie, { type AnimationItem } from 'lottie-web';
+import { type LottiePlayer, type AnimationItem } from 'lottie-web';
 import clamp from 'lodash/clamp';
 // Other standard imports.
 import PropTypes from 'prop-types';
@@ -84,25 +84,27 @@ export const SteppedAnimatedMedia = React.forwardRef(
     }, [filePaths]);
 
     useEffect(() => {
-      const prefersReducedMotion = window?.matchMedia
-        ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
-        : true;
-      if (localRefValue) {
-        animRef.current?.destroy();
-        animRef.current = lottie.loadAnimation({
-          container: localRefValue,
-          renderer: 'svg',
-          animationData: jsonData[clamp(playStep, 0, jsonData.length - 1)],
-          loop: false,
-          autoplay: false,
-          rendererSettings: {
-            preserveAspectRatio: 'xMidYMid slice',
-          },
-        });
-        prefersReducedMotion
-          ? animRef.current?.goToAndStop(0)
-          : animRef.current?.goToAndPlay(0);
-      }
+      import('lottie-web').then((lottie) => {
+        const prefersReducedMotion = window?.matchMedia
+          ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+          : true;
+        if (localRefValue) {
+          animRef.current?.destroy();
+          animRef.current = (lottie as unknown as LottiePlayer).loadAnimation({
+            container: localRefValue,
+            renderer: 'svg',
+            animationData: jsonData[clamp(playStep, 0, jsonData.length - 1)],
+            loop: false,
+            autoplay: false,
+            rendererSettings: {
+              preserveAspectRatio: 'xMidYMid slice',
+            },
+          });
+          prefersReducedMotion
+            ? animRef.current?.goToAndStop(0)
+            : animRef.current?.goToAndPlay(0);
+        }
+      });
 
       return () => animRef.current?.destroy();
     }, [jsonData, localRefValue, playStep]);


### PR DESCRIPTION
Closes #6243 

lottie-web package will be dynamically imported at the time of usage only. That is only when media prop is passed with animation paths.

#### What did you change?
used `import().then()` syntax to dynamically import the package
#### How did you test and verify your work?
local