### PR TITLE
refactor: remove immutability helper 

### DIFF
--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -104,7 +104,6 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@ibm/telemetry-js": "^1.5.0",
     "framer-motion": "^6.5.1 < 7",
-    "immutability-helper": "^3.1.1",
     "lodash": "^4.17.21",
     "lottie-web": "^5.12.2",
     "react-table": "^7.8.0",

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022, 2024
+ * Copyright IBM Corp. 2022, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -8,7 +8,6 @@
 import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Checkbox } from '@carbon/react';
-import update from 'immutability-helper';
 import { pkg } from '../../../../../settings';
 import cx from 'classnames';
 import { DraggableItemsList } from './DraggableItemsList';
@@ -34,18 +33,15 @@ const Columns = ({
   // after a drag/drop action set the columns
   const moveElement = React.useCallback(
     (from, to) => {
-      const fromCol = columns[from];
-
-      setColumnsObject(
-        update(columns, {
-          $splice: [
-            [from, 1],
-            [to, 0, fromCol],
-          ],
-        })
-      );
+      setColumnsObject((prev) => {
+        const prevClone = [...prev];
+        const item = prevClone[from];
+        prevClone.splice(from, 1);
+        prevClone.splice(to, 0, item);
+        return prevClone;
+      });
     },
-    [columns, setColumnsObject]
+    [setColumnsObject]
   );
 
   const filteredStickyColumn = columns?.filter((item) => !item.sticky);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1879,7 +1879,6 @@ __metadata:
     framer-motion: "npm:^6.5.1 < 7"
     fs-extra: "npm:^11.2.0"
     glob: "npm:^10.3.10"
-    immutability-helper: "npm:^3.1.1"
     jest: "npm:^29.7.0"
     jest-config-ibm-cloud-cognitive: "npm:^1.18.0-rc.0"
     jest-environment-jsdom: "npm:^29.7.0"
@@ -14101,13 +14100,6 @@ __metadata:
   version: 3.0.6
   resolution: "immediate@npm:3.0.6"
   checksum: f9b3486477555997657f70318cc8d3416159f208bec4cca3ff3442fd266bc23f50f0c9bd8547e1371a6b5e82b821ec9a7044a4f7b944798b25aa3cc6d5e63e62
-  languageName: node
-  linkType: hard
-
-"immutability-helper@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "immutability-helper@npm:3.1.1"
-  checksum: f5cbbd3c39341f6119c0533618dc282c828a752994670f459eebb2ac35f051255963ba1480031230800b19eb05acdd09d2e757e7804d7494eb024eed065a33b5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #6806

This PR removes `immutability-helper` from our package, it is only used in one place (column customization in Datagrid) and  we were able to achieve the same thing without a library.

#### What did you change?
```
packages/ibm-products/package.json
packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
yarn.lock
```
#### How did you test and verify your work?
Verified in Column customization Datagrid story