### PR TITLE
refactor(jest): support ts/tsx test files

### DIFF
--- a/config/jest-config-ibm-cloud-cognitive/index.js
+++ b/config/jest-config-ibm-cloud-cognitive/index.js
@@ -33,9 +33,9 @@ module.exports = {
   setupFiles: [require.resolve('./setup/setupFiles.js')],
   setupFilesAfterEnv: [require.resolve('./setup/setupFilesAfterEnv.js')],
   testMatch: [
-    '<rootDir>/**/__tests__/**/*.js?(x)',
-    '<rootDir>/**/*.(spec|test).js?(x)',
-    '<rootDir>/**/*-(spec|test).js?(x)',
+    '<rootDir>/**/__tests__/**/*.(js|jsx|ts|tsx)?(x)',
+    '<rootDir>/**/*.(spec|test).(js|jsx|ts|tsx)?(x)',
+    '<rootDir>/**/*-(spec|test).(js|jsx|ts|tsx)?(x)',
   ],
   transform: {
     '^.+\\.(mjs|cjs|js|jsx|ts|tsx)$': require.resolve(


### PR DESCRIPTION
We'll likely want to be writing more tests in TypeScript moving forward, this PR updates our jest config to run test files with `ts` or `tsx` extensions.

#### What did you change?
```
config/jest-config-ibm-cloud-cognitive/index.js
```
#### How did you test and verify your work?
Existing tests still run as expected