### PR TITLE
fix: remove unnecessary props in feature flag tests

### DIFF
--- a/packages/ibm-products/src/components/FeatureFlags/FeatureFlags.test.js
+++ b/packages/ibm-products/src/components/FeatureFlags/FeatureFlags.test.js
@@ -44,87 +44,29 @@ describe('FeatureFlags', () => {
     function TestComponent() {
       const featureFlags = useFeatureFlags();
       const a = useFeatureFlag('a');
-      const b = useFeatureFlag('b');
 
       checkFlags({
         a: featureFlags.enabled('a'),
-        b: featureFlags.enabled('b'),
       });
 
       checkFlag({
         a,
-        b,
       });
 
       return null;
     }
 
     render(
-      <FeatureFlags a b={false}>
+      <FeatureFlags a>
         <TestComponent />
       </FeatureFlags>
     );
 
     expect(checkFlags).toHaveBeenLastCalledWith({
       a: true,
-      b: false,
     });
     expect(checkFlag).toHaveBeenLastCalledWith({
       a: true,
-      b: false,
-    });
-  });
-
-  it('should re-render when flags change', () => {
-    const checkFlags = jest.fn();
-    const checkFlag = jest.fn();
-
-    function TestComponent() {
-      const featureFlags = useFeatureFlags();
-      const a = useFeatureFlag('a');
-      const b = useFeatureFlag('b');
-
-      checkFlags({
-        a: featureFlags.enabled('a'),
-        b: featureFlags.enabled('b'),
-      });
-
-      checkFlag({
-        a,
-        b,
-      });
-
-      return null;
-    }
-
-    const { rerender } = render(
-      <FeatureFlags a b={false}>
-        <TestComponent />
-      </FeatureFlags>
-    );
-
-    expect(checkFlags).toHaveBeenLastCalledWith({
-      a: true,
-      b: false,
-    });
-    expect(checkFlag).toHaveBeenLastCalledWith({
-      a: true,
-      b: false,
-    });
-
-    rerender(
-      <FeatureFlags a={false} b>
-        <TestComponent />
-      </FeatureFlags>
-    );
-
-    expect(checkFlags).toHaveBeenLastCalledWith({
-      a: false,
-      b: true,
-    });
-    expect(checkFlag).toHaveBeenLastCalledWith({
-      a: false,
-      b: true,
     });
   });
 


### PR DESCRIPTION
Closes #6235 

removes some unnecessary usage of setting a prop explicitly to false.

i also wanted to point something out in regards to the test that was removed. this approach doesn't really work for unknown flags. consider the following:

```
function TestComponent() {
  const featureFlags = useFeatureFlags();
  const a = useFeatureFlag('a');
  const b = useFeatureFlag('b');

  checkFlags({
    a: featureFlags.enabled('a'),
    b: featureFlags.enabled('b'),
  });

  checkFlag({
    a,
    b,
  });

  return null;
}

const { rerender } = render(
  <FeatureFlags a>
    <TestComponent />
  </FeatureFlags>
);
```

this will throw an error. `useFeatureFlag` throws an error when the props don't match the hooks. in the above example `b` is set in the hook, but it's not set as a prop to `FeatureFlags`. this causes an `flag b not found` error to be thrown on line 4. so it's kind of this weird thing in regards to implementation. basically this test / use case establishes that the `b` flag is going to be used, but it's not actually set in the component. i'm not sure if this is the intended behavior from core (seeing how this code appears to just be copied from core) but basically the test re-factor would require additional work to change the way the feature flags work to support this use case.

this works in the context of core because the [tests](https://github.com/carbon-design-system/carbon/blob/c300d451e97f16ebbc9df35744173430b2318740/packages/react/src/components/FeatureFlags/__tests__/FeatureFlags-test.js#L117) are explicitly written using the [predefined flags](https://github.com/carbon-design-system/carbon/blob/c300d451e97f16ebbc9df35744173430b2318740/packages/react/src/components/FeatureFlags/index.tsx#L57). they aren't actually testing unknown flags in this case like we are.