### PR TITLE
feat(CoachmarkOverlayElements): Add next/back callbacks and currentStep properties

### DIFF
--- a/packages/ibm-products/src/components/CoachmarkOverlayElements/CoachmarkOverlayElements.test.js
+++ b/packages/ibm-products/src/components/CoachmarkOverlayElements/CoachmarkOverlayElements.test.js
@@ -22,12 +22,18 @@ const children = `hello, world (${uuidv4()})`;
 const dataTestId = uuidv4();
 const className = `class-${uuidv4()}`;
 
-const childrenContent = (
+const childrenContent = [
   <CoachmarkOverlayElement
+    key="element1"
     title="Hello World"
     description="this is a description test"
-  />
-);
+  />,
+  <CoachmarkOverlayElement
+    key="element2"
+    title="Hello World"
+    description="this is a another description test"
+  />,
+];
 
 const renderCoachmarkWithOverlayElements = (
   { ...rest } = {},
@@ -164,5 +170,23 @@ describe(componentName, () => {
     await act(() => user.click(beaconOrButton));
 
     expect(screen.getByRole('img')).toBeInTheDocument();
+  });
+
+  it('calls onNext', async () => {
+    const user = userEvent.setup();
+    const onNext = jest.fn();
+    renderCoachmarkWithOverlayElements({
+      'data-testid': dataTestId,
+      onNext,
+    });
+    const beaconOrButton = screen.getByRole('button', {
+      name: 'Show information',
+    });
+    await act(() => user.click(beaconOrButton));
+    const nextButton = screen.getByRole('button', {
+      name: 'Next',
+    });
+    await act(() => user.click(nextButton));
+    await expect(onNext).toHaveBeenCalled();
   });
 });

--- a/packages/ibm-products/src/components/CoachmarkOverlayElements/CoachmarkOverlayElements.tsx
+++ b/packages/ibm-products/src/components/CoachmarkOverlayElements/CoachmarkOverlayElements.tsx
@@ -80,11 +80,11 @@ export interface CoachmarkOverlayElementsProps {
   /**
    * Callback called when clicking on the Next button.
    */
-  onClickNext?: () => void;
+  onNext?: () => void;
   /**
    * Callback called when clicking on the Previous button.
    */
-  onClickBack?: () => void;
+  onBack?: () => void;
   /**
    * Current step of the coachmarks.
    */
@@ -108,8 +108,8 @@ const defaults = {
   nextButtonText: 'Next',
   previousButtonLabel: 'Back',
   closeButtonLabel: 'Got it',
-  onClickNext: undefined,
-  onClickBack: undefined,
+  onNext: undefined,
+  onBack: undefined,
   currentStep: 0,
 };
 /**
@@ -131,8 +131,8 @@ export let CoachmarkOverlayElements = React.forwardRef<
       nextButtonText = defaults.nextButtonText,
       previousButtonLabel = defaults.previousButtonLabel,
       closeButtonLabel = defaults.closeButtonLabel,
-      onClickNext = defaults.onClickNext,
-      onClickBack = defaults.onClickBack,
+      onNext = defaults.onNext,
+      onBack = defaults.onBack,
       // Collect any other property values passed in.
       ...rest
     },
@@ -162,6 +162,16 @@ export let CoachmarkOverlayElements = React.forwardRef<
       () => renderMedia?.({ playStep: currentProgStep }),
       [currentProgStep, renderMedia]
     );
+
+    useEffect(() => {
+      // When current step is set by props
+      // scroll to the appropriate view on the carrousel
+      const targetStep = clamp(currentStep, progStepFloor, progStepCeil);
+
+      scrollRef?.current?.scrollToView?.(targetStep);
+      // Avoid circular call to this hook
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [currentStep]);
 
     useEffect(() => {
       // On mount, one of the two primary buttons ("next" or "close")
@@ -240,7 +250,6 @@ export let CoachmarkOverlayElements = React.forwardRef<
         ) : (
           <>
             <Carousel
-              disableArrowScroll
               ref={scrollRef as RefObject<HTMLDivElement>}
               onScroll={(scrollPercent) => {
                 setScrollPosition(scrollPercent);
@@ -266,7 +275,7 @@ export let CoachmarkOverlayElements = React.forwardRef<
                     );
                     scrollRef?.current?.scrollToView?.(targetStep);
                     setCurrentProgStep(targetStep);
-                    onClickBack?.();
+                    onBack?.();
                   }}
                 >
                   {previousButtonLabel}
@@ -287,7 +296,7 @@ export let CoachmarkOverlayElements = React.forwardRef<
                     );
                     scrollRef?.current?.scrollToView?.(targetStep);
                     setCurrentProgStep(targetStep);
-                    onClickNext?.();
+                    onNext?.();
                   }}
                 >
                   {nextButtonText}
@@ -371,11 +380,11 @@ CoachmarkOverlayElements.propTypes = {
   /**
    * Optional callback called when clicking on the Previous button.
    */
-  onClickBack: PropTypes.func,
+  onBack: PropTypes.func,
   /**
    * Optional callback called when clicking on the Next button.
    */
-  onClickNext: PropTypes.func,
+  onNext: PropTypes.func,
   /**
    * The label for the Previous button.
    */

--- a/packages/ibm-products/src/components/CoachmarkOverlayElements/CoachmarkOverlayElements.tsx
+++ b/packages/ibm-products/src/components/CoachmarkOverlayElements/CoachmarkOverlayElements.tsx
@@ -140,8 +140,8 @@ export let CoachmarkOverlayElements = React.forwardRef<
   ) => {
     const buttonFocusRef = useRef<ButtonProps<any> | undefined>(undefined);
     const scrollRef = useRef<CarouselProps | undefined>(undefined);
-    const [scrollPosition, setScrollPosition] = useState(currentStep);
-    const [currentProgStep, _setCurrentProgStep] = useState(0);
+    const [scrollPosition, setScrollPosition] = useState(0);
+    const [currentProgStep, _setCurrentProgStep] = useState(currentStep);
     const coachmark = useCoachmark();
     const hasMedia = media || renderMedia;
 

--- a/packages/ibm-products/src/components/CoachmarkOverlayElements/CoachmarkOverlayElements.tsx
+++ b/packages/ibm-products/src/components/CoachmarkOverlayElements/CoachmarkOverlayElements.tsx
@@ -85,6 +85,10 @@ export interface CoachmarkOverlayElementsProps {
    * Callback called when clicking on the Previous button.
    */
   onClickBack?: () => void;
+  /**
+   * Current step of the coachmarks.
+   */
+  currentStep?: number;
 }
 
 // NOTE: the component SCSS is not imported here: it is rolled up separately.
@@ -106,6 +110,7 @@ const defaults = {
   closeButtonLabel: 'Got it',
   onClickNext: undefined,
   onClickBack: undefined,
+  currentStep: 0,
 };
 /**
  * Composable container to allow for the displaying of CoachmarkOverlayElement
@@ -122,6 +127,7 @@ export let CoachmarkOverlayElements = React.forwardRef<
       isVisible = defaults.isVisible,
       media,
       renderMedia,
+      currentStep = defaults.currentStep,
       nextButtonText = defaults.nextButtonText,
       previousButtonLabel = defaults.previousButtonLabel,
       closeButtonLabel = defaults.closeButtonLabel,
@@ -134,7 +140,7 @@ export let CoachmarkOverlayElements = React.forwardRef<
   ) => {
     const buttonFocusRef = useRef<ButtonProps<any> | undefined>(undefined);
     const scrollRef = useRef<CarouselProps | undefined>(undefined);
-    const [scrollPosition, setScrollPosition] = useState(0);
+    const [scrollPosition, setScrollPosition] = useState(currentStep);
     const [currentProgStep, _setCurrentProgStep] = useState(0);
     const coachmark = useCoachmark();
     const hasMedia = media || renderMedia;
@@ -334,6 +340,10 @@ CoachmarkOverlayElements.propTypes = {
    * The label for the Close button.
    */
   closeButtonLabel: PropTypes.string,
+  /**
+   * Current step of the coachmarks
+   */
+  currentStep: PropTypes.number,
   /**
    * The visibility of CoachmarkOverlayElements is
    * managed in the parent component.

--- a/packages/ibm-products/src/components/CoachmarkOverlayElements/CoachmarkOverlayElements.tsx
+++ b/packages/ibm-products/src/components/CoachmarkOverlayElements/CoachmarkOverlayElements.tsx
@@ -77,6 +77,14 @@ export interface CoachmarkOverlayElementsProps {
    * The label for the Close button.
    */
   closeButtonLabel?: string;
+  /**
+   * Callback called when clicking on the Next button.
+   */
+  onClickNext?: () => void;
+  /**
+   * Callback called when clicking on the Previous button.
+   */
+  onClickBack?: () => void;
 }
 
 // NOTE: the component SCSS is not imported here: it is rolled up separately.
