### PR TITLE
feat: setup renovate, add batch upgrade for all carbon packages

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    // https://docs.renovatebot.com/presets-config/#configjs-lib
+    "config:js-lib",
+
+    // https://docs.renovatebot.com/presets-default/#maintainlockfilesweekly
+    ":maintainLockFilesWeekly",
+
+    // https://docs.renovatebot.com/presets-default/#preservesemverranges
+    ":preserveSemverRanges",
+
+    // https://docs.renovatebot.com/presets-npm/#npmunpublishsafe
+    "npm:unpublishSafe",
+  ],
+  "schedule": [
+    "after 10pm every weekday",
+    "before 5am every weekday",
+    "every weekend",
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "rebaseWhen": "never",
+  // Batch all Carbon package dependency upgrades together
+  "packageRules": [
+    {
+      "matchPackageNames": ["@carbon/**"],
+      "groupName": "Carbon core packages",
+      // Update at 4:00 UTC on the 1st and 15th of every month
+      "schedule": "0 4 1,15 * *"
+    }
+  ]
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,7 +27,7 @@
       "matchPackageNames": ["@carbon/**"],
       "groupName": "Carbon core packages",
       // Update at 4:00 UTC on the 1st and 15th of every month
-      "schedule": "0 4 1,15 * *"
+      "schedule": "* 4 1,15 * *"
     }
   ]
 }


### PR DESCRIPTION
Closes #7118 

Adds renovate config, this will allow us to upgrade packages more easily since renovate does upgrades for single packages. However, you can batch packages together which I've configured in this PR so that all `@carbon/*` packages are upgraded together. I used the same time interval that we've been using (1st and 15th of every month).

These changes should also allow us to delete the workflow files we have for upgrading packages via `npm-check-updates`, want to make sure this setup works before deleting those.

#### What did you change?
```
.github/renovate.json5
```
#### How did you test and verify your work?
I've been able to test that there are no renovate configuration errors via the following:
```
npx --yes --package renovate -- renovate-config-validator
```
![image](https://github.com/user-attachments/assets/d8fb6892-f054-49f9-821e-e78ea8530e30)
