### PR TITLE
refactor(reduced-motion): use our own `usePrefersReducedMotion` hook

### DIFF
--- a/packages/ibm-products/src/components/CoachmarkFixed/CoachmarkFixed.tsx
+++ b/packages/ibm-products/src/components/CoachmarkFixed/CoachmarkFixed.tsx
@@ -24,8 +24,10 @@ import { createPortal } from 'react-dom';
 import cx from 'classnames';
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { pkg } from '../../settings';
-import { useIsomorphicEffect } from '../../global/js/hooks';
-import { usePrefersReducedMotion } from '../../global/js/hooks';
+import {
+  useIsomorphicEffect,
+  usePrefersReducedMotion,
+} from '../../global/js/hooks';
 
 // Carbon and package components we use.
 /* TODO: @import(s) of carbon components and other package components. */

--- a/packages/ibm-products/src/components/CoachmarkFixed/CoachmarkFixed.tsx
+++ b/packages/ibm-products/src/components/CoachmarkFixed/CoachmarkFixed.tsx
@@ -25,7 +25,7 @@ import cx from 'classnames';
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { pkg } from '../../settings';
 import { useIsomorphicEffect } from '../../global/js/hooks';
-import { useReducedMotion } from 'framer-motion';
+import { usePrefersReducedMotion } from '../../global/js/hooks';
 
 // Carbon and package components we use.
 /* TODO: @import(s) of carbon components and other package components. */
@@ -106,7 +106,7 @@ export let CoachmarkFixed = React.forwardRef<
     const [targetRect, setTargetRect] = useState();
     const [targetOffset, setTargetOffset] = useState({ x: 0, y: 0 });
     const [fixedIsVisible, setFixedIsVisible] = useState(false);
