### PR TITLE
fix(tearsheet): address portalTarget type

### DIFF
--- a/packages/ibm-products/src/components/AddSelect/AddSelect.tsx
+++ b/packages/ibm-products/src/components/AddSelect/AddSelect.tsx
@@ -5,7 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-import React, { ForwardedRef, ReactNode, forwardRef } from 'react';
+import React, { ForwardedRef, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { AddSelectBody } from './AddSelectBody';
 import { normalize, getGlobalFilterValues } from './add-select-utils';
@@ -48,7 +48,7 @@ export interface AddSelectProps {
   /**
    * portal target for the all tags modal
    */
-  portalTarget?: ReactNode;
+  portalTarget?: HTMLElement;
   searchResultsTitle?: string;
   sortByLabel?: string;
   title: string;
@@ -172,6 +172,7 @@ AddSelect.propTypes = {
   /**
    * portal target for the all tags modal
    */
+  /**@ts-ignore */
   portalTarget: PropTypes.node,
   searchResultsTitle: PropTypes.string,
   sortByLabel: PropTypes.string,

--- a/packages/ibm-products/src/components/AddSelect/AddSelectBody.tsx
+++ b/packages/ibm-products/src/components/AddSelect/AddSelectBody.tsx
@@ -5,7 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-import React, { ForwardedRef, ReactNode, forwardRef, useState } from 'react';
+import React, { ForwardedRef, forwardRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Tag } from '@carbon/react';
@@ -67,7 +67,7 @@ export interface AddSelectBodyProps {
   onSubmit?: (selection) => void;
   onSubmitButtonText?: string;
   open?: boolean;
-  portalTarget?: ReactNode;
+  portalTarget?: HTMLElement;
   searchResultsTitle?: string;
   sortByLabel?: string;
   title?: string;
@@ -457,6 +457,7 @@ AddSelectBody.propTypes = {
   onSubmit: PropTypes.func,
   onSubmitButtonText: PropTypes.string,
   open: PropTypes.bool,
+  /**@ts-ignore */
   portalTarget: PropTypes.node,
   searchResultsTitle: PropTypes.string,
   sortByLabel: PropTypes.string,

--- a/packages/ibm-products/src/components/Tearsheet/Tearsheet.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/Tearsheet.tsx
@@ -145,7 +145,7 @@ export interface TearsheetProps extends PropsWithChildren {
   /**
    * The DOM element that the tearsheet should be rendered within. Defaults to document.body.
    */
-  portalTarget?: ReactNode;
+  portalTarget?: HTMLElement;
 
   /**
    * Specify a CSS selector that matches the DOM element that should be

--- a/packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.tsx
@@ -86,7 +86,7 @@ interface TearsheetNarrowBaseProps extends PropsWithChildren {
   /**
    * The DOM element that the tearsheet should be rendered within. Defaults to document.body.
    */
-  portalTarget?: ReactNode;
+  portalTarget?: HTMLElement;
 
   /**
    * Specify a CSS selector that matches the DOM element that should be

--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
@@ -141,7 +141,7 @@ interface TearsheetShellProps extends PropsWithChildren {
   /**
    * The DOM element that the tearsheet should be rendered within. Defaults to document.body.
    */
-  portalTarget?: ReactNode;
+  portalTarget?: HTMLElement;
 
   /**
    * Specify a CSS selector that matches the DOM element that should be


### PR DESCRIPTION
Closes #6345 

Change the `portalTarget` type from `ReactNode` to `HTMLElement`

#### What did you change?
Changed type `ReactNode` to `HTMLElement`

#### How did you test and verify your work?
`yarn avt`
`yarn test`
Storybook
