### PR TITLE
test(Tagset): add avt tests for complex states

### DIFF
--- a/e2e/components/TagSet/TagSet-test.avt.e2e.js
+++ b/e2e/components/TagSet/TagSet-test.avt.e2e.js
@@ -164,24 +164,24 @@ test.describe('TagSet @avt', () => {
     });
     const modalElement = page.locator(`.${carbon.prefix}--modal.is-visible`);
 
-    simulateKeyPress(page, 'Tab');
+    await simulateKeyPress(page, 'Tab');
 
     await expect(
       page.getByRole('button', { name: 'Dismiss' }).first()
     ).toBeFocused();
-    simulateKeyPress(page, 'Tab', 6);
+    await simulateKeyPress(page, 'Tab', 6);
 
     const moreTagsButton = page.locator(
       `.${pkg.prefix}--tag-set-overflow__popover-trigger`
     );
     await expect(moreTagsButton).toBeFocused();
-    simulateKeyPress(page, 'Enter');
+    await simulateKeyPress(page, 'Enter');
 
     await expect(
       page.locator(`.${carbon.prefix}--popover--open`)
     ).toBeVisible();
 
-    simulateKeyPress(page, 'Tab');
+    await simulateKeyPress(page, 'Tab');
     //first tag inside popover is focussed
     await expect(
       page
@@ -190,13 +190,13 @@ test.describe('TagSet @avt', () => {
         .first()
     ).toBeFocused();
 
-    simulateKeyPress(page, 'Tab', 10);
+    await simulateKeyPress(page, 'Tab', 10);
 
     await expect(
       page.locator(`.${pkg.prefix}--tag-set-overflow__show-all-tags-link`)
     ).toBeFocused(); //view all tags modal link is focussed
 
-    simulateKeyPress(page, 'Enter');
+    await simulateKeyPress(page, 'Enter');
 
     await modalElement.evaluate((element) =>
       Promise.all(
@@ -205,9 +205,9 @@ test.describe('TagSet @avt', () => {
     );
 
     await expect(page.getByRole('heading', { name: 'All tags' })).toBeVisible();
-    simulateKeyPress(page, 'Tab');
+    await simulateKeyPress(page, 'Tab');
 
-    simulateKeyPress(page, 'Enter');
+    await simulateKeyPress(page, 'Enter');
     await expect(page.locator(`.${carbon.prefix}--modal`)).toBeHidden();
   });
 });

--- a/e2e/components/TagSet/TagSet-test.avt.e2e.js
+++ b/e2e/components/TagSet/TagSet-test.avt.e2e.js
@@ -9,6 +9,7 @@
 
 import { expect, test } from '@playwright/test';
 import { visitStory } from '../../test-utils/storybook';
+import { carbon, pkg } from '../../../packages/ibm-products/src/settings';
 
 test.describe('TagSet @avt', () => {
   test('@avt-default-state', async ({ page }) => {
@@ -21,4 +22,193 @@ test.describe('TagSet @avt', () => {
     });
     await expect(page).toHaveNoACViolations('TagSet @avt-default-state');
   });
+  test('@avt-many-tags', async ({ page }) => {
+    await visitStory(page, {
+      component: 'TagSet',
+      id: 'ibm-products-components-tag-set-tagset--many-tags',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('TagSet @avt-many-tags');
+  });
+  test('@avt-multiline-tags', async ({ page }) => {
+    await visitStory(page, {
+      component: 'TagSet',
+      id: 'ibm-products-components-tag-set-tagset--multiline-tags',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('TagSet @avt-multiline-tags');
+  });
+  test('@avt-hundreds-of-tags', async ({ page }) => {
+    await visitStory(page, {
+      component: 'TagSet',
+      id: 'ibm-products-components-tag-set-tagset--hundreds-of-tags',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('TagSet @avt-hundreds-of-tags');
+  });
+  test('@avt-with-close', async ({ page }) => {
+    await visitStory(page, {
+      component: 'TagSet',
+      id: 'ibm-products-components-tag-set-tagset--with-close',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('TagSet @avt-with-close');
+  });
+  test('@avt-with-close-and-overflow-tags', async ({ page }) => {
+    await visitStory(page, {
+      component: 'TagSet',
+      id: 'ibm-products-components-tag-set-tagset--with-close-and-overflow-tags',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations(
+      'TagSet @avt-with-close-and-overflow-tags'
+    );
+  });
+
+  //open close popover
+  test('@avt-open-and-close-tags', async ({ page }) => {
+    await visitStory(page, {
+      component: 'TagSet',
+      id: 'ibm-products-components-tag-set-tagset--many-tags',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    const moreTagsButton = page.locator(
+      `.${pkg.prefix}--tag-set-overflow__popover-trigger`
+    );
+
+    moreTagsButton.click();
+    await expect(
+      page.locator(`.${carbon.prefix}--popover--open`)
+    ).toBeVisible();
+
+    moreTagsButton.click();
+    await expect(page.locator(`.${carbon.prefix}--popover--open`)).toBeHidden();
+  });
+
+  //open close popover
+  test('@avt-open-and-close-all-tags-modal', async ({ page }) => {
+    await visitStory(page, {
+      component: 'TagSet',
+      id: 'ibm-products-components-tag-set-tagset--many-tags',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    const moreTagsButton = page.locator(
+      `.${pkg.prefix}--tag-set-overflow__popover-trigger`
+    );
+    const modalElement = page.locator(`.${carbon.prefix}--modal.is-visible`);
+
+    moreTagsButton.click();
+
+    await page
+      .locator(`.${pkg.prefix}--tag-set-overflow__show-all-tags-link`)
+      .click();
+
+    await modalElement.evaluate((element) =>
+      Promise.all(
+        element.getAnimations().map((animation) => animation.finished)
+      )
+    );
+
+    await expect(page.getByRole('heading', { name: 'All tags' })).toBeVisible();
+
+    //checking search funtionality
+    await expect(page.getByRole('searchbox')).toBeFocused();
+    await expect(modalElement.getByText('Two')).toBeVisible();
+    await page.getByRole('searchbox').fill('One');
+    await expect(modalElement.getByText('Two')).toBeHidden();
+
+    await page.getByRole('button', { name: 'Close' }).click();
+    await expect(page.locator(`.${carbon.prefix}--modal`)).toBeHidden();
+  });
+
+  test('@avt-close-tags', async ({ page }) => {
+    await visitStory(page, {
+      component: 'TagSet',
+      id: 'ibm-products-components-tag-set-tagset--with-close-and-overflow-tags',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+
+    await expect(
+      page.locator('.dev-prefix--c4p--tag-set__displayed-tag').getByText('One')
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Dismiss' }).first().click();
+    await expect(
+      page.locator('.dev-prefix--c4p--tag-set__displayed-tag').getByText('One')
+    ).toBeHidden();
+  });
+
+  test('@avt-keyboard', async ({ page }) => {
+    await visitStory(page, {
+      component: 'TagSet',
+      id: 'ibm-products-components-tag-set-tagset--with-close-and-overflow-tags',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    const modalElement = page.locator(`.${carbon.prefix}--modal.is-visible`);
+
+    await page.keyboard.press('Tab');
+    await expect(
+      page.getByRole('button', { name: 'Dismiss' }).first()
+    ).toBeFocused();
+    pressTabKey(page, 6);
+
+    const moreTagsButton = page.locator(
+      `.${pkg.prefix}--tag-set-overflow__popover-trigger`
+    );
+    await expect(moreTagsButton).toBeFocused();
+    await page.keyboard.press('Enter');
+
+    await expect(
+      page.locator(`.${carbon.prefix}--popover--open`)
+    ).toBeVisible();
+
+    pressTabKey(page, 1); //first tag inside popover is focussed
+    await expect(
+      page
+        .locator(`.${pkg.prefix}--tag-set-overflow__tag-list`)
+        .getByRole('button', { name: 'Dismiss' })
+        .first()
+    ).toBeFocused();
+
+    pressTabKey(page, 10);
+
+    await expect(
+      page.locator(`.${pkg.prefix}--tag-set-overflow__show-all-tags-link`)
+    ).toBeFocused(); //view all tags modal link is focussed
+
+    await page.keyboard.press('Enter');
+
+    await modalElement.evaluate((element) =>
+      Promise.all(
+        element.getAnimations().map((animation) => animation.finished)
+      )
+    );
+
+    await expect(page.getByRole('heading', { name: 'All tags' })).toBeVisible();
+    pressTabKey(page, 1);
+    await page.keyboard.press('Enter');
+    await expect(page.locator(`.${carbon.prefix}--modal`)).toBeHidden();
+  });
 });
+async function pressTabKey(page, number) {
+  for (let i = 0; i < number; i++) {
+    await page.keyboard.press('Tab');
+  }
+}

--- a/e2e/components/TagSet/TagSet-test.avt.e2e.js
+++ b/e2e/components/TagSet/TagSet-test.avt.e2e.js
@@ -145,15 +145,11 @@ test.describe('TagSet @avt', () => {
     });
 
     await expect(
-      page
-        .locator(`.${pkg.prefix}--c4p--tag-set__displayed-tag`)
-        .getByText('One')
+      page.locator(`.${pkg.prefix}--tag-set__displayed-tag`).getByText('One')
     ).toBeVisible();
     await page.getByRole('button', { name: 'Dismiss' }).first().click();
     await expect(
-      page
-        .locator(`.${pkg.prefix}--c4p--tag-set__displayed-tag`)
-        .getByText('One')
+      page.locator(`.${pkg.prefix}--tag-set__displayed-tag`).getByText('One')
     ).toBeHidden();
   });
 

--- a/e2e/components/TagSet/TagSet-test.avt.e2e.js
+++ b/e2e/components/TagSet/TagSet-test.avt.e2e.js
@@ -10,6 +10,7 @@
 import { expect, test } from '@playwright/test';
 import { visitStory } from '../../test-utils/storybook';
 import { carbon, pkg } from '../../../packages/ibm-products/src/settings';
+import { simulateKeyPress } from '../../test-utils/simulateKeyPress';
 
 test.describe('TagSet @avt', () => {
   test('@avt-default-state', async ({ page }) => {
@@ -163,23 +164,25 @@ test.describe('TagSet @avt', () => {
     });
     const modalElement = page.locator(`.${carbon.prefix}--modal.is-visible`);
 
-    await page.keyboard.press('Tab');
+    simulateKeyPress(page, 'Tab');
+
     await expect(
       page.getByRole('button', { name: 'Dismiss' }).first()
     ).toBeFocused();
-    pressTabKey(page, 6);
+    simulateKeyPress(page, 'Tab', 6);
 
     const moreTagsButton = page.locator(
       `.${pkg.prefix}--tag-set-overflow__popover-trigger`
     );
     await expect(moreTagsButton).toBeFocused();
-    await page.keyboard.press('Enter');
+    simulateKeyPress(page, 'Enter');
 
     await expect(
       page.locator(`.${carbon.prefix}--popover--open`)
     ).toBeVisible();
 
-    pressTabKey(page, 1); //first tag inside popover is focussed
+    simulateKeyPress(page, 'Tab');
+    //first tag inside popover is focussed
     await expect(
       page
         .locator(`.${pkg.prefix}--tag-set-overflow__tag-list`)
@@ -187,13 +190,13 @@ test.describe('TagSet @avt', () => {
         .first()
     ).toBeFocused();
 
-    pressTabKey(page, 10);
+    simulateKeyPress(page, 'Tab', 10);
 
     await expect(
       page.locator(`.${pkg.prefix}--tag-set-overflow__show-all-tags-link`)
     ).toBeFocused(); //view all tags modal link is focussed
 
-    await page.keyboard.press('Enter');
+    simulateKeyPress(page, 'Enter');
 
     await modalElement.evaluate((element) =>
       Promise.all(
@@ -202,13 +205,9 @@ test.describe('TagSet @avt', () => {
     );
 
     await expect(page.getByRole('heading', { name: 'All tags' })).toBeVisible();
-    pressTabKey(page, 1);
-    await page.keyboard.press('Enter');
+    simulateKeyPress(page, 'Tab');
+
+    simulateKeyPress(page, 'Enter');
     await expect(page.locator(`.${carbon.prefix}--modal`)).toBeHidden();
   });
 });
-async function pressTabKey(page, number) {
-  for (let i = 0; i < number; i++) {
-    await page.keyboard.press('Tab');
-  }
-}

--- a/e2e/components/TagSet/TagSet-test.avt.e2e.js
+++ b/e2e/components/TagSet/TagSet-test.avt.e2e.js
@@ -145,11 +145,15 @@ test.describe('TagSet @avt', () => {
     });
 
     await expect(
-      page.locator('.dev-prefix--c4p--tag-set__displayed-tag').getByText('One')
+      page
+        .locator(`.${pkg.prefix}--c4p--tag-set__displayed-tag`)
+        .getByText('One')
     ).toBeVisible();
     await page.getByRole('button', { name: 'Dismiss' }).first().click();
     await expect(
-      page.locator('.dev-prefix--c4p--tag-set__displayed-tag').getByText('One')
+      page
+        .locator(`.${pkg.prefix}--c4p--tag-set__displayed-tag`)
+        .getByText('One')
     ).toBeHidden();
   });
 

--- a/e2e/test-utils/simulateKeyPress.ts
+++ b/e2e/test-utils/simulateKeyPress.ts
@@ -1,0 +1,15 @@
+import { Page } from '@playwright/test';
+
+export const simulateKeyPress = async (
+  page: Page,
+  key: string,
+  count: number = 1,
+  waitDuration?: number
+) => {
+  for (let i = 0; i < count; i++) {
+    await page.keyboard.press(key);
+    if (waitDuration && waitDuration > 0) {
+      await page.waitForTimeout(waitDuration);
+    }
+  }
+};

--- a/e2e/test-utils/simulateKeyPress.ts
+++ b/e2e/test-utils/simulateKeyPress.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright IBM Corp. 2024, 2024
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import { Page } from '@playwright/test';
 
 export const simulateKeyPress = async (


### PR DESCRIPTION
Closes #6473



- Test latest accessibility-checker rulesets on various states of tag set
- Add tests for open and close states in popover/tooltip
- Add tests for open and close states in tag modal
- Review any additional states we may need to capture or add tests for : covered remove tags functionality and search functionality in the modal.
- Add keyboard navigation tests to AVT



#### How did you test and verify your work?
yarn avt