### PR TITLE
Fix percy notification panel timestamps

### DIFF
--- a/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel_data.js
+++ b/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel_data.js
@@ -8,12 +8,25 @@
 import { action } from '@storybook/addon-actions';
 import uuidv4 from '../../global/js/utils/uuidv4';
 
-const currentDate = new Date();
-let yesterdayDate = new Date();
-yesterdayDate.setDate(yesterdayDate.getDate() - 1);
-let dayBeforeYesterday = new Date();
-dayBeforeYesterday.setDate(dayBeforeYesterday.getDate() - 2);
+/**
+ Currently setting this to Jan 1st of the current year so notifications aren't too far back. I set it to current year for this case.
+ The reason we changed this to hardcode is because percy was showing the change in timestamp as a design change. So technically it will
+  only trigger a percy check once a year.
+*/
+const currentYear = new Date().getFullYear();
+const currentDate = new Date(currentYear, 0, 1); // Month is 0-based, 4 = May
+
+// Static yesterday date (May 3, 2024)
+let yesterdayDate = new Date(currentDate);
+yesterdayDate.setDate(currentDate.getDate() - 1);
+
+// Static day before yesterday date (May 2, 2024)
+let dayBeforeYesterday = new Date(currentDate);
+dayBeforeYesterday.setDate(currentDate.getDate() - 2);
+
+// Constant for milliseconds in one minute
 const msInOneMinute = 60000;
+
 const data = [
   {
     id: uuidv4(),

--- a/packages/ibm-products/src/components/PageHeader/PageHeader.stories.jsx
+++ b/packages/ibm-products/src/components/PageHeader/PageHeader.stories.jsx
@@ -91,16 +91,7 @@ const makeBreadcrumb = (item, title) => ({
   key: `Breadcrumb ${item}`,
   label: typeof title === 'string' ? title : `Breadcrumb ${item}`,
 });
-const now = new Date();
-const m = now.getMonth();
-if (m === 0) {
-  now.setFullYear(now.getFullYear() - 1);
-  now.setMonth(11);
-} else {
-  now.setMonth(m - 1);
-}
-const ms = now.toLocaleString('default', { month: 'long' });
-const ys = now.toLocaleString('default', { year: 'numeric' });
+
 const breadcrumbs = {
   'No breadcrumb': null,
   'A single breadcrumb': [makeBreadcrumb(1, 'Home page')],
@@ -116,7 +107,7 @@ const breadcrumbs = {
   'Demo breadcrumbs': [
     makeBreadcrumb(1, 'Home page', '../../../homepage'),
     makeBreadcrumb(2, 'Reports', '../../Reports'),
-    makeBreadcrumb(3, `${ms} ${ys}`, `../${ms}{ys}`),
+    makeBreadcrumb(3, `January 2025`, `../January 2025`),
   ],
 };
 


### PR DESCRIPTION
Closes #6808 

This PR removes date timestamps so that it doesn't show up on percy builds and fail them.

#### What did you change?
- Timestamps in notifications panel
- Timestamps in page header

#### How did you test and verify your work?
storybook