### PR TITLE
fix(OptionsTile): use correct heading levels

### DIFF
--- a/packages/ibm-products/src/components/OptionsTile/OptionsTile.tsx
+++ b/packages/ibm-products/src/components/OptionsTile/OptionsTile.tsx
@@ -13,7 +13,7 @@ import {
   WarningAltFilled,
   WarningFilled,
 } from '@carbon/react/icons';
-import { Layer, Toggle } from '@carbon/react';
+import { Heading, Layer, Section, Toggle } from '@carbon/react';
 import React, { MouseEvent, ReactNode, useRef, useState } from 'react';
 import { CarbonIconType } from '@carbon/icons-react/lib/CarbonIcon';
 import PropTypes from 'prop-types';
@@ -274,17 +274,17 @@ export let OptionsTile = React.forwardRef<HTMLDivElement, OptionsTileProps>(
       });
 
       return (
-        <div className={`${blockClass}__heading`}>
-          <h6 id={titleId} className={`${blockClass}__title`}>
+        <Section className={`${blockClass}__heading`}>
+          <Heading id={titleId} className={`${blockClass}__title`}>
             {title}
-          </h6>
+          </Heading>
           {text && (
             <span className={summaryClasses} aria-hidden={summaryHidden}>
               {Icon && <Icon size={16} />}
               <span className={`${blockClass}__summary-text`}>{text}</span>
             </span>
           )}
-        </div>
+        </Section>
       );
     };
 


### PR DESCRIPTION
Closes #7162.

Make `OptionsTile` use heading levels in line with its hierarchy in the document, assuming the document was written correctly using `Section` and `Heading`.

Both for the main heading rendered by `OptionsTile` itself as well as headings in the content passed to `OptionsTile`.

#### What did you change?

Use `Section` and `Heading` instead of `<div>` and `<h6>`.

Based on code from #6816 but without the ability to override the level.  See also https://github.com/carbon-design-system/carbon/pull/18871, which is the same thing for TableContainer.

#### How did you test and verify your work?

Tested locally.

Note: depends on #7161.