### PR TITLE
fix(conditionBuilder): address issues inside conditionBuilder popover

### DIFF
--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItemOption/ItemOption.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItemOption/ItemOption.tsx
@@ -85,8 +85,6 @@ export const ItemOption = ({
     );
   };
 
-  const preventDefault = (evt) => evt.preventDefault();
-
   if (!allOptions) {
     return;
   }
@@ -99,7 +97,6 @@ export const ItemOption = ({
             labelText={clearSearchText}
             closeButtonLabelText={clearSearchText}
             onChange={onSearchChangeHandler}
-            onKeyDown={preventDefault}
           />
         </div>
       )}

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItemOption/ItemOptionForValueField.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItemOption/ItemOptionForValueField.tsx
@@ -145,6 +145,10 @@ export const ItemOptionForValueField = ({
     } else {
       onChange(option, evt);
     }
+    if (evt.target instanceof SVGElement) {
+      evt.stopPropagation();
+      //stop propagate event , since this closes the popover when clicked on checkboxes which are SVGs.
+    }
   };
 
   const getAriaLabel = () => {
@@ -154,7 +158,6 @@ export const ItemOptionForValueField = ({
       ? conditionState.property
       : propertyText;
   };
-  const preventDefault = (evt) => evt.preventDefault();
 
   if (!allOptions) {
     return <SelectSkeleton />;
@@ -168,7 +171,6 @@ export const ItemOptionForValueField = ({
             labelText={clearSearchText}
             closeButtonLabelText={clearSearchText}
             onChange={onSearchChangeHandler}
-            onKeyDown={preventDefault}
           />
         </div>
       )}

--- a/packages/ibm-products/src/components/ConditionBuilder/assets/SampleData.js
+++ b/packages/ibm-products/src/components/ConditionBuilder/assets/SampleData.js
@@ -140,12 +140,12 @@ export const sampleDataStructure_nonHierarchical = {
           operator: 'oneOf',
           value: [
             {
-              label: 'Africa',
-              id: 'Africa',
+              label: 'Afghanistan',
+              id: 'AF',
             },
             {
-              label: { id: 'India', label: 'India' },
-              id: 'Ind',
+              label: 'Albania',
+              id: 'AL',
             },
           ],
           id: uuidv4(),


### PR DESCRIPTION
Closes #6402 

- Cannot type in to the search box to filter the list.
- Dropdown auto closes after every time a checkbox is selected
- Corrected a corrupt  data for a storybook story

#### What did you change?

- Removed preventDefault from search input. This will give carbon search input behaviour , which is to clear any search text on Escape keypress rather than closing the popover.
- StopPropogation on checkbox icon click to prevent closing

#### How did you test and verify your work?
local