### PR TITLE
fix(SidePanel web components): SlideIn option issue

### DIFF
--- a/packages/ibm-products-web-components/src/components/side-panel/side-panel.ts
+++ b/packages/ibm-products-web-components/src/components/side-panel/side-panel.ts
@@ -337,10 +337,11 @@ class CDSSidePanel extends HostListenerMixin(LitElement) {
             newValues.marginInlineEnd = `${this?._sidePanel?.offsetWidth}px`;
           }
         }
-
-        Object.keys(newValues).forEach((key) => {
-          pageContentEl.style[key] = newValues[key];
-        });
+        if (this.slideIn) {
+          Object.keys(newValues).forEach((key) => {
+            pageContentEl.style[key] = newValues[key];
+          });
+        }
       }
     }
   };
@@ -680,7 +681,6 @@ class CDSSidePanel extends HostListenerMixin(LitElement) {
     const actionsMultiple = ['', 'single', 'double', 'triple'][
       this._actionsCount
     ];
-
     const titleTemplate = html`<div
       class=${`${blockClass}__title`}
       ?no-label=${!!labelText}


### PR DESCRIPTION
Closes #6219

Web component SidePanel: always slideIn even when slideIn is false

#### What did you change?

Updated the `side-panel.ts` file to check if `slideIn` is enabled or not before applying styles.

#### How did you test and verify your work?
Storybook
