### PR TITLE
fix(tearsheet web components): cancel button not working

### DIFF
--- a/packages/ibm-products-web-components/src/components/tearsheet/tearsheet.stories.ts
+++ b/packages/ibm-products-web-components/src/components/tearsheet/tearsheet.stories.ts
@@ -25,8 +25,13 @@ import { prefix } from '../../globals/settings';
 
 import styles from './story-styles.scss?lit';
 import { BUTTON_KIND } from '@carbon/web-components/es/components/button/defs.js';
+
 const toggleButton = () => {
   document.querySelector(`${prefix}-tearsheet`)?.toggleAttribute('open');
+};
+
+const cancelButton = () => {
+  document.querySelector(`${prefix}-tearsheet`)?.removeAttribute('open');
 };
 
 const widths = {
@@ -250,7 +255,12 @@ const actionItems = {
 
 const toActions = (kinds: BUTTON_KIND[]) => {
   return kinds?.map((kind) => {
-    return html`<cds-button key=${kind} slot="actions" kind=${kind}>
+    return html`<cds-button
+      key=${kind}
+      slot="actions"
+      kind=${kind}
+      @click=${kind === 'ghost' && cancelButton}
+    >
       ${kind.charAt(0).toUpperCase() + kind.slice(1)}
     </cds-button>`;
   });


### PR DESCRIPTION
Closes #6305

Cancel button not working as expected in Tearsheet web components. 
The issue was with story and not component.

#### What did you change?
Added click event handler for cancel button just as in react Tearsheet.

#### How did you test and verify your work?
Storybook
