### PR TITLE
chore: update stylelint from v15 to v16

### DIFF
--- a/examples/carbon-for-ibm-products/APIKeyModal/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/APIKeyModal/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/AboutModal/src/Example/Example.jsx
+++ b/examples/carbon-for-ibm-products/AboutModal/src/Example/Example.jsx
@@ -82,7 +82,7 @@ export const Example = () => {
             IBM{' '}
             <span
               style={
-                // stylelint-disable-next-line carbon/type-token-use
+                
                 { fontWeight: '600' }
               }
             >

--- a/examples/carbon-for-ibm-products/AboutModal/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/AboutModal/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/BigNumbers/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/BigNumbers/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/Cascade/src/Example/_example.scss
+++ b/examples/carbon-for-ibm-products/Cascade/src/Example/_example.scss
@@ -4,8 +4,8 @@
   display: inline-block;
   width: 150px;
   height: 150px;
-  // stylelint-disable-next-line carbon/layout-token-use
+
   margin: 1rem;
-  // stylelint-disable-next-line carbon/theme-token-use
+
   background-color: $background-inverse;
 }

--- a/examples/carbon-for-ibm-products/Cascade/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/Cascade/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/Coachmark/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/Coachmark/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/CoachmarkBeacon/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/CoachmarkBeacon/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/CoachmarkButton/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/CoachmarkButton/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/CoachmarkFixed/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/CoachmarkFixed/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/CoachmarkOverlayElement/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/CoachmarkOverlayElement/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/CoachmarkOverlayElements/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/CoachmarkOverlayElements/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/CoachmarkStack/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/CoachmarkStack/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/ConditionBuilder/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/ConditionBuilder/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/CreateFullPage/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/CreateFullPage/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/CreateModal/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/CreateModal/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/CreateSidePanel/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/CreateSidePanel/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/CreateTearsheet/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/CreateTearsheet/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/CreateTearsheetNarrow/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/CreateTearsheetNarrow/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/DataSpreadsheet/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/DataSpreadsheet/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/Datagrid/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/Datagrid/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/Decorator/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/Decorator/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/DelimitedList/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/DelimitedList/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/DescriptionList/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/DescriptionList/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/EditInPlace/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/EditInPlace/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/EmptyStates/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/EmptyStates/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/ExportModal/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/ExportModal/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/ExpressiveCard/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/ExpressiveCard/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/FilterPanel/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/FilterPanel/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/FullPageError/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/FullPageError/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/GetStartedCard/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/GetStartedCard/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/HTTPErrors/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/HTTPErrors/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/ImportModal/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/ImportModal/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/InterstitialScreen/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/InterstitialScreen/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/InterstitialScreenView/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/InterstitialScreenView/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/InterstitialScreenViewModule/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/InterstitialScreenViewModule/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/Nav/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/Nav/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/NotificationsPanel/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/NotificationsPanel/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/OptionsTile/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/OptionsTile/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/PageHeader/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/PageHeader/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/ProductiveCard/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/ProductiveCard/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/RemoveModal/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/RemoveModal/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/Saving/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/Saving/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/ScrollGradient/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/ScrollGradient/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/SearchBar/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/SearchBar/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/SidePanel/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/SidePanel/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/StatusIcon/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/StatusIcon/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/StatusIndicator/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/StatusIndicator/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/StringFormatter/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/StringFormatter/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/TagOverflow/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/TagOverflow/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/TagSet/src/Example/components/_display-box.scss
+++ b/examples/carbon-for-ibm-products/TagSet/src/Example/components/_display-box.scss
@@ -30,7 +30,6 @@
   opacity: 0.7;
   outline: none;
   -webkit-transition: 0.2s;
-  // stylelint-disable-next-line carbon/motion-duration-use
   transition: background-color 0.2s;
 
   /* stylelint-disable-next-line max-nesting-depth */

--- a/examples/carbon-for-ibm-products/TagSet/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/TagSet/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/Tearsheet/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/Tearsheet/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/TruncatedList/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/TruncatedList/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/UserAvatar/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/UserAvatar/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/UserProfileImage/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/UserProfileImage/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/WebTerminal/src/Example/_example.scss
+++ b/examples/carbon-for-ibm-products/WebTerminal/src/Example/_example.scss
@@ -11,7 +11,7 @@
   @include type-style('code-02');
 
   padding: $spacing-05;
-  // stylelint-disable-next-line carbon/theme-token-use
+
   color: $gray-10;
 }
 

