### PR TITLE
fix(Condition Builder): accessibility violations part 1

### DIFF
--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItem.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItem.tsx
@@ -16,7 +16,13 @@ import React, {
   Ref,
 } from 'react';
 
-import { Popover, PopoverContent, Layer } from '@carbon/react';
+import {
+  Popover,
+  PopoverContent,
+  Layer,
+  Heading,
+  Section,
+} from '@carbon/react';
 import PropTypes from 'prop-types';
 import { Add, CarbonIconType } from '@carbon/react/icons';
 import { ConditionBuilderButton } from '../ConditionBuilderButton/ConditionBuilderButton';
@@ -266,10 +272,14 @@ export const ConditionBuilderItem = ({
           onKeyDown={handleKeyDownHandler}
         >
           <Layer>
-            <h1 className={`${blockClass}__item__title`}>{title}</h1>
-            <div className={`${blockClass}__popover-content`}>
-              {renderChildren ? renderChildren(popoverRef) : children}
-            </div>
+            <Section>
+              <Heading className={`${blockClass}__item__title`}>
+                {title}
+              </Heading>
+              <div className={`${blockClass}__popover-content`}>
+                {renderChildren ? renderChildren(popoverRef) : children}
+              </div>
+            </Section>
           </Layer>
         </PopoverContent>
       )}

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItemDate/ConditionBuilderItemDate.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItemDate/ConditionBuilderItemDate.tsx
@@ -36,12 +36,6 @@ export const ConditionBuilderItemDate = ({
       selectedDate && selectedDate.length > 0 ? selectedDate : 'INVALID'
     );
   };
