### PR TITLE
feat: preview commit resize bar side panel

### DIFF
--- a/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
+++ b/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
@@ -75,6 +75,33 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
   }
 }
 
+$resizer-block-class: #{c4p-settings.$pkg-prefix}--resize-bar;
+
+.#{$resizer-block-class} {
+  background-color: $border-subtle-02;
+  // background-color: transparent;
+  transition: background-color $duration-moderate-01;
+
+  &:hover {
+    background-color: #0f62fe;
+  }
+
+  &:focus {
+    background-color: #0f62fe;
+    outline: none;
+  }
+
+  &--horizontal {
+    block-size: 0.2rem;
+    cursor: ns-resize;
+  }
+
+  &--vertical {
+    cursor: ew-resize;
+    inline-size: 0.2rem;
+  }
+}
+
 .#{$block-class} {
   --panel-transform: 320px;
   --#{$block-class}--title-stop: #{$spacing-05};
@@ -90,6 +117,7 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
   block-size: calc(100% - 3rem);
   color: $text-primary;
   /* if the title does not scroll then we have a child scrolling section. */
+  grid-template-columns: auto 1fr; /* resizer and the rest */
   grid-template-rows: auto 1fr auto; /* titles content and actions */
   inset-block-start: $spacing-09;
 
@@ -198,6 +226,12 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
     box-shadow:
       inset 0 -80px 70px -65px $ai-inner-shadow,
       0 4px 10px 2px $ai-drop-shadow;
+  }
+
+  &__resize-bar {
+    background-color: transparent;
+    grid-row: span 3 / span 3;
+    margin-inline-start: -0.2rem;
   }
 
   .#{$block-class}__header {

