### PR TITLE
fix(Tearsheet): undo previous "readonly" css fix

### DIFF
--- a/packages/ibm-products-styles/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/ibm-products-styles/src/components/Tearsheet/_tearsheet.scss
@@ -401,18 +401,12 @@ $motion-duration: $duration-moderate-02;
   }
 
   &.#{$block-class}--wide .#{$block-class}__content {
-    // Revert background color overridden by Carbon's modal - https://github.com/carbon-design-system/carbon/blob/main/packages/styles/scss/components/modal/_modal.scss#L54
-    .#{$carbon-prefix}--pagination,
-    .#{$carbon-prefix}--pagination__control-buttons,
-    .#{$carbon-prefix}--text-input,
-    .#{$carbon-prefix}--text-area,
-    .#{$carbon-prefix}--search-input,
-    .#{$carbon-prefix}--select-input,
-    .#{$carbon-prefix}--dropdown,
-    .#{$carbon-prefix}--dropdown-list,
-    .#{$carbon-prefix}--number input[type='number'],
-    .#{$carbon-prefix}--date-picker__input {
-      background-color: $field;
+    // Specific to the Tearsheet *and* radio buttons,
+    // `readOnly` styling is not applying a grey outline.
+    .#{$carbon-prefix}--radio-button[readonly]
+      + .#{$carbon-prefix}--radio-button__label
+      .#{$carbon-prefix}--radio-button__appearance {
+      border-color: $icon-disabled;
     }
 
     .#{$carbon-prefix}--select--inline .#{$carbon-prefix}--select-input {

--- a/packages/ibm-products/src/components/Tearsheet/Tearsheet.docs-page.js
+++ b/packages/ibm-products/src/components/Tearsheet/Tearsheet.docs-page.js
@@ -29,6 +29,9 @@ const DocsPage = () => (
         story: stories.firstElementDisabled,
       },
       {
+        story: stories.firstElementReadOnly,
+      },
+      {
         story: stories.fullyLoaded,
       },
       {

--- a/packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.jsx
+++ b/packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.jsx
@@ -453,6 +453,80 @@ const FirstElementDisabledTemplate = (
   );
 };
 
+const FirstElementReadOnlyTemplate = (
+  { actions, decorator, slug, ...args },
+  context
+) => {
+  const [open, setOpen] = useState(false);
+  const wiredActions =
+    actions &&
+    Array.prototype.map.call(actions, (action) => {
+      if (action.label === 'Cancel') {
+        const previousClick = action.onClick;
+        return {
+          ...action,
+          onClick: (evt) => {
+            setOpen(false);
+            previousClick(evt);
+          },
+        };
+      }
+      return action;
+    });
+
+  const ref = useRef(undefined);
+
+  useEffect(() => {
+    setTimeout(() => setOpen(context.viewMode !== 'docs'), 0);
+  }, []);
+
+  return (
+    <>
+      <style>{`.${pkg.prefix}--tearsheet { opacity: 0 }`};</style>
+      <Button onClick={() => setOpen(true)}>Open Tearsheet</Button>
+      <div ref={ref}>
+        <Tearsheet
+          {...args}
+          actions={wiredActions}
+          open={open}
+          onClose={() => setOpen(false)}
+          decorator={decorator && sampleDecorator(decorator)}
+          slug={slug && sampleDecorator(slug)}
+        >
+          <div className="tearsheet-stories__dummy-content-block">
+            <Form>
+              <p>Main content</p>
+              <FormGroup
+                legendId="tearsheet-form-group"
+                legendText="FormGroup Legend"
+              >
+                <TextInput
+                  id="tss-ft1"
+                  labelText="This field's value is 'read only':"
+                  readOnly={true}
+                  style={
+                    // stylelint-disable-next-line carbon/layout-use
+                    { marginBottom: '1em' }
+                  }
+                  value="Value"
+                />
+                <TextInput
+                  id="tss-ft2"
+                  labelText="Here is an entry field:"
+                  style={
+                    // stylelint-disable-next-line carbon/layout-use
+                    { marginBottom: '1em' }
+                  }
+                />
+              </FormGroup>
+            </Form>
+          </div>
+        </Tearsheet>
+      </div>
+    </>
+  );
+};
+
 // eslint-disable-next-line react/prop-types
 const StackedTemplate = (
   { mixedSizes, actions, decorator, slug, ...args },
@@ -679,6 +753,18 @@ ReturnFocusToOpenButton.args = {
 export const firstElementDisabled = FirstElementDisabledTemplate.bind({});
 firstElementDisabled.storyName = 'First Element Disabled';
 firstElementDisabled.args = {
+  closeIconDescription,
+  hasCloseIcon: true,
+  description,
+  onClose: action('onClose called'),
+  title,
+  actions: 7,
+  selectorPrimaryFocus: '#tss-ft1',
+};
+
+export const firstElementReadOnly = FirstElementReadOnlyTemplate.bind({});
+firstElementReadOnly.storyName = 'First Element ReadOnly';
+firstElementReadOnly.args = {
   closeIconDescription,
   hasCloseIcon: true,
   description,


### PR DESCRIPTION
Closes #6698 

**Issue**

The `Tearsheet` stylesheet included a CSS fix for form fields that were set to `readOnly`. This was an inherited issue from the parent `Modal` component. 

**Solution**

It seems the `Modal` styling has been fixed, and the existing CSS in the `Tearsheet` broke those changes. Removing the old fix has restored the correct styling for `readOnly` form fields.

#### What did you change?

```
packages/ibm-products-styles/src/components/Tearsheet/_tearsheet.scss
packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.jsx
packages/ibm-products/src/components/Tearsheet/Tearsheet.docs-page.js
```

#### How did you test and verify your work?

- Added story `firstElementReadOnly`: [Direct Storybook link](https://deploy-preview-6961--carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-tearsheet--tearsheet-read-only-input-fields&globals=viewport:basic) 
- See also #6961 for a demo page showing the `enabled | disabled | readonly` states for all form fields.