### PR TITLE
feat(create-full-page): null as a viable step

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,8 @@
     "cross-spawn": "7.0.6",
     "micromatch": "4.0.8",
     "semver": "7.7.1",
-    "ws": "^8.17.1"
+    "ws": "^8.17.1",
+    "@babel/runtime": "7.26.10"
   },
   "lint-staged": {
     "!(examples/**/*)**/*.{js,jsx,ts,tsx,mjs}": [

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.test.js
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2024
+ * Copyright IBM Corp. 2021, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -620,5 +620,39 @@ describe(componentName, () => {
         .getByRole('button', { description: 'Title 3' })
         .querySelector(`.${carbon.prefix}--progress__warning`)
     ).toBeInTheDocument();
+  });
+
+  it('should not throw an error if null is passed as one of the children', async () => {
+    const children = [
+      <CreateFullPageStep title="Title 1" subtitle="Subtitle 1" key="1">
+        <p>1</p>
+      </CreateFullPageStep>,
+      null,
+      <CreateFullPageStep title="Title 2" description="2" key="2">
+        <p>2</p>
+      </CreateFullPageStep>,
+    ];
+
+    const { container } = render(
+      <CreateFullPage
+        {...defaultFullPageProps}
+        onRequestSubmit={onRequestSubmitFn}
+      >
+        {children}
+      </CreateFullPage>
+    );
+
+    // Select the next button
+    const nextButtonElement = screen.getByText(nextButtonText);
+
+    await waitFor(() => userEvent.click(nextButtonElement));
+
+    // Make sure the next step is on step 2
+    const influencerSteps = container.querySelector(
+      `.${pkg.prefix}--create-influencer__progress-indicator`
+    );
+
+    expect(influencerSteps.childNodes[0].classList.contains('complete'));
+    expect(influencerSteps.childNodes[1].classList.contains('current'));
   });
 });

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.tsx
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2023
+ * Copyright IBM Corp. 2021, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -383,11 +383,16 @@ export let CreateFullPage = React.forwardRef(
                       } as any
                     }
                   >
-                    {React.Children.map(children, (child, index) => (
-                      <StepNumberContext.Provider value={index + 1}>
-                        {child}
-                      </StepNumberContext.Provider>
-                    ))}
+                    {React.Children.toArray(children)
+                      .filter(Boolean)
+                      .map((child, index) => (
+                        <StepNumberContext.Provider
+                          value={index + 1}
+                          key={index}
+                        >
+                          {child}
+                        </StepNumberContext.Provider>
+                      ))}
                   </StepsContext.Provider>
                 </Form>
               </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1519,12 +1519,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.24.5, @babel/runtime@npm:^7.24.7, @babel/runtime@npm:^7.26.10, @babel/runtime@npm:^7.8.4":
-  version: 7.27.0
-  resolution: "@babel/runtime@npm:7.27.0"
+"@babel/runtime@npm:7.26.10":
+  version: 7.26.10
+  resolution: "@babel/runtime@npm:7.26.10"
   dependencies:
     regenerator-runtime: "npm:^0.14.0"
-  checksum: 10/e6966e03b695feb4c0ac0856a4355231c2580bf9ebd0298f47739f85c0ea658679dd84409daf26378d42c86c1cbe7e33feab709b14e784254b6c441d91606465
+  checksum: 10/9d7ff8e96abe3791047c1138789c742411e3ef19c4d7ca18ce916f83cec92c06ec5dc64401759f6dd1e377cf8a01bbd2c62e033eb7550f435cf6579768d0d4a5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #7101 

This feature enhancements allows null to be a viable step and then filtered out to reflect the progress indicator step correctly

#### How did you test and verify your work?
- Added a test to test the functionality
- Storybook
