### PR TITLE
fix: correctly renders component when using feature flags

### DIFF
--- a/packages/core/.storybook/WithFeatureFlags/index.js
+++ b/packages/core/.storybook/WithFeatureFlags/index.js
@@ -31,7 +31,7 @@ export const WithFeatureFlags = ({ flags, children }) => {
   }, [flags]);
 
   return (
-    <FeatureFlags flags={flags ? updatedFlags : allFlagsEnabled}>
+    <FeatureFlags flags={updatedFlags ?? allFlagsEnabled}>
       <Annotation
         type="feature-flags"
         text={


### PR DESCRIPTION
Closes #6356 6356

This is a fix to the storybook feature flag utility component so that it re-renders with the updates flags.

#### What did you change?
```
packages/core/.storybook/WithFeatureFlags/index.js
```
#### How did you test and verify your work?
Storybook