### PR TITLE
fix(Datagrid): onRowClick results in toggleRow.toggleRowSelected is not a function error in console

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useOnRowClick.ts
+++ b/packages/ibm-products/src/components/Datagrid/useOnRowClick.ts
@@ -35,8 +35,10 @@ const useOnRowClick = (hooks: Hooks) => {
 
           if (!withSelectRows) {
             instance.selectedFlatRows &&
-              instance.selectedFlatRows.map((toggleRow) =>
-                toggleRow.toggleRowSelected(false)
+              instance.selectedFlatRows.map(
+                (toggleRow) =>
+                  toggleRow.toggleRowSelected &&
+                  toggleRow.toggleRowSelected(false)
               );
             toggleRowSelected(id, true);
           }

--- a/packages/ibm-products/src/components/Datagrid/useOnRowClick.ts
+++ b/packages/ibm-products/src/components/Datagrid/useOnRowClick.ts
@@ -37,8 +37,7 @@ const useOnRowClick = (hooks: Hooks) => {
             instance.selectedFlatRows &&
               instance.selectedFlatRows.map(
                 (toggleRow) =>
-                  toggleRow.toggleRowSelected &&
-                  toggleRow.toggleRowSelected(false)
+                  toggleRow.toggleRowSelected?.(false)
               );
             toggleRowSelected(id, true);
           }

--- a/packages/ibm-products/src/components/Datagrid/useOnRowClick.ts
+++ b/packages/ibm-products/src/components/Datagrid/useOnRowClick.ts
@@ -35,9 +35,8 @@ const useOnRowClick = (hooks: Hooks) => {
 
           if (!withSelectRows) {
             instance.selectedFlatRows &&
-              instance.selectedFlatRows.map(
-                (toggleRow) =>
-                  toggleRow.toggleRowSelected?.(false)
+              instance.selectedFlatRows.map((toggleRow) =>
+                toggleRow.toggleRowSelected?.(false)
               );
             toggleRowSelected(id, true);
           }


### PR DESCRIPTION
Closes #6547 

Added a null check for `toggleRowSelected` callback since for some rows objects, `toggleRowSelected` is not present.



#### How did you test and verify your work?
local 