### PR TITLE
chore: deprecate empty state v2

### DIFF
--- a/e2e/components/EmptyState/EmptyStateV2-test.avt.e2e.js
+++ b/e2e/components/EmptyState/EmptyStateV2-test.avt.e2e.js
@@ -14,7 +14,7 @@ test.describe('EmptyStateV2 @avt', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'EmptyStateV2',
-      id: 'experimental-patterns-empty-state-emptystatev2--default',
+      id: 'deprecated-empty-state-emptystatev2--default',
       globals: {
         carbonTheme: 'white',
       },

--- a/packages/ibm-products/src/components/EmptyStates/EmptyStateV2.stories.jsx
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyStateV2.stories.jsx
@@ -11,9 +11,10 @@ import { Add } from '@carbon/react/icons';
 import CustomIllustration from './story_assets/empty-state-bright-magnifying-glass.svg';
 import { EmptyStateV2 } from '.';
 import { StoryDocsPage } from '../../global/js/utils/StoryDocsPage';
+import { Annotation } from '../../../../core/.storybook/Annotation';
 
 export default {
-  title: 'Experimental/Patterns/Empty state/EmptyStateV2',
+  title: 'Deprecated/Empty state/EmptyStateV2',
   component: EmptyStateV2,
   tags: ['autodocs'],
   parameters: {
@@ -30,10 +31,38 @@ export default {
               label: 'Carbon empty pattern usage guidelines',
             },
           ]}
+          blocks={[
+            {
+              title: 'Deprecation notice',
+              description:
+                'This component is deprecated and will be removed in the next major version. For more information, please refer to the [Carbon docs](https://carbondesignsystem.com/patterns/empty-states-pattern/).',
+            },
+          ]}
         />
       ),
     },
   },
+  decorators: [
+    (story) => (
+      <div>
+        <Annotation
+          type="deprecation-notice"
+          text={
+            <div>
+              This component is deprecated and will be removed in the next major
+              version. For more information, please refer to the{' '}
+              <a href="https://carbondesignsystem.com/patterns/empty-states-pattern/">
+                Carbon docs
+              </a>
+              .
+            </div>
+          }
+        >
+          {story()}
+        </Annotation>
+      </div>
+    ),
+  ],
 };
 
 const defaultProps = {

--- a/packages/ibm-products/src/components/EmptyStates/EmptyStateV2.stories.jsx
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyStateV2.stories.jsx
@@ -31,13 +31,7 @@ export default {
               label: 'Carbon empty pattern usage guidelines',
             },
           ]}
-          blocks={[
-            {
-              title: 'Deprecation notice',
-              description:
-                'This component is deprecated and will be removed in the next major version. For more information, please refer to the [Carbon docs](https://carbondesignsystem.com/patterns/empty-states-pattern/).',
-            },
-          ]}
+          deprecationNotice="This component is deprecated and will be removed in the next major version. For more information, please refer to the [Carbon docs](https://carbondesignsystem.com/patterns/empty-states-pattern/)."
         />
       ),
     },

--- a/packages/ibm-products/src/components/EmptyStates/EmptyStateV2.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyStateV2.tsx
@@ -180,6 +180,13 @@ export let EmptyStateV2 = React.forwardRef<HTMLDivElement, EmptyStateV2Props>(
   }
 );
 
+/**@ts-ignore*/
+EmptyStateV2.deprecated = {
+  level: 'warn',
+  details:
+    'For more information, please refer to the Carbon docs https://carbondesignsystem.com/patterns/empty-states-pattern/',
+};
+
 // Return a placeholder if not released and not enabled by feature flag
 EmptyStateV2 = pkg.checkComponentEnabled(EmptyStateV2, componentName);
 

--- a/packages/ibm-products/src/components/EmptyStates/EmptyStateV2.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyStateV2.tsx
@@ -90,6 +90,7 @@ export interface EmptyStateV2Props {
 /**
  * This is the V2 version of the `EmptyState` component. To use you must pass the `v2` prop to the V1 version of the component `EmptyState` and use the props below.
  * In order to avoid breaking changes in the future `EmptyStateV2` is not actually directly importable.
+ * @deprecated
  */
 
 export let EmptyStateV2 = React.forwardRef<HTMLDivElement, EmptyStateV2Props>(


### PR DESCRIPTION
Closes #6324 

note to self: update this PR or code to replace the deprecation notice block in `block` with the new `deprecationNotice` prop that will be added to the `StoryDocsPage` component here https://github.com/carbon-design-system/ibm-products/pull/6419/files#diff-d1d59f3ffba9e6226e5a00cedc4dc1cf7264ae4926deb6bfd27e902febf070eeR144