### PR TITLE
fix(customizeColumns): update column ids for accessibility

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.tsx
@@ -21,12 +21,14 @@ interface DraggableElementProps extends PropsWithChildren {
   classList?: string;
   disabled?: boolean;
   id: string;
+  elementId?: string;
   isSticky?: boolean;
   selected?: boolean;
 }
 
 const DraggableElement = ({
   id,
+  elementId,
   children,
   classList,
   disabled,
@@ -72,7 +74,7 @@ const DraggableElement = ({
         [`${blockClass}__draggable-handleHolder--sticky`]: isSticky,
         [`${blockClass}__draggable-handleHolder--dragging`]: isDragging,
       })}
-      id={id}
+      id={elementId}
       ref={setNodeRef}
       style={style}
       {...attributes}
@@ -103,6 +105,7 @@ DraggableElement.propTypes = {
   children: PropTypes.element.isRequired,
   classList: PropTypes.string,
   disabled: PropTypes.bool,
+  elementId: PropTypes.string,
   id: PropTypes.string.isRequired,
   isSticky: PropTypes.bool,
   selected: PropTypes.bool,

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DraggableElement.tsx
@@ -74,7 +74,7 @@ const DraggableElement = ({
         [`${blockClass}__draggable-handleHolder--sticky`]: isSticky,
         [`${blockClass}__draggable-handleHolder--dragging`]: isDragging,
       })}
-      id={elementId}
+      id={elementId ? elementId : id}
       ref={setNodeRef}
       style={style}
       {...attributes}

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
@@ -9,6 +9,7 @@ import React from 'react';
 import { PropTypes } from 'prop-types';
 import { Checkbox } from '@carbon/react';
 import { isColumnVisible } from './common';
+import { v4 as uuidv4 } from 'uuid';
 import DraggableElement from '../../DraggableElement';
 import { pkg } from '../../../../../settings';
 import { getNodeTextContent } from '../../../../../global/js/utils/getNodeTextContent';
@@ -245,6 +246,7 @@ export const DraggableItemsList = ({
                 classList={draggableClass}
                 key={colDef.id}
                 id={colDef.id}
+                elementId={`${colDef.id}-${uuidv4()}`}
                 disabled={filterString.length > 0 || isFrozenColumn}
                 ariaLabel={colHeaderTitle}
                 isSticky={isFrozenColumn}

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
@@ -9,7 +9,7 @@ import React from 'react';
 import { PropTypes } from 'prop-types';
 import { Checkbox } from '@carbon/react';
 import { isColumnVisible } from './common';
-import { v4 as uuidv4 } from 'uuid';
+import { useId } from '../../../../../global/js/utils/useId';
 import DraggableElement from '../../DraggableElement';
 import { pkg } from '../../../../../settings';
 import { getNodeTextContent } from '../../../../../global/js/utils/getNodeTextContent';
@@ -246,7 +246,7 @@ export const DraggableItemsList = ({
                 classList={draggableClass}
                 key={colDef.id}
                 id={colDef.id}
-                elementId={`${colDef.id}-${uuidv4()}`}
+                elementId={`${colDef.id}-${useId()}`}
                 disabled={filterString.length > 0 || isFrozenColumn}
                 ariaLabel={colHeaderTitle}
                 isSticky={isFrozenColumn}


### PR DESCRIPTION
Closes #https://github.com/carbon-design-system/ibm-products/issues/7110

{{short description}}

#### What did you change?
updated the id's of the customised coloumns. 
The data-grid table headers and the customised coloumns are sharing the same id's causing `The <li> element has the id (id) that is already in use` 
#### How did you test and verify your work?
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/f02473e1-6f69-46a5-91cb-c9268c2ee897" />

