### PR TITLE
chore: move Notification panel to Components in Storybook

### DIFF
--- a/e2e/components/NotificationsPanel/NotificationsPanel-test.avt.e2e.js
+++ b/e2e/components/NotificationsPanel/NotificationsPanel-test.avt.e2e.js
@@ -15,7 +15,7 @@ test.describe('NotificationsPanel @avt', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'NotificationsPanel',
-      id: 'ibm-products-patterns-notifications-notificationspanel--default',
+      id: 'ibm-products-components-notifications-panel-notificationspanel--default',
       globals: {
         carbonTheme: 'white',
       },
@@ -28,7 +28,7 @@ test.describe('NotificationsPanel @avt', () => {
   test('@avt-notification-panel-focus-trap', async ({ page }) => {
     await visitStory(page, {
       component: 'NotificationsPanel',
-      id: 'ibm-products-patterns-notifications-notificationspanel--default',
+      id: 'ibm-products-components-notifications-panel-notificationspanel--default',
       globals: {
         carbonTheme: 'white',
       },

--- a/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.stories.jsx
+++ b/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.stories.jsx
@@ -30,7 +30,7 @@ const storyBlockClass = `${pkg.prefix}--notifications-panel__story`;
 const blockClass = `${pkg.prefix}--notifications-panel`;
 
 export default {
-  title: 'IBM Products/Patterns/Notifications/NotificationsPanel',
+  title: 'IBM Products/Components/Notifications panel/NotificationsPanel',
   component: NotificationsPanel,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.stories.jsx
+++ b/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.stories.jsx
@@ -16,6 +16,7 @@ import {
   HeaderGlobalAction,
 } from '@carbon/react';
 import { User, Notification } from '@carbon/react/icons';
+import { StoryDocsPage } from '../../global/js/utils/StoryDocsPage';
 import styles from './_storybook-styles.scss?inline';
 import uuidv4 from '../../global/js/utils/uuidv4';
 import { UnreadNotificationBell } from './preview-components/UnreadNotificationBell';
@@ -36,11 +37,11 @@ export default {
   parameters: {
     styles,
     layout: 'fullscreen',
-    /*
-docs: {
-      page: mdx,
+    docs: {
+      page: () => (
+        <StoryDocsPage altGuidelinesHref="https://pages.github.ibm.com/carbon/ibm-products/components/notification-panel/usage/" />
+      ),
     },
-*/
   },
 };
 


### PR DESCRIPTION
Closes #6522

Recategorize NotificationsPanel as a component in Storybook to match the website.
Also required an override to the usage docs because of a minor difference in website v. component naming — website uses “notification panel” whereas the component is already named “Notification**s**Panel.”

#### What did you change?
- Move to Components
- Update e2e links
- Fix link to usage docs

#### How did you test and verify your work?
`yarn avt /NotificationPanel/`
`yarn ci-check`
Locally verify URLs.