### PR TITLE
build(web-components): move `tslib` to dev dependency

### DIFF
--- a/packages/ibm-products-web-components/package.json
+++ b/packages/ibm-products-web-components/package.json
@@ -39,7 +39,7 @@
     "web components"
   ],
   "scripts": {
-    "build": "node tasks/build.js && yarn wca",
+    "build": "yarn clean && node tasks/build.js && yarn wca",
     "build:storybook": "storybook build",
     "clean": "rimraf es lib scss dist storybook-static",
     "preview": "vite preview",

--- a/packages/ibm-products-web-components/package.json
+++ b/packages/ibm-products-web-components/package.json
@@ -52,8 +52,7 @@
     "@carbon/ibm-products-styles": "^2.54.0-rc.0",
     "@carbon/styles": "1.71.0",
     "@carbon/web-components": "2.19.0",
-    "lit": "^3.1.0",
-    "tslib": "^2.6.3"
+    "lit": "^3.1.0"
   },
   "devDependencies": {
     "@carbon/icon-helpers": "^10.54.0",
@@ -90,6 +89,7 @@
     "sass": "^1.80.6",
     "storybook": "^8.4.5",
     "storybook-addon-accessibility-checker": "^3.1.61-rc.3",
+    "tslib": "^2.8.1",
     "typescript": "^5.5.3",
     "vite": "^6.0.3",
     "vitest": "^2.1.2",

--- a/packages/ibm-products-web-components/package.json
+++ b/packages/ibm-products-web-components/package.json
@@ -78,7 +78,7 @@
     "@vitest/ui": "latest",
     "autoprefixer": "^10.4.20",
     "cssnano": "^7.0.6",
-    "eslint": "^9.11.1",
+    "eslint": "^8.56.0",
     "eslint-config-carbon": "3.18.0",
     "globby": "^14.0.2",
     "happy-dom": "^15.11.6",

--- a/packages/ibm-products-web-components/tasks/build.js
+++ b/packages/ibm-products-web-components/tasks/build.js
@@ -21,71 +21,88 @@ import path from 'path';
 import postcss from 'postcss';
 import typescript from '@rollup/plugin-typescript';
 import json from '@rollup/plugin-json';
-import fs from 'fs';
 
 import * as packageJson from '../package.json' assert { type: 'json' };
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-/**
- * Gets all of the folders and returns out
- *
- * @param {string} dir Directory to check
- * @returns {string[]} List of folders
- * @private
- */
-function _getFolders(dir) {
-  return fs
-    .readdirSync(dir)
-    .filter((file) => fs.statSync(path.join(dir, file)).isDirectory());
-}
-
 async function build() {
-  if (!fs.existsSync('dist')) {
-    fs.mkdirSync('dist');
-  }
+  const esInputs = await globby([
+    'src/**/*.ts',
+    '!src/**/*.stories.ts',
+    '!src/**/*.d.ts',
+    '!src/polyfills',
+  ]);
 
-  const folders = _getFolders('src/components');
+  const libInputs = await globby([
+    'src/components/**/defs.ts',
+    'src/globals/**/*.ts',
+    '!src/globals/decorators/**/*.ts',
+    '!src/globals/directives/**/*.ts',
+    '!src/globals/internal/**/*.ts',
+    '!src/globals/mixins/**/*.ts',
+  ]);
 
-  for (let i = folders.length - 1; i >= 0; i--) {
-    if (!fs.existsSync(`src/components/${folders[i]}/index.ts`)) {
-      folders.splice(i, 1);
-    }
-  }
+  const iconInput = await globby([
+    '../node_modules/@carbon/icons/lib/**/*.js',
+    '../../node_modules/@carbon/icons/lib/**/*.js',
+    '!**/index.js',
+  ]);
 
-  return rollup(getRollupConfig({ folders }))
-    .then((bundle) => {
-      bundle.write({
-        format: 'es',
-        dir: 'dist',
-        banner: 'let process = { env: {} };',
-      });
-    })
-    .catch((err) => {
-      console.error(err);
+  const entryPoint = {
+    rootDir: 'src',
+    outputDirectory: path.resolve(__dirname, '..'),
+  };
+
+  const formats = [
+    {
+      type: 'esm',
+      directory: 'es',
+    },
+    {
+      type: 'commonjs',
+      directory: 'lib',
+    },
+  ];
+
+  for (const format of formats) {
+    const outputDirectory = path.join(
+      entryPoint.outputDirectory,
+      format.directory
+    );
+
+    const cwcInputConfig = getRollupConfig(
+      format.type === 'esm' ? esInputs : libInputs,
+      entryPoint.rootDir,
+      outputDirectory,
+      format.type === 'esm' ? iconInput : []
+    );
+
+    const cwcBundle = await rollup(cwcInputConfig);
+
+    await cwcBundle.write({
+      dir: outputDirectory,
+      format: format.type,
+      preserveModules: true,
+      preserveModulesRoot: 'src',
+      banner,
+      exports: 'named',
+      sourcemap: true,
     });
+  }
 }
 
-/**
- * Generates the multi-input for the rollup config
+const banner = `/**
+ * Copyright IBM Corp. 2024
  *
- * @param {Array} folders Package names as inputs
- * @returns {{}} Object with inputs
- * @private
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
-function _generateInputs(folders) {
-  const inputs = {};
+`;
 
-  folders.forEach((folder) => {
-    inputs[`${folder}.min`] = `src/components/${folder}/index.ts`;
-  });
-
-  return inputs;
-}
-
-function getRollupConfig({ folders = [] } = {}) {
+function getRollupConfig(input, rootDir, outDir, iconInput) {
   return {
-    input: _generateInputs(folders),
+    input,
     // Mark dependencies listed in `package.json` as external so that they are
     // not included in the output bundle.
     external: [
@@ -116,7 +133,6 @@ function getRollupConfig({ folders = [] } = {}) {
       }),
       commonjs({
         include: [/node_modules/],
-        sourceMap: true,
       }),
       litSCSS({
         includePaths: [
@@ -133,10 +149,9 @@ function getRollupConfig({ folders = [] } = {}) {
       }),
       typescript({
         noEmitOnError: true,
-        declaration: false,
         compilerOptions: {
-          rootDir: 'src',
-          outDir: 'dist',
+          rootDir,
+          outDir,
         },
       }),
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1777,7 +1777,7 @@ __metadata:
     "@vitest/ui": "npm:latest"
     autoprefixer: "npm:^10.4.20"
     cssnano: "npm:^7.0.6"
-    eslint: "npm:^9.11.1"
+    eslint: "npm:^8.56.0"
     eslint-config-carbon: "npm:3.18.0"
     globby: "npm:^14.0.2"
     happy-dom: "npm:^15.11.6"
@@ -3244,35 +3244,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/regexpp@npm:^4.11.0":
-  version: 4.11.1
-  resolution: "@eslint-community/regexpp@npm:4.11.1"
-  checksum: 934b6d3588c7f16b18d41efec4fdb89616c440b7e3256b8cb92cfd31ae12908600f2b986d6c1e61a84cbc10256b1dd3448cd1eec79904bd67ac365d0f1aba2e2
-  languageName: node
-  linkType: hard
-
 "@eslint-community/regexpp@npm:^4.4.0, @eslint-community/regexpp@npm:^4.5.1, @eslint-community/regexpp@npm:^4.6.1":
   version: 4.10.0
   resolution: "@eslint-community/regexpp@npm:4.10.0"
   checksum: 8c36169c815fc5d726078e8c71a5b592957ee60d08c6470f9ce0187c8046af1a00afbda0a065cc40ff18d5d83f82aed9793c6818f7304a74a7488dc9f3ecbd42
-  languageName: node
-  linkType: hard
-
-"@eslint/config-array@npm:^0.18.0":
-  version: 0.18.0
-  resolution: "@eslint/config-array@npm:0.18.0"
-  dependencies:
-    "@eslint/object-schema": "npm:^2.1.4"
-    debug: "npm:^4.3.1"
-    minimatch: "npm:^3.1.2"
-  checksum: 60ccad1eb4806710b085cd739568ec7afd289ee5af6ca0383f0876f9fe375559ef525f7b3f86bdb3f961493de952f2cf3ab4aa4a6ccaef0ae3cd688267cabcb3
-  languageName: node
-  linkType: hard
-
-"@eslint/core@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@eslint/core@npm:0.6.0"
-  checksum: ec5cce168c8773fbd60c5a505563c6cf24398b3e1fa352929878d63129e0dd5b134d3232be2f2c49e8124a965d03359b38962aa0dcf7dfaf50746059d2a2f798
   languageName: node
   linkType: hard
 
@@ -3293,50 +3268,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/eslintrc@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@eslint/eslintrc@npm:3.1.0"
-  dependencies:
-    ajv: "npm:^6.12.4"
-    debug: "npm:^4.3.2"
-    espree: "npm:^10.0.1"
-    globals: "npm:^14.0.0"
-    ignore: "npm:^5.2.0"
-    import-fresh: "npm:^3.2.1"
-    js-yaml: "npm:^4.1.0"
-    minimatch: "npm:^3.1.2"
-    strip-json-comments: "npm:^3.1.1"
-  checksum: 02bf892d1397e1029209dea685e9f4f87baf643315df2a632b5f121ec7e8548a3b34f428a007234fa82772218fa8a3ac2d10328637b9ce63b7f8344035b74db3
-  languageName: node
-  linkType: hard
-
 "@eslint/js@npm:8.57.0":
   version: 8.57.0
   resolution: "@eslint/js@npm:8.57.0"
   checksum: 3c501ce8a997cf6cbbaf4ed358af5492875e3550c19b9621413b82caa9ae5382c584b0efa79835639e6e0ddaa568caf3499318e5bdab68643ef4199dce5eb0a0
-  languageName: node
-  linkType: hard
-
-"@eslint/js@npm:9.11.1":
-  version: 9.11.1
-  resolution: "@eslint/js@npm:9.11.1"
-  checksum: 77b9c744bdf24e2ca1f99f671139767d6c31cb10d732cf22a85ef28f1f95f2a621cf204f572fd9fee67da6193ff2597a5d236cef3b557b07624230b622612339
-  languageName: node
-  linkType: hard
-
-"@eslint/object-schema@npm:^2.1.4":
-  version: 2.1.4
-  resolution: "@eslint/object-schema@npm:2.1.4"
-  checksum: 221e8d9f281c605948cd6e030874aacce83fe097f8f9c1964787037bccf08e82b7aa9eff1850a30fffac43f1d76555727ec22a2af479d91e268e89d1e035131e
-  languageName: node
-  linkType: hard
-
-"@eslint/plugin-kit@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "@eslint/plugin-kit@npm:0.2.0"
-  dependencies:
-    levn: "npm:^0.4.1"
-  checksum: ebb363174397341dea47dc35fc206e24328083e4f0fa1c539687dbb7f94bef77e43faa12867d032e6eea5ac980ea8fbb6b1d844186e422d327c04088041b99f3
   languageName: node
   linkType: hard
 
@@ -3469,13 +3404,6 @@ __metadata:
   version: 2.0.3
   resolution: "@humanwhocodes/object-schema@npm:2.0.3"
   checksum: 05bb99ed06c16408a45a833f03a732f59bf6184795d4efadd33238ff8699190a8c871ad1121241bb6501589a9598dc83bf25b99dcbcf41e155cdf36e35e937a3
-  languageName: node
-  linkType: hard
-
-"@humanwhocodes/retry@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@humanwhocodes/retry@npm:0.3.0"
-  checksum: e574bab58680867414e225c9002e9a97eb396f85871c180fbb1a9bcdf9ded4b4de0b327f7d0c43b775873362b7c92956d4b322e8bc4b90be56077524341f04b2
   languageName: node
   linkType: hard
 
@@ -7413,7 +7341,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.15, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
+"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 1a3c3e06236e4c4aab89499c428d585527ce50c24fe8259e8b3926d3df4cfbbbcf306cfc73ddfb66cbafc973116efd15967020b0f738f63e09e64c7d260519e7
@@ -12353,16 +12281,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:^8.0.2":
-  version: 8.1.0
-  resolution: "eslint-scope@npm:8.1.0"
-  dependencies:
-    esrecurse: "npm:^4.3.0"
-    estraverse: "npm:^5.2.0"
-  checksum: 4c34a12fbeb0677822a9e93e81f2027e39e6f27557c17bc1e5ff76debbd41e748c3673517561792bda9e276245f89fbfd9b0b24fcec3b33a04ee2196729b3489
-  languageName: node
-  linkType: hard
-
 "eslint-visitor-keys@npm:^2.1.0":
   version: 2.1.0
   resolution: "eslint-visitor-keys@npm:2.1.0"
@@ -12381,13 +12299,6 @@ __metadata:
   version: 4.0.0
   resolution: "eslint-visitor-keys@npm:4.0.0"
   checksum: c7617166e6291a15ce2982b5c4b9cdfb6409f5c14562712d12e2584480cdf18609694b21d7dad35b02df0fa2cd037505048ded54d2f405c64f600949564eb334
-  languageName: node
-  linkType: hard
-
-"eslint-visitor-keys@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "eslint-visitor-keys@npm:4.1.0"
-  checksum: 3fb5bd1b2f36db89d0ac57ddd66d36ccd3b1e3cddb2a55a0f9f6f1c85268cfcc1cc32e7eda4990e3423107a120dd254fb6cb52d6154cf81d344d8c3fa671f7c2
   languageName: node
   linkType: hard
 
@@ -12439,69 +12350,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.11.1":
-  version: 9.11.1
-  resolution: "eslint@npm:9.11.1"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.2.0"
-    "@eslint-community/regexpp": "npm:^4.11.0"
-    "@eslint/config-array": "npm:^0.18.0"
-    "@eslint/core": "npm:^0.6.0"
-    "@eslint/eslintrc": "npm:^3.1.0"
-    "@eslint/js": "npm:9.11.1"
-    "@eslint/plugin-kit": "npm:^0.2.0"
-    "@humanwhocodes/module-importer": "npm:^1.0.1"
-    "@humanwhocodes/retry": "npm:^0.3.0"
-    "@nodelib/fs.walk": "npm:^1.2.8"
-    "@types/estree": "npm:^1.0.6"
-    "@types/json-schema": "npm:^7.0.15"
-    ajv: "npm:^6.12.4"
-    chalk: "npm:^4.0.0"
-    cross-spawn: "npm:^7.0.2"
-    debug: "npm:^4.3.2"
-    escape-string-regexp: "npm:^4.0.0"
-    eslint-scope: "npm:^8.0.2"
-    eslint-visitor-keys: "npm:^4.0.0"
-    espree: "npm:^10.1.0"
-    esquery: "npm:^1.5.0"
-    esutils: "npm:^2.0.2"
-    fast-deep-equal: "npm:^3.1.3"
-    file-entry-cache: "npm:^8.0.0"
-    find-up: "npm:^5.0.0"
-    glob-parent: "npm:^6.0.2"
-    ignore: "npm:^5.2.0"
-    imurmurhash: "npm:^0.1.4"
-    is-glob: "npm:^4.0.0"
-    is-path-inside: "npm:^3.0.3"
-    json-stable-stringify-without-jsonify: "npm:^1.0.1"
-    lodash.merge: "npm:^4.6.2"
-    minimatch: "npm:^3.1.2"
-    natural-compare: "npm:^1.4.0"
-    optionator: "npm:^0.9.3"
-    strip-ansi: "npm:^6.0.1"
-    text-table: "npm:^0.2.0"
-  peerDependencies:
-    jiti: "*"
-  peerDependenciesMeta:
-    jiti:
-      optional: true
-  bin:
-    eslint: bin/eslint.js
-  checksum: 38de03a51044a5f708c93302cff5e860355447d424f1a21fa67f5b2f0541d092d3f3807c0242820d9795553a3f1165db51769e9a042816334d05c86f015fdfef
-  languageName: node
-  linkType: hard
-
-"espree@npm:^10.0.1":
-  version: 10.2.0
-  resolution: "espree@npm:10.2.0"
-  dependencies:
-    acorn: "npm:^8.12.0"
-    acorn-jsx: "npm:^5.3.2"
-    eslint-visitor-keys: "npm:^4.1.0"
-  checksum: 365076a963ca84244c1e2d36e4f812362d21cfa7e7df10d67f7b82b759467796df81184721d153c4e235d9ef5eb5b4d044167dd66be3be00f53a21a515b1bfb1
-  languageName: node
-  linkType: hard
-
 "espree@npm:^10.1.0":
   version: 10.1.0
   resolution: "espree@npm:10.1.0"
@@ -12543,7 +12391,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esquery@npm:^1.5.0, esquery@npm:^1.6.0":
+"esquery@npm:^1.6.0":
   version: 1.6.0
   resolution: "esquery@npm:1.6.0"
   dependencies:
@@ -13643,13 +13491,6 @@ __metadata:
   dependencies:
     type-fest: "npm:^0.20.2"
   checksum: 62c5b1997d06674fc7191d3e01e324d3eda4d65ac9cc4e78329fa3b5c4fd42a0e1c8722822497a6964eee075255ce21ccf1eec2d83f92ef3f06653af4d0ee28e
-  languageName: node
-  linkType: hard
-
-"globals@npm:^14.0.0":
-  version: 14.0.0
-  resolution: "globals@npm:14.0.0"
-  checksum: 03939c8af95c6df5014b137cac83aa909090c3a3985caef06ee9a5a669790877af8698ab38007e4c0186873adc14c0b13764acc754b16a754c216cc56aa5f021
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1790,7 +1790,7 @@ __metadata:
     sass: "npm:^1.80.6"
     storybook: "npm:^8.4.5"
     storybook-addon-accessibility-checker: "npm:^3.1.61-rc.3"
-    tslib: "npm:^2.6.3"
+    tslib: "npm:^2.8.1"
     typescript: "npm:^5.5.3"
     vite: "npm:^6.0.3"
     vitest: "npm:^2.1.2"
@@ -21900,7 +21900,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.3.1":
+"tslib@npm:^2.3.1, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7


### PR DESCRIPTION
Closes #6736 

In order for `@rollup/plugin-typescript` to work correctly we need `tslib` as a dev dependency, turns out we just hadn't properly configured the rollup TS plugin. I also downgraded `eslint` until the rest of our monorepo is able to use v9.

#### What did you change?
```
packages/ibm-products-web-components/package.json
yarn.lock
```
#### How did you test and verify your work?
I was able to confirm these changes by confirming the correct import of `__decorate` from the `tslib` library in the built versions of `side-panel` and `tearsheet` by running `yarn build` from `packages/ibm-products-web-components` and inspecting the import of `__decorate` from `tslib` directly (previously was importing from `../../node_modules/tslib` rather than from `tslib`).