-  // this will close the popover on enter key press
-  const onKeyPressHandler = (evt: KeyboardEvent) => {
-    if (evt.key === 'Enter') {
-      focusThisField(evt, conditionBuilderRef);
-    }
-  };
   return (
     <div className={`${blockClass}__item-date `}>
       {datePickerType == 'single' && (
@@ -52,7 +46,6 @@ export const ConditionBuilderItemDate = ({
           value={conditionState.value}
           onClose={onCloseHandler}
           appendTo={parentRef?.current}
-          onKeyPress={onKeyPressHandler}
         >
           <DatePickerInput
             id="datePicker"
@@ -70,7 +63,6 @@ export const ConditionBuilderItemDate = ({
           onClose={onCloseHandler}
           value={conditionState.value}
           appendTo={parentRef?.current}
-          onKeyPress={onKeyPressHandler}
         >
           <DatePickerInput
             id="datePickerStart"

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItemDate/ConditionBuilderItemDate.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItemDate/ConditionBuilderItemDate.tsx
@@ -5,14 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { ForwardedRef, useRef } from 'react';
+import React, { ForwardedRef, useContext, useRef } from 'react';
 
 import { DatePicker, DatePickerInput } from '@carbon/react';
 
 import PropTypes from 'prop-types';
 import { useTranslations } from '../../utils/useTranslations';
 import { Condition } from '../../ConditionBuilder.types';
-import { blockClass } from '../../utils/util';
+import { blockClass, focusThisField } from '../../utils/util';
+import { ConditionBuilderContext } from '../../ConditionBuilderContext/ConditionBuilderProvider';
 
 interface ConditionBuilderItemDate {
   conditionState: Condition;
@@ -26,6 +27,7 @@ export const ConditionBuilderItemDate = ({
 }) => {
   const DatePickerInputRef = useRef<HTMLDivElement>(null);
   const [startText, endText] = useTranslations(['startText', 'endText']);
+  const { conditionBuilderRef } = useContext(ConditionBuilderContext);
   const datePickerType =
     conditionState.operator == 'between' ? 'range' : 'single';
 
@@ -33,6 +35,12 @@ export const ConditionBuilderItemDate = ({
     onChange(
       selectedDate && selectedDate.length > 0 ? selectedDate : 'INVALID'
     );
+  };
+  // this will close the popover on enter key press
+  const onKeyPressHandler = (evt: KeyboardEvent) => {
+    if (evt.key === 'Enter') {
+      focusThisField(evt, conditionBuilderRef);
+    }
   };
   return (
     <div className={`${blockClass}__item-date `}>
@@ -44,6 +52,7 @@ export const ConditionBuilderItemDate = ({
           value={conditionState.value}
           onClose={onCloseHandler}
           appendTo={parentRef?.current}
+          onKeyPress={onKeyPressHandler}
         >
           <DatePickerInput
             id="datePicker"
@@ -61,6 +70,7 @@ export const ConditionBuilderItemDate = ({
           onClose={onCloseHandler}
           value={conditionState.value}
           appendTo={parentRef?.current}
+          onKeyPress={onKeyPressHandler}
         >
           <DatePickerInput
             id="datePickerStart"

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItemOption/ItemOption.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItemOption/ItemOption.tsx
@@ -15,7 +15,7 @@ import PropTypes from 'prop-types';
 import { ConditionBuilderContext } from '../../ConditionBuilderContext/ConditionBuilderProvider';
 import { useTranslations } from '../../utils/useTranslations';
 import { option, statementConfig } from '../../ConditionBuilder.types';
-import { blockClass } from '../../utils/util';
+import { blockClass, onKeyDownHandlerForSearch } from '../../utils/util';
 
 interface ItemOptionProps {
   conditionState: {
@@ -38,6 +38,7 @@ export const ItemOption = ({
     'propertyText',
     'clearSearchText',
   ]);
+  const { conditionBuilderRef } = useContext(ConditionBuilderContext);
   const allOptions = config.options;
   const [searchValue, setSearchValue] = useState('');
 
@@ -99,6 +100,9 @@ export const ItemOption = ({
             labelText={clearSearchText}
             closeButtonLabelText={clearSearchText}
             onChange={onSearchChangeHandler}
+            onKeyDown={(evt: KeyboardEvent) =>
+              onKeyDownHandlerForSearch(evt, conditionBuilderRef)
+            }
           />
         </div>
       )}

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItemOption/ItemOptionForValueField.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItemOption/ItemOptionForValueField.tsx
@@ -26,7 +26,11 @@ import {
   Option,
   PropertyConfigOption,
 } from '../../ConditionBuilder.types';
-import { blockClass, checkForMultiSelectOperator } from '../../utils/util';
+import {
+  blockClass,
+  checkForMultiSelectOperator,
+  onKeyDownHandlerForSearch,
+} from '../../utils/util';
 
 interface ItemOptionForValueFieldProps {
   conditionState: Condition & { label?: string };
@@ -47,6 +51,7 @@ export const ItemOptionForValueField = ({
     'propertyText',
     'clearSearchText',
   ]);
+  const { conditionBuilderRef } = useContext(ConditionBuilderContext);
   const contentRef = useRef<HTMLDivElement>(null);
 
   const [allOptions, setAllOptions] = useState<Option[]>(
@@ -171,6 +176,9 @@ export const ItemOptionForValueField = ({
             labelText={clearSearchText}
             closeButtonLabelText={clearSearchText}
             onChange={onSearchChangeHandler}
+            onKeyDown={(evt) =>
+              onKeyDownHandlerForSearch(evt, conditionBuilderRef)
+            }
           />
         </div>
       )}

--- a/packages/ibm-products/src/components/ConditionBuilder/utils/handleKeyboardEvents.js
+++ b/packages/ibm-products/src/components/ConditionBuilder/utils/handleKeyboardEvents.js
@@ -43,8 +43,7 @@ export const handleKeyDownForPopover = (
 const excludeKeyPress = (evt) => {
   return (
     !['Escape'].includes(evt.key) &&
-    (evt.target.closest(`.${blockClass}__item-date`) ||
-      evt.target.closest(`.${blockClass}__item-time`))
+    evt.target.closest(`.${blockClass}__item-date`)
   );
 };
 
@@ -159,23 +158,23 @@ const handleKeyPressForPopover = (
 
         break;
       case 'Enter':
-        if (isMultiSelect === 'true') {
-          if (document.activeElement.type !== 'button') {
-            //for button , enter key is click which already handled by framework, for other elements trigger click
-            evt.preventDefault();
-            document.activeElement?.click();
-          }
-        } else {
-          if (document.activeElement.type !== 'button') {
-            //for button , enter key is click which already handled by framework, else trigger click
-            focusThisField(evt, conditionBuilderRef);
-            document.activeElement?.click();
-          }
+        if (document.activeElement.type !== 'button') {
+          //for button , enter key is click which already handled by framework, else trigger click
+          focusThisField(evt, conditionBuilderRef);
+          document.activeElement?.click();
         }
 
         break;
       default:
         break;
+    }
+  } else {
+    if (key === 'Enter' && !isHoldingShiftKey) {
+      if (document.activeElement.type !== 'button') {
+        //for button , enter key is click which already handled by framework, else trigger click
+        focusThisField(evt, conditionBuilderRef);
+        document.activeElement?.click();
+      }
     }
   }
 };

--- a/packages/ibm-products/src/components/ConditionBuilder/utils/util.js
+++ b/packages/ibm-products/src/components/ConditionBuilder/utils/util.js
@@ -162,3 +162,9 @@ export const checkForMultiSelectOperator = (condition, config) => {
     )
   );
 };
+//this will close the popover on escape key on search box
+export const onKeyDownHandlerForSearch = (evt, conditionBuilderRef) => {
+  if (!evt.currentTarget.value && evt.key === 'Escape') {
+    focusThisField(evt, conditionBuilderRef);
+  }
+};


### PR DESCRIPTION
Closes #6788 

- For search box inside popover, clear the text inside the search box on escape key press if any search text is present. Close the popover on escape only if search box is empty. If some search text is present, user has to press escape twice to close the popover.

- Close the multiselect popover when enter is pressed . Space can be used to toggle between the selection. Implement this on every other input types. On a textarea input, press enter will close popover with entered value. Shift + enter will enable user to move to new line inside the text area.

- Use carbon Heading component as popover heading.


#### How did you test and verify your work?
local storybook