### PR TITLE
chore: updates deprecated vite browser api

### DIFF
--- a/packages/ibm-products-web-components/vite.config.ts
+++ b/packages/ibm-products-web-components/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="@vitest/browser/providers/playwright" />
 /**
  * Copyright IBM Corp. 2024, 2024
  *
@@ -30,7 +31,7 @@ export default defineConfig({
       provider: 'playwright',
       enabled: true,
       headless: true,
-      name: 'chromium',
+      instances: [{ browser: 'chromium' }],
     },
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
This PR gets rid of this error when running vite tests on build. 
[Example](https://github.com/carbon-design-system/ibm-products/actions/runs/14084383649/job/39444536051?pr=7177#step:8:13)

```
@carbon/ibm-products-web-components:  Vitest  No browser "instances" were defined. Running tests in "chromium" browser. The "browser.name" field is deprecated since Vitest 3. Read more: https://vitest.dev/guide/browser/config#browser-instances
```

#### What did you change?
packages/ibm-products-web-components/vite.config.ts