### PR TITLE
fix(CreateFullPage): use correct heading levels

### DIFF
--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPageStep.tsx
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPageStep.tsx
@@ -18,7 +18,7 @@ import React, {
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { pkg } from '../../settings';
-import { Column, FormGroup, Grid } from '@carbon/react';
+import { Column, FormGroup, Grid, Heading, Section } from '@carbon/react';
 import { StepsContext, StepNumberContext } from './CreateFullPage';
 import { usePreviousValue, useRetrieveStepData } from '../../global/js/hooks';
 import pconsole from '../../global/js/utils/pconsole';
@@ -214,7 +214,7 @@ export let CreateFullPageStep = forwardRef(
     };
 
     return stepsContext ? (
-      <section
+      <Section
         {
           // Pass through any other property values as HTML attributes.
           ...rest
@@ -230,12 +230,12 @@ export let CreateFullPageStep = forwardRef(
         <Grid>
           <Column {...span}>
             <Grid>
-              <Column className={`${blockClass}-title`} as="h5" {...span}>
+              <Column className={`${blockClass}-title`} as={Heading} {...span}>
                 {title}
               </Column>
 
               {subtitle && (
-                <Column className={`${blockClass}-subtitle`} as="h6" {...span}>
+                <Column className={`${blockClass}-subtitle`} as="p" {...span}>
                   {subtitle}
                 </Column>
               )}
@@ -255,7 +255,7 @@ export let CreateFullPageStep = forwardRef(
         ) : (
           children
         )}
-      </section>
+      </Section>
     ) : (
       pconsole.warn(
         `You have tried using a ${componentName} component outside of a CreateFullPage. This is not allowed. ${componentName}s should always be children of the CreateFullPage`

--- a/packages/ibm-products/src/components/CreateInfluencer/CreateInfluencer.tsx
+++ b/packages/ibm-products/src/components/CreateInfluencer/CreateInfluencer.tsx
@@ -9,7 +9,7 @@
 import React, { PropsWithChildren, ReactNode } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { ProgressIndicator, ProgressStep } from '@carbon/react';
+import { Heading, ProgressIndicator, ProgressStep, Section } from '@carbon/react';
 import '../../global/js/utils/props-helper';
 
 import { pkg } from '../../settings';
@@ -79,8 +79,8 @@ export const CreateInfluencer = ({
       0;
 
     return (
-      <div className={`${blockClass}__left-nav`}>
-        {title && <h3 className={`${blockClass}__title`}>{title}</h3>}
+      <Section className={`${blockClass}__left-nav`}>
+        {title && <Heading className={`${blockClass}__title`}>{title}</Heading>}
         {currentStep === 1 && stepData[0]?.introStep ? null : (
           <ProgressIndicator
             currentIndex={
@@ -105,7 +105,7 @@ export const CreateInfluencer = ({
             })}
           </ProgressIndicator>
         )}
-      </div>
+      </Section>
     );
   };
 

--- a/packages/ibm-products/src/components/CreateInfluencer/CreateInfluencer.tsx
+++ b/packages/ibm-products/src/components/CreateInfluencer/CreateInfluencer.tsx
@@ -9,7 +9,12 @@
 import React, { PropsWithChildren, ReactNode } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { Heading, ProgressIndicator, ProgressStep, Section } from '@carbon/react';
+import {
+  Heading,
+  ProgressIndicator,
+  ProgressStep,
+  Section,
+} from '@carbon/react';
 import '../../global/js/utils/props-helper';
 
 import { pkg } from '../../settings';

--- a/packages/ibm-products/src/components/SimpleHeader/SimpleHeader.js
+++ b/packages/ibm-products/src/components/SimpleHeader/SimpleHeader.js
@@ -13,7 +13,7 @@ import { pkg } from '../../settings';
 import pconsole from '../../global/js/utils/pconsole';
 import { BreadcrumbWithOverflow } from '../BreadcrumbWithOverflow';
 import { isRequiredIf } from '../../global/js/utils/props-helper';
-import { Tooltip } from '@carbon/react';
+import { Tooltip, Heading } from '@carbon/react';
 
 const blockClass = `${pkg.prefix}--simple-header`;
 const componentName = 'SimpleHeader';
@@ -63,7 +63,9 @@ const SimpleHeader = ({
           overflowTooltipAlign={overflowTooltipAlign}
         />
       )}
-      {title && <h1 className={cx(`${blockClass}__title`)}>{title}</h1>}
+      {title && (
+        <Heading className={cx(`${blockClass}__title`)}>{title}</Heading>
+      )}
     </header>
   );
 };


### PR DESCRIPTION
Closes #6815.

The top heading (assuming it's specified) is H1, so the subheadings should be H2, not H3, H5, or H6. 

#### What did you change?

Use `Section` and `Heading` for the heading subheadings, so they come out at the right level.

Could have hardcoded the headings to H2, but this way seems less brittle.

Also, change the subtitle to `<p>` as it is really more of a description than another heading.

Based on some of the code from #6816.

#### How did you test and verify your work?

Tested from Storybook.

Note: depends on https://github.com/carbon-design-system/ibm-products/pull/7161.