### PR TITLE
fix: https://github.com/carbon-design-system/ibm-products/issues/7067

### DIFF
--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_useSortableColumns.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_useSortableColumns.scss
@@ -11,6 +11,9 @@
 @use './variables' as *;
 
 .#{$block-class}__sortableColumn {
+  /* stylelint-disable-next-line declaration-no-important */
+  padding-inline: $spacing-05 !important;
+
   .#{c4p-settings.$carbon-prefix}--table-header-label .header-title {
     display: inline-block;
     inline-size: auto;

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridHeaderRow.tsx
@@ -114,6 +114,27 @@ const ResizeHeader = ({
   );
 };
 
+const getAriaSortValue = (col, datagridState) => {
+  const {
+    ascendingSortableLabelText,
+    descendingSortableLabelText,
+    defaultSortableLabelText,
+  } = datagridState;
+  if (!col) {
+    return;
+  }
+  const { isSorted, isSortedDesc } = col;
+  if (!isSorted) {
+    return defaultSortableLabelText;
+  }
+  if (isSorted && !isSortedDesc) {
+    return ascendingSortableLabelText;
+  }
+  if (isSorted && isSortedDesc) {
+    return descendingSortableLabelText;
+  }
+};
+
 const HeaderRow = (
   datagridState: DataGridState,
   headRef: MutableRefObject<HTMLDivElement>,
@@ -256,6 +277,11 @@ const HeaderRow = (
               )}
               key={header.id}
               aria-hidden={header.id === 'spacer' && 'true'}
+              aria-sort={
+                datagridState.isTableSortable
+                  ? getAriaSortValue(header, datagridState)
+                  : ''
+              }
               {...getAccessibilityProps(header)}
             >
               {header.render('Header')}

--- a/packages/ibm-products/src/components/Datagrid/useSortableColumns.tsx
+++ b/packages/ibm-products/src/components/Datagrid/useSortableColumns.tsx
@@ -48,29 +48,6 @@ export const getNewSortOrder = (currentOrder?: boolean | string) => {
   return order;
 };
 
-const getAriaSortValue = (
-  col,
-  {
-    ascendingSortableLabelText,
-    descendingSortableLabelText,
-    defaultSortableLabelText,
-  }
-) => {
-  if (!col) {
-    return;
-  }
-  const { isSorted, isSortedDesc } = col;
-  if (!isSorted) {
-    return defaultSortableLabelText;
-  }
-  if (isSorted && !isSortedDesc) {
-    return ascendingSortableLabelText;
-  }
-  if (isSorted && isSortedDesc) {
-    return descendingSortableLabelText;
-  }
-};
-
 const getAriaPressedValue = (col) => {
   if (!col) {
     return;
@@ -84,12 +61,7 @@ const getAriaPressedValue = (col) => {
 
 const useSortableColumns = (hooks: Hooks) => {
   const sortableVisibleColumns = (visibleColumns, { instance }) => {
-    const {
-      onSort,
-      ascendingSortableLabelText,
-      descendingSortableLabelText,
-      defaultSortableLabelText,
-    } = instance;
+    const { onSort } = instance;
     const onSortClick = (event, column) => {
       const aiLabel =
         event.target.classList.contains(`${carbon.prefix}--slug`) ||
@@ -145,11 +117,6 @@ const useSortableColumns = (hooks: Hooks) => {
           )
         ) : (
           <Button
-            aria-sort={getAriaSortValue(headerProp?.column, {
-              ascendingSortableLabelText,
-              descendingSortableLabelText,
-              defaultSortableLabelText,
-            })}
             aria-pressed={getAriaPressedValue(headerProp?.column)}
             onClick={(event) => onSortClick(event, headerProp?.column)}
             kind="ghost"


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/ibm-products/issues/7067

move aria-sort to th on datagrid

#### What did you change?
I moved the aria-sort label from the `Button` component and into the `th` element of the header row. A carbon styles file is applying `padding 0` to the headers so that had to be overwritten as well.

#### How did you test and verify your work?
I ran `yarn storybook` and verified that the sortable datagrid component styling was consistent with the existing code, and I verified that the page can now pass the accessibility checker. 