### PR TITLE
build: update dependency action to use carbon bot/app token

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -32,11 +32,11 @@ jobs:
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
           token: ${{ steps.generate_token.outputs.token }}
-          commit-message: 'chore(deps): update Carbon 11 compatible versions to latest'
+          commit-message: 'build(deps): update Carbon 11 compatible versions to latest'
           delete-branch: true
           branch: 'deps/update-carbon-packages'
           branch-suffix: random
-          title: 'chore(deps): update to Carbon 11 compatible versions to latest'
+          title: 'build(deps): update to Carbon 11 compatible versions to latest'
           body: |
             This PR was automatically generated to update Carbon 11 compatible versions on a regular basis. This is not intended to create any breaking changes, and will be reflected as a minor version bump for affected packages. NB we'll run all tests and do visual verifications, but there is always the opportunity for unexpected regressions. If you're using one of the packages in a stable or production context you may want to check this before taking the next minor version, and do let us know ASAP if you see anything problematic.
 
@@ -79,11 +79,11 @@ jobs:
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
           token: ${{ steps.generate_token.outputs.token }}
-          commit-message: 'chore(deps): update dev dependencies'
+          commit-message: 'build(deps): update dev dependencies'
           delete-branch: true
           branch: 'deps/update-dev-packages'
           branch-suffix: random
-          title: 'chore(deps): update dev dependencies'
+          title: 'build(deps): update dev dependencies'
           body: |
             This PR was automatically generated to update versions of dev dependencies to their latest versions. This helps ensure we get fixes and improvements in a timely fashion and reduces the impact of updating the versions that can arise if versions are allowed to become stale for an extended period.
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install
         run: yarn
@@ -21,19 +21,22 @@ jobs:
           yarn
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
-
+      - name: Generate token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a #v2.1.0
+        id: generate_token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Create PR
         id: create-pr
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
-          token: ${{ secrets.CREATE_PR_ACCESS_TOKEN }}
-          commit-message: 'fix: update Carbon 11 compatible versions to latest'
-          committer: GitHub <noreply@github.com>
-          author:
-            ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          branch: 'update-packages'
+          token: ${{ steps.generate_token.outputs.token }}
+          commit-message: 'build(deps): update Carbon 11 compatible versions to latest'
+          delete-branch: true
+          branch: 'deps/update-carbon-packages'
           branch-suffix: random
-          title: 'fix: update to Carbon 11 compatible versions to latest'
+          title: 'build(deps): update to Carbon 11 compatible versions to latest'
           body: |
             This PR was automatically generated to update Carbon 11 compatible versions on a regular basis. This is not intended to create any breaking changes, and will be reflected as a minor version bump for affected packages. NB we'll run all tests and do visual verifications, but there is always the opportunity for unexpected regressions. If you're using one of the packages in a stable or production context you may want to check this before taking the next minor version, and do let us know ASAP if you see anything problematic.
 
@@ -52,27 +55,11 @@ jobs:
             - [ ] `yarn ci-check` runs cleanly and all tests pass (done automatically as part of the PR checks).
             - [ ] the Netlify deploy-preview has been used to ensure that storybook runs and the main published components render correctly.
 
-      - name: Post reminder to Slack
-        id: post-reminder
-        uses: archive/github-actions-slack@v2.0.0
-        with:
-          slack-bot-user-oauth-access-token:
-            ${{ secrets.CREATE_PR_SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
-          slack-channel: G01PUCL3V8R # cspell:disable-line
-          slack-text: >
-            Hello! This is a test post. PR number:
-            ${{steps.create-pr.outputs.pull-request-number}} 🤓
-
-      - name: Result from "Post reminder to Slack"
-        run: |
-          echo "The PR number was ${{ steps.create-pr.outputs.pull-request-number }}"
-          echo "The result was ${{ steps.post-reminder.outputs.slack-result }}"
-
   dependencies:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install
         run: yarn
@@ -89,16 +76,14 @@ jobs:
 
       - name: Create PR
         id: create-pr
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
-          token: ${{ secrets.CREATE_PR_ACCESS_TOKEN }}
-          commit-message: 'chore: update dev dependencies'
-          committer: GitHub <noreply@github.com>
-          author:
-            ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          branch: 'update-packages'
+          token: ${{ steps.generate_token.outputs.token }}
+          commit-message: 'build(deps): update dev dependencies'
+          delete-branch: true
+          branch: 'deps/update-dev-packages'
           branch-suffix: random
-          title: 'chore: update dev dependencies'
+          title: 'build(deps): update dev dependencies'
           body: |
             This PR was automatically generated to update versions of dev dependencies to their latest versions. This helps ensure we get fixes and improvements in a timely fashion and reduces the impact of updating the versions that can arise if versions are allowed to become stale for an extended period.
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -32,11 +32,11 @@ jobs:
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
           token: ${{ steps.generate_token.outputs.token }}
-          commit-message: 'build(deps): update Carbon 11 compatible versions to latest'
+          commit-message: 'chore(deps): update Carbon 11 compatible versions to latest'
           delete-branch: true
           branch: 'deps/update-carbon-packages'
           branch-suffix: random
-          title: 'build(deps): update to Carbon 11 compatible versions to latest'
+          title: 'chore(deps): update to Carbon 11 compatible versions to latest'
           body: |
             This PR was automatically generated to update Carbon 11 compatible versions on a regular basis. This is not intended to create any breaking changes, and will be reflected as a minor version bump for affected packages. NB we'll run all tests and do visual verifications, but there is always the opportunity for unexpected regressions. If you're using one of the packages in a stable or production context you may want to check this before taking the next minor version, and do let us know ASAP if you see anything problematic.
 
@@ -79,11 +79,11 @@ jobs:
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
           token: ${{ steps.generate_token.outputs.token }}
-          commit-message: 'build(deps): update dev dependencies'
+          commit-message: 'chore(deps): update dev dependencies'
           delete-branch: true
           branch: 'deps/update-dev-packages'
           branch-suffix: random
-          title: 'build(deps): update dev dependencies'
+          title: 'chore(deps): update dev dependencies'
           body: |
             This PR was automatically generated to update versions of dev dependencies to their latest versions. This helps ensure we get fixes and improvements in a timely fashion and reduces the impact of updating the versions that can arise if versions are allowed to become stale for an extended period.
 


### PR DESCRIPTION
Closes #6497 

Uses same token approach as Core to open PRs so that it is opened by one of the Carbon github bots/apps. I also removed the slack integration piece since it doesn't work and wanted to do some cleanup.

#### What did you change?
```
.github/workflows/update.yml
```
#### How did you test and verify your work?
Haven't been able to yet! But the same `APP_ID` and `APP_PRIVATE_KEY` secrets have been added to our repo that are also used in core and those are used to generate the token used by `peter-evans/create-pull-request`.