@@ -96,6 +104,8 @@ const defaults = {
   nextButtonText: 'Next',
   previousButtonLabel: 'Back',
   closeButtonLabel: 'Got it',
+  onClickNext: undefined,
+  onClickBack: undefined,
 };
 /**
  * Composable container to allow for the displaying of CoachmarkOverlayElement
@@ -115,6 +125,8 @@ export let CoachmarkOverlayElements = React.forwardRef<
       nextButtonText = defaults.nextButtonText,
       previousButtonLabel = defaults.previousButtonLabel,
       closeButtonLabel = defaults.closeButtonLabel,
+      onClickNext = defaults.onClickNext,
+      onClickBack = defaults.onClickBack,
       // Collect any other property values passed in.
       ...rest
     },
@@ -248,6 +260,7 @@ export let CoachmarkOverlayElements = React.forwardRef<
                     );
                     scrollRef?.current?.scrollToView?.(targetStep);
                     setCurrentProgStep(targetStep);
+                    onClickBack?.();
                   }}
                 >
                   {previousButtonLabel}
@@ -268,6 +281,7 @@ export let CoachmarkOverlayElements = React.forwardRef<
                     );
                     scrollRef?.current?.scrollToView?.(targetStep);
                     setCurrentProgStep(targetStep);
+                    onClickNext?.();
                   }}
                 >
                   {nextButtonText}
@@ -344,6 +358,14 @@ CoachmarkOverlayElements.propTypes = {
    * The label for the Next button.
    */
   nextButtonText: PropTypes.string,
+  /**
+   * Optional callback called when clicking on the Previous button.
+   */
+  onClickBack: PropTypes.func,
+  /**
+   * Optional callback called when clicking on the Next button.
+   */
+  onClickNext: PropTypes.func,
   /**
    * The label for the Previous button.
    */


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/ibm-products/issues/5596

This PR:
- Adds callbacks when clicking on Next and Previous buttons.
- Allows to set the current progression.

#### What did you change?

Add three optional properties to CoachmarkOverlayElements:
- onNextCallback
- onBackCallback
- currentStep

#### How did you test and verify your work?

I modified the story book as follows:

![image](https://github.com/user-attachments/assets/502ea220-26f5-42a3-969a-bd7184872adc)

Then manually checked that:
- next and back callbacks correctly logged into the console
- the progression was correctly set.