### PR TITLE
feat: adds stylelint-use-logical rule

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ['stylelint-config-carbon'],
-  plugins: ['stylelint-plugin-carbon-tokens'],
+  plugins: ['stylelint-plugin-carbon-tokens', 'stylelint-use-logical'],
   rules: {
     'max-nesting-depth': null,
     'scss/no-global-function-names': null,
@@ -14,5 +14,8 @@ module.exports = {
     'carbon/motion-easing-use': true,
     'carbon/theme-use': true,
     'carbon/type-use': true,
+
+    // CSS Logical properties
+    'csstools/use-logical': 'ignore',
   },
 };

--- a/package.json
+++ b/package.json
@@ -142,7 +142,8 @@
     ]
   },
   "dependencies": {
-    "stylelint-plugin-carbon-tokens": "^3.2.1"
+    "stylelint-plugin-carbon-tokens": "^3.2.1",
+    "stylelint-use-logical": "^2.1.2"
   },
   "packageManager": "yarn@4.0.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14017,6 +14017,7 @@ __metadata:
     stylelint: "npm:^16.10.0"
     stylelint-config-carbon: "npm:^1.20.0"
     stylelint-plugin-carbon-tokens: "npm:^3.2.1"
+    stylelint-use-logical: "npm:^2.1.2"
     webpack: "npm:^5.96.1"
   languageName: unknown
   linkType: soft
@@ -21492,7 +21493,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylelint-use-logical@npm:^2.1.0":
+"stylelint-use-logical@npm:^2.1.0, stylelint-use-logical@npm:^2.1.2":
   version: 2.1.2
   resolution: "stylelint-use-logical@npm:2.1.2"
   peerDependencies:


### PR DESCRIPTION
This PR adds the use logical properties stylelint rule. This PR is necessary to go ahead and change all physical properties to logical i.e. `width` -> `inline-size`

https://www.npmjs.com/package/stylelint-use-logical

#### What did you change?

- Installed `stylelint-use-logical`
- Added  `stylelint-use-logical` `to stylelintrc.js`.

**Note:** we are ignoring the rules for now until all other PR's change the logical properties. Then there will be a follow up PR to enforce the lint

#### How did you test and verify your work?
