### PR TITLE
chore: bump vite in web component examples

### DIFF
--- a/packages/ibm-products-web-components/examples/about-modal/package.json
+++ b/packages/ibm-products-web-components/examples/about-modal/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "vite": "5.4.17"
+    "vite": "5.4.18"
   }
 }

--- a/packages/ibm-products-web-components/examples/full-page-error/package.json
+++ b/packages/ibm-products-web-components/examples/full-page-error/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "vite": "5.4.17"
+    "vite": "5.4.18"
   }
 }

--- a/packages/ibm-products-web-components/examples/side-panel/package.json
+++ b/packages/ibm-products-web-components/examples/side-panel/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "vite": "5.4.17"
+    "vite": "5.4.18"
   }
 }

--- a/packages/ibm-products-web-components/examples/tearsheet/package.json
+++ b/packages/ibm-products-web-components/examples/tearsheet/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "vite": "5.4.17"
+    "vite": "5.4.18"
   }
 }

--- a/packages/ibm-products-web-components/examples/user-avatar/package.json
+++ b/packages/ibm-products-web-components/examples/user-avatar/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "vite": "5.4.17"
+    "vite": "5.4.18"
   }
 }


### PR DESCRIPTION
Closes #7296

Bump vite version in all Web Component examples.

#### What did you change?
Update `package.json` for each WC example

#### How did you test and verify your work?
