### PR TITLE
fix(tearsheet): fix heading levels of content

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.jsx
+++ b/packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.jsx
@@ -27,7 +27,7 @@ import {
   AILabelContent,
   Toggletip,
   ToggletipButton,
-  ToggletipContent,
+  ToggletipContent, Heading, Section,
 } from '@carbon/react';
 
 import { Tearsheet, deprecatedProps } from './Tearsheet';
@@ -148,13 +148,17 @@ const description =
   describe the flow over a couple of lines in the header of the tearsheet.';
 
 const influencer = (
-  <div className="tearsheet-stories__dummy-content-block">Influencer</div>
+  <Section className="tearsheet-stories__dummy-content-block">
+    <Heading>Influencer heading</Heading>
+    <p>Influencer content</p>
+  </Section>
 );
 
 const label = 'The label of the tearsheet';
 
 const mainContent = (
-  <div className="tearsheet-stories__dummy-content-block">
+  <Section className="tearsheet-stories__dummy-content-block">
+    <Heading>Main content heading</Heading>
     <Form>
       <p>Main content</p>
       <FormGroup legendId="tearsheet-form-group" legendText="FormGroup Legend">
@@ -176,7 +180,7 @@ const mainContent = (
         />
       </FormGroup>
     </Form>
-  </div>
+  </Section>
 );
 
 const title = 'Title of the tearsheet';

--- a/packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.jsx
+++ b/packages/ibm-products/src/components/Tearsheet/Tearsheet.stories.jsx
@@ -17,6 +17,8 @@ import {
   Dropdown,
   Form,
   FormGroup,
+  Heading,
+  Section,
   Tab,
   Tabs,
   TabPanels,
@@ -27,7 +29,7 @@ import {
   AILabelContent,
   Toggletip,
   ToggletipButton,
-  ToggletipContent, Heading, Section,
+  ToggletipContent,
 } from '@carbon/react';
 
 import { Tearsheet, deprecatedProps } from './Tearsheet';

--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
@@ -35,6 +35,7 @@ import {
   ModalHeader,
   usePrefix,
   unstable_FeatureFlags as FeatureFlags,
+  Section,
 } from '@carbon/react';
 
 import { ActionSet } from '../ActionSet';
@@ -422,6 +423,9 @@ export const TearsheetShell = React.forwardRef(
 
       const areAllSameSizeVariant = () => new Set(stack.sizes).size === 1;
 
+      const Level3Section = ({children}: {children: ReactNode}) =>
+        <Section level={3}>{children}</Section>;
+
       return renderPortalUse(
         <FeatureFlags enableExperimentalFocusWrapWithoutSentinels>
           <ComposedModal
@@ -523,8 +527,9 @@ export const TearsheetShell = React.forwardRef(
                   [`${bc}__influencer--wide`]: influencerWidth === 'wide',
                 })}
                 neverRender={influencerPosition === 'right'}
+                element={Level3Section}
               >
-                {influencer}
+                  {influencer}
               </Wrap>
               <Wrap className={`${bc}__right`}>
                 <Wrap className={`${bc}__main`} alwaysRender={includeActions}>
@@ -534,8 +539,9 @@ export const TearsheetShell = React.forwardRef(
                       !!(influencer && influencerPosition === 'right')
                     }
                     tabIndex={-1}
+                    element={Level3Section}
                   >
-                    {children}
+                      {children}
                   </Wrap>
                   <Wrap
                     className={cx({
@@ -543,8 +549,9 @@ export const TearsheetShell = React.forwardRef(
                       [`${bc}__influencer--wide`]: influencerWidth === 'wide',
                     })}
                     neverRender={influencerPosition !== 'right'}
+                    element={Level3Section}
                   >
-                    {influencer}
+                      {influencer}
                   </Wrap>
                 </Wrap>
                 {includeActions && (

--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
@@ -234,6 +234,19 @@ export const tearsheetHasCloseIcon = (actions, hasCloseIcon) =>
   hasCloseIcon ?? tearsheetIsPassive(actions);
 
 /**
+ * Since the Tearsheet has an H3 heading, any headings inside the Tearsheet should start at H4.
+ * This is a helper to do that.
+ */
+const SectionLevel3 = ({
+  children,
+  ...rest
+}: ComponentProps<typeof Section>) => (
+  <Section level={3} {...rest}>
+    {children}
+  </Section>
+);
+
+/**
  *  TearSheetShell is used internally by TearSheet and TearSheetNarrow
  *
  * The component is not public.
@@ -424,16 +437,6 @@ export const TearsheetShell = React.forwardRef(
       const includeActions = actions && actions?.length > 0;
 
       const areAllSameSizeVariant = () => new Set(stack.sizes).size === 1;
-
-      // Since the Tearsheet has an H3 heading, any headings inside the Tearsheet should start at H4.
-      const SectionLevel3 = ({
-        children,
-        ...rest
-      }: ComponentProps<typeof Section>) => (
-        <Section level={3} {...rest}>
-          {children}
-        </Section>
-      );
 
       return renderPortalUse(
         <FeatureFlags enableExperimentalFocusWrapWithoutSentinels>

--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
@@ -10,6 +10,7 @@ import React, {
   useEffect,
   useState,
   useRef,
+  ComponentProps,
   PropsWithChildren,
   ReactNode,
   ForwardedRef,
@@ -26,6 +27,7 @@ import pconsole from '../../global/js/utils/pconsole';
 import { getNodeTextContent } from '../../global/js/utils/getNodeTextContent';
 import { deprecateProp } from '../../global/js/utils/props-helper';
 import { checkHeightOverflow } from '../../global/js/utils/checkForOverflow';
+
 // Carbon and package components we use.
 import {
   Button,
@@ -424,8 +426,13 @@ export const TearsheetShell = React.forwardRef(
       const areAllSameSizeVariant = () => new Set(stack.sizes).size === 1;
 
       // Since the Tearsheet has an H3 heading, any headings inside the Tearsheet should start at H4.
-      const SectionLevel3 = ({ children }: { children: ReactNode }) => (
-        <Section level={3}>{children}</Section>
+      const SectionLevel3 = ({
+        children,
+        ...rest
+      }: ComponentProps<typeof Section>) => (
+        <Section level={3} {...rest}>
+          {children}
+        </Section>
       );
 
       return renderPortalUse(

--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
@@ -33,9 +33,9 @@ import {
   DefinitionTooltip,
   Layer,
   ModalHeader,
+  Section,
   usePrefix,
   unstable_FeatureFlags as FeatureFlags,
-  Section,
 } from '@carbon/react';
 
 import { ActionSet } from '../ActionSet';
@@ -423,8 +423,10 @@ export const TearsheetShell = React.forwardRef(
 
       const areAllSameSizeVariant = () => new Set(stack.sizes).size === 1;
 
-      const Level3Section = ({children}: {children: ReactNode}) =>
-        <Section level={3}>{children}</Section>;
+      // Since the Tearsheet has an H3 heading, any headings inside the Tearsheet should start at H4.
+      const SectionLevel3 = ({ children }: { children: ReactNode }) => (
+        <Section level={3}>{children}</Section>
+      );
 
       return renderPortalUse(
         <FeatureFlags enableExperimentalFocusWrapWithoutSentinels>
@@ -527,9 +529,9 @@ export const TearsheetShell = React.forwardRef(
                   [`${bc}__influencer--wide`]: influencerWidth === 'wide',
                 })}
                 neverRender={influencerPosition === 'right'}
-                element={Level3Section}
+                element={SectionLevel3}
               >
-                  {influencer}
+                {influencer}
               </Wrap>
               <Wrap className={`${bc}__right`}>
                 <Wrap className={`${bc}__main`} alwaysRender={includeActions}>
@@ -539,9 +541,9 @@ export const TearsheetShell = React.forwardRef(
                       !!(influencer && influencerPosition === 'right')
                     }
                     tabIndex={-1}
-                    element={Level3Section}
+                    element={SectionLevel3}
                   >
-                      {children}
+                    {children}
                   </Wrap>
                   <Wrap
                     className={cx({
@@ -549,9 +551,9 @@ export const TearsheetShell = React.forwardRef(
                       [`${bc}__influencer--wide`]: influencerWidth === 'wide',
                     })}
                     neverRender={influencerPosition !== 'right'}
-                    element={Level3Section}
+                    element={SectionLevel3}
                   >
-                      {influencer}
+                    {influencer}
                   </Wrap>
                 </Wrap>
                 {includeActions && (


### PR DESCRIPTION
Fixes #7164.

As per https://www.w3.org/WAI/tutorials/page-structure/headings/, the headings inside tearsheet content must have a level relative to the tearsheet's own heading.   This PR makes that easy.

In other words, applications can write like this and the heading levels will make sense when it renders:

```jsx
<Tearsheet
        ...
        description="This is a description for the tearsheet, providing an opportunity to   describe the flow over a couple of lines in the header of the tearsheet."
        influencer={
            <Section>
              <Heading>Heading in influencer 1</Heading>
              <p>...</p>
            </Section>
            <Section>
              <Heading>Heading in influencer 2</Heading>
              <p>...</p>
            </Section>
        }
       ...
>
        <Section>
          <Heading>Content Heading 1</Heading>
          <p>...</p>
        </Section>
        <Section>
          <Heading>Content heading 2</Heading>
          <p>...</p>
        </Section>
</Tearsheet>
```

Note that according to https://medium.com/@web-accessibility-education/which-heading-level-should-dialog-modals-have-7b3df89437f0, a dialog’s top heading should be either H1 or H2.   By corollary, the heading inside the dialog needs to start one level lower, at H2 or H3.

Tearsheet has a strange design w.r.t. heading levels:

- It sometimes has both H2 and H3 headings, for example at https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-tearsheet--with-navigation&globals=viewport:basic.
- It sometimes just has an H3 heading, for example at https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-tearsheet--tearsheet&globals=viewport:basic.

I’m skeptical if that makes sense, especially in the second case, but I wrote this PR under the assumption we don’t change that.


#### What did you change?

I added `<Section>` wrappers around the `influencer` and `children` so when applications use Tearsheet it just works as expected.


#### How did you test and verify your work?

Tested examples in Storybook.

Note: depends on https://github.com/carbon-design-system/ibm-products/pull/7161.