### PR TITLE
chore: update automerge action to ubuntu-latest

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   automerge:
     if: github.repository == 'carbon-design-system/ibm-products'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Closes #6884 and #7314

Update `automerge.yml` to run on `ubuntu-latest`.
This was the only action not yet on `ubuntu-latest`.

#### What did you change?
`automerge.yml`

#### How did you test and verify your work?