### PR TITLE
fix(Tearsheet): missing launcherbuttonref declaration

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/Tearsheet.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/Tearsheet.tsx
@@ -8,7 +8,12 @@
 // Carbon and package components we use.
 import { Button, type ButtonProps } from '@carbon/react';
 // Import portions of React that are needed.
-import React, { ForwardedRef, PropsWithChildren, ReactNode } from 'react';
+import React, {
+  ForwardedRef,
+  PropsWithChildren,
+  ReactNode,
+  RefObject,
+} from 'react';
 import { TearsheetShell } from './TearsheetShell';
 
 import { ActionSet } from '../ActionSet';
@@ -112,6 +117,11 @@ export interface TearsheetProps extends PropsWithChildren {
    * to page of a multi-page task).
    */
   label?: ReactNode;
+
+  /**
+   * Provide a ref to return focus to once the tearsheet is closed.
+   */
+  launcherButtonRef?: RefObject<any>;
 
   /**
    * Navigation content, such as a set of tabs, to be displayed at the bottom

--- a/packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetNarrow.tsx
@@ -12,7 +12,12 @@ import {
   tearsheetShellWideProps as blocked,
 } from './TearsheetShell';
 // Import portions of React that are needed.
-import React, { ForwardedRef, PropsWithChildren, ReactNode } from 'react';
+import React, {
+  ForwardedRef,
+  PropsWithChildren,
+  ReactNode,
+  RefObject,
+} from 'react';
 import { allPropTypes, prepareProps } from '../../global/js/utils/props-helper';
 
 import { ActionSet } from '../ActionSet';
@@ -74,6 +79,11 @@ export interface TearsheetNarrowProps extends PropsWithChildren {
    * to page of a multi-page task).
    */
   label?: ReactNode;
+
+  /**
+   * Provide a ref to return focus to once the tearsheet is closed.
+   */
+  launcherButtonRef?: RefObject<any>;
 
   /**
    * An optional handler that is called when the user closes the tearsheet (by


### PR DESCRIPTION
Refs #4687, #4751.

Fix missing typescript declaration for launcherButtonRef. It was in the base class (TearsheetShell), but
not Tearsheet nor TearsheetNarrow.

(It was in Tearsheet and TearsheetNarrow's PropTypes, but not the typescript declaration.)

#### What did you change?

Added Typescript declaration for launcherButtonRef.

#### How did you test and verify your work?

Tested locally.