### PR TITLE
chore: remove target spacing sufficient from playwright exclusions

### DIFF
--- a/config/jest-config-ibm-cloud-cognitive/setup/matchers/toHaveNoACViolations.js
+++ b/config/jest-config-ibm-cloud-cognitive/setup/matchers/toHaveNoACViolations.js
@@ -20,7 +20,7 @@ async function toHaveNoACViolations(node, label) {
       'html_skipnav_exists',
       'aria_content_in_landmark',
       'aria_child_tabbable',
-      'target_spacing_sufficient',
+      // 'target_spacing_sufficient',
     ]);
     const ruleset = await aChecker.getRuleset('IBM_Accessibility');
     const customRuleset = JSON.parse(JSON.stringify(ruleset));

--- a/config/jest-config-ibm-cloud-cognitive/setup/matchers/toHaveNoACViolations.js
+++ b/config/jest-config-ibm-cloud-cognitive/setup/matchers/toHaveNoACViolations.js
@@ -20,7 +20,6 @@ async function toHaveNoACViolations(node, label) {
       'html_skipnav_exists',
       'aria_content_in_landmark',
       'aria_child_tabbable',
-      // 'target_spacing_sufficient',
     ]);
     const ruleset = await aChecker.getRuleset('IBM_Accessibility');
     const customRuleset = JSON.parse(JSON.stringify(ruleset));

--- a/packages/ibm-products-styles/src/components/FullPageError/_full-page-error.scss
+++ b/packages/ibm-products-styles/src/components/FullPageError/_full-page-error.scss
@@ -71,6 +71,10 @@ $block-class: #{c4p-settings.$pkg-prefix}--full-page-error;
   margin-block-end: $spacing-07;
 }
 
+.#{$block-class}__body {
+  @include type-style('body-02');
+}
+
 // safari rendering fix
 .#{$block-class}__svg-container svg.#{$block-class}__svg {
   inline-size: 100%;

--- a/packages/ibm-products/src/components/FullPageError/FullPageError.stories.jsx
+++ b/packages/ibm-products/src/components/FullPageError/FullPageError.stories.jsx
@@ -51,9 +51,13 @@ const defaultProps = {
   kind: 'custom',
   children: (
     <>
-      <Link href={'/'}>– Forwarding Link 1</Link>
+      <Link size="lg" href={'/'}>
+        – Forwarding Link 1
+      </Link>
       <br />
-      <Link href={'/'}>– Forwarding Link 1</Link>
+      <Link size="lg" href={'/'}>
+        – Forwarding Link 1
+      </Link>
     </>
   ),
 };

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -88,7 +88,6 @@ expect.extend({
         'aria_content_in_landmark',
         'aria_child_tabbable',
         'skip_main_described',
-        // 'target_spacing_sufficient',
       ]);
 
       const ruleset = await aChecker.getRuleset('IBM_Accessibility');

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -88,7 +88,7 @@ expect.extend({
         'aria_content_in_landmark',
         'aria_child_tabbable',
         'skip_main_described',
-        'target_spacing_sufficient',
+        // 'target_spacing_sufficient',
       ]);
 
       const ruleset = await aChecker.getRuleset('IBM_Accessibility');


### PR DESCRIPTION
Closes #6365 

removes target spacing sufficient from playwright exclusions
fixes fullPageError report on target spacing sufficient

#### What did you change?
config/jest-config-ibm-cloud-cognitive/setup/matchers/toHaveNoACViolations.js
packages/ibm-products-styles/src/components/FullPageError/_full-page-error.scss
packages/ibm-products/src/components/FullPageError/FullPageError.stories.jsx
playwright.config.js

#### How did you test and verify your work?
avt checks