### PR TITLE
fix: add generate token step for the dependency upgrade job

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -74,6 +74,13 @@ jobs:
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
+      - name: Generate token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a #v2.1.0
+        id: generate_token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create PR
         id: create-pr
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5


### PR DESCRIPTION
This will fix a bug in the recent changes to the dependency upgrade action so that the non-Carbon dependencies have an access token to open a PR.

#### What did you change?
```
.github/workflows/update.yml
```
#### How did you test and verify your work?

For additional context, see [here](https://github.com/carbon-design-system/ibm-products/actions/runs/12147196556). You can see that the `carbon` job passed and a PR was opened successfully by the Carbon automation app/bot but the second job failed.