--- a/packages/ibm-products/src/components/SidePanel/ResizeBar.stories.jsx
+++ b/packages/ibm-products/src/components/SidePanel/ResizeBar.stories.jsx
@@ -1,0 +1,354 @@
+//cspell: disable
+import styles from './_storybook-styles.scss?inline';
+import React, { useEffect, useRef, useState } from 'react';
+import { action } from '@storybook/addon-actions';
+import ResizeBar from './ResizeBar';
+
+// const defaultStoryProps = {
+//   orientation: 'horizontal',
+//   onResize: action('onResize'),
+//   onResizeEnd: action('onResizeEnd'),
+// };
+
+export default {
+  title: 'IBM Products/Components/ResizeBar/ResizeBar',
+  component: ResizeBar,
+  // tags: ['autodocs'],
+  parameters: {
+    // layout: 'fullscreen',
+    styles,
+    // docs: {
+    //   page: DocsPage,
+    // },
+  },
+  argTypes: {
+    orientation: {
+      control: {
+        type: 'select',
+      },
+    },
+    onResize: {
+      control: {
+        type: 'function',
+      },
+    },
+    onResizeEnd: {
+      control: {
+        type: 'function',
+      },
+    },
+  },
+};
+
+const OneDivHorizontalTemplate = () => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '400px',
+        width: '600px',
+        // justifyContent: 'end',
+      }}
+    >
+      <div
+        className="div-1"
+        style={{
+          padding: '1rem',
+          backgroundColor: 'var(--cds-layer-01)',
+          minBlockSize: '60px',
+          overflow: 'auto',
+        }}
+      >
+        <h4>div 1</h4>
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut natus
+          officiis sed aliquam deleniti quae eius obcaecati quidem molestias
+          beatae!
+        </p>
+      </div>
+      <ResizeBar defaultSiblingSize="108" orientation="horizontal" />
+    </div>
+  );
+};
+const OneDivVerticalTemplate = () => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        // flexDirection: 'column',
+        height: '400px',
+        width: '600px',
+        // justifyContent: 'end',
+      }}
+    >
+      <div
+        className="div-1"
+        style={{
+          padding: '1rem',
+          backgroundColor: 'var(--cds-layer-01)',
+          minInlineSize: '60px',
+          overflow: 'auto',
+          width: 'fit-content',
+        }}
+      >
+        <h4>div 1</h4>
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut natus
+          officiis sed aliquam deleniti quae eius obcaecati quidem molestias
+          beatae!
+        </p>
+      </div>
+      <ResizeBar defaultSiblingSize={600} orientation="vertical" />
+    </div>
+  );
+};
+const OneDivHorizontalReverseTemplate = () => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '400px',
+        width: '600px',
+        justifyContent: 'end',
+      }}
+    >
+      <ResizeBar defaultSiblingSize={108} orientation="horizontal" />
+      <div
+        className="div-1"
+        style={{
+          padding: '1rem',
+          backgroundColor: 'var(--cds-layer-01)',
+          minBlockSize: '60px',
+          overflow: 'auto',
+        }}
+      >
+        <h4>div 1</h4>
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut natus
+          officiis sed aliquam deleniti quae eius obcaecati quidem molestias
+          beatae!
+        </p>
+      </div>
+    </div>
+  );
+};
+const OneDivVerticalReverseTemplate = () => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        // flexDirection: 'column',
+        height: '400px',
+        width: '600px',
+        justifyContent: 'end',
+      }}
+    >
+      <ResizeBar defaultSiblingSize={600} orientation="vertical" />
+      <div
+        className="div-1"
+        style={{
+          padding: '1rem',
+          backgroundColor: 'var(--cds-layer-01)',
+          minInlineSize: '60px',
+          overflow: 'auto',
+          width: 'fit-content',
+        }}
+      >
+        <h4>div 1</h4>
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut natus
+          officiis sed aliquam deleniti quae eius obcaecati quidem molestias
+          beatae!
+        </p>
+      </div>
+    </div>
+  );
+};
+
+const TwoDivsHorizontalTemplate = () => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '400px',
+        width: '600px',
+      }}
+    >
+      <div
+        className="div-1"
+        style={{
+          padding: '1rem',
+          backgroundColor: 'var(--cds-layer-01)',
+          overflow: 'auto',
+          minBlockSize: '60px',
+          height: '50%',
+        }}
+      >
+        <h4>div 1</h4>
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut natus
+          officiis sed aliquam deleniti quae eius obcaecati quidem molestias
+          beatae!
+        </p>
+      </div>
+      <ResizeBar defaultSiblingSize={[200, 200]} orientation="horizontal" />
+      <div
+        className="div-2"
+        style={{
+          padding: '1rem',
+          backgroundColor: 'var(--cds-layer-01)',
+          overflow: 'auto',
+          minBlockSize: '60px',
+          height: '50%',
+        }}
+      >
+        <h4>div 2</h4>
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut natus
+          officiis sed aliquam deleniti quae eius obcaecati quidem molestias
+          beatae!
+        </p>
+      </div>
+    </div>
+  );
+};
+const TwoDivsVerticalTemplate = () => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        // flexDirection: 'column',
+        height: '400px',
+        width: '600px',
+      }}
+    >
+      <div
+        className="div-1"
+        style={{
+          padding: '1rem',
+          backgroundColor: 'var(--cds-layer-01)',
+          overflow: 'auto',
+          minInlineSize: '60px',
+          width: '50%',
+        }}
+      >
+        <h4>div 1</h4>
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut natus
+          officiis sed aliquam deleniti quae eius obcaecati quidem molestias
+          beatae!
+        </p>
+      </div>
+      <ResizeBar defaultSiblingSize={[300, 300]} orientation="vertical" />
+      <div
+        className="div-2"
+        style={{
+          padding: '1rem',
+          backgroundColor: 'var(--cds-layer-01)',
+          overflow: 'auto',
+          minInlineSize: '60px',
+          width: '50%',
+        }}
+      >
+        <h4>div 2</h4>
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut natus
+          officiis sed aliquam deleniti quae eius obcaecati quidem molestias
+          beatae!
+        </p>
+      </div>
+    </div>
+  );
+};
+
+const MixedTemplate = () => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        // flexDirection: 'column',
+        height: '400px',
+        width: '600px',
+      }}
+    >
+      <div
+        className="div-1"
+        style={{
+          // padding: '1rem',
+          overflow: 'auto',
+          minInlineSize: '60px',
+          width: '50%',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <div
+          className="div-1.1"
+          style={{
+            padding: '1rem',
+            backgroundColor: 'var(--cds-layer-01)',
+            overflow: 'auto',
+            minBlockSize: '60px',
+            height: '50%',
+          }}
+        >
+          <h4>div 1</h4>
+          <p>
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut natus
+            officiis sed aliquam deleniti quae eius obcaecati quidem molestias
+            beatae!
+          </p>
+        </div>
+        <ResizeBar defaultSiblingSize={[200, 200]} orientation="horizontal" />
+        <div
+          className="div-1.2"
+          style={{
+            padding: '1rem',
+            backgroundColor: 'var(--cds-layer-01)',
+            overflow: 'auto',
+            minBlockSize: '60px',
+            height: '50%',
+          }}
+        >
+          <h4>div 2</h4>
+          <p>
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut natus
+            officiis sed aliquam deleniti quae eius obcaecati quidem molestias
+            beatae!
+          </p>
+        </div>
+      </div>
+      <ResizeBar defaultSiblingSize={[300, 300]} orientation="vertical" />
+      <div
+        className="div-2"
+        style={{
+          padding: '1rem',
+          backgroundColor: 'var(--cds-layer-01)',
+          overflow: 'auto',
+          minInlineSize: '60px',
+          width: '50%',
+        }}
+      >
+        <h4>div 2</h4>
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut natus
+          officiis sed aliquam deleniti quae eius obcaecati quidem molestias
+          beatae!
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export const OneDivHorizontal = OneDivHorizontalTemplate.bind({});
+export const OneDivVertical = OneDivVerticalTemplate.bind({});
+export const OneDivHorizontalReverse = OneDivHorizontalReverseTemplate.bind({});
+export const OneDivVerticalReverse = OneDivVerticalReverseTemplate.bind({});
+
+export const TwoDivsHorizontal = TwoDivsHorizontalTemplate.bind({});
+export const TwoDivsVertical = TwoDivsVerticalTemplate.bind({});
+
+export const Mixed = MixedTemplate.bind({});

--- a/packages/ibm-products/src/components/SidePanel/ResizeBar.tsx
+++ b/packages/ibm-products/src/components/SidePanel/ResizeBar.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright IBM Corp. 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import React, { useEffect } from 'react';
 import cx from 'classnames';
 import { pkg } from '../../settings';
@@ -155,10 +162,14 @@ const ResizeBar = ({
           const prev = currentRef.previousElementSibling as HTMLElement;
           const next = currentRef.nextElementSibling as HTMLElement;
           if (orientation === 'horizontal') {
+            // @ts-ignore
             prev.style.blockSize = `${defaultSiblingSize[0]}px`;
+            // @ts-ignore
             next.style.blockSize = `${defaultSiblingSize[1]}px`;
           } else {
+            // @ts-ignore
             prev.style.inlineSize = `${defaultSiblingSize[0]}px`;
+            // @ts-ignore
             next.style.inlineSize = `${defaultSiblingSize[1]}px`;
           }
         } else if (currentRef.previousElementSibling) {

--- a/packages/ibm-products/src/components/SidePanel/ResizeBar.tsx
+++ b/packages/ibm-products/src/components/SidePanel/ResizeBar.tsx
@@ -1,0 +1,204 @@
+import React, { useEffect } from 'react';
+import cx from 'classnames';
+import { pkg } from '../../settings';
+const blockClass = `${pkg.prefix}--resize-bar`;
+
+const ResizeBar = ({
+  orientation,
+  defaultSiblingSize,
+  onResize,
+  onResizeEnd,
+  onDoubleClick,
+  ...rest
+}: {
+  orientation: 'horizontal' | 'vertical';
+  defaultSiblingSize?: number | [];
+  onResize?: (delta: number) => void;
+  onResizeEnd?: () => void;
+  onDoubleClick?: () => void;
+  [key: string]: any;
+}) => {
+  const ref = React.useRef<HTMLDivElement>(null);
+  const [initialPosition, setInitialPosition] = React.useState<{
+    x: number;
+    y: number;
+  } | null>(null);
+  const [previousElement, setPreviousElement] = React.useState({
+    initialSize: {
+      width: 0,
+      height: 0,
+    },
+  });
+  const [nextElement, setNextElement] = React.useState({
+    initialSize: {
+      width: 0,
+      height: 0,
+    },
+  });
+  const [isResizing, setIsResizing] = React.useState(false);
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (isResizing && initialPosition) {
+        const deltaX = e.clientX - initialPosition.x;
+        const deltaY = e.clientY - initialPosition.y;
+
+        if (onResize) {
+          onResize(orientation === 'horizontal' ? deltaY : deltaX);
+        } else {
+          if (
+            ref.current?.previousElementSibling &&
+            ref.current?.nextElementSibling
+          ) {
+            const prev = ref.current.previousElementSibling as HTMLElement;
+            const next = ref.current.nextElementSibling as HTMLElement;
+            if (orientation === 'horizontal') {
+              prev.style.blockSize = `${previousElement.initialSize.height - (initialPosition.y - e.clientY)}px`;
+              next.style.blockSize = `${nextElement.initialSize.height + (initialPosition.y - e.clientY)}px`;
+            } else {
+              prev.style.inlineSize = `${previousElement.initialSize.width - (initialPosition.x - e.clientX)}px`;
+              next.style.inlineSize = `${nextElement.initialSize.width + (initialPosition.x - e.clientX)}px`;
+            }
+          } else if (ref.current?.previousElementSibling) {
+            const prev = ref.current.previousElementSibling as HTMLElement;
+            if (orientation === 'horizontal') {
+              prev.style.blockSize = `${previousElement.initialSize.height - (initialPosition.y - e.clientY)}px`;
+            } else {
+              prev.style.inlineSize = `${previousElement.initialSize.width - (initialPosition.x - e.clientX)}px`;
+            }
+          } else if (ref.current?.nextElementSibling) {
+            const next = ref.current.nextElementSibling as HTMLElement;
+            if (orientation === 'horizontal') {
+              next.style.blockSize = `${nextElement.initialSize.height + (initialPosition.y - e.clientY)}px`;
+            } else {
+              next.style.inlineSize = `${nextElement.initialSize.width + (initialPosition.x - e.clientX)}px`;
+            }
+          }
+        }
+      }
+    };
+
+    // yet to be implemented
+    // const handleKeyboardControl = (e: KeyboardEvent) => {
+    //   if (onResize) {
+    //     onResize(orientation === 'horizontal' ? deltaY : deltaX);
+    //   }
+    // };
+
+    const handleMouseUp = (e) => {
+      if (onResizeEnd) {
+        onResizeEnd();
+      }
+      setIsResizing(false);
+      setInitialPosition(null);
+    };
+
+    if (isResizing) {
+      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener('mouseup', handleMouseUp);
+    }
+
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [isResizing, orientation]); // eslint-disable-line
+
+  useEffect(() => {
+    const currentRef = ref.current;
+    if (currentRef) {
+      const handleMouseDown = (e: MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        setInitialPosition({
+          x: e.clientX,
+          y: e.clientY,
+        });
+        if (currentRef.previousElementSibling) {
+          setPreviousElement({
+            initialSize: {
+              width:
+                currentRef.previousElementSibling.getBoundingClientRect().width,
+              height:
+                currentRef.previousElementSibling.getBoundingClientRect()
+                  .height,
+            },
+          });
+        }
+        if (currentRef.nextElementSibling) {
+          setNextElement({
+            initialSize: {
+              width:
+                currentRef.nextElementSibling.getBoundingClientRect().width,
+              height:
+                currentRef.nextElementSibling.getBoundingClientRect().height,
+            },
+          });
+        }
+        setIsResizing(true);
+      };
+      const handleDblClick = (e: MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (onDoubleClick) {
+          onDoubleClick();
+          return;
+        }
+        console.log('internal double click', defaultSiblingSize);
+        if (
+          currentRef.previousElementSibling &&
+          currentRef.nextElementSibling
+        ) {
+          const prev = currentRef.previousElementSibling as HTMLElement;
+          const next = currentRef.nextElementSibling as HTMLElement;
+          if (orientation === 'horizontal') {
+            prev.style.blockSize = `${defaultSiblingSize[0]}px`;
+            next.style.blockSize = `${defaultSiblingSize[1]}px`;
+          } else {
+            prev.style.inlineSize = `${defaultSiblingSize[0]}px`;
+            next.style.inlineSize = `${defaultSiblingSize[1]}px`;
+          }
+        } else if (currentRef.previousElementSibling) {
+          const prev = currentRef.previousElementSibling as HTMLElement;
+          if (orientation === 'horizontal') {
+            prev.style.blockSize = `${defaultSiblingSize}px`;
+          } else {
+            prev.style.inlineSize = `${defaultSiblingSize}px`;
+          }
+        } else if (currentRef.nextElementSibling) {
+          const next = currentRef.nextElementSibling as HTMLElement;
+          if (orientation === 'horizontal') {
+            next.style.blockSize = `${defaultSiblingSize}px`;
+          } else {
+            next.style.inlineSize = `${defaultSiblingSize}px`;
+          }
+        }
+      };
+      currentRef.addEventListener('dblclick', handleDblClick);
+      currentRef.addEventListener('mousedown', handleMouseDown);
+      return () => {
+        currentRef.removeEventListener('mousedown', handleMouseDown);
+        currentRef.removeEventListener('dblclick', handleDblClick);
+      };
+    }
+  }, []); // eslint-disable-line
+
+  return (
+    <div
+      {...rest}
+      ref={rest.ref || ref}
+      role="separator"
+      tabIndex={0} // eslint-disable-line
+      className={cx([
+        blockClass,
+        `${blockClass}--${orientation}`,
+        rest.className,
+      ])}
+    ></div>
+  );
+};
+
+export default ResizeBar;

--- a/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
@@ -37,6 +37,7 @@ import { moderate02 } from '@carbon/motion';
 import pconsole from '../../global/js/utils/pconsole';
 import { pkg } from '../../settings';
 import { getSpecificElement } from '../../global/js/hooks/useFocus';
+import ResizeBar from './ResizeBar';
 
 const blockClass = `${pkg.prefix}--side-panel`;
 const componentName = 'SidePanel';
@@ -289,7 +290,7 @@ export let SidePanel = React.forwardRef(
     const { firstElement, keyDownListener } = useFocus(sidePanelRef);
     const panelRefValue = sidePanelRef.current;
     const previousOpen = usePreviousValue(open);
-
+    const [sidepanelWidth, setSidepanelWidth] = useState<number>(480); // predefined sizes 'xs','sm','md','lg','xl','2xl' in scss messes this up, need to find a cleaner approach, maybe get them and set here??
     const shouldReduceMotion = usePrefersReducedMotion();
     const exitAnimationName = shouldReduceMotion
       ? 'side-panel-exit-reduced'
@@ -476,6 +477,10 @@ export let SidePanel = React.forwardRef(
           '0'
         );
       }
+      if (sidePanelRef.current) {
+        sidePanelRef.current.style.width = `${sidepanelWidth}px`;
+      }
+      // eslint-disable-next-line
     }, [
       doAnimateTitle,
       handleScroll,
@@ -484,6 +489,9 @@ export let SidePanel = React.forwardRef(
       open,
       panelRefValue?.style,
     ]);
+
+    // note side panel without all these changes still renders ~5 times on initial load, i think we need to optimize it.
+    // console.log("render");
 
     // Calculate scroll distances
     useEffect(() => {
@@ -908,6 +916,25 @@ export let SidePanel = React.forwardRef(
           onAnimationStart={onAnimationStart}
           onKeyDown={handleKeyDown}
         >
+          <ResizeBar
+            // this callback can be used to set width of side panel
+            // in the context of grid, we can set grid template of the parent
+            // there is also a default behavior internally and double click is han
+            onResize={(delta) => {
+              // setSidepanelWidth(sidePanelRef.current.clientWidth);
+              sidePanelRef.current.style.inlineSize = `${Math.max(sidepanelWidth - delta, 48)}px`;
+            }}
+            // added this callback to set the initial width of the side panel, we don't want to set it on every resize for performance reasons
+            onResizeEnd={() => {
+              setSidepanelWidth(sidePanelRef.current.clientWidth);
+            }}
+            onDoubleClick={() => {
+              setSidepanelWidth(480);
+              sidePanelRef.current.style.inlineSize = '480px';
+            }}
+            orientation="vertical"
+            className={cx(`${blockClass}__resize-bar`)}
+          />
           {/* header */}
           {renderHeader()}
 


### PR DESCRIPTION
# **DO NOT MERGE | BUILT FOR PREVIEW**

this is a prototype of a ResizeBar component, that can be used in various contexts, it supports double click to reset, there are a few un met accessibility improvements and keyboard navigation. but this pr is just an example to show the re-usability of this component, in various contexts

changing the approach how split panel was built in labs, if we make an independent component called ResizeBar out of it. the reusability of this independent component can be greatly increased in various contexts.

this prototype is an example of the reusability of the component

ResizeBar added to start or end of an element resizes that element
ResizeBar added between 2 elements = split view
ResizeBar added in the side panel = resizable side panel
...it could solve many more use cases

preview links
side panel where ResizeBar is re used
https://deploy-preview-7294--carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-side-panel-sidepanel--slide-over&globals=viewport:basic

ResizeBar stories
https://deploy-preview-7294--carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-resizebar-resizebar--one-div-horizontal&globals=theme:g100;viewport:basic