### PR TITLE
chore: update release branch pattern in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - v1
-      - 'release/v2*'
+      - 'release\/v2**'
   merge_group:
     types: [checks_requested]
 


### PR DESCRIPTION
This change should allow for the expected PR checks to run against release branches (ie `release/2.*`).

#### What did you change?
```
.github/workflows/ci.yml
```
#### How did you test and verify your work?
I can test in a follow up PR against `release/2.54.0`