### PR TITLE
fix(actions): add checkout step back

### DIFF
--- a/.github/workflows/process-pr-review-data.yml
+++ b/.github/workflows/process-pr-review-data.yml
@@ -16,6 +16,7 @@ jobs:
       github.event.workflow_run.event == 'pull_request_review' &&
       github.event.workflow_run.conclusion == 'success'
     steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: ./actions/add-review-labels
         with:
           APP_ID: ${{ secrets.APP_ID }}


### PR DESCRIPTION
I removed the checkout step as well as `setup-node` in my previous PR, this is causing [issues](https://github.com/carbon-design-system/ibm-products/actions/runs/12257930292/job/34196535636) with getting the actual action to run. Adding it back in this PR 😄 

#### What did you change?
```
.github/workflows/process-pr-review-data.yml
```
#### How did you test and verify your work?
