### PR TITLE
fix(storybook): add fontBase

### DIFF
--- a/packages/core/.storybook/manager.js
+++ b/packages/core/.storybook/manager.js
@@ -6,14 +6,9 @@
  */
 
 import { addons } from '@storybook/manager-api';
-import { create } from '@storybook/theming/create';
-
 import React from 'react';
-
-import packageInfo from '../../ibm-products/package.json';
+import theme from './theme';
 import { checkCanaryStatus } from '../../ibm-products/src/global/js/utils/story-helper';
-
-const { description, version } = packageInfo;
 
 const renderComponentLabel = (label, dark, type = 'Canary') => {
   return (
@@ -46,10 +41,7 @@ const renderComponentLabel = (label, dark, type = 'Canary') => {
 };
 
 addons.setConfig({
-  theme: create({
-    brandTitle: `${description} v${version}`,
-  }),
-
+  theme: theme,
   sidebar: {
     renderLabel: (item) => {
       const isUnstable = !!(

--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -10,7 +10,7 @@ import { white, g10, g90, g100 } from '@carbon/themes';
 import '../../ibm-products/src/feature-flags';
 
 import { pkg } from '../../ibm-products/src/settings';
-
+import theme from '../.storybook/theme';
 import index from './index.scss?inline';
 import { StoryDocsPage } from '../../ibm-products/src/global/js/utils/StoryDocsPage';
 
@@ -142,6 +142,7 @@ const parameters = {
     defaultViewport: 'basic',
   },
   docs: {
+    theme,
     page: () => <StoryDocsPage />,
   },
 };

--- a/packages/core/.storybook/theme.js
+++ b/packages/core/.storybook/theme.js
@@ -3,8 +3,6 @@ import packageInfo from '../../ibm-products/package.json';
 
 const { description, version } = packageInfo;
 
-console.log(description, version);
-
 export default create({
   brandTitle: `${description} v${version}`,
   fontBase: "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",

--- a/packages/core/.storybook/theme.js
+++ b/packages/core/.storybook/theme.js
@@ -1,0 +1,12 @@
+import { create } from '@storybook/theming/create';
+import packageInfo from '../../ibm-products/package.json';
+
+const { description, version } = packageInfo;
+
+console.log(description, version);
+
+export default create({
+  brandTitle: `${description} v${version}`,
+  fontBase: "'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif",
+  fontCode: "'IBM Plex Mono', Menlo, 'DejaVu Sans Mono', Courier, monospace",
+});


### PR DESCRIPTION
Closes #6822

Changed storybook font to IBM Plex sans. 

#### What did you change?
packages/core/.storybook/manager.js
packages/core/.storybook/theme.js
packages/core/.storybook/preview.js

#### How did you test and verify your work? storybook
