### PR TITLE
fix(useravatar): renderIcon prop changed to slot

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -204,6 +204,7 @@
     "userprofileimage",
     "uuidv",
     "webfonts",
-    "useravatar"
+    "useravatar",
+    "rendericon"
   ]
 }

--- a/packages/ibm-products-web-components/src/components/user-avatar/user-avatar.mdx
+++ b/packages/ibm-products-web-components/src/components/user-avatar/user-avatar.mdx
@@ -44,6 +44,20 @@ import '@carbon/ibm-products-web-components/es/components/user-avatar/index.js';
 ></c4p-user-avatar>
 ```
 
+### With Icon
+An icon can be passed as a slot in `<c4p-user-avatar>` using `{ slot: 'rendericon' }`.
+```html
+ <c4p-user-avatar
+  name= 'Thomas J. Watson'
+  background-color='order-11-purple'
+  size="lg"
+  tooltip-text='TW, Thomas J. Watson user profile'
+  tooltip-alignment="right"
+>
+ ${Group({ slot: 'rendericon' })}
+</c4p-user-avatar>
+```
+
 ## `<c4p-user-avatar>` attributes, properties and events
 
 Note: For `boolean` attributes, `true` means simply setting the attribute.

--- a/packages/ibm-products-web-components/src/components/user-avatar/user-avatar.mdx
+++ b/packages/ibm-products-web-components/src/components/user-avatar/user-avatar.mdx
@@ -45,7 +45,7 @@ import '@carbon/ibm-products-web-components/es/components/user-avatar/index.js';
 ```
 
 ### With Icon
