### PR TITLE
docs(DragAndDrop): fix docs title

### DIFF
--- a/packages/ibm-products/src/components/DragAndDrop/DragAndDrop.mdx
+++ b/packages/ibm-products/src/components/DragAndDrop/DragAndDrop.mdx
@@ -2,7 +2,7 @@ import { Story, Controls, Source, Canvas } from '@storybook/addon-docs';
 import { CodesandboxLink } from '../../global/js/utils/story-helper';
 import * as stories from './DragAndDrop.stories';
 
-# DescriptionList
+# Drag and drop
 
 ## Table of Contents
 


### PR DESCRIPTION
Small fix to update incorrect page title for Drag and drop example.

#### What did you change?
```
packages/ibm-products/src/components/DragAndDrop/DragAndDrop.mdx
```
#### How did you test and verify your work?
Storybook