### PR TITLE
fix(actions): use correct reviewing team name

### DIFF
--- a/actions/add-review-labels/action.yml
+++ b/actions/add-review-labels/action.yml
@@ -7,6 +7,9 @@ inputs:
   APP_PRIVATE_KEY:
     description: GitHub app private key
     required: true
+  APP_INSTALLATION_ID:
+    description: Carbon automation GitHub app installation id
+    required: true
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/actions/add-review-labels/index.js
+++ b/actions/add-review-labels/index.js
@@ -101,7 +101,7 @@ async function run() {
   // Get reviewer team data
   const { data } = await octokit.request('GET /orgs/{org}/teams/{team_slug}', {
     org: organization.login,
-    team_slug: 'reviewing-team', // Should be only hardcoded value (outside of the labels) needed within this action. Replace with the appropriate reviewing team that is assigned to review PRs.
+    team_slug: 'carbon-for-ibm-products-reviewers', // Should be only hardcoded value (outside of the labels) needed within this action.
     headers: {
       'X-GitHub-Api-Version': '2022-11-28',
     },


### PR DESCRIPTION
Another follow up PR to get the PR review label action working. I've confirmed that the auth issues are fixed now but then noticed a 404 for the teams api because I forgot to update the `team_slug` with the name of our reviewing team.

One more small change included here is to just specify `APP_INSTALLATION_ID` as a valid input to be passed in.

#### What did you change?
```
actions/add-review-labels/action.yml
actions/add-review-labels/index.js
```