--- a/examples/carbon-for-ibm-products/WebTerminal/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/WebTerminal/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/example-gallery/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/example-gallery/src/ThemeSelector/_theme-dropdown.scss
@@ -21,8 +21,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/prefix-example/src/Example/Example.jsx
+++ b/examples/carbon-for-ibm-products/prefix-example/src/Example/Example.jsx
@@ -86,7 +86,7 @@ export const Example = () => {
             IBM{' '}
             <span
               style={
-                // stylelint-disable-next-line carbon/type-token-use
+                
                 { fontWeight: '600' }
               }
             >

--- a/examples/carbon-for-ibm-products/prefix-example/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/prefix-example/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/react-16-example/src/Example/Example.jsx
+++ b/examples/carbon-for-ibm-products/react-16-example/src/Example/Example.jsx
@@ -82,7 +82,7 @@ export const Example = () => {
             IBM{' '}
             <span
               style={
-                // stylelint-disable-next-line carbon/type-token-use
+                
                 { fontWeight: '600' }
               }
             >

--- a/examples/carbon-for-ibm-products/react-16-example/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/react-16-example/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/examples/carbon-for-ibm-products/react-17-example/src/Example/Example.jsx
+++ b/examples/carbon-for-ibm-products/react-17-example/src/Example/Example.jsx
@@ -82,7 +82,7 @@ export const Example = () => {
             IBM{' '}
             <span
               style={
-                // stylelint-disable-next-line carbon/type-token-use
+                
                 { fontWeight: '600' }
               }
             >

--- a/examples/carbon-for-ibm-products/react-17-example/src/ThemeSelector/_theme-dropdown.scss
+++ b/examples/carbon-for-ibm-products/react-17-example/src/ThemeSelector/_theme-dropdown.scss
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/package.json
+++ b/package.json
@@ -110,8 +110,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^5.0.5",
-    "stylelint": "^15.11.0",
-    "stylelint-config-carbon": "1.19.1",
+    "stylelint": "^16.10.0",
+    "stylelint-config-carbon": "^1.20.0",
     "webpack": "^5.96.1"
   },
   "//resolutions:http-signature": "package 'request' deprecated but still used, asks for http-signature ~1.2.0 which indirectly has vulnerabilities",

--- a/packages/core/src/component-playground/ComponentPlayground.js
+++ b/packages/core/src/component-playground/ComponentPlayground.js
@@ -79,7 +79,6 @@ const App = () => {
       <GlobalHeader />
       <div
         style={{
-          // stylelint-disable-next-line carbon/layout-token-use
           marginTop: '48px',
         }}
       ></div>
@@ -119,7 +118,6 @@ const App = () => {
               key={card.topic.name}
               lg={4}
               style={{
-                // stylelint-disable-next-line carbon/layout-token-use
                 marginTop: '36px',
               }}
             >

--- a/packages/core/src/component-playground/components/PageHeader/PageHeader.js
+++ b/packages/core/src/component-playground/components/PageHeader/PageHeader.js
@@ -16,7 +16,6 @@ const PageHeader = (props) => {
     <div style={{ display: 'flex' }}>
       <p
         style={{
-          // stylelint-disable-next-line carbon/layout-token-use
           marginRight: '50px',
           maxWidth: '400px',
         }}

--- a/packages/core/src/component-playground/components/Tearsheet/TearsheetWide.js
+++ b/packages/core/src/component-playground/components/Tearsheet/TearsheetWide.js
@@ -48,7 +48,6 @@ const TearsheetWide = (props) => {
             id="tss-ft1"
             labelText="Enter an important value here"
             style={{
-              // stylelint-disable-next-line carbon/layout-token-use
               marginBottom: '1em',
             }}
           />
@@ -57,7 +56,6 @@ const TearsheetWide = (props) => {
             labelText="Here is a light entry field:"
             light
             style={{
-              // stylelint-disable-next-line carbon/layout-token-use
               marginBottom: '1em',
             }}
           />

--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -254,6 +254,14 @@ p.c4p--about-modal__copyright-text:first-child {
   --cds-grid-column-hang: 0.96875rem;
 }
 
+.cds--css-grid--start {
+  margin-inline-start: 0;
+}
+
+.cds--css-grid--end {
+  margin-inline-end: 0;
+}
+
 .cds--subgrid {
   display: grid;
   grid-template-columns: repeat(var(--cds-grid-columns), minmax(0, 1fr));
@@ -3402,7 +3410,7 @@ p.c4p--about-modal__copyright-text:first-child {
 }
 .c4p--datagrid__grid-container table.c4p--datagrid__vertical-align-center .c4p--datagrid__head .c4p--datagrid__head-select-all.c4p--datagrid__checkbox-cell.c4p--datagrid__checkbox-cell-sticky-left {
   position: sticky;
-  z-index: 1;
+  z-index: 10;
   left: 0;
 }
 .c4p--datagrid__grid-container table.c4p--datagrid__vertical-align-center .c4p--datagrid__cell {
@@ -3640,29 +3648,24 @@ p.c4p--about-modal__copyright-text:first-child {
   flex-direction: column;
 }
 .c4p--datagrid__grid-container .c4p--datagrid__carbon-row {
-  /* stylelint-disable-next-line declaration-no-important */
   flex: none !important;
 }
 .c4p--datagrid__grid-container .c4p--datagrid__carbon-row .c4p--datagrid__carbon-row:hover a {
-  /* stylelint-disable-next-line declaration-no-important */
   color: var(--cds-link-primary-hover, #0043ce) !important;
 }
 .c4p--datagrid__grid-container .c4p--datagrid__carbon-row .c4p--datagrid__left-sticky-column-cell,
 .c4p--datagrid__grid-container .c4p--datagrid__carbon-row .c4p--datagrid__right-sticky-column-cell,
 .c4p--datagrid__grid-container .c4p--datagrid__carbon-row .c4p--datagrid__checkbox-cell-sticky-left {
-  /* stylelint-disable-next-line declaration-no-important */
   background-color: var(--cds-layer-01, #f4f4f4);
 }
 .c4p--datagrid__grid-container .c4p--datagrid__carbon-row:hover .c4p--datagrid__left-sticky-column-cell,
 .c4p--datagrid__grid-container .c4p--datagrid__carbon-row:hover .c4p--datagrid__right-sticky-column-cell,
 .c4p--datagrid__grid-container .c4p--datagrid__carbon-row:hover .c4p--datagrid__checkbox-cell-sticky-left {
-  /* stylelint-disable-next-line declaration-no-important */
   background-color: var(--cds-layer-hover-01, #e8e8e8);
 }
 .c4p--datagrid__grid-container .cds--data-table--selected .c4p--datagrid__left-sticky-column-cell,
 .c4p--datagrid__grid-container .cds--data-table--selected .c4p--datagrid__right-sticky-column-cell,
 .c4p--datagrid__grid-container .cds--data-table--selected .c4p--datagrid__checkbox-cell-sticky-left {
-  /* stylelint-disable-next-line declaration-no-important */
   background-color: var(--cds-layer-selected-01, #e0e0e0);
 }
 .c4p--datagrid__grid-container .cds--select-input {
@@ -3673,9 +3676,7 @@ p.c4p--about-modal__copyright-text:first-child {
 }
 .c4p--datagrid__grid-container td.cds--table-column-checkbox,
 .c4p--datagrid__grid-container th.cds--table-column-checkbox {
-  /* stylelint-disable-next-line declaration-no-important */
   width: 3rem !important;
-  /* stylelint-disable-next-line declaration-no-important */
   padding-right: 1rem !important;
 }
 
@@ -3773,7 +3774,7 @@ p.c4p--about-modal__copyright-text:first-child {
 }
 .c4p--datagrid__head-hidden-select-all.c4p--datagrid__select-all-sticky-left {
   position: sticky;
-  z-index: 1;
+  z-index: 10;
   left: 0;
   background-color: var(--cds-layer-accent-01, #e0e0e0);
 }
@@ -3795,7 +3796,6 @@ p.c4p--about-modal__copyright-text:first-child {
 }
 
 .c4p--datagrid__sticky.c4p--datagrid__table-simple {
-  /* stylelint-disable-next-line declaration-no-important */
   min-width: 0 !important;
 }
 
@@ -3805,7 +3805,6 @@ p.c4p--about-modal__copyright-text:first-child {
 
 .c4p--datagrid__sticky.c4p--datagrid__table-simple thead > div {
   overflow: hidden;
-  /* stylelint-disable-next-line declaration-no-important */
   width: 100% !important;
 }
 
@@ -4257,9 +4256,7 @@ p.c4p--about-modal__copyright-text:first-child {
 .c4p--datagrid__sortableColumn .cds--table-header-label .cds--table-sort:focus,
 .c4p--datagrid__sortableColumn .cds--table-header-label .cds--table-sort:active,
 .c4p--datagrid__sortableColumn .cds--table-header-label button:focus .c4p--datagrid__sortable-icon {
-  /* stylelint-disable-next-line declaration-no-important */
   background: none !important;
-  /* stylelint-disable-next-line declaration-no-important */
   color: var(--cds-text-primary, #161616) !important;
 }
 .c4p--datagrid__sortableColumn .cds--table-header-label .cds--table-sort:focus + .c4p--datagrid__resizer,
@@ -4271,9 +4268,7 @@ p.c4p--about-modal__copyright-text:first-child {
   min-width: 100%;
   padding: 0 1rem;
   border: none;
-  /* stylelint-disable-next-line declaration-no-important */
   background: none !important;
-  /* stylelint-disable-next-line declaration-no-important */
   color: var(--cds-text-primary, #161616) !important;
   font: inherit;
 }
@@ -4344,7 +4339,6 @@ p.c4p--about-modal__copyright-text:first-child {
  * LICENSE file in the root directory of this source tree.
  */
 .c4p--datagrid__right-sticky-column-cell {
-  /* stylelint-disable-next-line declaration-no-important */
   position: sticky !important;
   right: 0;
   display: flex;
@@ -4353,13 +4347,11 @@ p.c4p--about-modal__copyright-text:first-child {
 }
 
 .c4p--datagrid__right-sticky-column-header {
-  /* stylelint-disable-next-line declaration-no-important */
   position: sticky !important;
   right: 0;
 }
 
 .c4p--datagrid__left-sticky-column-cell {
-  /* stylelint-disable-next-line declaration-no-important */
   position: sticky !important;
   left: 0;
   display: flex;
@@ -4368,9 +4360,8 @@ p.c4p--about-modal__copyright-text:first-child {
 }
 
 .c4p--datagrid__left-sticky-column-header {
-  /* stylelint-disable-next-line declaration-no-important */
   position: sticky !important;
-  z-index: 1;
+  z-index: 10;
   left: 0;
   border-right: 1px solid var(--cds-border-subtle);
 }
@@ -4399,7 +4390,7 @@ p.c4p--about-modal__copyright-text:first-child {
 
 .c4p--datagrid__select-all-toggle-on.c4p--datagrid__select-all-sticky-left {
   position: sticky;
-  z-index: 1;
+  z-index: 10;
   left: 0;
 }
 
@@ -4680,7 +4671,7 @@ p.c4p--about-modal__copyright-text:first-child {
   position: relative;
   z-index: 0;
   overflow: auto;
-  padding: 0 1rem 4rem 1rem;
+  padding: 0 1rem 4rem;
   overscroll-behavior: contain;
 }
 
@@ -4774,9 +4765,7 @@ p.c4p--about-modal__copyright-text:first-child {
 
 .c4p--datagrid__grid-container th.c4p--datagrid__select-all-toggle-on,
 .c4p--datagrid__grid-container td.c4p--datagrid__select-all-toggle-on {
-  /* stylelint-disable-next-line declaration-no-important */
   width: 4.5rem !important;
-  /* stylelint-disable-next-line declaration-no-important */
   min-width: initial !important;
   box-sizing: border-box;
   flex: 0 0 auto;
@@ -5933,7 +5922,7 @@ th.c4p--datagrid__select-all-toggle-on.button {
 }
 @media (min-width: 42rem) {
   .c4p--full-page-error__svg-container {
-    padding: auto 0.5rem 5rem 0.5rem;
+    padding: auto 0.5rem 5rem;
   }
 }
 
@@ -8849,8 +8838,8 @@ button.c4p--add-select__global-filter-toggle--open {
   text-overflow: ellipsis;
 }
 
-.c4p--breadcrumb-with-overflow__overflow-menu-options.c4p--breadcrumb-with-overflow__overflow-menu-options {
-  z-index: 8000;
+.c4p--breadcrumb-with-overflow__overflow-menu {
+  line-height: 0;
 }
 
 .c4p--tag-set.c4p--tag-set {
@@ -8925,7 +8914,6 @@ button.c4p--add-select__global-filter-toggle--open {
   text-align: left;
 }
 .c4p--tag-set-overflow__tagset-popover .c4p--tag-set-overflow__popover-trigger {
-  /* stylelint-disable-next-line declaration-no-important */
   border: none !important;
   font-family: inherit;
 }

--- a/packages/ibm-products-styles/src/components/BigNumbers/_big-numbers.scss
+++ b/packages/ibm-products-styles/src/components/BigNumbers/_big-numbers.scss
@@ -111,7 +111,7 @@ $skeleton-block-class: #{c4p-settings.$pkg-prefix}--big-numbers-skeleton;
 }
 
 .#{$skeleton-block-class}__value {
-  /* stylelint-disable-next-line declaration-no-important */
+  // stylelint-disable-next-line declaration-no-important
   height: $spacing-08 !important;
   margin: 0;
 }
@@ -131,7 +131,7 @@ $skeleton-block-class: #{c4p-settings.$pkg-prefix}--big-numbers-skeleton;
 
 .#{$skeleton-block-class}.#{$skeleton-block-class}--lg
   .#{$skeleton-block-class}__value {
-  /* stylelint-disable-next-line declaration-no-important */
+  // stylelint-disable-next-line declaration-no-important
   height: $spacing-09 !important;
 }
 
@@ -142,7 +142,7 @@ $skeleton-block-class: #{c4p-settings.$pkg-prefix}--big-numbers-skeleton;
 
 .#{$skeleton-block-class}.#{$skeleton-block-class}--xl
   .#{$skeleton-block-class}__value {
-  /* stylelint-disable-next-line declaration-no-important */
+  // stylelint-disable-next-line declaration-no-important
   height: $spacing-10 !important;
 }
 

--- a/packages/ibm-products-styles/src/components/Card/_card.scss
+++ b/packages/ibm-products-styles/src/components/Card/_card.scss
@@ -24,7 +24,7 @@ $block-class: #{c4p-settings.$pkg-prefix}--card;
 
 .#{$block-class}__clickable {
   cursor: pointer;
-  // stylelint-disable-next-line carbon/motion-easing-use
+
   transition: background-color $duration-fast-02;
 }
 

--- a/packages/ibm-products-styles/src/components/Coachmark/_coachmark-tagline.scss
+++ b/packages/ibm-products-styles/src/components/Coachmark/_coachmark-tagline.scss
@@ -38,7 +38,6 @@ $block-class: #{c4p-settings.$pkg-prefix}--coachmark-tagline;
   color: $white-0 !important;
   grid-template-columns: [cta-col] auto [close-btn-col] $spacing-08;
   opacity: 1;
-  // stylelint-disable-next-line carbon/motion-duration-use
   transition: opacity $duration-moderate-02 motion(exit, productive) 300ms;
   transition-delay: $duration-moderate-02;
 

--- a/packages/ibm-products-styles/src/components/ConditionBuilder/styles/_conditionBuilderItem.scss
+++ b/packages/ibm-products-styles/src/components/ConditionBuilder/styles/_conditionBuilderItem.scss
@@ -221,7 +221,7 @@ $colors: (
         --#{$block-class}__condition-wrapper-color: #{list.nth(
             $group-colors,
             $item-index
-          )}; // stylelint-disable-line carbon/theme-token-use
+          )};
       }
     }
 

--- a/packages/ibm-products-styles/src/components/CreateInfluencer/_create-influencer.scss
+++ b/packages/ibm-products-styles/src/components/CreateInfluencer/_create-influencer.scss
@@ -16,7 +16,7 @@ $influencerAnimationStart: calc(-1 * #{$spacing-05});
 @keyframes influencer-menu-entrance {
   0% {
     opacity: 0;
-    // stylelint-disable-next-line carbon/layout-token-use
+
     transform: translateX($influencerAnimationStart);
   }
 
@@ -33,7 +33,7 @@ $influencerAnimationStart: calc(-1 * #{$spacing-05});
 
   100% {
     opacity: 0;
-    // stylelint-disable-next-line carbon/layout-token-use
+
     transform: translateX($influencerAnimationStart);
   }
 }
@@ -65,7 +65,6 @@ $influencerAnimationStart: calc(-1 * #{$spacing-05});
 
 .#{$influencer-block-class}__side-nav-opening,
 .#{$influencer-block-class}__progress-indicator-opening {
-  // stylelint-disable-next-line carbon/motion-easing-use
   animation: influencer-menu-entrance $duration-moderate-02 1;
   animation-fill-mode: forwards;
   @include motion(entrance, productive);
@@ -73,7 +72,6 @@ $influencerAnimationStart: calc(-1 * #{$spacing-05});
 
 .#{$influencer-block-class}__side-nav-closing,
 .#{$influencer-block-class}__progress-indicator-closing {
-  // stylelint-disable-next-line carbon/motion-easing-use
   animation: influencer-menu-exit $duration-moderate-02 1;
   animation-fill-mode: forwards;
   @include motion(exit, productive);

--- a/packages/ibm-products-styles/src/components/CreateTearsheet/_create-tearsheet.scss
+++ b/packages/ibm-products-styles/src/components/CreateTearsheet/_create-tearsheet.scss
@@ -24,7 +24,7 @@
 @keyframes step-content-entrance {
   0% {
     opacity: 0;
-    // stylelint-disable-next-line carbon/layout-token-use
+
     transform: translateY(-0.75rem);
   }
 
@@ -46,7 +46,6 @@ $tearsheet-fieldset-class: #{c4p-settings.$pkg-prefix}--tearsheet-create__step--
 
   margin-left: 0;
 
-  // stylelint-disable-next-line carbon/motion-easing-use
   animation: step-content-entrance $duration-slow-01;
   animation-fill-mode: forwards;
   animation-timing-function: $standard-easing;
@@ -66,7 +65,6 @@ $tearsheet-fieldset-class: #{c4p-settings.$pkg-prefix}--tearsheet-create__step--
 }
 
 .#{$create-tearsheet-block-class} .#{$step-block-class}__step--visible-step {
-  // stylelint-disable-next-line carbon/motion-easing-use
   animation: step-content-entrance $duration-slow-01;
   animation-fill-mode: forwards;
   animation-timing-function: $standard-easing;

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_datagrid.scss
@@ -404,11 +404,11 @@
   }
 
   .#{$block-class}__carbon-row {
-    /* stylelint-disable-next-line declaration-no-important */
+    // stylelint-disable-next-line declaration-no-important
     flex: none !important;
 
     .#{$block-class}__carbon-row:hover a {
-      /* stylelint-disable-next-line declaration-no-important */
+      // stylelint-disable-next-line declaration-no-important
       color: $link-primary-hover !important;
     }
   }
@@ -416,7 +416,7 @@
   .#{$block-class}__carbon-row .#{$block-class}__left-sticky-column-cell,
   .#{$block-class}__carbon-row .#{$block-class}__right-sticky-column-cell,
   .#{$block-class}__carbon-row .#{$block-class}__checkbox-cell-sticky-left {
-    /* stylelint-disable-next-line declaration-no-important */
+    // stylelint-disable-next-line declaration-no-important
     background-color: $layer-01;
   }
 
@@ -424,7 +424,7 @@
   .#{$block-class}__carbon-row:hover .#{$block-class}__right-sticky-column-cell,
   .#{$block-class}__carbon-row:hover
     .#{$block-class}__checkbox-cell-sticky-left {
-    /* stylelint-disable-next-line declaration-no-important */
+    // stylelint-disable-next-line declaration-no-important
     background-color: $layer-hover-01;
   }
 
@@ -434,7 +434,7 @@
     .#{$block-class}__right-sticky-column-cell,
   .#{c4p-settings.$carbon-prefix}--data-table--selected
     .#{$block-class}__checkbox-cell-sticky-left {
-    /* stylelint-disable-next-line declaration-no-important */
+    // stylelint-disable-next-line declaration-no-important
     background-color: $layer-selected-01;
   }
 
@@ -448,9 +448,9 @@
 
   td.#{c4p-settings.$carbon-prefix}--table-column-checkbox,
   th.#{c4p-settings.$carbon-prefix}--table-column-checkbox {
-    /* stylelint-disable-next-line declaration-no-important */
+    // stylelint-disable-next-line declaration-no-important
     width: $spacing-09 !important;
-    /* stylelint-disable-next-line declaration-no-important */
+    // stylelint-disable-next-line declaration-no-important
     padding-right: $spacing-05 !important;
   }
 }
@@ -596,7 +596,7 @@
 }
 
 .#{$block-class}__sticky.#{$block-class}__table-simple {
-  /* stylelint-disable-next-line declaration-no-important */
+  // stylelint-disable-next-line declaration-no-important
   min-width: 0 !important;
 }
 
@@ -606,7 +606,7 @@
 
 .#{$block-class}__sticky.#{$block-class}__table-simple thead > div {
   overflow: hidden;
-  /* stylelint-disable-next-line declaration-no-important */
+  // stylelint-disable-next-line declaration-no-important
   width: 100% !important;
 }
 

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_useSelectAllToggle.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_useSelectAllToggle.scss
@@ -13,9 +13,9 @@
 .#{variables.$block-class}__grid-container {
   th.#{variables.$block-class}__select-all-toggle-on,
   td.#{variables.$block-class}__select-all-toggle-on {
-    /* stylelint-disable-next-line declaration-no-important */
+    // stylelint-disable-next-line declaration-no-important
     width: 4.5rem !important;
-    /* stylelint-disable-next-line declaration-no-important */
+    // stylelint-disable-next-line declaration-no-important
     min-width: initial !important;
     box-sizing: border-box;
     flex: 0 0 auto;

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_useSortableColumns.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_useSortableColumns.scss
@@ -27,9 +27,9 @@
   .#{c4p-settings.$carbon-prefix}--table-header-label
     button:focus
     .#{$block-class}__sortable-icon {
-    /* stylelint-disable-next-line declaration-no-important */
+    // stylelint-disable-next-line declaration-no-important
     background: none !important;
-    /* stylelint-disable-next-line declaration-no-important */
+    // stylelint-disable-next-line declaration-no-important
     color: $text-primary !important;
   }
 
@@ -48,9 +48,9 @@
     min-width: 100%;
     padding: 0 $spacing-05;
     border: none;
-    /* stylelint-disable-next-line declaration-no-important */
+    // stylelint-disable-next-line declaration-no-important
     background: none !important;
-    /* stylelint-disable-next-line declaration-no-important */
+    // stylelint-disable-next-line declaration-no-important
     color: $text-primary !important;
     font: inherit;
   }

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_useStickyColumn.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_useStickyColumn.scss
@@ -10,7 +10,7 @@
 @use './variables';
 
 .#{variables.$block-class}__right-sticky-column-cell {
-  /* stylelint-disable-next-line declaration-no-important */
+  // stylelint-disable-next-line declaration-no-important
   position: sticky !important;
   right: 0;
   display: flex;
@@ -19,13 +19,13 @@
 }
 
 .#{variables.$block-class}__right-sticky-column-header {
-  /* stylelint-disable-next-line declaration-no-important */
+  // stylelint-disable-next-line declaration-no-important
   position: sticky !important;
   right: 0;
 }
 
 .#{variables.$block-class}__left-sticky-column-cell {
-  /* stylelint-disable-next-line declaration-no-important */
+  // stylelint-disable-next-line declaration-no-important
   position: sticky !important;
   left: 0;
   display: flex;
@@ -34,7 +34,7 @@
 }
 
 .#{variables.$block-class}__left-sticky-column-header {
-  /* stylelint-disable-next-line declaration-no-important */
+  // stylelint-disable-next-line declaration-no-important
   position: sticky !important;
   z-index: 10;
   left: 0;

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_CustomizeColumnsTearsheet.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_CustomizeColumnsTearsheet.scss
@@ -5,8 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// stylelint-disable carbon/layout-token-use
-
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type' as *;

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_FilterFlyout.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_FilterFlyout.scss
@@ -5,8 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// stylelint-disable carbon/layout-token-use
-
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/layout/scss/convert' as *;
 @use '@carbon/styles/scss/spacing';

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_FilterPanel.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_FilterPanel.scss
@@ -27,7 +27,7 @@
 
 .#{$block-class}-filter-panel__container::before {
   position: absolute;
-  top: -1px; // stylelint-disable-line
+  top: -1px;
   left: 0;
   display: block;
   /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
@@ -41,7 +41,7 @@
   position: relative;
   z-index: 0;
   overflow: auto;
-  padding: 0 $spacing-05 $spacing-10 $spacing-05;
+  padding: 0 $spacing-05 $spacing-10;
   overscroll-behavior: contain;
 }
 

--- a/packages/ibm-products-styles/src/components/EditTearsheet/_edit-tearsheet.scss
+++ b/packages/ibm-products-styles/src/components/EditTearsheet/_edit-tearsheet.scss
@@ -29,7 +29,7 @@
 @keyframes form-content-entrance {
   0% {
     opacity: 0;
-    // stylelint-disable-next-line carbon/layout-token-use
+
     transform: translateY(-0.75rem);
   }
 

--- a/packages/ibm-products-styles/src/components/EditUpdateCards/_edit-update-cards.scss
+++ b/packages/ibm-products-styles/src/components/EditUpdateCards/_edit-update-cards.scss
@@ -31,11 +31,9 @@ $block-class: #{c4p-settings.$pkg-prefix}--edit-update-cards;
     .#{c4p-settings.$pkg-prefix}--card__header,
     .#{c4p-settings.$pkg-prefix}--card__footer {
       button {
-        // stylelint-disable-next-line carbon/theme-token-use
         color: $white-0;
 
         &:hover {
-          // stylelint-disable-next-line carbon/theme-token-use
           background-color: $blue-60-hover;
         }
 
@@ -45,7 +43,6 @@ $block-class: #{c4p-settings.$pkg-prefix}--edit-update-cards;
 
         svg {
           path {
-            // stylelint-disable-next-line carbon/theme-token-use
             fill: $white-0;
           }
         }
@@ -59,9 +56,8 @@ $block-class: #{c4p-settings.$pkg-prefix}--edit-update-cards;
     }
 
     .#{c4p-settings.$pkg-prefix}--card__footer {
-      // stylelint-disable-next-line carbon/theme-token-use
       background-color: $blue-60;
-      // stylelint-disable-next-line carbon/theme-token-use
+
       color: $white-0;
     }
 
@@ -85,9 +81,8 @@ $block-class: #{c4p-settings.$pkg-prefix}--edit-update-cards;
   &:not(.#{$block-class}__actions-bottom) {
     &##{$block-class}--edit {
       .#{c4p-settings.$pkg-prefix}--card__header {
-        // stylelint-disable-next-line carbon/theme-token-use
         background-color: $blue-60;
-        // stylelint-disable-next-line carbon/theme-token-use
+
         color: $white-0;
       }
     }

--- a/packages/ibm-products-styles/src/components/FullPageError/_full-page-error.scss
+++ b/packages/ibm-products-styles/src/components/FullPageError/_full-page-error.scss
@@ -49,7 +49,7 @@ $block-class: #{c4p-settings.$pkg-prefix}--full-page-error;
   height: 100%;
   padding: $spacing-03 $spacing-03 $spacing-11 $spacing-03;
   @include breakpoint(md) {
-    padding: auto $spacing-03 $spacing-11 $spacing-03;
+    padding: auto $spacing-03 $spacing-11;
   }
 }
 

--- a/packages/ibm-products-styles/src/components/Guidebanner/_guidebanner.scss
+++ b/packages/ibm-products-styles/src/components/Guidebanner/_guidebanner.scss
@@ -105,7 +105,7 @@ $purple-3: #7433e3;
 
 // Specify Carousel look and feel.
 .#{$block-class}__carousel {
-  padding: 0 0 $spacing-05 0;
+  padding: 0 0 $spacing-05;
   color: $gray-10;
 
   @include when-collapsed() {

--- a/packages/ibm-products-styles/src/components/InlineTip/_inline-tip.scss
+++ b/packages/ibm-products-styles/src/components/InlineTip/_inline-tip.scss
@@ -177,7 +177,7 @@ $purple: #7f3ae7;
 }
 
 .#{$block-class} .#{$block-class}__close-icon {
-  padding: to-rem(6px) 0 0 0;
+  padding: to-rem(6px) 0 0;
   block-size: $spacing-07;
   color: $white-0;
   inline-size: $spacing-07;

--- a/packages/ibm-products-styles/src/components/InterstitialScreen/_interstitial-screen.scss
+++ b/packages/ibm-products-styles/src/components/InterstitialScreen/_interstitial-screen.scss
@@ -87,7 +87,7 @@ $one-grid-column: calc(100% / 16);
   &--container {
     min-width: 47rem;
     max-width: 82rem;
-    margin: calc($spacing-10 * 2) auto; // stylelint-disable-line carbon/layout-token-use
+    margin: calc($spacing-10 * 2) auto;
     background-color: $background;
   }
 

--- a/packages/ibm-products-styles/src/components/NonLinearReading/_non-linear-reading.scss
+++ b/packages/ibm-products-styles/src/components/NonLinearReading/_non-linear-reading.scss
@@ -70,7 +70,7 @@ $block-class: #{c4p-settings.$pkg-prefix}--non-linear-reading;
 }
 // The "up" chevron
 .#{$block-class} .#{$block-class}__keyword svg {
-  margin: to-rem(1px) 0 0 0;
+  margin: to-rem(1px) 0 0;
   vertical-align: text-top;
 }
 
