### PR TITLE
fix: update release branch pattern in codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - v1
+      - 'release\/v2**'
 
   push:
     branches:


### PR DESCRIPTION
Follow up to https://github.com/carbon-design-system/ibm-products/pull/6408, this PR will get the CodeQL scans to run against release branches now.

#### What did you change?
```
.github/workflows/codeql.yml
```
#### How did you test and verify your work?
Checks run as expected with new branch pattern in [test PR](https://github.com/carbon-design-system/ibm-products/pull/6417)