### PR TITLE
fix(conditionbuilder): property text in each condition should be bold

### DIFF
--- a/packages/ibm-products-styles/src/components/ConditionBuilder/styles/_conditionBuilderItem.scss
+++ b/packages/ibm-products-styles/src/components/ConditionBuilder/styles/_conditionBuilderItem.scss
@@ -31,7 +31,7 @@ $block-class: #{c4p-settings.$pkg-prefix}--condition-builder;
   transition: all $duration-fast-02 motion(standard, productive);
 }
 
-.#{$block-class}__condition-wrapper * {
+.#{$block-class}__condition-wrapper {
   @include type-style('body-01');
 }
 


### PR DESCRIPTION
Closes #6436 

property text in each condition should be bold

#### What did you change?
style correction
#### How did you test and verify your work?
local