### PR TITLE
chore: add theme to user avatar default story

### DIFF
--- a/packages/ibm-products/src/components/UserAvatar/UserAvatar.stories.jsx
+++ b/packages/ibm-products/src/components/UserAvatar/UserAvatar.stories.jsx
@@ -11,6 +11,7 @@ import React from 'react';
 // TODO: import action to handle events if required.
 // import { action } from '@storybook/addon-actions';
 import { UserAvatar } from '.';
+import { Theme, useTheme } from '@carbon/react';
 import mdx from './UserAvatar.mdx';
 import styles from './_storybook-styles.scss?inline';
 import { Add, Group, User } from '@carbon/react/icons';
@@ -85,6 +86,16 @@ export default {
   },
 };
 
+const ThemeText = () => {
+  const { theme, isDark } = useTheme();
+
+  return (
+    <p className="theme-text">
+      {`useTheme reveals theme: '${theme}', isDark: '${isDark}'`}
+    </p>
+  );
+};
+
 /**
  * TODO: Declare template(s) for one or more scenarios.
  */
@@ -97,11 +108,41 @@ const Template = (args) => {
     />
   );
 };
+const ThemeTemplate = (args) => {
+  return (
+    <>
+      <Theme theme="white">
+        <section className="theme-section">
+          <ThemeText />
+          <UserAvatar {...args} />
+        </section>
+      </Theme>
+      <Theme theme="g10">
+        <section className="theme-section">
+          <ThemeText />
+          <UserAvatar {...args} />
+        </section>
+      </Theme>
+      <Theme theme="g90">
+        <section className="theme-section">
+          <ThemeText />
+          <UserAvatar {...args} />
+        </section>
+      </Theme>
+      <Theme theme="g100">
+        <section className="theme-section">
+          <ThemeText />
+          <UserAvatar {...args} />
+        </section>
+      </Theme>
+    </>
+  );
+};
 /**
  * TODO: Declare one or more stories, generally one per design scenario.
  * NB no need for a 'Playground' because all stories have all controls anyway.
  */
-export const Default = Template.bind({});
+export const Default = ThemeTemplate.bind({});
 Default.storyName = 'Default';
 Default.args = {
   // TODO: Component args - https://storybook.js.org/docs/react/writing-stories/args#UserAvatar-args

--- a/packages/ibm-products/src/components/UserAvatar/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/UserAvatar/_storybook-styles.scss
@@ -6,5 +6,17 @@
 //
 
 @forward '../../../../ibm-products-styles/src/global/styles/project-settings';
+@use '@carbon/styles/scss/themes';
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/spacing';
 
 // TODO: add any additional styles used by UserAvatar.stories.js
+.theme-section {
+  padding: spacing.$spacing-05;
+  background: theme.$background;
+  color: theme.$text-primary;
+}
+
+.theme-text {
+  margin-bottom: spacing.$spacing-03;
+}


### PR DESCRIPTION
Contributes to #6168

One last followup task to show theme handling in user avatar story.
@AlexanderMelox @anamikaanu96 Marking this as a draft first — do we think this demonstrates the theme better?

#### What did you change?
Follow approach from Carbon [`useTheme`](https://react.carbondesignsystem.com/?path=/story/components-theme--use-theme) for better demonstration of how user avatar responds to the themes.

#### How did you test and verify your work?
Storybook and CI checks