### PR TITLE
feat: ExpressiveCard should have the ability to open a link in a new window

### DIFF
--- a/e2e/components/ExpressiveCard/ExpressiveCard-test.avt.e2e.js
+++ b/e2e/components/ExpressiveCard/ExpressiveCard-test.avt.e2e.js
@@ -65,19 +65,19 @@ test.describe('ExpressiveCard @avt', () => {
       'ExpressiveCard @avt-with-media-state'
     );
   });
-  test('@avt-with-action-icon-href-state', async ({ page }) => {
+  test('@avt-with-action-icon-link-state', async ({ page }) => {
     await visitStory(page, {
       component: 'ExpressiveCard',
-      id: 'ibm-products-components-cards-expressivecard--with-action-icon-href',
+      id: 'ibm-products-components-cards-expressivecard--with-action-icon-link',
       globals: {
         carbonTheme: 'white',
       },
     });
     await expect(page).toHaveNoACViolations(
-      'ExpressiveCard @avt-with-action-icon-href-state'
+      'ExpressiveCard @avt-with-action-icon-link-state'
     );
 
-    const hrefEle = page.locator('a[href="#"]');
+    const hrefEle = page.locator('a[href="https://carbondesignsystem.com/"]');
     // Pressing 'Tab' key to focus on the '->' href button
     await page.keyboard.press('Tab');
     await expect(hrefEle).toBeFocused();

--- a/packages/ibm-products/src/components/Card/Card.test.js
+++ b/packages/ibm-products/src/components/Card/Card.test.js
@@ -33,7 +33,7 @@ describe(componentName, () => {
     expect(onPrimaryButtonClick).toHaveBeenCalled();
   });
 
-  it('Renders expressive card with action icons and ensures that each click is being called', async () => {
+  it('renders expressive card with primary and secondary buttons and ensures that each click is being called', async () => {
     const { click } = userEvent;
     const onPrimaryButtonClick = jest.fn();
     const onSecondaryButtonClick = jest.fn();
@@ -50,7 +50,7 @@ describe(componentName, () => {
     expect(onSecondaryButtonClick).toHaveBeenCalled();
   });
 
-  it('renders expressive with action icons', async () => {
+  it('renders an expressive card with action icons', async () => {
     const { click } = userEvent;
     const onClick = jest.fn();
     const actionIcons = [
@@ -268,6 +268,49 @@ describe(componentName, () => {
       click(container.querySelector(`.${blockClass}__clickable`))
     );
     expect(onClick).toHaveBeenCalled();
+  });
+
+  it('renders a productive card with action icons', async () => {
+    const actionIcons = [
+      {
+        id: '1',
+        icon: ArrowRight,
+        iconDescription: 'Visit Carbon official site',
+        link: {
+          url: 'https://carbondesignsystem.com/',
+          target: '_blank',
+          rel: 'noreferrer noopener',
+        },
+      },
+    ];
+
+    const props = {
+      title: 'Title',
+      description: 'Description',
+      productive: true,
+      actionIcons,
+      children: <p>body</p>,
+    };
+
+    render(<Card {...props} />);
+
+    // link with url, target and rel
+    const LinkWithTargetAndRel = screen.getByRole('link', {
+      name: actionIcons[0].iconDescription,
+    });
+    expect(LinkWithTargetAndRel).toBeInTheDocument();
+    expect(LinkWithTargetAndRel).toHaveAttribute(
+      'href',
+      actionIcons[0].link.url
+    );
+    expect(LinkWithTargetAndRel).toHaveAttribute(
+      'target',
+      actionIcons[0].link.target
+    );
+    expect(LinkWithTargetAndRel).toHaveAttribute(
+      'rel',
+      actionIcons[0].link.rel
+    );
   });
 
   it('has no accessibility violations', async () => {

--- a/packages/ibm-products/src/components/Card/Card.test.js
+++ b/packages/ibm-products/src/components/Card/Card.test.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Add, UserIdentification, ArrowRight } from '@carbon/react/icons';
@@ -50,8 +50,8 @@ describe(componentName, () => {
     expect(onSecondaryButtonClick).toHaveBeenCalled();
   });
 
-  it('renders an expressive card with action icons', async () => {
-    const { click } = userEvent;
+  it('renders expressive card with action icons', async () => {
+    const user = userEvent.setup();
     const onClick = jest.fn();
     const actionIcons = [
       {
@@ -87,7 +87,10 @@ describe(componentName, () => {
       name: actionIcons[0].iconDescription,
     });
     expect(AddButton).toBeInTheDocument();
-    await act(() => click(AddButton));
+    // The use of act is deprecated. Wrapping the click in a waitFor is a workaround to ensure that all the state updates related to Tooltip is completed.
+    await waitFor(async () => {
+      await user.click(AddButton);
+    });
     expect(onClick).toHaveBeenCalled();
 
     // link with href

--- a/packages/ibm-products/src/components/Card/Card.test.js
+++ b/packages/ibm-products/src/components/Card/Card.test.js
@@ -71,10 +71,30 @@ describe(componentName, () => {
         icon: ArrowRight,
         iconDescription: 'Visit Carbon official site',
         link: {
-          url: 'https://carbondesignsystem.com/',
+          href: 'https://carbondesignsystem.com/',
           target: '_blank',
           rel: 'noreferrer noopener',
           download: 'carbon-site.pdf',
+        },
+      },
+      {
+        id: '4',
+        icon: ArrowRight,
+        iconDescription: 'Visit another page',
+        href: 'dummy.link',
+        link: {
+          href: 'https://carbondesignsystem.com/designing/get-started/',
+          target: '_blank',
+          rel: 'noreferrer noopener',
+        },
+      },
+      {
+        id: '5',
+        icon: ArrowRight,
+        iconDescription: 'Visit page',
+        onClick,
+        link: {
+          href: '#',
         },
       },
     ];
@@ -101,12 +121,12 @@ describe(componentName, () => {
     expect(LinkWithHref).toBeInTheDocument();
     expect(LinkWithHref).toHaveAttribute('href', actionIcons[1].href);
 
-    // link with url, target, rel and download
+    // link with href, target, rel and download
     const LinkWithLinkProps = screen.getByRole('link', {
       name: actionIcons[2].iconDescription,
     });
     expect(LinkWithLinkProps).toBeInTheDocument();
-    expect(LinkWithLinkProps).toHaveAttribute('href', actionIcons[2].link.url);
+    expect(LinkWithLinkProps).toHaveAttribute('href', actionIcons[2].link.href);
     expect(LinkWithLinkProps).toHaveAttribute(
       'target',
       actionIcons[2].link.target
@@ -116,6 +136,27 @@ describe(componentName, () => {
       'download',
       actionIcons[2].link.download
     );
+
+    // with link.href and href (link.href should have precedence)
+    const LinkAndHref = screen.getByRole('link', {
+      name: actionIcons[3].iconDescription,
+    });
+    expect(LinkAndHref).toBeInTheDocument();
+    expect(LinkAndHref).toHaveAttribute('href', actionIcons[3].link.href);
+    expect(LinkAndHref).toHaveAttribute('target', actionIcons[3].link.target);
+    expect(LinkAndHref).toHaveAttribute('rel', actionIcons[3].link.rel);
+
+    // with link and onClick
+    const LinkAndOnClick = screen.getByRole('link', {
+      name: actionIcons[4].iconDescription,
+    });
+    expect(LinkAndOnClick).toBeInTheDocument();
+    expect(LinkAndOnClick).toHaveAttribute('href', actionIcons[4].link.href);
+    // The use of act is deprecated. Wrapping the click in a waitFor is a workaround to ensure that all the state updates related to Tooltip is completed.
+    await waitFor(async () => {
+      await user.click(LinkAndOnClick);
+    });
+    expect(onClick).toHaveBeenCalled();
   });
 
   it('renders expressive with onClick', async () => {
@@ -273,15 +314,37 @@ describe(componentName, () => {
   });
 
   it('renders a productive card with action icons', async () => {
+    const user = userEvent.setup();
+    const onClick = jest.fn();
     const actionIcons = [
       {
         id: '1',
         icon: ArrowRight,
         iconDescription: 'Visit Carbon official site',
         link: {
-          url: 'https://carbondesignsystem.com/',
+          href: 'https://carbondesignsystem.com/',
           target: '_blank',
           rel: 'noreferrer noopener',
+        },
+      },
+      {
+        id: '2',
+        icon: ArrowRight,
+        iconDescription: 'Visit next page',
+        href: 'dummy.link',
+        link: {
+          href: 'https://carbondesignsystem.com/',
+          target: '_blank',
+          rel: 'noreferrer noopener',
+        },
+      },
+      {
+        id: '3',
+        icon: ArrowRight,
+        iconDescription: 'Visit page',
+        onClick,
+        link: {
+          href: '#',
         },
       },
     ];
@@ -296,14 +359,14 @@ describe(componentName, () => {
 
     render(<Card {...props} />);
 
-    // link with url, target and rel
+    // link with href, target and rel
     const LinkWithTargetAndRel = screen.getByRole('link', {
       name: actionIcons[0].iconDescription,
     });
     expect(LinkWithTargetAndRel).toBeInTheDocument();
     expect(LinkWithTargetAndRel).toHaveAttribute(
       'href',
-      actionIcons[0].link.url
+      actionIcons[0].link.href
     );
     expect(LinkWithTargetAndRel).toHaveAttribute(
       'target',
@@ -313,6 +376,25 @@ describe(componentName, () => {
       'rel',
       actionIcons[0].link.rel
     );
+
+    // with link.href and href (link.href should have precedence)
+    const LinkAndHref = screen.getByRole('link', {
+      name: actionIcons[1].iconDescription,
+    });
+    expect(LinkAndHref).toBeInTheDocument();
+    expect(LinkAndHref).toHaveAttribute('href', actionIcons[1].link.href);
+
+    // with link and onClick
+    const LinkAndOnClick = screen.getByRole('link', {
+      name: actionIcons[2].iconDescription,
+    });
+    expect(LinkAndOnClick).toBeInTheDocument();
+    expect(LinkAndOnClick).toHaveAttribute('href', actionIcons[2].link.href);
+    // The use of act is deprecated. Wrapping the click in a waitFor is a workaround to ensure that all the state updates related to Tooltip is completed.
+    await waitFor(async () => {
+      await user.click(LinkAndOnClick);
+    });
+    expect(onClick).toHaveBeenCalled();
   });
 
   it('has no accessibility violations', async () => {

--- a/packages/ibm-products/src/components/Card/Card.test.js
+++ b/packages/ibm-products/src/components/Card/Card.test.js
@@ -74,6 +74,7 @@ describe(componentName, () => {
           url: 'https://carbondesignsystem.com/',
           target: '_blank',
           rel: 'noreferrer noopener',
+          download: 'carbon-site.pdf',
         },
       },
     ];
@@ -100,22 +101,20 @@ describe(componentName, () => {
     expect(LinkWithHref).toBeInTheDocument();
     expect(LinkWithHref).toHaveAttribute('href', actionIcons[1].href);
 
-    // link with url, target and rel
-    const LinkWithTargetAndRel = screen.getByRole('link', {
+    // link with url, target, rel and download
+    const LinkWithLinkProps = screen.getByRole('link', {
       name: actionIcons[2].iconDescription,
     });
-    expect(LinkWithTargetAndRel).toBeInTheDocument();
-    expect(LinkWithTargetAndRel).toHaveAttribute(
-      'href',
-      actionIcons[2].link.url
-    );
-    expect(LinkWithTargetAndRel).toHaveAttribute(
+    expect(LinkWithLinkProps).toBeInTheDocument();
+    expect(LinkWithLinkProps).toHaveAttribute('href', actionIcons[2].link.url);
+    expect(LinkWithLinkProps).toHaveAttribute(
       'target',
       actionIcons[2].link.target
     );
-    expect(LinkWithTargetAndRel).toHaveAttribute(
-      'rel',
-      actionIcons[2].link.rel
+    expect(LinkWithLinkProps).toHaveAttribute('rel', actionIcons[2].link.rel);
+    expect(LinkWithLinkProps).toHaveAttribute(
+      'download',
+      actionIcons[2].link.download
     );
   });
 

--- a/packages/ibm-products/src/components/Card/Card.test.js
+++ b/packages/ibm-products/src/components/Card/Card.test.js
@@ -8,6 +8,7 @@
 import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { Add, UserIdentification, ArrowRight } from '@carbon/react/icons';
 
 import { Card } from '.';
 import { pkg, carbon } from '../../settings';
@@ -56,25 +57,62 @@ describe(componentName, () => {
       {
         id: '1',
         onClick,
-        icon: () => <div>withOnClick</div>,
-        iconDescription: 'icon',
+        icon: Add,
+        iconDescription: 'Click here to add a new user',
       },
       {
         id: '2',
         href: '#',
-        icon: () => <div>withHref</div>,
-        iconDescription: 'icon',
+        icon: UserIdentification,
+        iconDescription: 'Contact IBM Support',
+      },
+      {
+        id: '3',
+        icon: ArrowRight,
+        iconDescription: 'Visit Carbon official site',
+        link: {
+          url: 'https://carbondesignsystem.com/',
+          target: '_blank',
+          rel: 'noreferrer noopener',
+        },
       },
     ];
     const props = {
       actionIcons,
     };
     render(<Card {...props} />);
-    await act(() => click(screen.getByText('withOnClick')));
+
+    // with onClick
+    const AddButton = screen.getByRole('button', {
+      name: actionIcons[0].iconDescription,
+    });
+    expect(AddButton).toBeInTheDocument();
+    await act(() => click(AddButton));
     expect(onClick).toHaveBeenCalled();
-    expect(screen.getByText('withHref').closest('a')).toHaveAttribute(
+
+    // link with href
+    const LinkWithHref = screen.getByRole('link', {
+      name: actionIcons[1].iconDescription,
+    });
+    expect(LinkWithHref).toBeInTheDocument();
+    expect(LinkWithHref).toHaveAttribute('href', actionIcons[1].href);
+
+    // link with url, target and rel
+    const LinkWithTargetAndRel = screen.getByRole('link', {
+      name: actionIcons[2].iconDescription,
+    });
+    expect(LinkWithTargetAndRel).toBeInTheDocument();
+    expect(LinkWithTargetAndRel).toHaveAttribute(
       'href',
-      '#'
+      actionIcons[2].link.url
+    );
+    expect(LinkWithTargetAndRel).toHaveAttribute(
+      'target',
+      actionIcons[2].link.target
+    );
+    expect(LinkWithTargetAndRel).toHaveAttribute(
+      'rel',
+      actionIcons[2].link.rel
     );
   });
 

--- a/packages/ibm-products/src/components/Card/Card.tsx
+++ b/packages/ibm-products/src/components/Card/Card.tsx
@@ -29,15 +29,22 @@ interface Metadata {
   iconDescription?: string;
 }
 
-interface ActionIcon extends Metadata {
-  onKeydown?: () => void;
-  onClick?: () => void;
+type LinkType = {
+  url: string;
+  target?: string;
+  rel?: string;
+};
+
+export interface ActionIcon extends Metadata {
+  onKeydown?: (event: KeyboardEvent) => void;
+  onClick?: (
+    event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>
+  ) => void;
+  /**
+   * @deprecated please use the `link.url` instead
+   */
   href?: string;
-  link?: {
-    url: string;
-    target?: string;
-    rel?: string;
-  };
+  link?: LinkType;
 }
 
 type OverflowActions = {
@@ -150,10 +157,10 @@ export const Card = forwardRef(
     }: CardProp,
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {
-    const IconList: readonly ActionIcon[] = getStarted ? metadata : actionIcons;
+    const iconList: readonly ActionIcon[] = getStarted ? metadata : actionIcons;
     const blockClass = `${pkg.prefix}--card`;
     const hasActions =
-      IconList?.length > 0 ||
+      iconList?.length > 0 ||
       overflowActions.length > 0 ||
       (!!primaryButtonText && primaryButtonPlacement === 'top');
     const hasHeaderActions = hasActions && actionsPlacement === 'top';
@@ -193,7 +200,7 @@ export const Card = forwardRef(
         );
       }
 
-      const icons = IconList?.map(
+      const icons = iconList?.map(
         ({ id, icon: Icon, onClick, iconDescription, href, link, ...rest }) => {
           if (getStarted) {
             return (
@@ -214,7 +221,9 @@ export const Card = forwardRef(
                 size={actionsPlacement === 'top' ? 'sm' : 'md'}
                 iconDescription={iconDescription}
                 kind="ghost"
-                href={href}
+                href={link?.url ?? href}
+                target={link?.target ?? '_self'}
+                rel={link?.rel ?? ''}
               />
             );
           }
@@ -296,7 +305,7 @@ export const Card = forwardRef(
       actions: actionsPlacement === 'top' ? getActions() : '',
       decorator,
       noActionIcons:
-        IconList?.length > 0 && actionsPlacement === 'top' ? false : true,
+        iconList?.length > 0 && actionsPlacement === 'top' ? false : true,
       actionsPlacement,
       onPrimaryButtonClick,
       onSecondaryButtonClick,
@@ -398,6 +407,9 @@ Card.propTypes = {
       onKeyDown: PropTypes.func,
       onClick: PropTypes.func,
       iconDescription: PropTypes.string,
+      /**
+       * @deprecated please use the `link.url` instead
+       */
       href: PropTypes.string,
       link: PropTypes.shape({
         url: PropTypes.string.isRequired,

--- a/packages/ibm-products/src/components/Card/Card.tsx
+++ b/packages/ibm-products/src/components/Card/Card.tsx
@@ -30,6 +30,11 @@ type ActionIcon = {
   onClick?: () => void;
   iconDescription?: string;
   href?: string;
+  link?: {
+    url: string;
+    target?: string;
+    rel?: string;
+  };
 };
 type OverflowActions = {
   id?: string;
@@ -44,6 +49,11 @@ type Metadata = {
   iconDescription?: string;
   onClick?: () => void;
   href?: string;
+  link?: {
+    url: string;
+    target?: string;
+    rel?: string;
+  };
 };
 interface CardProp extends PropsWithChildren {
   actionIcons?: readonly ActionIcon[];
@@ -192,7 +202,7 @@ export const Card = forwardRef(
       }
 
       const icons = getIcons().map(
-        ({ id, icon: Icon, onClick, iconDescription, href, ...rest }) => {
+        ({ id, icon: Icon, onClick, iconDescription, href, link, ...rest }) => {
           if (getStarted) {
             return (
               <span key={id} className={`${blockClass}__icon`}>
@@ -216,13 +226,15 @@ export const Card = forwardRef(
               />
             );
           }
-          if (href) {
+          if (link?.url || href) {
             return (
               <a
                 key={id}
                 className={`${blockClass}__icon`}
-                href={href}
+                href={link?.url || href}
                 onClick={onClick}
+                target={link?.target ?? '_self'}
+                rel={link?.rel ?? ''}
               >
                 {Icon && <Icon aria-label={iconDescription} />}
               </a>
@@ -395,6 +407,11 @@ Card.propTypes = {
       onClick: PropTypes.func,
       iconDescription: PropTypes.string,
       href: PropTypes.string,
+      link: {
+        url: PropTypes.string.isRequired,
+        target: PropTypes.string,
+        rel: PropTypes.string,
+      },
     })
   ),
   actionsPlacement: PropTypes.oneOf(['top', 'bottom']),

--- a/packages/ibm-products/src/components/Card/Card.tsx
+++ b/packages/ibm-products/src/components/Card/Card.tsx
@@ -23,19 +23,23 @@ import { CardFooter } from './CardFooter';
 import { pkg } from '../../settings';
 const componentName = 'Card';
 
-type ActionIcon = {
+interface Metadata {
   id?: string;
   icon?: () => ReactNode;
+  iconDescription?: string;
+}
+
+interface ActionIcon extends Metadata {
   onKeydown?: () => void;
   onClick?: () => void;
-  iconDescription?: string;
   href?: string;
   link?: {
     url: string;
     target?: string;
     rel?: string;
   };
-};
+}
+
 type OverflowActions = {
   id?: string;
   itemText?: string;
@@ -43,18 +47,6 @@ type OverflowActions = {
   onKeydown?: () => void;
 };
 
-type Metadata = {
-  id?: string;
-  icon?: () => ReactNode;
-  iconDescription?: string;
-  onClick?: () => void;
-  href?: string;
-  link?: {
-    url: string;
-    target?: string;
-    rel?: string;
-  };
-};
 interface CardProp extends PropsWithChildren {
   actionIcons?: readonly ActionIcon[];
   actionsPlacement?: 'top' | 'bottom';
@@ -158,10 +150,10 @@ export const Card = forwardRef(
     }: CardProp,
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {
-    const getIcons = () => (getStarted ? metadata : actionIcons);
+    const IconList: readonly ActionIcon[] = getStarted ? metadata : actionIcons;
     const blockClass = `${pkg.prefix}--card`;
     const hasActions =
-      getIcons().length > 0 ||
+      IconList?.length > 0 ||
       overflowActions.length > 0 ||
       (!!primaryButtonText && primaryButtonPlacement === 'top');
     const hasHeaderActions = hasActions && actionsPlacement === 'top';
@@ -201,7 +193,7 @@ export const Card = forwardRef(
         );
       }
 
-      const icons = getIcons().map(
+      const icons = IconList?.map(
         ({ id, icon: Icon, onClick, iconDescription, href, link, ...rest }) => {
           if (getStarted) {
             return (
@@ -304,7 +296,7 @@ export const Card = forwardRef(
       actions: actionsPlacement === 'top' ? getActions() : '',
       decorator,
       noActionIcons:
-        getIcons().length > 0 && actionsPlacement === 'top' ? false : true,
+        IconList?.length > 0 && actionsPlacement === 'top' ? false : true,
       actionsPlacement,
       onPrimaryButtonClick,
       onSecondaryButtonClick,

--- a/packages/ibm-products/src/components/Card/Card.tsx
+++ b/packages/ibm-products/src/components/Card/Card.tsx
@@ -399,11 +399,11 @@ Card.propTypes = {
       onClick: PropTypes.func,
       iconDescription: PropTypes.string,
       href: PropTypes.string,
-      link: {
+      link: PropTypes.shape({
         url: PropTypes.string.isRequired,
         target: PropTypes.string,
         rel: PropTypes.string,
-      },
+      }),
     })
   ),
   actionsPlacement: PropTypes.oneOf(['top', 'bottom']),

--- a/packages/ibm-products/src/components/Card/Card.tsx
+++ b/packages/ibm-products/src/components/Card/Card.tsx
@@ -30,7 +30,7 @@ interface Metadata {
 }
 
 type LinkType = {
-  url: string;
+  href: string;
 } & {
   [key: string]: unknown;
 };
@@ -41,7 +41,7 @@ export interface ActionIcon extends Metadata {
     event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>
   ) => void;
   /**
-   * @deprecated please use the `link.url` instead
+   * @deprecated please use the `link.href` instead
    */
   href?: string;
   link?: LinkType;
@@ -157,10 +157,11 @@ export const Card = forwardRef(
     }: CardProp,
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {
-    const iconList: readonly ActionIcon[] = getStarted ? metadata : actionIcons;
+    const getIcons = (): readonly ActionIcon[] =>
+      getStarted ? metadata : actionIcons;
     const blockClass = `${pkg.prefix}--card`;
     const hasActions =
-      iconList?.length > 0 ||
+      getIcons().length > 0 ||
       overflowActions.length > 0 ||
       (!!primaryButtonText && primaryButtonPlacement === 'top');
     const hasHeaderActions = hasActions && actionsPlacement === 'top';
@@ -200,9 +201,17 @@ export const Card = forwardRef(
         );
       }
 
-      const icons = iconList?.map(
-        ({ id, icon: Icon, onClick, iconDescription, href, link, ...rest }) => {
-          const { url, ...linkProps } = link ?? {};
+      const icons = getIcons().map(
+        ({
+          id,
+          icon: Icon,
+          onClick,
+          iconDescription,
+          href: deprecatedHref,
+          link,
+          ...rest
+        }) => {
+          const { href, ...linkProps } = link ?? { href: deprecatedHref };
 
           if (getStarted) {
             return (
@@ -223,17 +232,17 @@ export const Card = forwardRef(
                 size={actionsPlacement === 'top' ? 'sm' : 'md'}
                 iconDescription={iconDescription}
                 kind="ghost"
-                href={link?.url ?? href}
+                href={href}
                 {...linkProps}
               />
             );
           }
-          if (link?.url || href) {
+          if (href) {
             return (
               <a
                 key={id}
                 className={`${blockClass}__icon`}
-                href={link?.url ?? href}
+                href={href}
                 onClick={onClick}
                 {...linkProps}
               >
@@ -305,7 +314,7 @@ export const Card = forwardRef(
       actions: actionsPlacement === 'top' ? getActions() : '',
       decorator,
       noActionIcons:
-        iconList?.length > 0 && actionsPlacement === 'top' ? false : true,
+        getIcons().length > 0 && actionsPlacement === 'top' ? false : true,
       actionsPlacement,
       onPrimaryButtonClick,
       onSecondaryButtonClick,
@@ -408,13 +417,11 @@ Card.propTypes = {
       onClick: PropTypes.func,
       iconDescription: PropTypes.string,
       /**
-       * @deprecated please use the `link.url` instead
+       * @deprecated please use the `link.href` instead
        */
       href: PropTypes.string,
       link: PropTypes.shape({
-        url: PropTypes.string.isRequired,
-        target: PropTypes.string,
-        rel: PropTypes.string,
+        href: PropTypes.string.isRequired,
       }),
     })
   ),

--- a/packages/ibm-products/src/components/Card/Card.tsx
+++ b/packages/ibm-products/src/components/Card/Card.tsx
@@ -31,8 +31,8 @@ interface Metadata {
 
 type LinkType = {
   url: string;
-  target?: string;
-  rel?: string;
+} & {
+  [key: string]: unknown;
 };
 
 export interface ActionIcon extends Metadata {
@@ -202,6 +202,8 @@ export const Card = forwardRef(
 
       const icons = iconList?.map(
         ({ id, icon: Icon, onClick, iconDescription, href, link, ...rest }) => {
+          const { url, ...linkProps } = link ?? {};
+
           if (getStarted) {
             return (
               <span key={id} className={`${blockClass}__icon`}>
@@ -222,8 +224,7 @@ export const Card = forwardRef(
                 iconDescription={iconDescription}
                 kind="ghost"
                 href={link?.url ?? href}
-                target={link?.target ?? '_self'}
-                rel={link?.rel ?? ''}
+                {...linkProps}
               />
             );
           }
@@ -232,10 +233,9 @@ export const Card = forwardRef(
               <a
                 key={id}
                 className={`${blockClass}__icon`}
-                href={link?.url || href}
+                href={link?.url ?? href}
                 onClick={onClick}
-                target={link?.target ?? '_self'}
-                rel={link?.rel ?? ''}
+                {...linkProps}
               >
                 {Icon && <Icon aria-label={iconDescription} />}
               </a>

--- a/packages/ibm-products/src/components/EditUpdateCards/EditUpdateCards.tsx
+++ b/packages/ibm-products/src/components/EditUpdateCards/EditUpdateCards.tsx
@@ -39,7 +39,7 @@ type PlacementType = 'top' | 'bottom';
 
 export interface EditUpdateCardsProps {
   /**
-   * Icons that are displayed on the card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property. link object can have any anchor element properties. link.url, href has precedence over onClick.
+   * Icons that are displayed on the card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.href for href functionality. If you are setting link object, href is a required property. link object supports all anchor element properties. Precedence: link.href > href. If link.href or href is set => anchor element, else button.
    */
   actionIcons?: Array<ActionIcon>;
   /**
@@ -231,7 +231,7 @@ EditUpdateCards.displayName = componentName;
 // See https://www.npmjs.com/package/prop-types#usage.
 EditUpdateCards.propTypes = {
   /**
-   * Icons that are displayed on the card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property. link object can have any anchor element properties. link.url, href has precedence over onClick.
+   * Icons that are displayed on the card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.href for href functionality. If you are setting link object, href is a required property. link object supports all anchor element properties. Precedence: link.href > href. If link.href or href is set => anchor element, else button.
    */
   /**@ts-ignore */
   actionIcons: PropTypes.arrayOf(
@@ -242,11 +242,11 @@ EditUpdateCards.propTypes = {
       onClick: PropTypes.func,
       iconDescription: PropTypes.string,
       /**
-       * @deprecated please use the `link.url` instead
+       * @deprecated please use the `link.href` instead
        */
       href: PropTypes.string,
       link: PropTypes.shape({
-        url: PropTypes.string.isRequired,
+        href: PropTypes.string.isRequired,
       }),
     })
   ),

--- a/packages/ibm-products/src/components/EditUpdateCards/EditUpdateCards.tsx
+++ b/packages/ibm-products/src/components/EditUpdateCards/EditUpdateCards.tsx
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { pkg } from '../../settings';
+import { ActionIcon } from '../Card/Card';
 
 // Carbon and package components we use.
 /* TODO: @import(s) of carbon components and other package components. */
@@ -34,19 +35,11 @@ const componentName = 'EditUpdateCards';
 // Default values should be provided when the component needs to make a choice
 // or assumption when a prop is not supplied.
 
-type ActionIcon = {
-  id: string;
-  icon: CarbonIconType;
-  onKeyDown?(): void;
-  onClick?(): void;
-  iconDescription: string;
-  href?: string;
-};
 type PlacementType = 'top' | 'bottom';
 
 export interface EditUpdateCardsProps {
   /**
-   * Icons that are displayed on card. Refer to design documentation for implementation guidelines
+   * Icons that are displayed on card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property. link.url, href has precedence over onClick.
    */
   actionIcons?: Array<ActionIcon>;
   /**
@@ -238,7 +231,7 @@ EditUpdateCards.displayName = componentName;
 // See https://www.npmjs.com/package/prop-types#usage.
 EditUpdateCards.propTypes = {
   /**
-   * Icons that are displayed on card. Refer to design documentation for implementation guidelines
+   * Icons that are displayed on card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property. link.url, href has precedence over onClick.
    */
   /**@ts-ignore */
   actionIcons: PropTypes.arrayOf(
@@ -249,6 +242,11 @@ EditUpdateCards.propTypes = {
       onClick: PropTypes.func,
       iconDescription: PropTypes.string,
       href: PropTypes.string,
+      link: PropTypes.shape({
+        url: PropTypes.string.isRequired,
+        target: PropTypes.string,
+        rel: PropTypes.string,
+      }),
     })
   ),
   /**

--- a/packages/ibm-products/src/components/EditUpdateCards/EditUpdateCards.tsx
+++ b/packages/ibm-products/src/components/EditUpdateCards/EditUpdateCards.tsx
@@ -39,7 +39,7 @@ type PlacementType = 'top' | 'bottom';
 
 export interface EditUpdateCardsProps {
   /**
-   * Icons that are displayed on card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property. link.url, href has precedence over onClick.
+   * Icons that are displayed on the card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property. link object can have any anchor element properties. link.url, href has precedence over onClick.
    */
   actionIcons?: Array<ActionIcon>;
   /**
@@ -231,7 +231,7 @@ EditUpdateCards.displayName = componentName;
 // See https://www.npmjs.com/package/prop-types#usage.
 EditUpdateCards.propTypes = {
   /**
-   * Icons that are displayed on card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property. link.url, href has precedence over onClick.
+   * Icons that are displayed on the card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property. link object can have any anchor element properties. link.url, href has precedence over onClick.
    */
   /**@ts-ignore */
   actionIcons: PropTypes.arrayOf(
@@ -241,11 +241,12 @@ EditUpdateCards.propTypes = {
       onKeyDown: PropTypes.func,
       onClick: PropTypes.func,
       iconDescription: PropTypes.string,
+      /**
+       * @deprecated please use the `link.url` instead
+       */
       href: PropTypes.string,
       link: PropTypes.shape({
         url: PropTypes.string.isRequired,
-        target: PropTypes.string,
-        rel: PropTypes.string,
       }),
     })
   ),

--- a/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.stories.jsx
+++ b/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.stories.jsx
@@ -241,6 +241,25 @@ WithActionIconHref.args = {
   mediaRatio: null,
 };
 
+export const WithActionIconLink = Template.bind({});
+WithActionIconLink.args = {
+  ...defaultProps,
+  actionIcons: [
+    {
+      id: '1',
+      icon: (props) => <ArrowRight size={24} {...props} />,
+      iconDescription: 'Visit carbon official site',
+      link: {
+        url: 'https://carbondesignsystem.com/',
+        target: '_blank',
+        rel: 'noreferrer noopener',
+      },
+    },
+  ],
+  primaryButtonText: '',
+  mediaRatio: null,
+};
+
 export const WithPictogram = Template.bind({});
 WithPictogram.args = {
   ...defaultProps,

--- a/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.stories.jsx
+++ b/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.stories.jsx
@@ -226,6 +226,21 @@ WithMedia.args = {
   ...defaultProps,
 };
 
+export const WithActionIconButton = Template.bind({});
+WithActionIconButton.args = {
+  ...defaultProps,
+  actionIcons: [
+    {
+      id: '1',
+      icon: (props) => <ArrowRight size={18} {...props} />,
+      iconDescription: 'Visit carbon official site',
+      onClick: action('onClick'),
+    },
+  ],
+  primaryButtonText: '',
+  mediaRatio: null,
+};
+
 export const WithActionIconLink = Template.bind({});
 WithActionIconLink.args = {
   ...defaultProps,

--- a/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.stories.jsx
+++ b/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.stories.jsx
@@ -250,7 +250,7 @@ WithActionIconLink.args = {
       icon: (props) => <ArrowRight size={24} {...props} />,
       iconDescription: 'Visit carbon official site',
       link: {
-        url: 'https://carbondesignsystem.com/',
+        href: 'https://carbondesignsystem.com/',
         target: '_blank',
         rel: 'noreferrer noopener',
       },

--- a/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.stories.jsx
+++ b/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.stories.jsx
@@ -226,21 +226,6 @@ WithMedia.args = {
   ...defaultProps,
 };
 
-export const WithActionIconHref = Template.bind({});
-WithActionIconHref.args = {
-  ...defaultProps,
-  actionIcons: [
-    {
-      id: '1',
-      icon: (props) => <ArrowRight size={24} {...props} />,
-      href: '#',
-      iconDescription: 'Next',
-    },
-  ],
-  primaryButtonText: '',
-  mediaRatio: null,
-};
-
 export const WithActionIconLink = Template.bind({});
 WithActionIconLink.args = {
   ...defaultProps,

--- a/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.tsx
+++ b/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.tsx
@@ -13,20 +13,7 @@ import PropTypes from 'prop-types';
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { pkg } from '../../settings';
 import { prepareProps } from '../../global/js/utils/props-helper';
-
-type ActionIcon = {
-  id?: string;
-  icon?: () => void | object;
-  onKeydown?: () => void;
-  onClick?: () => void;
-  iconDescription?: string;
-  href?: string;
-  link?: {
-    url: string;
-    target?: string;
-    rel?: string;
-  };
-};
+import { ActionIcon } from '../Card/Card';
 
 export interface ExpressiveCardProps extends PropsWithChildren {
   /**
@@ -154,6 +141,9 @@ ExpressiveCard.propTypes = {
       onKeyDown: PropTypes.func,
       onClick: PropTypes.func,
       iconDescription: PropTypes.string,
+      /**
+       * @deprecated please use the `link.url` instead
+       */
       href: PropTypes.string,
       link: PropTypes.shape({
         url: PropTypes.string.isRequired,

--- a/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.tsx
+++ b/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.tsx
@@ -17,7 +17,7 @@ import { ActionIcon } from '../Card/Card';
 
 export interface ExpressiveCardProps extends PropsWithChildren {
   /**
-   * Icons that are displayed on card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property. link.url, href has precedence over onClick.
+   * Icons that are displayed on the card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property. link object can have any anchor element properties. link.url, href has precedence over onClick.
    */
   actionIcons?: ActionIcon[];
   /**
@@ -131,7 +131,7 @@ ExpressiveCard = pkg.checkComponentEnabled(ExpressiveCard, componentName);
 
 ExpressiveCard.propTypes = {
   /**
-   * Icons that are displayed on card. Refer to design documentation for implementation guidelines. Note- href will supersede onClick
+   * Icons that are displayed on the card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property. link object can have any anchor element properties. link.url, href has precedence over onClick.
    */
   /**@ts-ignore */
   actionIcons: PropTypes.arrayOf(
@@ -147,8 +147,6 @@ ExpressiveCard.propTypes = {
       href: PropTypes.string,
       link: PropTypes.shape({
         url: PropTypes.string.isRequired,
-        target: PropTypes.string,
-        rel: PropTypes.string,
       }),
     })
   ),

--- a/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.tsx
+++ b/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.tsx
@@ -17,7 +17,7 @@ import { ActionIcon } from '../Card/Card';
 
 export interface ExpressiveCardProps extends PropsWithChildren {
   /**
-   * Icons that are displayed on card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property.
+   * Icons that are displayed on card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property. link.url, href has precedence over onClick.
    */
   actionIcons?: ActionIcon[];
   /**

--- a/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.tsx
+++ b/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.tsx
@@ -30,7 +30,7 @@ type ActionIcon = {
 
 export interface ExpressiveCardProps extends PropsWithChildren {
   /**
-   * Icons that are displayed on card. Refer to design documentation for implementation guidelines. Note- href will supersede onClick
+   * Icons that are displayed on card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property.
    */
   actionIcons?: ActionIcon[];
   /**
@@ -155,11 +155,11 @@ ExpressiveCard.propTypes = {
       onClick: PropTypes.func,
       iconDescription: PropTypes.string,
       href: PropTypes.string,
-      link: {
+      link: PropTypes.shape({
         url: PropTypes.string.isRequired,
         target: PropTypes.string,
         rel: PropTypes.string,
-      },
+      }),
     })
   ),
   /**

--- a/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.tsx
+++ b/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.tsx
@@ -21,6 +21,11 @@ type ActionIcon = {
   onClick?: () => void;
   iconDescription?: string;
   href?: string;
+  link?: {
+    url: string;
+    target?: string;
+    rel?: string;
+  };
 };
 
 export interface ExpressiveCardProps extends PropsWithChildren {
@@ -150,6 +155,11 @@ ExpressiveCard.propTypes = {
       onClick: PropTypes.func,
       iconDescription: PropTypes.string,
       href: PropTypes.string,
+      link: {
+        url: PropTypes.string.isRequired,
+        target: PropTypes.string,
+        rel: PropTypes.string,
+      },
     })
   ),
   /**

--- a/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.tsx
+++ b/packages/ibm-products/src/components/ExpressiveCard/ExpressiveCard.tsx
@@ -17,7 +17,7 @@ import { ActionIcon } from '../Card/Card';
 
 export interface ExpressiveCardProps extends PropsWithChildren {
   /**
-   * Icons that are displayed on the card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property. link object can have any anchor element properties. link.url, href has precedence over onClick.
+   * Icons that are displayed on the card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.href for href functionality. If you are setting link object, href is a required property. link object supports all anchor element properties. Precedence: link.href > href. If link.href or href is set => anchor element, else button.
    */
   actionIcons?: ActionIcon[];
   /**
@@ -131,7 +131,7 @@ ExpressiveCard = pkg.checkComponentEnabled(ExpressiveCard, componentName);
 
 ExpressiveCard.propTypes = {
   /**
-   * Icons that are displayed on the card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property. link object can have any anchor element properties. link.url, href has precedence over onClick.
+   * Icons that are displayed on the card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.href for href functionality. If you are setting link object, href is a required property. link object supports all anchor element properties. Precedence: link.href > href. If link.href or href is set => anchor element, else button.
    */
   /**@ts-ignore */
   actionIcons: PropTypes.arrayOf(
@@ -142,11 +142,11 @@ ExpressiveCard.propTypes = {
       onClick: PropTypes.func,
       iconDescription: PropTypes.string,
       /**
-       * @deprecated please use the `link.url` instead
+       * @deprecated please use the `link.href` instead
        */
       href: PropTypes.string,
       link: PropTypes.shape({
-        url: PropTypes.string.isRequired,
+        href: PropTypes.string.isRequired,
       }),
     })
   ),

--- a/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.stories.jsx
+++ b/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.stories.jsx
@@ -279,7 +279,7 @@ WithActionIconLink.args = {
       icon: (props) => <ArrowRight size={18} {...props} />,
       iconDescription: 'Visit carbon official site',
       link: {
-        url: 'https://carbondesignsystem.com/',
+        href: 'https://carbondesignsystem.com/',
         target: '_blank',
         rel: 'noreferrer noopener',
       },

--- a/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.stories.jsx
+++ b/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.stories.jsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import styles from './_storybook-styles.scss?inline'; // import index in case more files are added later.
-import { TrashCan, Edit, Information } from '@carbon/react/icons';
+import { TrashCan, Edit, Information, ArrowRight } from '@carbon/react/icons';
 import {
   Grid,
   Column,
@@ -268,4 +268,21 @@ WithActionGhostButton.args = {
   primaryButtonText: 'Read more',
   primaryButtonIcon: (props) => <TrashCan size={16} {...props} />,
   primaryButtonDisabled: true,
+};
+
+export const WithActionIconLink = Template.bind({});
+WithActionIconLink.args = {
+  ...defaultProps,
+  actionIcons: [
+    {
+      id: '1',
+      icon: (props) => <ArrowRight size={18} {...props} />,
+      iconDescription: 'Visit carbon official site',
+      link: {
+        url: 'https://carbondesignsystem.com/',
+        target: '_blank',
+        rel: 'noreferrer noopener',
+      },
+    },
+  ],
 };

--- a/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.tsx
+++ b/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.tsx
@@ -18,17 +18,10 @@ import PropTypes from 'prop-types';
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { pkg } from '../../settings';
 import { prepareProps } from '../../global/js/utils/props-helper';
+import { ActionIcon } from '../Card/Card';
 
 const componentName = 'ProductiveCard';
 
-type ActionIcon = {
-  id?: string;
-  icon?: CarbonIconType;
-  onClick?: (event: MouseEvent) => void;
-  onKeydown?: (event: KeyboardEvent) => void;
-  iconDescription?: string;
-  href?: string;
-};
 type overflowAction = {
   id?: string;
   itemText?: string;
@@ -39,7 +32,7 @@ type PlacementType = 'top' | 'bottom';
 type ClickZoneType = 'one' | 'two' | 'three';
 export interface ProductiveCardProps extends PropsWithChildren {
   /**
-   * Icons that are displayed on card. Refer to design documentation for implementation guidelines. Note- href will supersede onClick
+   * Icons that are displayed on card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property.
    */
   actionIcons?: ActionIcon[];
   /**
@@ -199,7 +192,15 @@ ProductiveCard.propTypes = {
       onKeyDown: PropTypes.func,
       onClick: PropTypes.func,
       iconDescription: PropTypes.string,
+      /**
+       * @deprecated please use the `link.url` instead
+       */
       href: PropTypes.string,
+      link: PropTypes.shape({
+        url: PropTypes.string.isRequired,
+        target: PropTypes.string,
+        rel: PropTypes.string,
+      }),
     })
   ),
   /**

--- a/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.tsx
+++ b/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.tsx
@@ -32,7 +32,7 @@ type PlacementType = 'top' | 'bottom';
 type ClickZoneType = 'one' | 'two' | 'three';
 export interface ProductiveCardProps extends PropsWithChildren {
   /**
-   * Icons that are displayed on card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property. link.url, href has precedence over onClick
+   * Icons that are displayed on the card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property. link object can have any anchor element properties. link.url, href has precedence over onClick.
    */
   actionIcons?: ActionIcon[];
   /**
@@ -182,7 +182,7 @@ ProductiveCard = pkg.checkComponentEnabled(ProductiveCard, componentName);
 
 ProductiveCard.propTypes = {
   /**
-   * Icons that are displayed on card. Refer to design documentation for implementation guidelines
+   * Icons that are displayed on the card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property. link object can have any anchor element properties. link.url, href has precedence over onClick.
    */
   /**@ts-ignore */
   actionIcons: PropTypes.arrayOf(
@@ -198,8 +198,6 @@ ProductiveCard.propTypes = {
       href: PropTypes.string,
       link: PropTypes.shape({
         url: PropTypes.string.isRequired,
-        target: PropTypes.string,
-        rel: PropTypes.string,
       }),
     })
   ),

--- a/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.tsx
+++ b/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.tsx
@@ -32,7 +32,7 @@ type PlacementType = 'top' | 'bottom';
 type ClickZoneType = 'one' | 'two' | 'three';
 export interface ProductiveCardProps extends PropsWithChildren {
   /**
-   * Icons that are displayed on the card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property. link object can have any anchor element properties. link.url, href has precedence over onClick.
+   * Icons that are displayed on the card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.href for href functionality. If you are setting link object, href is a required property. link object supports all anchor element properties. Precedence: link.href > href. If link.href or href is set => anchor element, else button.
    */
   actionIcons?: ActionIcon[];
   /**
@@ -182,7 +182,7 @@ ProductiveCard = pkg.checkComponentEnabled(ProductiveCard, componentName);
 
 ProductiveCard.propTypes = {
   /**
-   * Icons that are displayed on the card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property. link object can have any anchor element properties. link.url, href has precedence over onClick.
+   * Icons that are displayed on the card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.href for href functionality. If you are setting link object, href is a required property. link object supports all anchor element properties. Precedence: link.href > href. If link.href or href is set => anchor element, else button.
    */
   /**@ts-ignore */
   actionIcons: PropTypes.arrayOf(
@@ -193,11 +193,11 @@ ProductiveCard.propTypes = {
       onClick: PropTypes.func,
       iconDescription: PropTypes.string,
       /**
-       * @deprecated please use the `link.url` instead
+       * @deprecated please use the `link.href` instead
        */
       href: PropTypes.string,
       link: PropTypes.shape({
-        url: PropTypes.string.isRequired,
+        href: PropTypes.string.isRequired,
       }),
     })
   ),

--- a/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.tsx
+++ b/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.tsx
@@ -32,7 +32,7 @@ type PlacementType = 'top' | 'bottom';
 type ClickZoneType = 'one' | 'two' | 'three';
 export interface ProductiveCardProps extends PropsWithChildren {
   /**
-   * Icons that are displayed on card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property.
+   * Icons that are displayed on card. Refer to design documentation for implementation guidelines. Note: href is deprecated. Set link.url for href functionality. If you are setting link, url is a required property. link.url, href has precedence over onClick
    */
   actionIcons?: ActionIcon[];
   /**


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/ibm-products/issues/3831

The Card component is used by `ExpressiveCard`, `ProductiveCard` and `GetStartedCard`. The `ExpressiveCard` and `ProductiveCard` exposes `actionIcon href`. In this PR, `actionIcon href` has been deprecated and a new `link` object has been introduced.

Note 1: There are other properties: `primaryButtonHref` and `secondaryButtonHref`, where the href string can be replaced with a link object. I haven't included those changes in this PR as these changes are not in the scope of [3831](https://github.com/carbon-design-system/ibm-products/issues/3831).

Note 2: The component `EditUpdateCards` uses `ProductiveCard`, but since `EditUpdateCards` is deprecated, I haven't added new storybook for it. I have updated the type so that typescript doesn't throw error.

Note 3: I have refactored the unit test that I have modified. I haven't refactored other unit tests as I believe they are not in the scope of this PR and I want to make this PR short.

#### What did you change?

- Added an optional `link` property:
```
link?: {
    url: string;
    target?: string;
    rel?: string;
};
```
- If `link` object is provided, `url` is required.
- With the introduction of `link` property, `href` can be marked as deprecated for `ExpressiveCard` and `ProductiveCard`.
- Added storybook. Removed deprecated storybook.
- Added/updated unit tests.

#### How did you test and verify your work?
- Verified my work in storybook.