-    const shouldReduceMotion = useReducedMotion();
+    const shouldReduceMotion = usePrefersReducedMotion();
 
     useIsomorphicEffect(() => {
       portalNode.current = portalTarget

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
@@ -938,6 +938,17 @@ describe(componentName, () => {
       unobserve: jest.fn(),
       disconnect: jest.fn(),
     }));
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
   });
 
   afterEach(() => {

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
@@ -27,7 +27,6 @@ import {
   panelVariants,
 } from './motion/variants';
 import { motion } from 'framer-motion';
-import { usePrefersReducedMotion } from '../../../../../global/js/hooks';
 import {
   useFilters,
   useShouldDisableButtons,
@@ -41,7 +40,10 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { pkg } from '../../../../../settings';
 import { rem } from '@carbon/layout';
-import { useIsomorphicEffect } from '../../../../../global/js/hooks';
+import {
+  useIsomorphicEffect,
+  usePrefersReducedMotion,
+} from '../../../../../global/js/hooks';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 export const componentClass = `${blockClass}-filter-panel`;

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
@@ -26,7 +26,8 @@ import {
   innerContainerVariants,
   panelVariants,
 } from './motion/variants';
-import { motion, useReducedMotion } from 'framer-motion';
+import { motion } from 'framer-motion';
+import { usePrefersReducedMotion } from '../../../../../global/js/hooks';
 import {
   useFilters,
   useShouldDisableButtons,
@@ -124,7 +125,7 @@ const FilterPanel = ({
       prevFiltersRef,
     });
 
-  const shouldReduceMotion = useReducedMotion();
+  const shouldReduceMotion = usePrefersReducedMotion();
 
   /** Memos */
   const showActionSet = useMemo(() => updateMethod === BATCH, [updateMethod]);

--- a/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.tsx
+++ b/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.tsx
@@ -37,8 +37,8 @@ import {
   useClickOutside,
   useIsomorphicEffect,
   usePreviousValue,
+  usePrefersReducedMotion,
 } from '../../global/js/hooks';
-import { usePrefersReducedMotion } from '../../global/js/hooks';
 import wrapFocus from '../../global/js/utils/wrapFocus';
 
 // The block part of our conventional BEM class names (blockClass__E--M).

--- a/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.tsx
+++ b/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.tsx
@@ -38,7 +38,7 @@ import {
   useIsomorphicEffect,
   usePreviousValue,
 } from '../../global/js/hooks';
-import usePrefersReducedMotion from '../../global/js/hooks/usePrefersReducedMotion';
+import { usePrefersReducedMotion } from '../../global/js/hooks';
 import wrapFocus from '../../global/js/utils/wrapFocus';
 
 // The block part of our conventional BEM class names (blockClass__E--M).

--- a/packages/ibm-products/src/components/OptionsTile/OptionsTile.tsx
+++ b/packages/ibm-products/src/components/OptionsTile/OptionsTile.tsx
@@ -21,8 +21,10 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { pkg } from '../../settings';
-import { useControllableState } from '../../global/js/hooks';
-import { usePrefersReducedMotion } from '../../global/js/hooks';
+import {
+  useControllableState,
+  usePrefersReducedMotion,
+} from '../../global/js/hooks';
 import uuidv4 from '../../global/js/utils/uuidv4';
 
 const blockClass = `${pkg.prefix}--options-tile`;

--- a/packages/ibm-products/src/components/OptionsTile/OptionsTile.tsx
+++ b/packages/ibm-products/src/components/OptionsTile/OptionsTile.tsx
@@ -22,7 +22,7 @@ import cx from 'classnames';
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { pkg } from '../../settings';
 import { useControllableState } from '../../global/js/hooks';
-import usePrefersReducedMotion from '../../global/js/hooks/usePrefersReducedMotion';
+import { usePrefersReducedMotion } from '../../global/js/hooks';
 import uuidv4 from '../../global/js/utils/uuidv4';
 
 const blockClass = `${pkg.prefix}--options-tile`;

--- a/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
@@ -38,7 +38,7 @@ import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { moderate02 } from '@carbon/motion';
 import pconsole from '../../global/js/utils/pconsole';
 import { pkg } from '../../settings';
-import usePrefersReducedMotion from '../../global/js/hooks/usePrefersReducedMotion';
+import { usePrefersReducedMotion } from '../../global/js/hooks';
 import { getSpecificElement } from '../../global/js/hooks/useFocus';
 
 const blockClass = `${pkg.prefix}--side-panel`;

--- a/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
@@ -25,7 +25,11 @@ import {
   overlayVariants,
   panelVariants,
 } from './motion/variants';
-import { useFocus, usePreviousValue } from '../../global/js/hooks';
+import {
+  useFocus,
+  usePreviousValue,
+  usePrefersReducedMotion,
+} from '../../global/js/hooks';
 
 import { ActionSet } from '../ActionSet';
 import { ButtonProps } from '@carbon/react';
@@ -38,7 +42,6 @@ import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { moderate02 } from '@carbon/motion';
 import pconsole from '../../global/js/utils/pconsole';
 import { pkg } from '../../settings';
-import { usePrefersReducedMotion } from '../../global/js/hooks';
 import { getSpecificElement } from '../../global/js/hooks/useFocus';
 
 const blockClass = `${pkg.prefix}--side-panel`;

--- a/packages/ibm-products/src/components/WebTerminal/WebTerminal.tsx
+++ b/packages/ibm-products/src/components/WebTerminal/WebTerminal.tsx
@@ -26,7 +26,7 @@ import cx from 'classnames';
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { moderate02 } from '@carbon/motion';
 import { pkg } from '../../settings';
-import usePrefersReducedMotion from '../../global/js/hooks/usePrefersReducedMotion';
+import { usePrefersReducedMotion } from '../../global/js/hooks';
 import { useWebTerminal } from './hooks';
 import { useIsomorphicEffect } from '../../global/js/hooks';
 

--- a/packages/ibm-products/src/components/WebTerminal/WebTerminal.tsx
+++ b/packages/ibm-products/src/components/WebTerminal/WebTerminal.tsx
@@ -26,9 +26,11 @@ import cx from 'classnames';
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { moderate02 } from '@carbon/motion';
 import { pkg } from '../../settings';
-import { usePrefersReducedMotion } from '../../global/js/hooks';
 import { useWebTerminal } from './hooks';
-import { useIsomorphicEffect } from '../../global/js/hooks';
+import {
+  useIsomorphicEffect,
+  usePrefersReducedMotion,
+} from '../../global/js/hooks';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 const componentName = 'WebTerminal';

--- a/packages/ibm-products/src/global/js/hooks/index.js
+++ b/packages/ibm-products/src/global/js/hooks/index.js
@@ -19,3 +19,4 @@ export { useControllableState } from './useControllableState';
 export { usePrefix } from './usePrefix';
 export { useFocus } from './useFocus';
 export { useIsomorphicEffect } from './useIsomorphicEffect';
+export { usePrefersReducedMotion } from './usePrefersReducedMotion';

--- a/packages/ibm-products/src/global/js/hooks/usePrefersReducedMotion.js
+++ b/packages/ibm-products/src/global/js/hooks/usePrefersReducedMotion.js
@@ -11,7 +11,7 @@
 import { useState } from 'react';
 import { useIsomorphicEffect } from './useIsomorphicEffect';
 
-const usePrefersReducedMotion = () => {
+export const usePrefersReducedMotion = () => {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
 
   useIsomorphicEffect(() => {
@@ -33,5 +33,3 @@ const usePrefersReducedMotion = () => {
 
   return prefersReducedMotion;
 };
-
-export default usePrefersReducedMotion;


### PR DESCRIPTION
Closes #6751 

This PR removes usage of `useReducedMotion` from `framer-motion` and replaces it with our own reduced motion hook that we have within our own library (`usePrefersReducedMotion`).

#### What did you change?
```
packages/ibm-products/src/components/CoachmarkFixed/CoachmarkFixed.tsx
packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.tsx
packages/ibm-products/src/components/OptionsTile/OptionsTile.tsx
packages/ibm-products/src/components/SidePanel/SidePanel.tsx
packages/ibm-products/src/components/WebTerminal/WebTerminal.tsx
packages/ibm-products/src/global/js/hooks/index.js
packages/ibm-products/src/global/js/hooks/usePrefersReducedMotion.js
```
#### How did you test and verify your work?
Verified same behavior in storybook with reduced motion enabled in system settings