@@ -105,7 +105,6 @@ $block-class: #{c4p-settings.$pkg-prefix}--non-linear-reading;
   border-left: to-rem(1.25px) solid $text-primary;
   margin: $spacing-02 0;
   // Onboarding does not always use Carbon defaults/tokens
-  // stylelint-disable-next-line carbon/motion-duration-use, carbon/motion-easing-use
   animation: fade 600ms;
 
   /* stylelint-disable-next-line max-nesting-depth */

--- a/packages/ibm-products-styles/src/components/NotificationsPanel/_notifications-panel.scss
+++ b/packages/ibm-products-styles/src/components/NotificationsPanel/_notifications-panel.scss
@@ -23,7 +23,7 @@ $block-class: #{c4p-settings.$pkg-prefix}--notifications-panel;
 @keyframes fade-in {
   0% {
     opacity: 0;
-    // stylelint-disable-next-line carbon/layout-token-use
+
     transform: translateY(-38.5rem); // the height of the notification panel
   }
 
@@ -41,7 +41,7 @@ $block-class: #{c4p-settings.$pkg-prefix}--notifications-panel;
 
   100% {
     opacity: 0;
-    // stylelint-disable-next-line carbon/layout-token-use
+
     transform: translateY(-38.5rem); // the height of the notification panel
   }
 }
@@ -93,7 +93,7 @@ $block-class: #{c4p-settings.$pkg-prefix}--notifications-panel;
 
     position: sticky;
     z-index: 2;
-    // stylelint-disable-next-line carbon/layout-token-use
+
     top: 4.8125rem;
     padding: $spacing-03 $spacing-05;
     background-color: $layer-01;
@@ -183,7 +183,6 @@ $block-class: #{c4p-settings.$pkg-prefix}--notifications-panel;
         padding: 0;
 
         .#{c4p-settings.$carbon-prefix}--btn__icon {
-          // stylelint-disable-next-line carbon/motion-easing-use
           transition: transform $duration-moderate-02 ease;
           /* stylelint-disable-next-line max-nesting-depth */
           @media (prefers-reduced-motion: reduce) {

--- a/packages/ibm-products-styles/src/components/OptionsTile/_options-tile.scss
+++ b/packages/ibm-products-styles/src/components/OptionsTile/_options-tile.scss
@@ -134,7 +134,6 @@ $block-class: #{c4p-settings.$pkg-prefix}--options-tile;
   overflow: hidden;
   height: max-content;
   // spacing-05 + toggle width
-  // stylelint-disable-next-line carbon/layout-token-use
   padding-right: calc(#{$spacing-05} + 2rem);
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -149,7 +148,6 @@ $block-class: #{c4p-settings.$pkg-prefix}--options-tile;
 .#{$block-class}__content {
   padding-right: $spacing-05;
   // spacing-05 + chevron size + spacing-05
-  // stylelint-disable-next-line carbon/layout-token-use
   padding-left: calc(#{$spacing-05} * 2 + 1rem);
 }
 
@@ -208,13 +206,11 @@ $block-class: #{c4p-settings.$pkg-prefix}--options-tile;
 
 .#{$block-class}--lg .#{$block-class}__toggle {
   // "top" shouldn't be spacing token as it depends on the toggle size
-  // stylelint-disable-next-line carbon/layout-token-use
   top: 1rem;
 }
 
 .#{$block-class}--xl .#{$block-class}__toggle {
   // "top" shouldn't be spacing token as it depends on the toggle size
-  // stylelint-disable-next-line carbon/layout-token-use
   top: 1.5rem;
 }
 