-An icon can be passed as a slot in `<c4p-user-avatar>` using `{ slot: 'rendericon' }`.
+A carbon icon can be passed as a slot in `<c4p-user-avatar>` using `{ slot: 'rendericon' }`. For a custom icon, specify the slot by adding the `slot="rendericon"` attribute to the element.
 ```html
  <c4p-user-avatar
   name= 'Thomas J. Watson'

--- a/packages/ibm-products-web-components/src/components/user-avatar/user-avatar.scss
+++ b/packages/ibm-products-web-components/src/components/user-avatar/user-avatar.scss
@@ -32,6 +32,31 @@ $block-class: #{$prefix}--user-avatar;
   @extend .#{$block-class}__tooltip;
 }
 
+:host(#{$prefix}-user-avatar) .#{$block-class}--xl {
+  ::slotted([slot='rendericon']) {
+    block-size: $spacing-07;
+    inline-size: $spacing-07;
+  }
+}
+:host(#{$prefix}-user-avatar) .#{$block-class}--lg {
+  ::slotted([slot='rendericon']) {
+    block-size: $spacing-06;
+    inline-size: $spacing-06;
+  }
+}
+:host(#{$prefix}-user-avatar) .#{$block-class}--md {
+  ::slotted([slot='rendericon']) {
+    block-size: $spacing-04 + $spacing-03;
+    inline-size: $spacing-04 + $spacing-03;
+  }
+}
+:host(#{$prefix}-user-avatar) .#{$block-class}--sm {
+  ::slotted([slot='rendericon']) {
+    block-size: $spacing-05;
+    inline-size: $spacing-05;
+  }
+}
+
 :host(#{$prefix}-user-avatar) .#{$block-class}__tooltip-trigger {
   padding: 0;
   border: 0;

--- a/packages/ibm-products-web-components/src/components/user-avatar/user-avatar.stories.ts
+++ b/packages/ibm-products-web-components/src/components/user-avatar/user-avatar.stories.ts
@@ -10,10 +10,7 @@
 import { html } from 'lit';
 import './index';
 import { POPOVER_ALIGNMENT } from '@carbon/web-components/es/components/popover/defs.js';
-import styles from './story-styles.scss?lit';
 import Group from '@carbon/web-components/es/icons/group/16';
-import User from '@carbon/web-components/es/icons/user/16';
-import Add from '@carbon/web-components/es/icons/add/16';
 import headshot from './_story-assets/headshot.jpg';
 
 const storyPrefix = 'user-avatar-stories__';
@@ -29,80 +26,62 @@ const tooltipAlignments = {
   [`right`]: POPOVER_ALIGNMENT.RIGHT,
 };
 
-const defaultTemplate = {
-  args: {
-    tooltipAlignment: POPOVER_ALIGNMENT.RIGHT,
-    size: 'md',
-  },
+const args = { tooltipAlignment: POPOVER_ALIGNMENT.RIGHT, size: 'md' };
 
-  argTypes: {
-    backgroundColor: {
-      control: {
-        type: 'select',
-      },
-      options: [
-        'order-1-cyan',
-        'order-2-gray',
-        'order-3-green',
-        'order-4-magenta',
-        'order-5-purple',
-        'order-6-teal',
-        'order-7-cyan',
-        'order-8-gray',
-        'order-9-green',
-        'order-10-magenta',
-        'order-11-purple',
-        'order-12-teal',
-      ],
-    },
-    tooltipAlignment: {
-      control: 'select',
-      description: 'Specify the alignment of the tooltip.',
-      options: tooltipAlignments,
-    },
-    tooltipText: {
-      control: 'text',
-      description: 'Specify the text of the tooltip',
-    },
-    name: {
-      control: 'text',
-      description: 'Specify the name of the user',
-    },
-    renderIcon: {
-      control: 'select',
-      description: 'Specify the renderIcon for user',
-      options: ['No icon', 'User', 'Group', 'Add'],
-      mapping: { 'No icon': '', User: User, Group: Group, Add: Add },
-    },
-    size: {
-      control: {
-        type: 'radio',
-      },
-      options: ['xl', 'lg', 'md', 'sm'],
-    },
-    image: {
-      control: 'textNullable',
-      description: 'Specify the full path to the image to be displayed',
-    },
-    imageDescription: {
-      control: 'text',
-      description:
-        'Specify the to description of image for screen reader users',
-    },
-    theme: {
-      control: {
-        type: 'select',
-      },
-      options: ['light', 'dark'],
-    },
+const argTypes = {
+  backgroundColor: {
+    control: { type: 'select' },
+    options: [
+      'order-1-cyan',
+      'order-2-gray',
+      'order-3-green',
+      'order-4-magenta',
+      'order-5-purple',
+      'order-6-teal',
+      'order-7-cyan',
+      'order-8-gray',
+      'order-9-green',
+      'order-10-magenta',
+      'order-11-purple',
+      'order-12-teal',
+    ],
   },
+  tooltipAlignment: {
+    control: 'select',
+    description: 'Specify the alignment of the tooltip.',
+    options: tooltipAlignments,
+  },
+  tooltipText: {
+    control: 'text',
+    description: 'Specify the text of the tooltip',
+  },
+  name: { control: 'text', description: 'Specify the name of the user' },
+  size: { control: { type: 'radio' }, options: ['xl', 'lg', 'md', 'sm'] },
+  image: {
+    control: 'textNullable',
+    description: 'Specify the full path to the image to be displayed',
+  },
+  imageDescription: {
+    control: 'text',
+    description: 'Specify the to description of image for screen reader users',
+  },
+  theme: { control: { type: 'select' }, options: ['light', 'dark'] },
+};
+
+export const Default = {
+  args: {
+    ...args,
+    tooltipText: 'TW, Thomas J. Watson user profile',
+    name: 'Thomas J. Watson',
+    backgroundColor: 'order-1-cyan',
+  },
+  argTypes,
   render: (args) => {
     return html`
       <c4p-user-avatar
         tooltip-alignment=${args.tooltipAlignment}
         tooltip-text=${args.tooltipText}
         name=${args.name}
-        .renderIcon=${args.renderIcon}
         size=${args.size}
         image=${args.image}
         image-description=${args.imageDescription}
@@ -114,29 +93,57 @@ const defaultTemplate = {
   },
 };
 
