### PR TITLE
fix(web-components): addresses issues in wc build script

### DIFF
--- a/packages/ibm-products-web-components/package.json
+++ b/packages/ibm-products-web-components/package.json
@@ -56,6 +56,7 @@
   },
   "devDependencies": {
     "@carbon/icons": "^11.53.0",
+    "@carbon/icon-helpers": "^10.54.0",
     "@carbon/motion": "^11.24.0",
     "@mordech/vite-lit-loader": "^0.35.0",
     "@rollup/plugin-alias": "^5.1.1",

--- a/packages/ibm-products-web-components/package.json
+++ b/packages/ibm-products-web-components/package.json
@@ -55,8 +55,8 @@
     "lit": "^3.1.0"
   },
   "devDependencies": {
-    "@carbon/icons": "^11.53.0",
     "@carbon/icon-helpers": "^10.54.0",
+    "@carbon/icons": "^11.53.0",
     "@carbon/motion": "^11.24.0",
     "@mordech/vite-lit-loader": "^0.35.0",
     "@rollup/plugin-alias": "^5.1.1",

--- a/packages/ibm-products-web-components/tasks/build.js
+++ b/packages/ibm-products-web-components/tasks/build.js
@@ -46,7 +46,8 @@ async function build() {
   ]);
 
   const iconInput = await globby([
-    'node_modules/@carbon/icons/lib/**/*.js',
+    '../node_modules/@carbon/icons/lib/**/*.js',
+    '../../node_modules/@carbon/icons/lib/**/*.js',
     '!**/index.js',
   ]);
 

--- a/packages/ibm-products-web-components/tools/svg-result-carbon-icon-loader.js
+++ b/packages/ibm-products-web-components/tools/svg-result-carbon-icon-loader.js
@@ -7,15 +7,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const path = require('path');
-const createSVGResultFromCarbonIcon = require('./svg-result-carbon-icon');
+import createSVGResultFromCarbonIcon from './svg-result-carbon-icon';
 
 /**
  * A Vite loader to generate `lit-html`'s `SVGResult` from an icon descriptor from `@carbon/icons`.
  *
  * @returns {string} The massaged module content.
  */
