### PR TITLE
fix: set minWidth to 50 instead of 0, prioritize column.minWidth

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/useSortableColumns.tsx
+++ b/packages/ibm-products/src/components/Datagrid/useSortableColumns.tsx
@@ -183,9 +183,9 @@ const useSortableColumns = (hooks: Hooks) => {
       return {
         ...column,
         Header,
-        minWidth: column.disableSortBy
-          ? 0
-          : (column.minWidth ?? (column.isAction ? 50 : 90)),
+        minWidth:
+          column.minWidth ??
+          (column.disableSortBy ? 50 : column.isAction ? 50 : 90),
       };
     });
     return instance.customizeColumnsProps?.isTearsheetOpen


### PR DESCRIPTION
Closes #6957 

sets default min width to 50, also prioritizes min width thats passed through column definition

#### What did you change?
packages/ibm-products/src/components/Datagrid/useSortableColumns.tsx

#### How did you test and verify your work?
added disableSortBy for a column in sortable columns story to cross verify