### PR TITLE
chore: increase addselect coverage

### DIFF
--- a/packages/ibm-products/src/components/AddSelect/AddSelectBody.test.js
+++ b/packages/ibm-products/src/components/AddSelect/AddSelectBody.test.js
@@ -75,11 +75,14 @@ const hierarchyItems = {
       title: 'California',
       value: 'california',
       children: {
+        sortBy: ['title'],
+        filterBy: 'fileType',
         entries: [
           {
             id: '5',
             title: 'Los Angeles',
             value: 'la',
+            fileType: 'pdf',
           },
         ],
       },
@@ -242,6 +245,27 @@ describe(componentName, () => {
     const tearsheetElement = screen.getByRole('dialog').parentElement;
     expect(tearsheetElement).toHaveClass(`${blockClass}__single`);
     expect(tearsheetElement).toBeVisible();
+  });
+
+  it('handles item focusing with keyboard', async () => {
+    render(<AddSelectBody {...singleProps} open />);
+    const focus = document.querySelector('#add-select-focus');
+    fireEvent.keyDown(focus, { keyCode: '40' });
+    expect(
+      document.querySelector(`.${blockClass}__selections-row--focused`)
+    ).toHaveFocus();
+    fireEvent.keyDown(focus, { keyCode: '38' });
+    fireEvent.keyDown(focus, { keyCode: '40' });
+    fireEvent.keyDown(focus, { keyCode: '40' });
+    fireEvent.keyDown(focus, { keyCode: '40' });
+    fireEvent.keyDown(focus, { keyCode: '38' });
+    expect(
+      document.querySelector(`.${blockClass}__selections-row--focused`)
+    ).toHaveFocus();
+    fireEvent.keyDown(focus, { keyCode: '39' });
+    expect(
+      document.querySelector(`.${blockClass}__selections-row--focused`)
+    ).toHaveFocus();
   });
 
   it('returns the selected values on submit', async () => {

--- a/packages/ibm-products/src/components/AddSelect/AddSelectRow.js
+++ b/packages/ibm-products/src/components/AddSelect/AddSelectRow.js
@@ -135,6 +135,7 @@ export let AddSelectRow = ({
         [`${blockClass}-row--selected`]: isSelected(),
         [`${blockClass}-row-meta--selected`]: isInMetaPanel(item.id),
         [`${blockClass}-row--active`]: expanded,
+        [`${blockClass}-row--focused`]: focus === index,
       })}
       onKeyDown={onSelectKeyDown}
       tabIndex={tabIndex}


### PR DESCRIPTION
Closes #6653 

increases coverage for `AddSelectColumn` and the `useFocus` hook in `AddSelect`