-function svgResultCarbonIconLoader() {
+export default function svgResultCarbonIconLoader() {
   const descriptor = require(this.resourcePath); // eslint-disable-line global-require
   return `
     import { svg } from 'lit';
@@ -24,5 +23,3 @@ function svgResultCarbonIconLoader() {
     export default svgResultCarbonIcon;
   `;
 }
-
-module.exports = svgResultCarbonIconLoader;

--- a/packages/ibm-products-web-components/tools/svg-result-carbon-icon.js
+++ b/packages/ibm-products-web-components/tools/svg-result-carbon-icon.js
@@ -31,7 +31,7 @@ const toString = (descriptor) => {
  */
 const icon = (descriptor) => {
   descriptor.attrs = getAttributes(
-    Object.assign(descriptor.attrs, {
+    Object.assign(descriptor.attrs ?? {}, {
       '...': '${spread(attrs)}', // eslint-disable-line no-template-curly-in-string
     })
   );

--- a/packages/ibm-products-web-components/tools/vite-svg-result-carbon-icon-loader.ts
+++ b/packages/ibm-products-web-components/tools/vite-svg-result-carbon-icon-loader.ts
@@ -14,7 +14,7 @@ import createSVGResultFromCarbonIcon from './svg-result-carbon-icon';
  *
  * @returns {string} The massaged module content.
  */
-export default async function svgResultCarbonIconLoader() {
+export default function svgResultCarbonIconLoader() {
   const svgRegex = /@carbon[\\/]icons[\\/]/i;
 
   const paths = new Map<string, string>();
@@ -49,7 +49,6 @@ export default async function svgResultCarbonIconLoader() {
       if (!id.match(svgRegex)) {
         return outcome;
       }
-      console.log('id: ', id);
       const descriptor = require(id);
       return `
           import { svg } from 'lit';

--- a/packages/ibm-products-web-components/tools/vite-svg-result-carbon-icon-loader.ts
+++ b/packages/ibm-products-web-components/tools/vite-svg-result-carbon-icon-loader.ts
@@ -1,14 +1,13 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2019, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-const path = require('path');
-const createSVGResultFromCarbonIcon = require('./svg-result-carbon-icon');
+import createSVGResultFromCarbonIcon from './svg-result-carbon-icon';
 
 /**
  * A Vite plugin to generate `lit-html`'s `SVGResult` from an icon descriptor from `@carbon/icons`.

--- a/packages/ibm-products-web-components/tools/vite-svg-result-carbon-icon-loader.ts
+++ b/packages/ibm-products-web-components/tools/vite-svg-result-carbon-icon-loader.ts
@@ -14,7 +14,7 @@ import createSVGResultFromCarbonIcon from './svg-result-carbon-icon';
  *
  * @returns {string} The massaged module content.
  */
-export default function svgResultCarbonIconLoader() {
+export default async function svgResultCarbonIconLoader() {
   const svgRegex = /@carbon[\\/]icons[\\/]/i;
 
   const paths = new Map<string, string>();
@@ -49,12 +49,12 @@ export default function svgResultCarbonIconLoader() {
       if (!id.match(svgRegex)) {
         return outcome;
       }
-
+      console.log('id: ', id);
       const descriptor = require(id);
       return `
           import { svg } from 'lit';
           import spread from '@carbon/web-components/es/globals/directives/spread.js';
-          const svgResultCarbonIcon = ${createSVGResultFromCarbonIcon.default(
+          const svgResultCarbonIcon = ${createSVGResultFromCarbonIcon(
             descriptor
           )};
           export default svgResultCarbonIcon;

--- a/packages/ibm-products-web-components/vite.config.ts
+++ b/packages/ibm-products-web-components/vite.config.ts
@@ -7,14 +7,13 @@
 
 import { defineConfig, configDefaults } from 'vitest/config';
 import { litStyleLoader, litTemplateLoader } from '@mordech/vite-lit-loader';
+import viteSVGResultCarbonIconLoader from './tools/vite-svg-result-carbon-icon-loader';
 
-// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
-    // @ts-ignore
     litStyleLoader(),
-    // @ts-ignore
     litTemplateLoader(),
+    viteSVGResultCarbonIconLoader(),
   ],
   test: {
     environment: 'happy-dom',

--- a/packages/ibm-products-web-components/vite.config.ts
+++ b/packages/ibm-products-web-components/vite.config.ts
@@ -7,14 +7,9 @@
 
 import { defineConfig, configDefaults } from 'vitest/config';
 import { litStyleLoader, litTemplateLoader } from '@mordech/vite-lit-loader';
-import viteSVGResultCarbonIconLoader from './tools/vite-svg-result-carbon-icon-loader';
 
 export default defineConfig({
-  plugins: [
-    litStyleLoader(),
-    litTemplateLoader(),
-    viteSVGResultCarbonIconLoader(),
-  ],
+  plugins: [litStyleLoader(), litTemplateLoader()],
   test: {
     environment: 'happy-dom',
     include: ['./src/**/*.{test,spec}.{js,ts}'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1753,6 +1753,7 @@ __metadata:
   resolution: "@carbon/ibm-products-web-components@workspace:packages/ibm-products-web-components"
   dependencies:
     "@carbon/ibm-products-styles": "npm:^2.53.0"
+    "@carbon/icon-helpers": "npm:^10.54.0"
     "@carbon/icons": "npm:^11.53.0"
     "@carbon/motion": "npm:^11.24.0"
     "@carbon/styles": "npm:1.71.0"


### PR DESCRIPTION
Closes #6674 

This PR addresses the build issues described in #6674. The issue stemmed from incorrect glob patterns that are responsible for compiling and transforming icons, because the glob was incorrect we always ended up with an empty array for the icon paths, meaning that we never transformed any of the icons as expected.

#### What did you change?
```
packages/ibm-products-web-components/package.json
packages/ibm-products-web-components/tasks/build.js
packages/ibm-products-web-components/tools/svg-result-carbon-icon-loader.js
packages/ibm-products-web-components/tools/svg-result-carbon-icon.js
packages/ibm-products-web-components/tools/vite-svg-result-carbon-icon-loader.ts
packages/ibm-products-web-components/vite.config.ts
yarn.lock
```
#### How did you test and verify your work?
I tested this by including an example app and importing the side panel locally after building.