### PR TITLE
chore: bump upload-artifact action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
         run: kill ${{ steps.storybook.outputs.pid }}
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: playwright-avt-report
           path: .playwright

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
         run: kill ${{ steps.storybook.outputs.pid }}
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 #4.4.3
         with:
           name: playwright-avt-report
           path: .playwright

--- a/.github/workflows/received-pr-review.yml
+++ b/.github/workflows/received-pr-review.yml
@@ -21,7 +21,7 @@ jobs:
           echo $JSON > ./pr_data/github.json
       - name: Upload event data
         id: upload_artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr-data-to-process
           path: pr_data/

--- a/.github/workflows/received-pr-review.yml
+++ b/.github/workflows/received-pr-review.yml
@@ -21,7 +21,7 @@ jobs:
           echo $JSON > ./pr_data/github.json
       - name: Upload event data
         id: upload_artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 #4.4.3
         with:
           name: pr-data-to-process
           path: pr_data/


### PR DESCRIPTION
Closes #6381 

Upgrades the `upload-artifact` action used in `ci.yml` and PR review workflow, support for v3 will be removed in Dec 2024.

#### What did you change?
```
.github/workflows/ci.yml
.github/workflows/received-pr-review.yml
```
#### How did you test and verify your work?
Compared usage for playwright upload with Core