### PR TITLE
chore: onboard wc package with telemetry

### DIFF
--- a/packages/ibm-products-web-components/README.md
+++ b/packages/ibm-products-web-components/README.md
@@ -1,0 +1,10 @@
+# @carbon/ibm-products-web-components
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect de-identified and anonymized metrics
+data. By installing this package as a dependency you are agreeing to telemetry
+collection. To opt out, see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/ibm-products-web-components/package.json
+++ b/packages/ibm-products-web-components/package.json
@@ -17,7 +17,8 @@
     "es/**/*",
     "es-custom/**/*",
     "lib/**/*",
-    "scss/**/*"
+    "scss/**/*",
+    "telemetry.yml"
   ],
   "publishConfig": {
     "access": "public",
@@ -30,7 +31,8 @@
     "./dist/*": "./dist/*",
     "./scss/*": "./scss/*",
     "./custom-elements.json": "./custom-elements.json",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./telemetry.yml": "./telemetry.yml"
   },
   "keywords": [
     "carbon",
@@ -44,6 +46,7 @@
     "build": "yarn clean && node tasks/build.js && yarn wca",
     "build:storybook": "storybook build --quiet",
     "clean": "rimraf es lib scss dist storybook-static",
+    "postinstall": "ibmtelemetry --config=telemetry.yml",
     "preview": "vite preview",
     "storybook": "storybook dev -p 3000",
     "test": "vitest run",
@@ -54,6 +57,7 @@
     "@carbon/ibm-products-styles": "^2.59.0",
     "@carbon/styles": "1.75.0",
     "@carbon/web-components": "2.25.0",
+    "@ibm/telemetry-js": "^1.9.1",
     "lit": "^3.1.0"
   },
   "devDependencies": {

--- a/packages/ibm-products-web-components/telemetry.yml
+++ b/packages/ibm-products-web-components/telemetry.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+version: 1
+projectId: 8a79d901-a9c0-4672-94a4-fa8eea139832
+endpoint: 'https://www-api.ibm.com/ibm-telemetry/v1/metrics'
+collect:
+  npm:
+    dependencies: null
+  js:
+    functions: {}
+    tokens: null

--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -50,7 +50,7 @@
     "clean": "rimraf es lib css scss",
     "generate": "cross-env FORCE_COLOR=1 node scripts/generate",
     "postinstall": "ibmtelemetry --config=telemetry.yml",
-    "telemetry-config": "ibmtelemetry-config generate --id 495342db-5046-4ecf-85ea-9ffceb6f8cdf --endpoint https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics --files ./src/components/**/*.(tsx|js|jsx)",
+    "telemetry-config": "ibmtelemetry-config generate --id 495342db-5046-4ecf-85ea-9ffceb6f8cdf --endpoint https://www-api.ibm.com/ibm-telemetry/v1/metrics --files ./src/components/**/*.(tsx|js|jsx)",
     "test": "jest --colors",
     "//upgrade-dependencies": "# don't upgrade carbon (done globally), react/react-dom (explicit range peer dependency), chalk (issue #1596)",
     "upgrade-dependencies": "npm-check-updates -u --dep dev,peer,prod --color --reject '/(carbon|^react$|^react-dom$|^chalk$|^namor)/'"

--- a/packages/ibm-products/telemetry.yml
+++ b/packages/ibm-products/telemetry.yml
@@ -2,7 +2,7 @@
 
 version: 1
 projectId: 495342db-5046-4ecf-85ea-9ffceb6f8cdf
-endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+endpoint: https://www-api.ibm.com/ibm-telemetry/v1/metrics
 collect:
   jsx:
     elements:
@@ -230,6 +230,7 @@ collect:
         - onContextMenuValue
         - onDataUpdate
         - onFocus
+        - onKeyDown
         - onMount
         - onMouseEnter
         - onMouseLeave
@@ -504,7 +505,6 @@ collect:
         - componentName
         # Card
         - getStarted
-        - onKeyDown
         # CardFooter
         - hasButton
         # CardHeader
@@ -1176,9 +1176,6 @@ collect:
         - xl
   npm:
     dependencies: null
-  js:
-    functions: {}
-    tokens: null
   js:
     functions: {}
     tokens: null

--- a/yarn.lock
+++ b/yarn.lock
@@ -1780,6 +1780,7 @@ __metadata:
     "@carbon/motion": "npm:^11.24.0"
     "@carbon/styles": "npm:1.75.0"
     "@carbon/web-components": "npm:2.25.0"
+    "@ibm/telemetry-js": "npm:^1.9.1"
     "@mordech/vite-lit-loader": "npm:^0.37.0"
     "@open-wc/testing": "npm:^4.0.0"
     "@rollup/plugin-alias": "npm:^5.1.1"


### PR DESCRIPTION
Closes #7103 

Instruments the WC package with IBM Telemetry.

#### What did you change?

* Adds the Telemetry npm dependency, `telemetry.yml` config file with the newly issued project ID, README notice, postinstall script and `package.json` change so the `telemetry.yml` is included in the package's dist
* Updates the React packages Telemetry configuration script to include the stable collection URL
* Ran that to ensure the React prop and prop values in the React package config is up to date

#### How did you test and verify your work?

N/A