### PR TITLE
feat(conditionBuilder): add option for formatting values in custom and date input type

### DIFF
--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.test.js
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.test.js
@@ -267,6 +267,7 @@ const inputData = {
       config: {
         component: CustomInput,
         operators: customOperators,
+        valueFormatter: (value) => value?.toUpperCase(),
       },
     },
   ],
@@ -1616,8 +1617,9 @@ describe(componentName, () => {
 
     const container = document.querySelector(`.${blockClass}`);
     await act(() => userEvent.click(container));
-
-    const selectedItem = screen.getByRole('button', { name: 'testID123' });
+    // the value formatter will format to uppercase
+    // cspell: disable
+    const selectedItem = screen.getByRole('button', { name: 'TESTID123' });
 
     expect(selectedItem);
   });

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.types.ts
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.types.ts
@@ -90,7 +90,9 @@ export interface PropertyConfigNumber {
 
 export type PropertyConfigDate = {
   type: 'date';
-  config: object;
+  config: {
+    valueFormatter?: (value: string) => string;
+  };
 };
 
 export type PropertyConfigTime = {
@@ -108,6 +110,7 @@ export type PropertyConfigCustom = {
       label: string;
       id: string;
     }[];
+    valueFormatter?: (value: string) => string;
   };
 };
 

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItem.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItem.tsx
@@ -118,7 +118,7 @@ export const ConditionBuilderItem = ({
     }
     const propertyId =
       rest['data-name'] == 'valueField' && type
-        ? getValue[type](label, config)
+        ? getValue(type, label, config)
         : labelText;
 
     return {

--- a/packages/ibm-products/src/components/ConditionBuilder/assets/sampleInput.js
+++ b/packages/ibm-products/src/components/ConditionBuilder/assets/sampleInput.js
@@ -660,6 +660,10 @@ export const inputData = {
       config: {
         component: CustomInput,
         operators: customOperators,
+        valueFormatter: (value) => {
+          // add any customization to the value to be populated
+          return value;
+        },
       },
     },
   ],

--- a/packages/ibm-products/src/components/ConditionBuilder/utils/util.js
+++ b/packages/ibm-products/src/components/ConditionBuilder/utils/util.js
@@ -112,35 +112,42 @@ const formatDate = (date) => {
   return `${day}/${month}/${year}`;
 };
 
-export const getValue = {
-  text: (value) => value,
-  textarea: (value) => value,
-  time: (value) => value,
-  number: (value) => value,
-  option: (value) => {
-    if (value && typeof value !== 'string') {
-      const selectedValues = Array.isArray(value) ? value : [value];
-      return selectedValues.map((option) => option.label).join(', ');
-    }
+export const getValue = (type, value, config) => {
+  if (config?.valueFormatter && ['date', 'custom'].includes(type)) {
+    return config.valueFormatter(value);
+  } else {
+    const formatters = {
+      text: (value) => value,
+      textarea: (value) => value,
+      time: (value) => value,
+      number: (value) => value,
+      option: (value) => {
+        if (value && typeof value !== 'string') {
+          const selectedValues = Array.isArray(value) ? value : [value];
+          return selectedValues.map((option) => option.label).join(', ');
+        }
 
-    return value;
-  },
-  date: (value) => {
-    if (Array.isArray(value) && value.length > 1) {
-      const start =
-        value?.[0] && !isNaN(new Date(value[0]))
-          ? formatDate(new Date(value[0]))
-          : '';
-      const end =
-        value?.[1] && !isNaN(new Date(value[1]))
-          ? formatDate(new Date(value[1]))
-          : '';
-      return `${start} To ${end}`;
-    } else if (Array.isArray(value) && !isNaN(new Date(value[0]))) {
-      return formatDate(new Date(value[0]));
-    } else {
-      return value;
-    }
-  },
-  custom: (value) => value,
+        return value;
+      },
+      date: (value) => {
+        if (Array.isArray(value) && value.length > 1) {
+          const start =
+            value?.[0] && !isNaN(new Date(value[0]))
+              ? formatDate(new Date(value[0]))
+              : '';
+          const end =
+            value?.[1] && !isNaN(new Date(value[1]))
+              ? formatDate(new Date(value[1]))
+              : '';
+          return `${start} To ${end}`;
+        } else if (Array.isArray(value) && !isNaN(new Date(value[0]))) {
+          return formatDate(new Date(value[0]));
+        } else {
+          return value;
+        }
+      },
+      custom: (value) => value,
+    };
+    return formatters[type](value, config);
+  }
 };


### PR DESCRIPTION
Closes #6439 

This is allow user to pass an optional formatter function along with input config for date and custom input types.
This value returned from this callback will be used to display in the value field. 



#### How did you test and verify your work?
local storybook