### PR TITLE
fix(GetStartedCard): #6949 - 2 Sass deprecation warnings

### DIFF
--- a/packages/ibm-products-styles/src/components/GetStartedCard/_get-started-card.scss
+++ b/packages/ibm-products-styles/src/components/GetStartedCard/_get-started-card.scss
@@ -78,14 +78,14 @@ $block-class: #{c4p-settings.$pkg-prefix}--card;
   .#{$block-class}__pictogram ~ .#{$block-class}__content-container {
     .#{$block-class}__media {
       /* stylelint-disable-next-line function-no-unknown */
-      margin-block: to-rem(-50px) -$spacing-09;
+      margin-block: to-rem(-50px) - $spacing-09;
     }
   }
 
   .#{$block-class}__sequence ~ .#{$block-class}__content-container {
     .#{$block-class}__media {
       /* stylelint-disable-next-line function-no-unknown */
-      margin-block: to-rem(-56px) -$spacing-09;
+      margin-block: to-rem(-56px) - $spacing-09;
     }
   }
 


### PR DESCRIPTION
Closes #6949

SASS raises deprecation warnings on these two lines introduced in v2.60.0 (for details, see original issue description):
`margin-block: to-rem(-50px) -$spacing-09;`
`margin-block: to-rem(-56px) -$spacing-09;`

#### What did you change?
I change this to what SASS will currently compiles it to (according to Webpack log), namely:
`margin-block: to-rem(-50px) - $spacing-09;`
`margin-block: to-rem(-56px) - $spacing-09;`

#### How did you test and verify your work?
1. I look at the storybook for GetStrtedCard for the one with Pictogram and the one with Sequence in my localhost environment, and then I compare it with the deployed Storybook for Carbon v2.60.0. I did not spot any difference. My change is the one SASS currently compiles into, so if it is incorrect, then the original SASS code doesn't do what it is supposed to do anyway.
2. I check the log in yarn storybook and do not see the original warnings for this file anymore.
