### PR TITLE
fix: these at imports should not exist

### DIFF
--- a/packages/ibm-products-styles/src/components/EditFullPage/_index.scss
+++ b/packages/ibm-products-styles/src/components/EditFullPage/_index.scss
@@ -5,4 +5,4 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import './edit-full-page';
+@use './edit-full-page';

--- a/packages/ibm-products-styles/src/components/EditTearsheet/_index.scss
+++ b/packages/ibm-products-styles/src/components/EditTearsheet/_index.scss
@@ -5,4 +5,4 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import './edit-tearsheet';
+@use './edit-tearsheet';

--- a/packages/ibm-products-styles/src/components/EditTearsheetNarrow/_index.scss
+++ b/packages/ibm-products-styles/src/components/EditTearsheetNarrow/_index.scss
@@ -5,4 +5,4 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import './edit-tearsheet-narrow';
+@use './edit-tearsheet-narrow';

--- a/packages/ibm-products-styles/src/components/EditUpdateCards/_edit-update-cards.scss
+++ b/packages/ibm-products-styles/src/components/EditUpdateCards/_edit-update-cards.scss
@@ -8,16 +8,16 @@
 // Standard imports.
 
 // Other Carbon settings.
-// TODO: @import 'carbon-components/scss/globals/grid/grid'; if needed
+// TODO: @use 'carbon-components/scss/globals/grid/grid'; if needed
 @use '@carbon/colors/' as *;
 @use '@carbon/motion/' as *;
 @use '../../global/styles/project-settings' as c4p-settings;
 
 // EditUpdateCards uses the following Carbon components:
-// TODO: @import(s) of Carbon component styles used by EditUpdateCards
+// TODO: @use(s) of Carbon component styles used by EditUpdateCards
 
 // EditUpdateCards uses the following Carbon for IBM Products components:
-// TODO: @import(s) of IBM Products component styles used by EditUpdateCards
+// TODO: @use(s) of IBM Products component styles used by EditUpdateCards
 
 // Define all component styles in a mixin which is then exported using
 // the Carbon import-once mechanism.

--- a/packages/ibm-products/src/components/Carousel/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/Carousel/_storybook-styles.scss
@@ -5,7 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// @import '../../global/styles/project-settings';
+// @use '../../global/styles/project-settings';
 @use '../../../../ibm-products-styles/src/global/styles/project-settings';
 
 // TODO: add any additional styles used by Carousel.stories.js

--- a/packages/ibm-products/src/components/SteppedAnimatedMedia/_index.scss
+++ b/packages/ibm-products/src/components/SteppedAnimatedMedia/_index.scss
@@ -5,4 +5,4 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import './stepped-animated-media';
+@use './stepped-animated-media';


### PR DESCRIPTION
Seeing deprecation warnings when building my SASS

Warning: 3 repetitive deprecation warnings omitted.

Deprecation Warning: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

  ╷
8 │ @import './edit-tearsheet';
  │         ^^^^^^^^^^^^^^^^^^
  ╵
    node_modules/@carbon/ibm-products/scss/components/EditTearsheet/_index.scss 8:9  @use
    node_modules/@carbon/ibm-products/scss/components/_index.scss 56:1               @forward
    node_modules/@carbon/ibm-products/scss/index-without-carbon.scss 12:1            @use
    src/index.scss 4:1                   