--- a/packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
+++ b/packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
@@ -69,11 +69,8 @@ $right-section-alt-width: 100% - $left-section-alt-width;
   $to-color: $layer-01,
   $to-color-shadow: $layer-accent-01
 ) {
-  // stylelint-disable-next-line carbon/theme-token-use
   --from-color: #{$from-color};
-  // stylelint-disable-next-line carbon/theme-token-use
   --to-color: #{$to-color};
-  // stylelint-disable-next-line carbon/theme-token-use
   --to-color-shadow: #{$to-color-shadow};
 
   position: absolute;
@@ -196,7 +193,7 @@ $right-section-alt-width: 100% - $left-section-alt-width;
     content: '';
     opacity: 0;
     transform: translateX(-50%) scaleX(1);
-    // stylelint-disable-next-line carbon/motion-easing-use
+
     transition: all $duration-moderate-01 ease-out;
   }
 
@@ -417,7 +414,6 @@ $right-section-alt-width: 100% - $left-section-alt-width;
 
   .#{$block-class}__breadcrumb-row--has-breadcrumbs
     + .#{$block-class}__title-row--sticky {
-    // stylelint-disable-next-line carbon/layout-token-use
     top: calc(
       var(--#{$block-class}--breadcrumb-top) - var(--title-row-margin-top)
     );
@@ -473,7 +469,7 @@ $right-section-alt-width: 100% - $left-section-alt-width;
 
   .#{$block-class}__title-icon {
     margin-right: $spacing-04;
-    // stylelint-disable-next-line carbon/layout-token-use
+
     transform: translateY(-2px); // positional tweak requested by design review
 
     vertical-align: middle;

--- a/packages/ibm-products-styles/src/components/ProductiveCard/_productive-card.scss
+++ b/packages/ibm-products-styles/src/components/ProductiveCard/_productive-card.scss
@@ -52,9 +52,9 @@ $block-class: #{c4p-settings.$pkg-prefix}--card;
 
   .#{$block-class}__actions-header-ghost-button {
     min-height: $spacing-07;
-    // stylelint-disable-next-line carbon/layout-token-use
+
     padding-right: calc($spacing-01 + $spacing-03);
-    // stylelint-disable-next-line carbon/layout-token-use
+
     padding-left: calc($spacing-01 + $spacing-03);
 
     /* stylelint-disable-next-line max-nesting-depth */

--- a/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
+++ b/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
@@ -453,7 +453,7 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
   height: 1px;
   padding: 0;
   border: 0;
-  // stylelint-disable-next-line carbon/layout-token-use
+
   margin: -1px;
   clip: rect(0, 0, 0, 0);
   visibility: inherit;

--- a/packages/ibm-products-styles/src/components/StatusIcon/_status-icon.scss
+++ b/packages/ibm-products-styles/src/components/StatusIcon/_status-icon.scss
@@ -74,7 +74,6 @@ $themes: ('light', 'dark');
 $block-class: #{$pkg-prefix}--status-icon;
 
 @function carbon-clr($name, $theme: light) {
-  // stylelint-disable-next-line carbon/theme-token-use
   $color: map-get(map-get($colors, $name), $theme);
   @return $color;
 }
@@ -96,7 +95,6 @@ $block-class: #{$pkg-prefix}--status-icon;
 
 .#{$block-class}--light.#{$block-class}--light-minor-warning,
 .#{$block-class}--dark.#{$block-class}--dark-minor-warning {
-  // stylelint-disable-next-line carbon/theme-token-use
   fill: $yellow-20;
 }
 
@@ -106,7 +104,6 @@ $block-class: #{$pkg-prefix}--status-icon;
 .#{$block-class}--light.#{$block-class}--light-minor-warning
   path:nth-of-type(1),
 .#{$block-class}--dark.#{$block-class}--dark-minor-warning path:nth-of-type(1) {
-  // stylelint-disable-next-line carbon/theme-token-use
   fill: $gray-100;
 }
 
@@ -122,15 +119,13 @@ $block-class: #{$pkg-prefix}--status-icon;
           @media (prefers-reduced-motion: reduce) {
             animation: none;
           }
-          // stylelint-disable-next-line carbon/motion-duration-use, carbon/motion-easing-use
+
           animation: rotating 8000ms infinite linear;
-          // stylelint-disable-next-line carbon/theme-token-use
+
           fill: carbon-clr($icon, $theme);
         } @else if $icon == running {
-          // stylelint-disable-next-line carbon/theme-token-use
           fill: carbon-clr($icon, $theme);
         } @else {
-          // stylelint-disable-next-line carbon/theme-token-use
           fill: carbon-clr($icon, $theme);
           @media (prefers-reduced-motion) {
             .#{$block-class}--#{$theme}.#{$block-class}--#{$theme-key}-in-progress {

--- a/packages/ibm-products-styles/src/components/TagOverflow/_tag-overflow.scss
+++ b/packages/ibm-products-styles/src/components/TagOverflow/_tag-overflow.scss
@@ -100,7 +100,7 @@ $block-class-modal: #{$block-class}-modal;
   }
 
   .#{$block-class-overflow}__trigger {
-    /* stylelint-disable-next-line declaration-no-important */
+    // stylelint-disable-next-line declaration-no-important
     border: none !important;
     font-family: inherit;
   }

--- a/packages/ibm-products-styles/src/components/TagSet/_tag-set.scss
+++ b/packages/ibm-products-styles/src/components/TagSet/_tag-set.scss
@@ -104,7 +104,7 @@ $block-class-modal: #{$_block-class}-modal;
   }
 
   .#{$block-class-overflow}__popover-trigger {
-    /* stylelint-disable-next-line declaration-no-important */
+    // stylelint-disable-next-line declaration-no-important
     border: none !important;
     font-family: inherit;
   }

--- a/packages/ibm-products-styles/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/ibm-products-styles/src/components/Tearsheet/_tearsheet.scss
@@ -22,7 +22,6 @@
 
 $block-class: #{$pkg-prefix}--tearsheet;
 