-export const Default = {
-  ...defaultTemplate,
+export const WithIcon = {
   args: {
-    ...defaultTemplate.args,
+    ...args,
     tooltipText: 'TW, Thomas J. Watson user profile',
     name: 'Thomas J. Watson',
     backgroundColor: 'order-1-cyan',
-    renderIcon: 'No icon',
+  },
+  argTypes,
+  render: (args) => {
+    return html`
+      <c4p-user-avatar
+        tooltip-alignment=${args.tooltipAlignment}
+        tooltip-text=${args.tooltipText}
+        name=${args.name}
+        size=${args.size}
+        image=${args.image}
+        image-description=${args.imageDescription}
+        background-color=${args.backgroundColor}
+        theme=${args.theme}
+      >
+        ${Group({ slot: 'rendericon' })}
+      </c4p-user-avatar>
+    `;
   },
 };
 
 export const WithImage = {
-  ...defaultTemplate,
   args: {
-    ...defaultTemplate.args,
+    ...args,
     image: headshot,
     tooltipText: 'TW, Thomas J. Watson user profile',
     imageDescription: 'Avatar of Thomas J. Watson',
   },
+  argTypes,
+  render: (args) => {
+    return html`
+      <c4p-user-avatar
+        tooltip-alignment=${args.tooltipAlignment}
+        tooltip-text=${args.tooltipText}
+        name=${args.name}
+        size=${args.size}
+        image=${args.image}
+        image-description=${args.imageDescription}
+        background-color=${args.backgroundColor}
+        theme=${args.theme}
+      >
+      </c4p-user-avatar>
+    `;
+  },
 };
 
-const meta = {
-  title: 'Experimental/Useravatar',
-};
+const meta = { title: 'Experimental/Useravatar' };
 
 export default meta;

--- a/packages/ibm-products-web-components/src/components/user-avatar/user-avatar.ts
+++ b/packages/ibm-products-web-components/src/components/user-avatar/user-avatar.ts
@@ -19,8 +19,6 @@ import User from '@carbon/web-components/es/icons/user/16';
 
 const blockClass = `${prefix}--user-avatar`;
 
-const iconSize = { sm: 16, md: 20, lg: 24, xl: 32 };
-
 /**
  * Useravatar.
  *
@@ -47,12 +45,6 @@ class CDSUseravatar extends HostListenerMixin(LitElement) {
    */
   @property({ reflect: true })
   name;
-
-  /**
-   * Provide a custom icon to use if you need to use an icon other than the default one
-   */
-  @property()
-  renderIcon;
 
   /**
    * Set the size of the avatar circle
@@ -85,7 +77,6 @@ class CDSUseravatar extends HostListenerMixin(LitElement) {
 
   render() {
     const getItem = () => {
-      const iconProps = { size: iconSize[this.size] };
       if (this.image) {
         const imageClasses = classMap({
           [`${blockClass}__photo`]: true,
@@ -97,11 +88,8 @@ class CDSUseravatar extends HostListenerMixin(LitElement) {
           class="${imageClasses}"
         />`;
       }
-      if (this.renderIcon) {
-        return html`${this.renderIcon({
-          width: `${iconProps.size}`,
-          height: `${iconProps.size}`,
-        })}`;
+      if (this.querySelector('[slot="rendericon"]')) {
+        return html`<slot name="rendericon"></slot>`;
       }
       if (this.name) {
         const parts = this.name?.split(' ') || [];
@@ -118,11 +106,7 @@ class CDSUseravatar extends HostListenerMixin(LitElement) {
 
         return ''.concat(...initials);
       }
-      return html`${User({
-        slot: 'icon',
-        width: `${iconProps.size}`,
-        height: `${iconProps.size}`,
-      })} `;
+      return html`${User({ slot: 'rendericon' })} `;
     };
 
     const { tooltipText, tooltipAlignment, size, backgroundColor, theme } =


### PR DESCRIPTION
 closes #7100 

RenderIcon prop changed to slot.
Based on the [suggestion](https://github.com/carbon-design-system/carbon/pull/18703#discussion_r1977846565) in Menu(carbon). Same logic applies here.

#### What did you change? packages/ibm-products-web-components/src/components/user-avatar/user-avatar.mdx
packages/ibm-products-web-components/src/components/user-avatar/user-avatar.stories.ts
packages/ibm-products-web-components/src/components/user-avatar/user-avatar.ts
cspell.json

#### How did you test and verify your work? yarn storybook
