### PR TITLE
fix(checklist): use appropriate heading levels

### DIFF
--- a/packages/ibm-products/src/components/Checklist/Checklist.tsx
+++ b/packages/ibm-products/src/components/Checklist/Checklist.tsx
@@ -13,7 +13,7 @@
  */
 
 // Carbon and package components we use.
-import { Button, IconButton } from '@carbon/react';
+import { Button, Heading, IconButton, Section } from '@carbon/react';
 import { Kind, Kinds, Theme, Themes } from './Checklist.types';
 // Import portions of React that are needed.
 import React, {
@@ -205,12 +205,13 @@ export let Checklist = React.forwardRef(
     }, [open]);
 
     return (
-      <aside
+      <Section
         {
           // Pass through any other property values as HTML attributes.
           ...rest
         }
         aria-label={checklistAriaLabel}
+        as="aside"
         className={cx(
           blockClass, // Apply the block class to the main HTML element
           className, // Apply any supplied class names to the main HTML element.
@@ -233,12 +234,14 @@ export let Checklist = React.forwardRef(
             )}
 
             <div className={`${blockClass}__titles`}>
-              {title && <h2 className={`${blockClass}__title`}>{title}</h2>}
+              {title && (
+                <Heading className={`${blockClass}__title`}>{title}</Heading>
+              )}
 
               {chartLabelAndValue && (
-                <h3 id={chartLabelId} className={`${blockClass}__chart-label`}>
+                <p id={chartLabelId} className={`${blockClass}__chart-label`}>
                   {chartLabel}
-                </h3>
+                </p>
               )}
             </div>
 
@@ -262,20 +265,20 @@ export let Checklist = React.forwardRef(
 
         <div id={listContainerId} className={`${blockClass}__content-outer`}>
           <div className={`${blockClass}__content-inner`}>
-            <section className={cx(`${blockClass}__body`)}>
+            <div className={cx(`${blockClass}__body`)}>
               {taskLists.map((list, index) => {
                 return (
-                  <div
+                  <Section
                     className={`${blockClass}__list-group`}
                     key={`${list.title}-${index}`}
                   >
                     {list.title && (
-                      <h3
+                      <Heading
                         title={list.title}
                         className={`${blockClass}__list-title`}
                       >
                         {list.title}
-                      </h3>
+                      </Heading>
                     )}
                     <ol className={`${blockClass}__list`}>
                       {list.tasks.map((item, index) => {
@@ -315,10 +318,10 @@ export let Checklist = React.forwardRef(
                         );
                       })}
                     </ol>
-                  </div>
+                  </Section>
                 );
               })}
-            </section>
+            </div>
 
             {viewAllLabel && (
               <footer className={`${blockClass}__footer`}>
@@ -336,7 +339,7 @@ export let Checklist = React.forwardRef(
             )}
           </div>
         </div>
-      </aside>
+      </Section>
     );
   }
 );


### PR DESCRIPTION
Closes #7168.

Use appropriate heading levels for the Checklist component, rather than hardcoding to a particular level.

Doesn't address label-only cards though, not sure if it's OK that they don't have any heading.

For the card content, I followed the example at
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/section, having a separate `<section>` for each heading,
rather than one `<section>` wrapping all the headings.

Note: I'm not sure why the outer node of Checklist is an `<aside>` rather than `<section>` etc., but I didn't change it in this PR.

#### What did you change?

Use `<Section>` and `<Heading>` rather than hardcoded headings.

#### How did you test and verify your work?

Storybook and Jest tests.