### PR TITLE
docs(useravatar): doc on migrating from userprofileimage to useravatar

### DIFF
--- a/packages/ibm-products/src/components/UserAvatar/UserAvatar.mdx
+++ b/packages/ibm-products/src/components/UserAvatar/UserAvatar.mdx
@@ -13,7 +13,31 @@ import * as UserAvatarStories from './UserAvatar.stories';
 
 ## Overview
 
-{/* TODO: Overview. */}
+User avatars are a representation of a user or group of users. They can be used to identify a user or indicate collaborators.
+By default the component will display `name` on a 'order-1-cyan' background if name exist else it will render a user icon. 
+UserAvatar allows an image of the user to be displayed by passing in the `image` prop as well as customizing icons using `renderIcon` prop. 
+
+
+## Migration from `UserProfileImage`
+
+If you are currently using `UserProfileImage` you can use the following guide to
+migrate to the newer `UserAvatar` component using the below command:
+
+`npx @carbon/upgrade migrate ibm-products-update-userprofileimage --write`
+
+The following props have been updated in `UserAvatar`:
+
+`icon` has been replaced with `renderIcon`
+
+`backgroundColor` remains the same but the values have changed. To see the new
+values please refer to the component API table below.
+
+`initials` has been replaced with `name`. Please refer to the component API
+table below to see the new specifications.
+
+`sm` has been added to the list of available `size` options
+
+`theme` and `kind` have been removed
 
 ## Note on theming
 

--- a/packages/ibm-products/src/components/UserProfileImage/UserProfileImage.docs-page.js
+++ b/packages/ibm-products/src/components/UserProfileImage/UserProfileImage.docs-page.js
@@ -11,6 +11,8 @@ import * as stories from './UserProfileImage.stories';
 
 const DocsPage = () => (
   <StoryDocsPage
+    // cspell:disable-next-line
+    deprecationNotice="This component will soon be deprecated, Please migrate to [UserAvatar](?path=/docs/ibm-products-components-user-avatar-useravatar--docs#migration-from-userprofileimage)."
     blocks={[
       {
         story: stories.Default,


### PR DESCRIPTION
Closes #4074 

Add link from `UserProfileImage` to `UserAvatar`
Add migration notes in section of `UserAvatar` mdx including codmod command

#### What did you change? 
packages/ibm-products/src/components/UserAvatar/UserAvatar.mdx
packages/ibm-products/src/components/UserProfileImage/UserProfileImage.docs-page.js

#### How did you test and verify your work? storybook
