### PR TITLE
fix(actions): process pr review action, remove `setup-node`

### DIFF
--- a/.github/workflows/process-pr-review-data.yml
+++ b/.github/workflows/process-pr-review-data.yml
@@ -16,9 +16,9 @@ jobs:
       github.event.workflow_run.event == 'pull_request_review' &&
       github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: '20.x'
           cache: yarn

--- a/.github/workflows/process-pr-review-data.yml
+++ b/.github/workflows/process-pr-review-data.yml
@@ -16,12 +16,6 @@ jobs:
       github.event.workflow_run.event == 'pull_request_review' &&
       github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-        with:
-          node-version: '20.x'
-          cache: yarn
       - uses: ./actions/add-review-labels
         with:
           APP_ID: ${{ secrets.APP_ID }}


### PR DESCRIPTION
Fixes another bug I found in the PR review label action. Because we include `setup-node` and specify a `cache` configuration, the `Post Setup Node.js` job fails because it's looking for a `.yarn/cache` directory, however since this action doesn't depend on any dependencies being installed the `cache` directory doesn't exist. I think it's safe for us to just remove the `setup-node` step.

[Example of failing job](https://github.com/carbon-design-system/ibm-products/actions/runs/12237876420/job/34134624242)

Good news is that the action looks to be working now, outside of this one issue!

![image](https://github.com/user-attachments/assets/8d4e02b5-b6fb-4c1e-bc69-30a81bdffedd)


#### What did you change?
```
.github/workflows/process-pr-review-data.yml
```

#### How did you test and verify your work?
Manually verified in the action that we don't need to install dependencies, it's all based on results from various GH api requests.