### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,9 +3,3 @@
 # be requested for review when someone opens a pull request.
 
 * @carbon-design-system/carbon-for-ibm-products-reviewers
-
-# Security package
-/packages/security/ @jlongshore @paul-balchin-ibm
-
-# Admins and team should be notified of changes to CI/CD workflows
-/.github/workflows @elycheea @matthewgallo @kennylam @carbon-design-system/carbon-for-ibm-products-development


### PR DESCRIPTION
Now that Jeff and Paul are on the team, the Security package had its last v1 release, and more team members have gotten familiar with GitHub Actions and CI/CD, we’re able to remove some of the previous granularity. 🎉

#### What did you change?
Clean up codeowners!

#### How did you test and verify your work?
The file is valid. 😒