### PR TITLE
chore: enables css logical property rule

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -16,6 +16,6 @@ module.exports = {
     'carbon/type-use': true,
 
     // CSS Logical properties
-    'csstools/use-logical': 'ignore',
+    'csstools/use-logical': true,
   },
 };

--- a/packages/ibm-products-styles/src/components/NotificationsPanel/_notifications-panel.scss
+++ b/packages/ibm-products-styles/src/components/NotificationsPanel/_notifications-panel.scss
@@ -276,8 +276,6 @@ $block-class: #{c4p-settings.$pkg-prefix}--notifications-panel;
     min-block-size: 2.5rem;
     .#{$block-class}__view-all-button {
       display: flex;
-      width: 100%;
-      max-width: calc(100% - 2.5rem);
       align-items: center;
       block-size: 2.5rem;
       border-inline-end: 1px solid $layer-02;


### PR DESCRIPTION
Closes #6802 

We merged all css logical properties PR so now we can enable the linter to give us errors from now on.


**PR List**

- https://github.com/carbon-design-system/ibm-products/pull/6746
- https://github.com/carbon-design-system/ibm-products/pull/6768
- https://github.com/carbon-design-system/ibm-products/pull/6774
- https://github.com/carbon-design-system/ibm-products/pull/6777
- https://github.com/carbon-design-system/ibm-products/pull/6746

#### What did you change?

- Turned CSS logical property linter to true

#### How did you verify it works?
I added physical properties and it gave errors, also using `yarn lint:styles` should fix most of the errors
