### PR TITLE
refactor: EmptyState TS to extend Carbon `ButtonProps`

### DIFF
--- a/packages/ibm-products/src/components/EmptyStates/EmptyState.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyState.tsx
@@ -104,6 +104,8 @@ export interface EmptyStateProps {
   v2?: boolean;
 }
 
+export type EmptyStatePresetProps = Omit<EmptyStateProps, 'illustration'>;
+
 /**
  * The `EmptyState` component follows the Carbon guidelines for empty states with some added specifications around illustration usage. For additional usage guidelines and documentation please refer to the links above.
  */

--- a/packages/ibm-products/src/components/EmptyStates/EmptyState.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyState.tsx
@@ -18,7 +18,6 @@ import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import '../../global/js/utils/props-helper';
 import { pkg } from '../../settings';
 import { ButtonProps } from '@carbon/react';
-import { CarbonIconType } from '@carbon/icons-react/lib/CarbonIcon';
 
 import { EmptyStateContent } from './EmptyStateContent';
 
@@ -38,16 +37,16 @@ export const defaults: { position: string; size: sizes; headingAs: string } = {
   headingAs: 'h3',
 };
 
+interface EmptyStateAction extends ButtonProps<React.ElementType> {
+  kind?: 'primary' | 'secondary' | 'tertiary';
+  text?: string;
+}
+
 export interface EmptyStateProps {
   /**
    * Empty state action button
    */
-  action?: {
-    kind?: 'primary' | 'secondary' | 'tertiary';
-    renderIcon?: CarbonIconType;
-    onClick?: ButtonProps<React.ElementType>['onClick'];
-    text?: string;
-  };
+  action?: EmptyStateAction;
 
   /**
    * Provide an optional class to be applied to the containing node.

--- a/packages/ibm-products/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.tsx
@@ -6,7 +6,7 @@
  */
 
 // Import portions of React that are needed.
-import React, { ElementType, ReactNode } from 'react';
+import React from 'react';
 
 // Other standard imports.
 import PropTypes from 'prop-types';
@@ -18,40 +18,13 @@ import { pkg } from '../../../settings';
 
 import { EmptyStateContent } from '../EmptyStateContent';
 import ErrorIllustration from '../assets/ErrorIllustration';
-import { defaults } from '../EmptyState';
-import { ButtonProps } from '@carbon/react';
-import { CarbonIconType } from '@carbon/icons-react/lib/CarbonIcon';
+import { defaults, EmptyStatePresetProps } from '../EmptyState';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 const blockClass = `${pkg.prefix}--empty-state`;
 const componentName = 'ErrorEmptyState';
 
-export interface ErrorEmptyStateProps {
-  /**
-   * Empty state action button
-   */
-  action?: {
-    kind?: 'primary' | 'secondary' | 'tertiary';
-    renderIcon?: CarbonIconType;
-    onClick?: ButtonProps<React.ElementType>['onClick'];
-    text?: string;
-  };
-
-  /**
-   * Provide an optional class to be applied to the containing node.
-   */
-  className?: string;
-
-  /**
-   * The alt text for empty state svg images. If not provided , title will be used.
-   */
-  illustrationDescription?: string;
-
-  /**
-   * Designates the position of the illustration relative to the content
-   */
-  illustrationPosition?: 'top' | 'right' | 'bottom' | 'left';
-
+export interface ErrorEmptyStateProps extends EmptyStatePresetProps {
   /**
    * Empty state illustration theme variations.
    * To ensure you use the correct themed illustrations, you can conditionally specify light or dark
@@ -59,33 +32,6 @@ export interface ErrorEmptyStateProps {
    * `illustrationTheme={appTheme === ('carbon--g100' || 'carbon--g90') ? 'dark' : 'light'}`
    */
   illustrationTheme?: 'light' | 'dark';
-
-  /**
-   * Empty state link object
-   */
-  link?: {
-    text?: string | ReactNode;
-    href?: string;
-  };
-
-  /**
-   * Empty state headingAs allows you to customize the type of heading element
-   */
-  headingAs?: (() => ReactNode) | string | ElementType;
-  /**
-   * Empty state size
-   */
-  size?: 'lg' | 'sm';
-
-  /**
-   * Empty state subtitle
-   */
-  subtitle?: string | ReactNode;
-
-  /**
-   * Empty state title
-   */
-  title: string | ReactNode;
 }
 
 /**

--- a/packages/ibm-products/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.tsx
@@ -6,51 +6,25 @@
  */
 
 // Import portions of React that are needed.
-import React, { ElementType, ReactNode } from 'react';
+import React from 'react';
 
 // Other standard imports.
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { Button, Link, ButtonProps } from '@carbon/react';
-import { CarbonIconType } from '@carbon/icons-react/lib/CarbonIcon';
+import { Button, Link } from '@carbon/react';
 
 import { getDevtoolsProps } from '../../../global/js/utils/devtools';
 import { pkg } from '../../../settings';
 
 import { EmptyStateContent } from '../EmptyStateContent';
 import NoDataIllustration from '../assets/NoDataIllustration';
-import { defaults } from '../EmptyState';
+import { defaults, EmptyStatePresetProps } from '../EmptyState';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 const blockClass = `${pkg.prefix}--empty-state`;
 const componentName = 'NoDataEmptyState';
 
-export interface NoDataEmptyStateProps {
-  /**
-   * Empty state action button
-   */
-  action?: {
-    kind?: 'primary' | 'secondary' | 'tertiary';
-    renderIcon?: CarbonIconType;
-    onClick?: ButtonProps<React.ElementType>['onClick'];
-    text?: string;
-  };
-
-  /**
-   * Provide an optional class to be applied to the containing node.
-   */
-  className?: string;
-
-  /**
-   * The alt text for empty state svg images. If not provided, title will be used.
-   */
-  illustrationDescription?: string;
-
-  /**
-   * Designates the position of the illustration relative to the content
-   */
-  illustrationPosition?: 'top' | 'right' | 'bottom' | 'left';
-
+export interface NoDataEmptyStateProps extends EmptyStatePresetProps {
   /**
    * Empty state illustration theme variations.
    * To ensure you use the correct themed illustrations, you can conditionally specify light or dark
@@ -58,34 +32,6 @@ export interface NoDataEmptyStateProps {
    * `illustrationTheme={appTheme === ('carbon--g100' || 'carbon--g90') ? 'dark' : 'light'}`
    */
   illustrationTheme?: 'light' | 'dark';
-
-  /**
-   * Empty state link object
-   */
-  link?: {
-    text?: string | ReactNode;
-    href?: string;
-  };
-
-  /**
-   * Empty state headingAs allows you to customize the type of heading element
-   */
-  headingAs?: (() => ReactNode) | string | ElementType;
-
-  /**
-   * Empty state size
-   */
-  size?: 'lg' | 'sm';
-
-  /**
-   * Empty state subtitle
-   */
-  subtitle?: string | React.ReactNode;
-
-  /**
-   * Empty state title
-   */
-  title: string | React.ReactNode;
 }
 
 /**

--- a/packages/ibm-products/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.tsx
@@ -6,7 +6,7 @@
  */
 
 // Import portions of React that are needed.
-import React, { ElementType, ReactNode } from 'react';
+import React from 'react';
 
 // Other standard imports.
 import PropTypes from 'prop-types';
@@ -18,40 +18,13 @@ import { pkg } from '../../../settings';
 
 import { EmptyStateContent } from '../EmptyStateContent';
 import NoTagsIllustration from '../assets/NoTagsIllustration';
-import { defaults } from '../EmptyState';
-import { ButtonProps } from '@carbon/react';
-import { CarbonIconType } from '@carbon/icons-react/lib/CarbonIcon';
+import { defaults, EmptyStatePresetProps } from '../EmptyState';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 const blockClass = `${pkg.prefix}--empty-state`;
 const componentName = 'NoTagsEmptyState';
 
-export interface NoTagsEmptyStateProps {
-  /**
-   * Empty state action button
-   */
-  action?: {
-    kind?: 'primary' | 'secondary' | 'tertiary';
-    renderIcon?: CarbonIconType;
-    onClick?: ButtonProps<React.ElementType>['onClick'];
-    text?: string;
-  };
-
-  /**
-   * Provide an optional class to be applied to the containing node.
-   */
-  className?: string;
-
-  /**
-   * The alt text for empty state svg images. If not provided , title will be used.
-   */
-  illustrationDescription?: string;
-
-  /**
-   * Designates the position of the illustration relative to the content
-   */
-  illustrationPosition?: 'top' | 'right' | 'bottom' | 'left';
-
+export interface NoTagsEmptyStateProps extends EmptyStatePresetProps {
   /**
    * Empty state illustration theme variations.
    * To ensure you use the correct themed illustrations, you can conditionally specify light or dark
@@ -59,34 +32,6 @@ export interface NoTagsEmptyStateProps {
    * `illustrationTheme={appTheme === ('carbon--g100' || 'carbon--g90') ? 'dark' : 'light'}`
    */
   illustrationTheme?: 'light' | 'dark';
-
-  /**
-   * Empty state link object
-   */
-  link?: {
-    text?: string | ReactNode;
-    href?: string;
-  };
-
-  /**
-   * Empty state headingAs allows you to customize the type of heading element
-   */
-  headingAs?: (() => ReactNode) | string | ElementType;
-
-  /**
-   * Empty state size
-   */
-  size?: 'lg' | 'sm';
-
-  /**
-   * Empty state subtitle
-   */
-  subtitle?: string | ReactNode;
-
-  /**
-   * Empty state title
-   */
-  title: string | ReactNode;
 }
 
 /**

--- a/packages/ibm-products/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.tsx
@@ -6,7 +6,7 @@
  */
 
 // Import portions of React that are needed.
-import React, { ElementType, ReactNode } from 'react';
+import React from 'react';
 
 // Other standard imports.
 import PropTypes from 'prop-types';
@@ -18,39 +18,13 @@ import { pkg } from '../../../settings';
 
 import { EmptyStateContent } from '../EmptyStateContent';
 import NotFoundIllustration from '../assets/NotFoundIllustration';
-import { defaults } from '../EmptyState';
-import { ButtonProps } from '@carbon/react';
-import { CarbonIconType } from '@carbon/icons-react/lib/CarbonIcon';
+import { defaults, EmptyStatePresetProps } from '../EmptyState';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 const blockClass = `${pkg.prefix}--empty-state`;
 const componentName = 'NotFoundEmptyState';
 
-export interface NotFoundEmptyStateProps {
-  /**
-   * Empty state action button
-   */
-  action?: {
-    kind?: 'primary' | 'secondary' | 'tertiary';
-    renderIcon?: CarbonIconType;
-    onClick?: ButtonProps<React.ElementType>['onClick'];
-    text?: string;
-  };
-
-  /**
-   * Provide an optional class to be applied to the containing node.
-   */
-  className?: string;
-
-  /**
-   * The alt text for empty state svg images. If not provided , title will be used.
-   */
-  illustrationDescription?: string;
-  /**
-   * Designates the position of the illustration relative to the content
-   */
-  illustrationPosition?: 'top' | 'right' | 'bottom' | 'left';
-
+export interface NotFoundEmptyStateProps extends EmptyStatePresetProps {
   /**
    * Empty state illustration theme variations.
    * To ensure you use the correct themed illustrations, you can conditionally specify light or dark
@@ -58,34 +32,6 @@ export interface NotFoundEmptyStateProps {
    * `illustrationTheme={appTheme === ('carbon--g100' || 'carbon--g90') ? 'dark' : 'light'}`
    */
   illustrationTheme?: 'light' | 'dark';
-
-  /**
-   * Empty state link object
-   */
-  link?: {
-    text?: string | ReactNode;
-    href?: string;
-  };
-
-  /**
-   * Empty state headingAs allows you to customize the type of heading element
-   */
-  headingAs?: (() => ReactNode) | string | ElementType;
-
-  /**
-   * Empty state size
-   */
-  size?: 'lg' | 'sm';
-
-  /**
-   * Empty state subtitle
-   */
-  subtitle: string | ReactNode;
-
-  /**
-   * Empty state title
-   */
-  title: string | ReactNode;
 }
 
 /**

--- a/packages/ibm-products/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.tsx
@@ -18,41 +18,13 @@ import { pkg } from '../../../settings';
 
 import { EmptyStateContent } from '../EmptyStateContent';
 import NotificationsIllustration from '../assets/NotificationsIllustration';
-import { defaults } from '../EmptyState';
-import { ButtonProps } from '@carbon/react';
-import { CarbonIconType } from '@carbon/icons-react/lib/CarbonIcon';
+import { defaults, EmptyStatePresetProps } from '../EmptyState';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 const blockClass = `${pkg.prefix}--empty-state`;
 const componentName = 'NotificationsEmptyState';
 
-export interface NotificationsEmptyStateProps {
-  /**
-   * Empty state action button
-   */
-
-  action?: {
-    kind?: 'primary' | 'secondary' | 'tertiary';
-    renderIcon?: CarbonIconType;
-    onClick?: ButtonProps<React.ElementType>['onClick'];
-    text?: string;
-  };
-
-  /**
-   * Provide an optional class to be applied to the containing node.
-   */
-  className?: string;
-
-  /**
-   * The alt text for empty state svg images. If not provided , title will be used.
-   */
-  illustrationDescription?: string;
-
-  /**
-   * Designates the position of the illustration relative to the content
-   */
-  illustrationPosition?: 'top' | 'right' | 'bottom' | 'left';
-
+export interface NotificationsEmptyStateProps extends EmptyStatePresetProps {
   /**
    * Empty state illustration theme variations.
    * To ensure you use the correct themed illustrations, you can conditionally specify light or dark
@@ -60,34 +32,6 @@ export interface NotificationsEmptyStateProps {
    * `illustrationTheme={appTheme === ('carbon--g100' || 'carbon--g90') ? 'dark' : 'light'}`
    */
   illustrationTheme?: 'light' | 'dark';
-
-  /**
-   * Empty state link object
-   */
-  link?: {
-    text?: string | ReactNode;
-    href?: string;
-  };
-
-  /**
-   * Empty state headingAs allows you to customize the type of heading element
-   */
-  headingAs?: (() => ReactNode) | string | ElementType;
-
-  /**
-   * Empty state size
-   */
-  size?: 'lg' | 'sm';
-
-  /**
-   * Empty state subtitle
-   */
-  subtitle: ReactNode;
-
-  /**
-   * Empty state title
-   */
-  title: ReactNode;
 }
 
 /**

--- a/packages/ibm-products/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.tsx
@@ -6,51 +6,25 @@
  */
 
 // Import portions of React that are needed.
-import React, { ElementType, ReactNode } from 'react';
+import React from 'react';
 
 // Other standard imports.
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { Button, Link, ButtonProps } from '@carbon/react';
-import { CarbonIconType } from '@carbon/icons-react/lib/CarbonIcon';
+import { Button, Link } from '@carbon/react';
 
 import { getDevtoolsProps } from '../../../global/js/utils/devtools';
 import { pkg } from '../../../settings';
 
 import { EmptyStateContent } from '../EmptyStateContent';
 import UnauthorizedIllustration from '../assets/UnauthorizedIllustration';
-import { defaults } from '../EmptyState';
+import { defaults, EmptyStatePresetProps } from '../EmptyState';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 const blockClass = `${pkg.prefix}--empty-state`;
 const componentName = 'UnauthorizedEmptyState';
 
-export interface UnauthorizedEmptyStateProps {
-  /**
-   * Empty state action button
-   */
-  action?: {
-    kind?: 'primary' | 'secondary' | 'tertiary';
-    renderIcon?: CarbonIconType;
-    onClick?: ButtonProps<React.ElementType>['onClick'];
-    text?: string;
-  };
-
-  /**
-   * Provide an optional class to be applied to the containing node.
-   */
-  className?: string;
-
-  /**
-   * The alt text for empty state svg images. If not provided , title will be used.
-   */
-  illustrationDescription?: string;
-
-  /**
-   * Designates the position of the illustration relative to the content
-   */
-  illustrationPosition?: 'top' | 'right' | 'bottom' | 'left';
-
+export interface UnauthorizedEmptyStateProps extends EmptyStatePresetProps {
   /**
    * Empty state illustration theme variations.
    * To ensure you use the correct themed illustrations, you can conditionally specify light or dark
@@ -58,33 +32,6 @@ export interface UnauthorizedEmptyStateProps {
    * `illustrationTheme={appTheme === ('carbon--g100' || 'carbon--g90') ? 'dark' : 'light'}`
    */
   illustrationTheme?: 'light' | 'dark';
-
-  /**
-   * Empty state link object
-   */
-  link?: {
-    text?: string | ReactNode;
-    href?: string;
-  };
-  /**
-   * Empty state headingAs allows you to customize the type of heading element
-   */
-  headingAs?: (() => ReactNode) | string | ElementType;
-
-  /**
-   * Empty state size
-   */
-  size?: 'lg' | 'sm';
-
-  /**
-   * Empty state subtitle
-   */
-  subtitle: string | ReactNode;
-
-  /**
-   * Empty state title
-   */
-  title: string | ReactNode;
 }
 
 /**


### PR DESCRIPTION
Closes #7011 

Small refactor to extend `ButtonProps` for empty state action (button).
Also reuse `EmptyStatePresetProps` for common props across the empty state presets.

#### What did you change?
- Extend Carbon `ButtonProps` for `EmptyStateAction`.
- Add `EmptyStatePresetProps` to reuse `EmptyStateProps` with `illustration` omitted since these are set at each preset.

#### How did you test and verify your work?
Tests and CI pass