### PR TITLE
fix(Condition builder): initial state getting reset on re-rendering

### DIFF
--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderContent/ConditionBuilderContent.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderContent/ConditionBuilderContent.tsx
@@ -99,8 +99,7 @@ const ConditionBuilderContent = ({
   }, [actionState]);
   useEffect(() => {
     if (initialState?.enabledDefault) {
-      setRootState?.(initialConditionState.current as ConditionBuilderState);
-      initialConditionState.current = null;
+      setRootState?.(initialState.state);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialState]);
@@ -120,12 +119,17 @@ const ConditionBuilderContent = ({
 
   const onRemove = useCallback(
     (groupId) => {
+      const groups = rootState?.groups?.filter(
+        (group) => groupId !== group?.id
+      );
       setRootState?.({
         ...rootState,
-        groups: rootState
-          ? rootState?.groups?.filter((group) => groupId !== group?.id)
-          : [],
+        groups: rootState ? groups : [],
       });
+      //set the initial state to empty.
+      if (groups?.length === 0) {
+        initialConditionState.current = null;
+      }
     },
     [setRootState, rootState]
   );


### PR DESCRIPTION
Closes #6457 

Initial state issue fix.

#### What did you change?
Set the initial state to root state and clear initial state on manually deleting all conditions

#### How did you test and verify your work?
local