-// stylelint-disable-next-line carbon/theme-token-use
 $motion-duration: $duration-moderate-02;
 
 @include block-wrap($block-class) {
@@ -54,7 +53,7 @@ $motion-duration: $duration-moderate-02;
     z-index: utilities.z('modal') + 1;
     align-items: flex-end;
     color: $text-primary;
-    // stylelint-disable-next-line carbon/motion-duration-use, carbon/motion-easing-use
+
     transition: visibility 0s linear $motion-duration,
       background-color $motion-duration motion(exit, expressive),
       opacity $motion-duration motion(exit, expressive);
@@ -65,7 +64,7 @@ $motion-duration: $duration-moderate-02;
   &.is-visible {
     z-index: utilities.z('modal');
     align-items: flex-end;
-    // stylelint-disable-next-line carbon/motion-duration-use, carbon/motion-easing-use
+
     transition: visibility 0s linear,
       background-color $motion-duration motion(entrance, expressive),
       opacity $motion-duration motion(entrance, expressive);
@@ -105,7 +104,6 @@ $motion-duration: $duration-moderate-02;
     // viewport, capped at 500px to set an upper limit on the movement speed
     // For the reason for calc() see https://github.com/sass/sass/issues/2849
     // and https://github.com/sass/node-sass/issues/2815.
-    // stylelint-disable-next-line carbon/layout-token-use
     transform: translate3d(0, calc(min(95vh, 500px)), 0);
   }
 

--- a/packages/ibm-products-styles/src/components/UserAvatar/_user-avatar.scss
+++ b/packages/ibm-products-styles/src/components/UserAvatar/_user-avatar.scss
@@ -60,7 +60,6 @@ $sizes: (
 
 .#{$block-class}__tooltip {
   &:focus-within .#{$block-class} {
-    // stylelint-disable-next-line carbon/theme-token-use
     outline: 2px solid $focus;
     outline-offset: 1px;
   }
@@ -72,7 +71,6 @@ $sizes: (
 }
 
 @mixin setBgColor($color) {
-  // stylelint-disable-next-line carbon/theme-token-use
   background-color: $color;
 }
 

--- a/packages/ibm-products-styles/src/components/UserProfileImage/_user-profile-image.scss
+++ b/packages/ibm-products-styles/src/components/UserProfileImage/_user-profile-image.scss
@@ -58,7 +58,6 @@ $theme-keys: map-keys($themes);
   @each $color in $base-colors {
     @each $contrast-key in $theme-keys {
       .#{$block-class}--#{$key}.#{$block-class}--#{$contrast-key}-#{$color} {
-        // stylelint-disable-next-line carbon/theme-token-use
         background-color: carbon-get-background-color(
           $color,
           $key,

--- a/packages/ibm-products-styles/src/components/WebTerminal/_web-terminal.scss
+++ b/packages/ibm-products-styles/src/components/WebTerminal/_web-terminal.scss
@@ -18,7 +18,7 @@ $block-class: #{$pkg-prefix}--web-terminal;
 @keyframes web-terminal-entrance {
   from {
     opacity: 0;
-    // stylelint-disable-next-line carbon/layout-token-use
+
     transform: translateX(#{$web-terminal-width});
   }
 
@@ -36,7 +36,7 @@ $block-class: #{$pkg-prefix}--web-terminal;
 
   to {
     opacity: 0;
-    // stylelint-disable-next-line carbon/layout-token-use
+
     transform: translateX(#{$web-terminal-width});
   }
 }

--- a/packages/ibm-products/src/components/AboutModal/AboutModal.stories.jsx
+++ b/packages/ibm-products/src/components/AboutModal/AboutModal.stories.jsx
@@ -143,15 +143,7 @@ export default {
         1: <>IBM Product name example that is longer than one line</>,
         2: (
           <>
-            IBM{' '}
-            <span
-              style={
-                // stylelint-disable-next-line carbon/type-token-use
-                { fontWeight: '600' }
-              }
-            >
-              Product name
-            </span>
+            IBM <span style={{ fontWeight: '600' }}>Product name</span>
           </>
         ),
       },

--- a/packages/ibm-products/src/components/CreateFullPage/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/CreateFullPage/_storybook-styles.scss
@@ -35,7 +35,6 @@ $block-class: #{c4p-settings.$pkg-prefix}--create-full-page;
 
 .#{$story-class}__tooltip {
   position: relative;
-  // stylelint-disable-next-line carbon/layout-token-use
   top: calc(#{$spacing-05} + #{$spacing-01});
   left: $spacing-11;
 }

--- a/packages/ibm-products/src/components/EditInPlace/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/EditInPlace/_storybook-styles.scss
@@ -11,6 +11,5 @@ $block-class: 'edit-in-place-example';
 
 .#{$block-class}__viewport {
   // width: 300px; // larger than standard size needed by text input at standard font size (html input attribute size)
-  // stylelint-disable-next-line carbon/layout-token-use
   margin: 100px;
 }

--- a/packages/ibm-products/src/components/EditUpdateCards/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/EditUpdateCards/_storybook-styles.scss
@@ -26,10 +26,9 @@ $block-class: #{c4p-settings.$pkg-prefix}--edit-update-cards;
     width: 100%;
     height: auto;
     padding: 0;
-    // stylelint-disable-next-line
     font-size: type-scale(3);
     letter-spacing: 0;
-    // stylelint-disable-next-line carbon/type-token-use
+
     line-height: 1.5;
   }
 }
@@ -48,7 +47,6 @@ $block-class: #{c4p-settings.$pkg-prefix}--edit-update-cards;
     margin-right: $spacing-01;
 
     path {
-      // stylelint-disable-next-line carbon/theme-token-use
       fill: $green-50;
     }
   }

--- a/packages/ibm-products/src/components/InterstitialScreen/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/InterstitialScreen/_storybook-styles.scss
@@ -32,42 +32,28 @@
 }
 
 .GenericView {
-  /* stylelint-disable-next-line declaration-no-important */
+  // stylelint-disable-next-line declaration-no-important
   margin-top: $spacing-12 !important;
 }
 
 .NoImageExampleModal {
-  $one-grid-column: calc(
-    100% / 16
-  ); // stylelint-disable-line carbon/layout-token-use
+  $one-grid-column: calc(100% / 16);
 
-  width: calc(
-    $one-grid-column * 16
-  ); // stylelint-disable-line carbon/layout-token-use
+  width: calc($one-grid-column * 16);
 
   @media (min-width: 672px) {
-    width: calc(
-      $one-grid-column * 12
-    ); // stylelint-disable-line carbon/layout-token-use
+    width: calc($one-grid-column * 12);
   }
 }
 
 .NoImageExampleFullScreen {
-  $one-grid-column: calc(
-    100% / 16
-  ); // stylelint-disable-line carbon/layout-token-use
+  $one-grid-column: calc(100% / 16);
 
-  width: calc(
-    $one-grid-column * 16
-  ); // stylelint-disable-line carbon/layout-token-use
+  width: calc($one-grid-column * 16);
   @media (min-width: 672px) {
-    width: calc(
-      $one-grid-column * 12
-    ); // stylelint-disable-line carbon/layout-token-use
+    width: calc($one-grid-column * 12);
   }
   @media (min-width: 1056px) {
-    width: calc(
-      $one-grid-column * 8
-    ); // stylelint-disable-line carbon/layout-token-use
+    width: calc($one-grid-column * 8);
   }
 }

--- a/packages/ibm-products/src/components/PageHeader/PageHeader.stories.jsx
+++ b/packages/ibm-products/src/components/PageHeader/PageHeader.stories.jsx
@@ -133,7 +133,6 @@ const children = {
     <div style={{ display: 'flex' }}>
       <p
         style={{
-          // stylelint-disable-next-line carbon/layout-token-use
           marginRight: '50px',
           maxWidth: '400px',
         }}

--- a/packages/ibm-products/src/components/ProductiveCard/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/ProductiveCard/_storybook-styles.scss
@@ -19,7 +19,7 @@ $story-class: 'productive-card-stories';
   border-right-color: $support-success;
   border-bottom: 0;
   border-left-color: $support-error;
-  margin: 0 auto $spacing-06 auto;
+  margin: 0 auto $spacing-06;
   border-top-left-radius: 110px;
   border-top-right-radius: 110px;
 }

--- a/packages/ibm-products/src/components/ScrollGradient/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/ScrollGradient/_storybook-styles.scss
@@ -9,7 +9,7 @@
 
 .sb-show-main,
 .docs-story {
-  /* stylelint-disable-next-line declaration-no-important */
+  // stylelint-disable-next-line declaration-no-important
   background-color: $layer-01 !important;
 }
 

--- a/packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.jsx
+++ b/packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.jsx
@@ -159,18 +159,12 @@ const mainContent = (
         <TextInput
           id="tss-ft1"
           labelText="Enter an important value here"
-          style={
-            // stylelint-disable-next-line carbon/layout-token-use
-            { marginBottom: '1em' }
-          }
+          style={{ marginBottom: '1em' }}
         />
         <TextInput
           id="tss-ft2"
           labelText="Here is an entry field:"
-          style={
-            // stylelint-disable-next-line carbon/layout-token-use
-            { marginBottom: '1em' }
-          }
+          style={{ marginBottom: '1em' }}
         />
       </FormGroup>
     </Form>
@@ -388,19 +382,13 @@ const FirstElementDisabledTemplate = ({ actions, aiLabel, slug, ...args }) => {
                 <TextInput
                   id="tss-ft1"
                   labelText="Enter an important value here"
-                  style={
-                    // stylelint-disable-next-line carbon/layout-token-use
-                    { marginBottom: '1em' }
-                  }
+                  style={{ marginBottom: '1em' }}
                   disabled
                 />
                 <TextInput
                   id="tss-ft2"
                   labelText="Here is an entry field:"
-                  style={
-                    // stylelint-disable-next-line carbon/layout-token-use
-                    { marginBottom: '1em' }
-                  }
+                  style={{ marginBottom: '1em' }}
                 />
               </FormGroup>
             </Form>

--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.story.jsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.story.jsx
@@ -53,10 +53,8 @@ const className = 'client-class-1 client-class-2';
 const dummyContent = (
   <div
     style={{
-      // stylelint-disable-next-line carbon/layout-token-use
       padding: '50px',
       height: '400px',
-      // stylelint-disable-next-line color-named
     }}
   >
     {Array.from({ length: 10 }, (_, k) => ({ key: `Paragraph-${k}` })).map(

--- a/scripts/example-gallery-builder/update-example/templates/src/ThemeSelector/_theme-dropdown.scss
+++ b/scripts/example-gallery-builder/update-example/templates/src/ThemeSelector/_theme-dropdown.scss
@@ -4,7 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
- 
+
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/themes';
 @use '@carbon/styles/scss/type';
@@ -58,8 +58,8 @@
 
 .carbon-theme-dropdown {
   position: fixed;
-  bottom: 1rem; // stylelint-disable-line carbon/layout-token-use
-  left: 1rem; // stylelint-disable-line carbon/layout-token-use
+  bottom: 1rem;
+  left: 1rem;
   min-width: 11.5rem;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2884,38 +2884,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@csstools/css-parser-algorithms@npm:^2.3.1":
-  version: 2.6.3
-  resolution: "@csstools/css-parser-algorithms@npm:2.6.3"
+"@csstools/css-parser-algorithms@npm:^3.0.1":
+  version: 3.0.4
+  resolution: "@csstools/css-parser-algorithms@npm:3.0.4"
   peerDependencies:
-    "@csstools/css-tokenizer": ^2.3.1
-  checksum: b893e284ebcccf37d7928be31be94fb0d6725defc544b39892d5e59ed5950b413366491817539b0add08deb9fc258c57588053d4436f84b7bd3b43bfeee67bb1
+    "@csstools/css-tokenizer": ^3.0.3
+  checksum: dfb6926218d9f8ba25d8b43ea46c03863c819481f8c55e4de4925780eaab9e6bcd6bead1d56b4ef82d09fcd9d69a7db2750fa9db08eece9470fd499dc76d0edb
   languageName: node
   linkType: hard
 
-"@csstools/css-tokenizer@npm:^2.2.0":
-  version: 2.3.1
-  resolution: "@csstools/css-tokenizer@npm:2.3.1"
-  checksum: 25c8643151667bfc2ce653174786d9f97fea93aa38d48432937bc634d8478dfa03e5e6ad18d3fff3d6fa245e9f6578f87ca07d9fd764a274702e4bb8dd34dede
+"@csstools/css-tokenizer@npm:^3.0.1":
+  version: 3.0.3
+  resolution: "@csstools/css-tokenizer@npm:3.0.3"
+  checksum: 6baa3160e426e1f177b8f10d54ec7a4a596090f65a05f16d7e9e4da049962a404eabc5f885f4867093702c259cd4080ac92a438326e22dea015201b3e71f5bbb
   languageName: node
   linkType: hard
 
-"@csstools/media-query-list-parser@npm:^2.1.4":
-  version: 2.1.11
-  resolution: "@csstools/media-query-list-parser@npm:2.1.11"
+"@csstools/media-query-list-parser@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@csstools/media-query-list-parser@npm:3.0.1"
   peerDependencies:
-    "@csstools/css-parser-algorithms": ^2.6.3
-    "@csstools/css-tokenizer": ^2.3.1
-  checksum: 23ede5583c6f1f51ec45b9293fcaf1ecac0f69c7ea750bfe2245926a66a6ae8f7dea8b3604fc4a5b8be4a25c1bccf519a357bf926d486a7ff479e89685011ff4
+    "@csstools/css-parser-algorithms": ^3.0.1
+    "@csstools/css-tokenizer": ^3.0.1
+  checksum: 794344c67b126ad93d516ab3f01254d44cfa794c3401e34e8cc62ddc7fc13c9ab6c76cb517b643dbda47b57f2eb578c6a11c4a9a4b516d88e260a4016b64ce7f
   languageName: node
   linkType: hard
 
-"@csstools/selector-specificity@npm:^3.0.0":
-  version: 3.1.1
-  resolution: "@csstools/selector-specificity@npm:3.1.1"
+"@csstools/selector-specificity@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@csstools/selector-specificity@npm:4.0.0"
   peerDependencies:
-    postcss-selector-parser: ^6.0.13
-  checksum: 3786a6afea97b08ad739ee8f4004f7e0a9e25049cee13af809dbda6462090744012a54bd9275a44712791e8f103f85d21641f14e81799f9dab946b0459a5e1ef
+    postcss-selector-parser: ^6.1.0
+  checksum: 7076c1d8af0fba94f06718f87fba5bfea583f39089efa906ae38b5ecd6912d3d5865f7047a871ac524b1057e4c970622b2ade456b90d69fb9393902250057994
   languageName: node
   linkType: hard
 
@@ -2985,6 +2985,24 @@ __metadata:
   peerDependencies:
     react: ">=16.8.0"
   checksum: 6cfe46a5fcdaced943982e7ae66b08b89235493e106eb5bc833737c25905e13375c6ecc3aa0c357d136cb21dae3966213dba063f19b7a60b1235a29a7b05ff84
+  languageName: node
+  linkType: hard
+
+"@double-great/stylelint-a11y@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@double-great/stylelint-a11y@npm:3.0.2"
+  dependencies:
+    postcss: "npm:^8.4.33"
+  peerDependencies:
+    stylelint: ">=16.0.0"
+  checksum: 5abfe4f251e67eb9ef9d8e96a1fe9ae9c620e3f8279d5aab79269bd4d2ce86c578185072822346dd118e9cd915b3a11ada0980e26b6b6c4547111be2152f7fdb
+  languageName: node
+  linkType: hard
+
+"@dual-bundle/import-meta-resolve@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@dual-bundle/import-meta-resolve@npm:4.1.0"
+  checksum: a69d804a8e8e93732ac5525f85b9366ae78ec60fa02f0d5b4f2d625e18b355ba02502cdaef616ab1eac4450b966d2a398b59577a17483e4f8a350d062357bdf4
   languageName: node
   linkType: hard
 
@@ -8443,7 +8461,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/minimist@npm:^1.2.0, @types/minimist@npm:^1.2.2":
+"@types/minimist@npm:^1.2.0":
   version: 1.2.5
   resolution: "@types/minimist@npm:1.2.5"
   checksum: 477047b606005058ab0263c4f58097136268007f320003c348794f74adedc3166ffc47c80ec3e94687787f2ab7f4e72c468223946e79892cf0fd9e25e9970a90
@@ -10845,18 +10863,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase-keys@npm:^7.0.0":
-  version: 7.0.2
-  resolution: "camelcase-keys@npm:7.0.2"
-  dependencies:
-    camelcase: "npm:^6.3.0"
-    map-obj: "npm:^4.1.0"
-    quick-lru: "npm:^5.1.1"
-    type-fest: "npm:^1.2.1"
-  checksum: 6f92d969b7fa97456ffc35fe93f0a42d0d0a00fbd94bfc6cac07c84da86e6acfb89fdf04151460d47c583d2dd38a3e9406f980efe9a3d2e143cdfe46a7343083
-  languageName: node
-  linkType: hard
-
 "camelcase@npm:^5.3.1":
   version: 5.3.1
   resolution: "camelcase@npm:5.3.1"
@@ -10864,7 +10870,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase@npm:^6.2.0, camelcase@npm:^6.3.0":
+"camelcase@npm:^6.2.0":
   version: 6.3.0
   resolution: "camelcase@npm:6.3.0"
   checksum: 8c96818a9076434998511251dcb2761a94817ea17dbdc37f47ac080bd088fc62c7369429a19e2178b993497132c8cbcf5cc1f44ba963e76782ba469c0474938d
@@ -11982,6 +11988,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cosmiconfig@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "cosmiconfig@npm:9.0.0"
+  dependencies:
+    env-paths: "npm:^2.2.1"
+    import-fresh: "npm:^3.3.0"
+    js-yaml: "npm:^4.1.0"
+    parse-json: "npm:^5.2.0"
+  peerDependencies:
+    typescript: ">=4.9.5"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 8bdf1dfbb6fdb3755195b6886dc0649a3c742ec75afa4cb8da7b070936aed22a4f4e5b7359faafe03180358f311dbc300d248fd6586c458203d376a40cc77826
+  languageName: node
+  linkType: hard
+
 "crc-32@npm:^1.2.0":
   version: 1.2.2
   resolution: "crc-32@npm:1.2.2"
@@ -12210,10 +12233,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-functions-list@npm:^3.2.1":
-  version: 3.2.2
-  resolution: "css-functions-list@npm:3.2.2"
-  checksum: b8a564118b93b87b63236a57132a3ef581416896a70c1d0df73360a9ec43dc582f7c2a586b578feb8476179518e557c6657570a8b6185b16300c7232a84d43e3
+"css-functions-list@npm:^3.2.3":
+  version: 3.2.3
+  resolution: "css-functions-list@npm:3.2.3"
+  checksum: 25f12fb0ef1384b1cf45a6e7e0afd596a19bee90b90316d9e50f7820888f4a8f265be7a6a96b10a5c81e403bd7a5ff8010fa936144f84959d9d91c9350cda0d4
   languageName: node
   linkType: hard
 
@@ -12260,6 +12283,16 @@ __metadata:
     mdn-data: "npm:2.0.30"
     source-map-js: "npm:^1.0.1"
   checksum: e5e39b82eb4767c664fa5c2cd9968c8c7e6b7fd2c0079b52680a28466d851e2826d5e64699c449d933c0e8ca0554beca43c41a9fcb09fb6a46139d462dbdf0df
+  languageName: node
+  linkType: hard
+
+"css-tree@npm:^3.0.0, css-tree@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "css-tree@npm:3.0.1"
+  dependencies:
+    mdn-data: "npm:2.12.1"
+    source-map-js: "npm:^1.0.1"
+  checksum: 877a77669739f94e57589c94c1ea8b7b105e373d4855e94375638b411e2913337a900120dc45c13511d0f7c339b73cecf8dc61ce28034984dbf75993dac756b0
   languageName: node
   linkType: hard
 
@@ -12545,6 +12578,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^4.3.7":
+  version: 4.3.7
+  resolution: "debug@npm:4.3.7"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 71168908b9a78227ab29d5d25fe03c5867750e31ce24bf2c44a86efc5af041758bb56569b0a3d48a9b5344c00a24a777e6f4100ed6dfd9534a42c1dde285125a
+  languageName: node
+  linkType: hard
+
 "decamelize-keys@npm:^1.1.0":
   version: 1.1.1
   resolution: "decamelize-keys@npm:1.1.1"
@@ -12559,13 +12604,6 @@ __metadata:
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
   checksum: ad8c51a7e7e0720c70ec2eeb1163b66da03e7616d7b98c9ef43cce2416395e84c1e9548dd94f5f6ffecfee9f8b94251fc57121a8b021f2ff2469b2bae247b8aa
-  languageName: node
-  linkType: hard
-
-"decamelize@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "decamelize@npm:5.0.1"
-  checksum: 643e88804c538a334fae303ae1da8b30193b81dad8689643b35e6ab8ab60a3b03492cab6096d8163bd41fd384d969485f0634c000f80af502aa7f4047258d5b4
   languageName: node
   linkType: hard
 
@@ -12953,7 +12991,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"doiuse@npm:^6.0.1":
+"doiuse@npm:^6.0.5":
   version: 6.0.5
   resolution: "doiuse@npm:6.0.5"
   dependencies:
@@ -13330,7 +13368,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"env-paths@npm:^2.2.0":
+"env-paths@npm:^2.2.0, env-paths@npm:^2.2.1":
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
   checksum: 65b5df55a8bab92229ab2b40dad3b387fad24613263d103a97f91c9fe43ceb21965cd3392b1ccb5d77088021e525c4e0481adb309625d0cb94ade1d1fb8dc17e
@@ -14702,7 +14740,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.0.3, fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.2, fast-glob@npm:^3.2.7, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.1, fast-glob@npm:^3.3.2":
+"fast-glob@npm:^3.0.3, fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.2, fast-glob@npm:^3.2.7, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.2":
   version: 3.3.2
   resolution: "fast-glob@npm:3.3.2"
   dependencies:
@@ -14840,21 +14878,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"file-entry-cache@npm:^7.0.0":
-  version: 7.0.2
-  resolution: "file-entry-cache@npm:7.0.2"
-  dependencies:
-    flat-cache: "npm:^3.2.0"
-  checksum: e03e99beb9809a5679699ebd7146f3b93870b57775705f4b61bda4a1d8454dfd261b48e770a601f6c36a4789b4c0750f262e4d5fb2c7eeceb75e16439b07211a
-  languageName: node
-  linkType: hard
-
 "file-entry-cache@npm:^8.0.0":
   version: 8.0.0
   resolution: "file-entry-cache@npm:8.0.0"
   dependencies:
     flat-cache: "npm:^4.0.0"
   checksum: afe55c4de4e0d226a23c1eae62a7219aafb390859122608a89fa4df6addf55c7fd3f1a2da6f5b41e7cdff496e4cf28bbd215d53eab5c817afa96d2b40c81bfb0
+  languageName: node
+  linkType: hard
+
+"file-entry-cache@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "file-entry-cache@npm:9.1.0"
+  dependencies:
+    flat-cache: "npm:^5.0.0"
+  checksum: fd67a9552f272ac4a1731c545e1350bd135e208659144cc5311baac6b8bbf55da7c8c3a0bf25c71ed78eff2bdd26d2a3a8f9ba3d8bec968fe8d1eeba6ab14a96
   languageName: node
   linkType: hard
 
@@ -14968,7 +15006,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flat-cache@npm:^3.0.4, flat-cache@npm:^3.2.0":
+"flat-cache@npm:^3.0.4":
   version: 3.2.0
   resolution: "flat-cache@npm:3.2.0"
   dependencies:
@@ -14986,6 +15024,16 @@ __metadata:
     flatted: "npm:^3.2.9"
     keyv: "npm:^4.5.4"
   checksum: 58ce851d9045fffc7871ce2bd718bc485ad7e777bf748c054904b87c351ff1080c2c11da00788d78738bfb51b71e4d5ea12d13b98eb36e3358851ffe495b62dc
+  languageName: node
+  linkType: hard
+
+"flat-cache@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "flat-cache@npm:5.0.0"
+  dependencies:
+    flatted: "npm:^3.3.1"
+    keyv: "npm:^4.5.4"
+  checksum: 42570762052b17a1dec221d73a1e417d0ba07137de6debaabb51389cac265a12a027a895dc84e1725bc5cdde04fe8b706ad836860b05488e9a04bda9301d2529
   languageName: node
   linkType: hard
 
@@ -16414,8 +16462,8 @@ __metadata:
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     rimraf: "npm:^5.0.5"
-    stylelint: "npm:^15.11.0"
-    stylelint-config-carbon: "npm:1.19.1"
+    stylelint: "npm:^16.10.0"
+    stylelint-config-carbon: "npm:^1.20.0"
     stylelint-plugin-carbon-tokens: "npm:2.8.0"
     webpack: "npm:^5.96.1"
   languageName: unknown
@@ -16493,6 +16541,13 @@ __metadata:
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
   checksum: cceb6a457000f8f6a50e1196429750d782afce5680dd878aa4221bd79972d68b3a55b4b1458fc682be978f4d3c6a249046aa0880637367216444ab7b014cfc98
+  languageName: node
+  linkType: hard
+
+"ignore@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "ignore@npm:6.0.2"
+  checksum: af39e49996cd989763920e445eff897d0ae1e36b5f27b0e09e14a4fd2df89b362f92e720ecf06ef729056842366527db8561d310e904718810b92ffbcd23056d
   languageName: node
   linkType: hard
 
@@ -16582,13 +16637,6 @@ __metadata:
   version: 4.0.0
   resolution: "indent-string@npm:4.0.0"
   checksum: cd3f5cbc9ca2d624c6a1f53f12e6b341659aba0e2d3254ae2b4464aaea8b4294cdb09616abbc59458f980531f2429784ed6a420d48d245bcad0811980c9efae9
-  languageName: node
-  linkType: hard
-
-"indent-string@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "indent-string@npm:5.0.0"
-  checksum: e466c27b6373440e6d84fbc19e750219ce25865cb82d578e41a6053d727e5520dc5725217d6eb1cc76005a1bb1696a0f106d84ce7ebda3033b963a38583fb3b3
   languageName: node
   linkType: hard
 
@@ -18418,10 +18466,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"known-css-properties@npm:^0.29.0":
-  version: 0.29.0
-  resolution: "known-css-properties@npm:0.29.0"
-  checksum: ab4e1d6bad10fe4ba15183e640dab8eec52aaa5a69899382de5843699f145e49c67e6a3ca5c8426ccd31577d3eec4459004ed317a550c3523b863a251280ddd4
+"known-css-properties@npm:^0.34.0":
+  version: 0.34.0
+  resolution: "known-css-properties@npm:0.34.0"
+  checksum: 0e93e83f84537e89b9dc56c16aff511ed9f24128fe509c3f601ce495eb10bf6678e2f4ff521f6b53feabc7bd18088e43efb31aae4cb771da831ef1408c23211a
+  languageName: node
+  linkType: hard
+
+"known-css-properties@npm:^0.35.0":
+  version: 0.35.0
+  resolution: "known-css-properties@npm:0.35.0"
+  checksum: a6f3f271a94913c72b29e59bd1e96836b0b5427c5dd9969f4673026cd39f7f441b5e8d0b704b0a830c43d745a5f7ca98d41d99961dc4c008ebf756545bada85c
   languageName: node
   linkType: hard
 
@@ -19328,7 +19383,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"map-obj@npm:^4.0.0, map-obj@npm:^4.1.0":
+"map-obj@npm:^4.0.0":
   version: 4.3.0
   resolution: "map-obj@npm:4.3.0"
   checksum: fbc554934d1a27a1910e842bc87b177b1a556609dd803747c85ece420692380827c6ae94a95cce4407c054fa0964be3bf8226f7f2cb2e9eeee432c7c1985684e
@@ -19532,6 +19587,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdn-data@npm:2.12.1":
+  version: 2.12.1
+  resolution: "mdn-data@npm:2.12.1"
+  checksum: 7928cfc828b0ebbde84ce56be2e3aa729c1770bfbc83ef1dadf5f98346ab003ca0a1b3339076115d77acf623719efa3f9f2be8c69f73c453fe887cb982bfa625
+  languageName: node
+  linkType: hard
+
+"mdn-data@npm:^2.12.2":
+  version: 2.12.2
+  resolution: "mdn-data@npm:2.12.2"
+  checksum: 854e41715a9358e69f9a530117cd6ca7e71d06176469de8d70b1e629753b6827f5bd730995c16ad3750f3c9bad92230f8e4e178de2b34926b05f5205d27d76af
+  languageName: node
+  linkType: hard
+
 "media-typer@npm:0.3.0":
   version: 0.3.0
   resolution: "media-typer@npm:0.3.0"
@@ -19572,30 +19641,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"meow@npm:^10.1.5":
-  version: 10.1.5
-  resolution: "meow@npm:10.1.5"
-  dependencies:
-    "@types/minimist": "npm:^1.2.2"
-    camelcase-keys: "npm:^7.0.0"
-    decamelize: "npm:^5.0.0"
-    decamelize-keys: "npm:^1.1.0"
-    hard-rejection: "npm:^2.1.0"
-    minimist-options: "npm:4.1.0"
-    normalize-package-data: "npm:^3.0.2"
-    read-pkg-up: "npm:^8.0.0"
-    redent: "npm:^4.0.0"
-    trim-newlines: "npm:^4.0.2"
-    type-fest: "npm:^1.2.2"
-    yargs-parser: "npm:^20.2.9"
-  checksum: 4d6d4c233b9405bace4fd6c60db0b5806d7186a047852ddce0748e56a57c75d4fef3ab2603a480bd74595e4e8e3a47b932d737397a62e043da1d3187f1240ff4
-  languageName: node
-  linkType: hard
-
 "meow@npm:^12.0.1":
   version: 12.1.1
   resolution: "meow@npm:12.1.1"
   checksum: 8594c319f4671a562c1fef584422902f1bbbad09ea49cdf9bb26dc92f730fa33398dd28a8cf34fcf14167f1d1148d05a867e50911fc4286751a4fb662fdd2dc2
+  languageName: node
+  linkType: hard
+
+"meow@npm:^13.2.0":
+  version: 13.2.0
+  resolution: "meow@npm:13.2.0"
+  checksum: 4eff5bc921fed0b8a471ad79069d741a0210036d717547d0c7f36fdaf84ef7a3036225f38b6a53830d84dc9cbf8b944b097fde62381b8b5b215119e735ce1063
   languageName: node
   linkType: hard
 
@@ -20353,7 +20409,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:2.1.3, ms@npm:^2.0.0, ms@npm:^2.1.1":
+"ms@npm:2.1.3, ms@npm:^2.0.0, ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
@@ -20677,7 +20733,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-package-data@npm:^3.0.0, normalize-package-data@npm:^3.0.2, normalize-package-data@npm:^3.0.3":
+"normalize-package-data@npm:^3.0.0, normalize-package-data@npm:^3.0.3":
   version: 3.0.3
   resolution: "normalize-package-data@npm:3.0.3"
   dependencies:
@@ -22579,19 +22635,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-resolve-nested-selector@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "postcss-resolve-nested-selector@npm:0.1.1"
-  checksum: b08fb76ab092a09ee01328bad620a01dcb445ac5eb02dd0ed9ed75217c2f779ecb3bf99a361c46e695689309c08c09f1a1ad7354c8d58c2c2c40d364657fcb08
+"postcss-resolve-nested-selector@npm:^0.1.6":
+  version: 0.1.6
+  resolution: "postcss-resolve-nested-selector@npm:0.1.6"
+  checksum: 85453901afe2a4db497b4e0d2c9cf2a097a08fa5d45bc646547025176217050334e423475519a1e6c74a1f31ade819d16bb37a39914e5321e250695ee3feea14
   languageName: node
   linkType: hard
 
-"postcss-safe-parser@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "postcss-safe-parser@npm:6.0.0"
+"postcss-safe-parser@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "postcss-safe-parser@npm:7.0.1"
   peerDependencies:
-    postcss: ^8.3.3
-  checksum: 06c733eaad83a3954367e7ee02ddfe3796e7a44d4299ccf9239f40964a4daac153c7d77613f32964b5a86c0c6c2f6167738f31d578b73b17cb69d0c4446f0ebe
+    postcss: ^8.4.31
+  checksum: 285f30877f3ef5d43586432394ef4fcab904cd5bcfff5c26f586eb630fbee490abf2ac6d81e64fa212fb64d03630d12c2f3c5196f5637bec5ba3d043562ddf30
   languageName: node
   linkType: hard
 
@@ -22604,7 +22660,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-selector-parser@npm:^6.0.11, postcss-selector-parser@npm:^6.1.2":
+"postcss-selector-parser@npm:^6.1.2":
   version: 6.1.2
   resolution: "postcss-selector-parser@npm:6.1.2"
   dependencies:
@@ -22614,13 +22670,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-selector-parser@npm:^6.0.13":
-  version: 6.0.16
-  resolution: "postcss-selector-parser@npm:6.0.16"
+"postcss-selector-parser@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "postcss-selector-parser@npm:7.0.0"
   dependencies:
     cssesc: "npm:^3.0.0"
     util-deprecate: "npm:^1.0.2"
-  checksum: 9324f63992c6564d392f9f6b16c56c05f157256e3be2d55d1234f7728252257dfd6b870a65a5d04ee3ceb9d9e7b78c043f630a58c9869b4b0481d6e064edc2cf
+  checksum: 0e92be7281e2b440a8be8cf207de40a24ca7bc765577916499614d5a47827a3e658206728cc559db96803e554270516104aad919a04f91bfa8914ccef1ba14ca
   languageName: node
   linkType: hard
 
@@ -22663,7 +22719,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.16, postcss@npm:^8.4.28, postcss@npm:^8.4.32, postcss@npm:^8.4.33":
+"postcss@npm:^8.4.16, postcss@npm:^8.4.32, postcss@npm:^8.4.33":
   version: 8.4.38
   resolution: "postcss@npm:8.4.38"
   dependencies:
@@ -23392,17 +23448,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read-pkg-up@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "read-pkg-up@npm:8.0.0"
-  dependencies:
-    find-up: "npm:^5.0.0"
-    read-pkg: "npm:^6.0.0"
-    type-fest: "npm:^1.0.1"
-  checksum: fe4c80401656b40b408884457fffb5a8015c03b1018cfd8e48f8d82a5e9023e24963603aeb2755608d964593e046c15b34d29b07d35af9c7aa478be81805209c
-  languageName: node
-  linkType: hard
-
 "read-pkg@npm:^3.0.0":
   version: 3.0.0
   resolution: "read-pkg@npm:3.0.0"
@@ -23423,18 +23468,6 @@ __metadata:
     parse-json: "npm:^5.0.0"
     type-fest: "npm:^0.6.0"
   checksum: eb696e60528b29aebe10e499ba93f44991908c57d70f2d26f369e46b8b9afc208ef11b4ba64f67630f31df8b6872129e0a8933c8c53b7b4daf0eace536901222
-  languageName: node
-  linkType: hard
-
-"read-pkg@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "read-pkg@npm:6.0.0"
-  dependencies:
-    "@types/normalize-package-data": "npm:^2.4.0"
-    normalize-package-data: "npm:^3.0.2"
-    parse-json: "npm:^5.2.0"
-    type-fest: "npm:^1.0.1"
-  checksum: 0cebdff381128e923815c643074a87011070e5fc352bee575d327d6485da3317fab6d802a7b03deeb0be7be8d3ad1640397b3d5d2f044452caf4e8d1736bf94f
   languageName: node
   linkType: hard
 
@@ -23560,16 +23593,6 @@ __metadata:
     indent-string: "npm:^4.0.0"
     strip-indent: "npm:^3.0.0"
   checksum: fa1ef20404a2d399235e83cc80bd55a956642e37dd197b4b612ba7327bf87fa32745aeb4a1634b2bab25467164ab4ed9c15be2c307923dd08b0fe7c52431ae6b
-  languageName: node
-  linkType: hard
-
-"redent@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "redent@npm:4.0.0"
-  dependencies:
-    indent-string: "npm:^5.0.0"
-    strip-indent: "npm:^4.0.0"
-  checksum: 6944e7b1d8f3fd28c2515f5c605b9f7f0ea0f4edddf41890bbbdd4d9ee35abb7540c3b278f03ff827bd278bb6ff4a5bd8692ca406b748c5c1c3ce7355e9fbf8f
   languageName: node
   linkType: hard
 
@@ -25324,13 +25347,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"style-search@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "style-search@npm:0.1.0"
-  checksum: 841049768c863737389558fafffa0b765f553bde041b7997c4cd54606b64b0d139936e2efee74dc1ce59fcde78aaa88484d9894838c31d5c98c1ccace312a59b
-  languageName: node
-  linkType: hard
-
 "style-value-types@npm:5.0.0":
   version: 5.0.0
   resolution: "style-value-types@npm:5.0.0"
@@ -25353,32 +25369,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylelint-a11y@npm:^1.2.3":
-  version: 1.2.3
-  resolution: "stylelint-a11y@npm:1.2.3"
-  peerDependencies:
-    stylelint: ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0
-  checksum: 97f0fd3e2ed79746a80b5b96037ddc6de16f25d5d3cfcecea0db054603336cafa0f52ab0027e1621e9ecb35aa5ee5217c273eec25e335901a82a96691537cc2d
-  languageName: node
-  linkType: hard
-
-"stylelint-config-carbon@npm:1.19.1":
-  version: 1.19.1
-  resolution: "stylelint-config-carbon@npm:1.19.1"
+"stylelint-config-carbon@npm:^1.20.0":
+  version: 1.20.0
+  resolution: "stylelint-config-carbon@npm:1.20.0"
   dependencies:
-    stylelint-a11y: "npm:^1.2.3"
+    "@double-great/stylelint-a11y": "npm:^3.0.2"
     stylelint-config-idiomatic-order: "npm:^10.0.0"
     stylelint-config-prettier: "npm:^9.0.3"
-    stylelint-config-standard: "npm:^34.0.0"
-    stylelint-config-standard-scss: "npm:^11.0.0"
-    stylelint-no-unsupported-browser-features: "npm:^7.0.0"
+    stylelint-config-standard: "npm:^36.0.0"
+    stylelint-config-standard-scss: "npm:^13.1.0"
+    stylelint-no-unsupported-browser-features: "npm:^8.0.1"
     stylelint-order: "npm:^6.0.0"
-    stylelint-prettier: "npm:^2.0.0"
-    stylelint-scss: "npm:^4.1.0"
+    stylelint-prettier: "npm:^5.0.0"
+    stylelint-scss: "npm:^6.2.1"
     stylelint-use-logical: "npm:^2.1.0"
   peerDependencies:
-    stylelint: ^15.0.0
-  checksum: 923a37ace652c98f34d806f9a49fac3b4c660a6cfac5aa274bdf07b6abfb735cf8549ff068b49accf7a9aebc15aff1efb4ce4293393e31174b89e255d47ef7fb
+    stylelint: ^16.0.0
+  checksum: d66020246b27e85cb8f411dc008364991e5efe4487c44317f33380c5f2f0ede571fdcf3ab54a4a77d030658d7240315aff9899125ff2e3dd8bf56dd3ba0ea977
   languageName: node
   linkType: hard
 
@@ -25405,69 +25412,68 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylelint-config-recommended-scss@npm:^13.1.0":
-  version: 13.1.0
-  resolution: "stylelint-config-recommended-scss@npm:13.1.0"
+"stylelint-config-recommended-scss@npm:^14.0.0":
+  version: 14.1.0
+  resolution: "stylelint-config-recommended-scss@npm:14.1.0"
   dependencies:
     postcss-scss: "npm:^4.0.9"
-    stylelint-config-recommended: "npm:^13.0.0"
-    stylelint-scss: "npm:^5.3.0"
+    stylelint-config-recommended: "npm:^14.0.1"
+    stylelint-scss: "npm:^6.4.0"
   peerDependencies:
     postcss: ^8.3.3
-    stylelint: ^15.10.0
+    stylelint: ^16.6.1
   peerDependenciesMeta:
     postcss:
       optional: true
-  checksum: 249cc4705759f779da2be797b2155b05b6d0ce49542b5144634d46295955c32b22734468529c772ba0a926fdf3bd3b0583088a74a0790cfc5e354d09b1f9a8c7
+  checksum: 4dbebd9883e94eea9a6c7e1dc6978f385c4631e88a7014f41b14e2d8a5e52db6b4ac0015b41c75e8031e53c227a381b252a92ed48e6f2296c28d90fbb185f6eb
   languageName: node
   linkType: hard
 
-"stylelint-config-recommended@npm:^13.0.0":
-  version: 13.0.0
-  resolution: "stylelint-config-recommended@npm:13.0.0"
+"stylelint-config-recommended@npm:^14.0.1":
+  version: 14.0.1
+  resolution: "stylelint-config-recommended@npm:14.0.1"
   peerDependencies:
-    stylelint: ^15.10.0
-  checksum: a56eb6d1a7c7f3a7a172b54bc34218859ba22a5a06816fb4d0964f66cb83cf372062f2c97830e994ad68243548e15fc49abf28887c3261ab1b471b3aa69f8e82
+    stylelint: ^16.1.0
+  checksum: 93c3fe920902abfd3f4130173876bb633230c910a3b293f5b74a0ea9c4427d197d7ade28dd62718246264f22f1e012899d0160a0176da723d14680d73876d701
   languageName: node
   linkType: hard
 
-"stylelint-config-standard-scss@npm:^11.0.0":
-  version: 11.1.0
-  resolution: "stylelint-config-standard-scss@npm:11.1.0"
+"stylelint-config-standard-scss@npm:^13.1.0":
+  version: 13.1.0
+  resolution: "stylelint-config-standard-scss@npm:13.1.0"
   dependencies:
-    stylelint-config-recommended-scss: "npm:^13.1.0"
-    stylelint-config-standard: "npm:^34.0.0"
+    stylelint-config-recommended-scss: "npm:^14.0.0"
+    stylelint-config-standard: "npm:^36.0.0"
   peerDependencies:
     postcss: ^8.3.3
-    stylelint: ^15.10.0
+    stylelint: ^16.3.1
   peerDependenciesMeta:
     postcss:
       optional: true
-  checksum: fdeb533e19230cec6975f18a5ef97252968b4387f385508c7157d8bef42fe75eb9888ff6ce97c8d6fd985fc7d7d28c897732cd3c3285907cb18a9bf8df91a6d2
+  checksum: c5105e3b3390c9d0aa95e252abdf1850fa50d82e1a25a1fcc11a88b111038e00c8033a4b34905405f2203c84c0fa26ce1d40248df2172c83c76cc3baa552db07
   languageName: node
   linkType: hard
 
-"stylelint-config-standard@npm:^34.0.0":
-  version: 34.0.0
-  resolution: "stylelint-config-standard@npm:34.0.0"
+"stylelint-config-standard@npm:^36.0.0":
+  version: 36.0.1
+  resolution: "stylelint-config-standard@npm:36.0.1"
   dependencies:
-    stylelint-config-recommended: "npm:^13.0.0"
+    stylelint-config-recommended: "npm:^14.0.1"
   peerDependencies:
-    stylelint: ^15.10.0
-  checksum: 536249800c04b48a9c354067765f042713982e8222be17bb897a27d26546e50adfb87e6f1e4541807d720de3554345da99ab470e13e8d7ab0ab326c73ae3df61
+    stylelint: ^16.1.0
+  checksum: 50b8fb396f1cb8cb3539aa97187eb8c2a4b2858c897374faa726837a809dae7c686cb5dc32528c9698745d4e97af1fe9035a04a5a8cb220bd6b1530795437013
   languageName: node
   linkType: hard
 
-"stylelint-no-unsupported-browser-features@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "stylelint-no-unsupported-browser-features@npm:7.0.0"
+"stylelint-no-unsupported-browser-features@npm:^8.0.1":
+  version: 8.0.2
+  resolution: "stylelint-no-unsupported-browser-features@npm:8.0.2"
   dependencies:
-    doiuse: "npm:^6.0.1"
-    lodash: "npm:^4.17.15"
-    postcss: "npm:^8.4.16"
+    doiuse: "npm:^6.0.5"
+    postcss: "npm:^8.4.32"
   peerDependencies:
-    stylelint: ^14.0.0||^15.0.0
-  checksum: cb6ba284988a0c5fcc49b8ed66f164a95ef34e3ddc6302baf4b6bd37ea8b3421ce781fe13455beb31f2a12279c0f0c62a5c3ec2c6324c53a2a1ee643962e6976
+    stylelint: ^16.0.2
+  checksum: e11a657a52dae7383fbc561401e4cb93d949096af7a41f40ea1d3627a0abc6b178caa8cdf9fe6f7dd412ab528d6b30817fc29b9aa721129f125816fbf45c4e50
   languageName: node
   linkType: hard
 
@@ -25502,44 +25508,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylelint-prettier@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "stylelint-prettier@npm:2.0.0"
+"stylelint-prettier@npm:^5.0.0":
+  version: 5.0.2
+  resolution: "stylelint-prettier@npm:5.0.2"
   dependencies:
     prettier-linter-helpers: "npm:^1.0.0"
   peerDependencies:
-    prettier: ">=2.0.0"
-    stylelint: ">=14.0.0"
-  checksum: 1366d7efaa11b60421ff4953df1f675fa204b960e663621707cc4e2c2306a21f46326c447158c93c96ba2fcb18a4323bf08197ca781ab81dda03eb9da9ef0d2e
+    prettier: ">=3.0.0"
+    stylelint: ">=16.0.0"
+  checksum: bee52ac6bfd03bfec07a429556d05e1cc754be9f0cf6802e19f06410d7d4cf6b2a01ca987f5e6f7816d8c88a0e73d04aa5b04be43fd121a9f805a9ab079a3719
   languageName: node
   linkType: hard
 
-"stylelint-scss@npm:^4.1.0":
-  version: 4.7.0
-  resolution: "stylelint-scss@npm:4.7.0"
+"stylelint-scss@npm:^6.2.1, stylelint-scss@npm:^6.4.0":
+  version: 6.10.0
+  resolution: "stylelint-scss@npm:6.10.0"
   dependencies:
+    css-tree: "npm:^3.0.1"
+    is-plain-object: "npm:^5.0.0"
+    known-css-properties: "npm:^0.35.0"
+    mdn-data: "npm:^2.12.2"
     postcss-media-query-parser: "npm:^0.2.3"
-    postcss-resolve-nested-selector: "npm:^0.1.1"
-    postcss-selector-parser: "npm:^6.0.11"
+    postcss-resolve-nested-selector: "npm:^0.1.6"
+    postcss-selector-parser: "npm:^7.0.0"
     postcss-value-parser: "npm:^4.2.0"
   peerDependencies:
-    stylelint: ^14.5.1 || ^15.0.0
-  checksum: 6a49f1f19339c812adc1fc89bb30d0a79ab1a88082f8d18b9403893f06e4f646131d9d4f2788a2fe2847fe38ff6cf505de8a3f6358665e022f91903c7453f4c4
-  languageName: node
-  linkType: hard
-
-"stylelint-scss@npm:^5.3.0":
-  version: 5.3.2
-  resolution: "stylelint-scss@npm:5.3.2"
-  dependencies:
-    known-css-properties: "npm:^0.29.0"
-    postcss-media-query-parser: "npm:^0.2.3"
-    postcss-resolve-nested-selector: "npm:^0.1.1"
-    postcss-selector-parser: "npm:^6.0.13"
-    postcss-value-parser: "npm:^4.2.0"
-  peerDependencies:
-    stylelint: ^14.5.1 || ^15.0.0
-  checksum: 1b8406bdb37dd00c81e1229d2c0153f88091ce98c31c1a2a5f453329ce9421f79bb18a94f1e65b39095e0ea3693480705fb5bbc5edd565afc396365018473c3a
+    stylelint: ^16.0.2
+  checksum: 16ce7aadf2eb95a47f6d8cf6fef28bdf65ecff5977a6e702b16709340a1ef4108ab90708ef0d63062e1386ff04d682b83599e7841291e15279035e4c65724767
   languageName: node
   linkType: hard
 
@@ -25552,53 +25547,51 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylelint@npm:^15.11.0":
-  version: 15.11.0
-  resolution: "stylelint@npm:15.11.0"
+"stylelint@npm:^16.10.0":
+  version: 16.10.0
+  resolution: "stylelint@npm:16.10.0"
   dependencies:
-    "@csstools/css-parser-algorithms": "npm:^2.3.1"
-    "@csstools/css-tokenizer": "npm:^2.2.0"
-    "@csstools/media-query-list-parser": "npm:^2.1.4"
-    "@csstools/selector-specificity": "npm:^3.0.0"
+    "@csstools/css-parser-algorithms": "npm:^3.0.1"
+    "@csstools/css-tokenizer": "npm:^3.0.1"
+    "@csstools/media-query-list-parser": "npm:^3.0.1"
+    "@csstools/selector-specificity": "npm:^4.0.0"
+    "@dual-bundle/import-meta-resolve": "npm:^4.1.0"
     balanced-match: "npm:^2.0.0"
     colord: "npm:^2.9.3"
-    cosmiconfig: "npm:^8.2.0"
-    css-functions-list: "npm:^3.2.1"
-    css-tree: "npm:^2.3.1"
-    debug: "npm:^4.3.4"
-    fast-glob: "npm:^3.3.1"
+    cosmiconfig: "npm:^9.0.0"
+    css-functions-list: "npm:^3.2.3"
+    css-tree: "npm:^3.0.0"
+    debug: "npm:^4.3.7"
+    fast-glob: "npm:^3.3.2"
     fastest-levenshtein: "npm:^1.0.16"
-    file-entry-cache: "npm:^7.0.0"
+    file-entry-cache: "npm:^9.1.0"
     global-modules: "npm:^2.0.0"
     globby: "npm:^11.1.0"
     globjoin: "npm:^0.1.4"
     html-tags: "npm:^3.3.1"
-    ignore: "npm:^5.2.4"
-    import-lazy: "npm:^4.0.0"
+    ignore: "npm:^6.0.2"
     imurmurhash: "npm:^0.1.4"
     is-plain-object: "npm:^5.0.0"
-    known-css-properties: "npm:^0.29.0"
+    known-css-properties: "npm:^0.34.0"
     mathml-tag-names: "npm:^2.1.3"
-    meow: "npm:^10.1.5"
-    micromatch: "npm:^4.0.5"
+    meow: "npm:^13.2.0"
+    micromatch: "npm:^4.0.8"
     normalize-path: "npm:^3.0.0"
-    picocolors: "npm:^1.0.0"
-    postcss: "npm:^8.4.28"
-    postcss-resolve-nested-selector: "npm:^0.1.1"
-    postcss-safe-parser: "npm:^6.0.0"
-    postcss-selector-parser: "npm:^6.0.13"
+    picocolors: "npm:^1.0.1"
+    postcss: "npm:^8.4.47"
+    postcss-resolve-nested-selector: "npm:^0.1.6"
+    postcss-safe-parser: "npm:^7.0.1"
+    postcss-selector-parser: "npm:^6.1.2"
     postcss-value-parser: "npm:^4.2.0"
     resolve-from: "npm:^5.0.0"
     string-width: "npm:^4.2.3"
-    strip-ansi: "npm:^6.0.1"
-    style-search: "npm:^0.1.0"
-    supports-hyperlinks: "npm:^3.0.0"
+    supports-hyperlinks: "npm:^3.1.0"
     svg-tags: "npm:^1.0.0"
-    table: "npm:^6.8.1"
+    table: "npm:^6.8.2"
     write-file-atomic: "npm:^5.0.1"
   bin:
     stylelint: bin/stylelint.mjs
-  checksum: 34b9242b8a009642f8a9a50319c9a6c94b745a8605890df99830fc4d4847031e59719e68df12eed897fd486724fbfb1d240a8f267bb8b4440152a4dbfc3765f5
+  checksum: 2bc1627e2681414d9c61a96e8298ca7697ce8bc78bb9ffe1c3e370e064ca81cd4d131493a3f315334195b1f039ff99ea0c900e264ca4516c93ee5c36d2e4490d
   languageName: node
   linkType: hard
 
@@ -25629,13 +25622,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-hyperlinks@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "supports-hyperlinks@npm:3.0.0"
+"supports-hyperlinks@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "supports-hyperlinks@npm:3.1.0"
   dependencies:
     has-flag: "npm:^4.0.0"
     supports-color: "npm:^7.0.0"
-  checksum: 911075a412d8bcfbbca413e8963d56ed0975e35ff98d599ef85301aed4221428653145263828b6c58cb4cb6ff24596be83ead3cca221a88a70428af93d5e2a73
+  checksum: e893fb035ecd86e42c5225dc1cd24db56eb950ed77b2e8f59c7aaf2836b8b2ef276ffd11f0df88b0b12184832aa2333f875eefcb74d3c47ed2633b6b41d4be43
   languageName: node
   linkType: hard
 
@@ -25701,7 +25694,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"table@npm:^6.8.1":
+"table@npm:^6.8.2":
   version: 6.8.2
   resolution: "table@npm:6.8.2"
   dependencies:
@@ -26110,13 +26103,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"trim-newlines@npm:^4.0.2":
-  version: 4.1.1
-  resolution: "trim-newlines@npm:4.1.1"
-  checksum: 5b09f8e329e8f33c1111ef26906332ba7ba7248cde3e26fc054bb3d69f2858bf5feedca9559c572ff91f33e52977c28e0d41c387df6a02a633cbb8c2d8238627
-  languageName: node
-  linkType: hard
-
 "trough@npm:^2.0.0":
   version: 2.2.0
   resolution: "trough@npm:2.2.0"
@@ -26305,7 +26291,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^1.0.1, type-fest@npm:^1.2.1, type-fest@npm:^1.2.2":
+"type-fest@npm:^1.0.1":
   version: 1.4.0
   resolution: "type-fest@npm:1.4.0"
   checksum: 89875c247564601c2650bacad5ff80b859007fbdb6c9e43713ae3ffa3f584552eea60f33711dd762e16496a1ab4debd409822627be14097d9a17e39c49db591a
@@ -27808,7 +27794,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^20.2.2, yargs-parser@npm:^20.2.3, yargs-parser@npm:^20.2.9":
+"yargs-parser@npm:^20.2.2, yargs-parser@npm:^20.2.3":
   version: 20.2.9
   resolution: "yargs-parser@npm:20.2.9"
   checksum: 0188f430a0f496551d09df6719a9132a3469e47fe2747208b1dd0ab2bb0c512a95d0b081628bbca5400fb20dbf2fabe63d22badb346cecadffdd948b049f3fcc


### PR DESCRIPTION
Closes #6424 

upgrades `stylelint` from `v15.11` to `v16.10` and `stylelint-config-carbon` from `v1.19.1` to `v1.20.0`

this PR also does some additional cleanup by removing unnecessary `stylelint-disable` comments
