### PR TITLE
fix(Tearsheet): remove nodes from dependencies

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
@@ -281,11 +281,10 @@ export const TearsheetShell = React.forwardRef(
     const modalRef = (ref || localRef) as MutableRefObject<HTMLDivElement>;
     const { width } = useResizeObserver(resizer);
     const prevOpen = usePreviousValue(open);
-    const { firstElement, keyDownListener } = useFocus(
+    const { getFocusable, keyDownListener } = useFocus(
       modalRef,
       selectorPrimaryFocus
     );
-    const modalRefValue = modalRef.current;
 
     const descriptionRef = useRef<HTMLSpanElement>(null);
     const isOverflowing = checkHeightOverflow(descriptionRef.current);
@@ -320,14 +319,13 @@ export const TearsheetShell = React.forwardRef(
     useEffect(() => {
       if (open && position === depth) {
         // Focusing the first element or selectorPrimaryFocus element
-        claimFocus(firstElement, modalRef, selectorPrimaryFocus);
+        claimFocus(getFocusable()?.first, modalRef, selectorPrimaryFocus);
       }
     }, [
       currentStep,
       depth,
-      firstElement,
+      getFocusable,
       modalRef,
-      modalRefValue,
       open,
       position,
       selectorPrimaryFocus,


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/ibm-products/issues/6981

When rendering conditionally instead of passing `open` to the tearsheet, the focus jumps back to the primary focus on re-render: https://stackblitz.com/edit/github-vqpu3jc2?file=src%2FExample%2FExample.jsx

#### What did you change?
- Removed `firstElement` from dependency array, calling getFocusable from within instead
- Removed unused `modalRefValue` from dependency array 

#### How did you test and verify your work?
- Storybook `selectorPrimaryFocus` is still working as expected 
- Storybook with new story for rendering conditionally and case from issue linked above (not included) is working as expected now
