### PR TITLE
fix: step Indicator and Buttons Not Updating on Forward Scroll in InterstitialScreen 

### DIFF
--- a/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreen.tsx
+++ b/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreen.tsx
@@ -25,6 +25,7 @@ import React, {
   isValidElement,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -288,6 +289,14 @@ export let InterstitialScreen = React.forwardRef<
       return () => window.removeEventListener('keydown', close);
     }, [handleClose]);
 
+    const stepSize = useMemo(
+      () =>
+        children && Children.count(children) > 1
+          ? parseFloat((1 / (Children.count(children) - 1)).toFixed(2))
+          : 0,
+      [children]
+    );
+
     if (!isOpen) {
       return null;
     }
@@ -394,6 +403,11 @@ export let InterstitialScreen = React.forwardRef<
       );
     };
 
+    const scrollToCurrentStep = (scrollPercent) => {
+      const currentStep = scrollPercent / stepSize;
+      setProgStep(Math.ceil(currentStep));
+    };
+
     const renderBody = () => {
       {
         /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
@@ -419,9 +433,7 @@ export let InterstitialScreen = React.forwardRef<
                         <Carousel
                           disableArrowScroll
                           ref={scrollRef}
-                          onScroll={(scrollPercent) => {
-                            scrollPercent === 0 && setProgStep(0);
-                          }}
+                          onScroll={scrollToCurrentStep}
                         >
                           {children}
                         </Carousel>
@@ -461,9 +473,7 @@ export let InterstitialScreen = React.forwardRef<
                   <Carousel
                     disableArrowScroll
                     ref={scrollRef}
-                    onScroll={(scrollPercent) => {
-                      scrollPercent === 0 && setProgStep(0);
-                    }}
+                    onScroll={scrollToCurrentStep}
                   >
                     {children}
                   </Carousel>


### PR DESCRIPTION
Closes #6444


#### What did you change?
handle step change on carousal scroll by determining current step from scroll percent and step size.
Eg: when there are 4 steps, scroll percent will be .25, .5, .75,1 respectively and stepsize will be .25
#### How did you test and verify your work?
local