### PR TITLE
feat(conditionBuilder): add pre add callback before adding

### DIFF
--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBlock/ConditionBlock.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBlock/ConditionBlock.tsx
@@ -365,6 +365,7 @@ const ConditionBlock = (props: ConditionBlockProps) => {
           showConditionPreviewHandler={showConditionPreviewHandler}
           hideConditionPreviewHandler={hideConditionPreviewHandler}
           className={`${blockClass}__gap ${blockClass}__gap-left`}
+          group={group}
         />
       )}
     </div>

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.stories.jsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.stories.jsx
@@ -6,6 +6,8 @@
  */
 
 import React, { useRef, useState } from 'react';
+import { action } from '@storybook/addon-actions';
+
 // TODO: import action to handle events if required.
 // import { action } from '@storybook/addon-actions';
 import { Wikis } from '@carbon/react/icons';
@@ -214,7 +216,14 @@ const translateWithId = (key) => {
 
 const ConditionBuilderTemplate = (args) => {
   const ref = useRef(undefined);
-  return <ConditionBuilder {...args} ref={ref} {...requiredProps} />;
+  return (
+    <ConditionBuilder
+      {...args}
+      ref={ref}
+      {...requiredProps}
+      onAddItem={(type) => action(`onAddItem is triggered , type: ${type}`)()}
+    />
+  );
 };
 
 /**

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.test.js
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.test.js
@@ -460,6 +460,10 @@ const getOptions = async (conditionState, { property }) => {
       return [];
   }
 };
+
+const onAddItem = jest.fn(() => {
+  preventAdd: false;
+});
 describe(componentName, () => {
   it('renders a component ConditionBuilder', async () => {
     render(<ConditionBuilder data-testid={dataTestId} {...defaultProps} />);
@@ -1028,6 +1032,7 @@ describe(componentName, () => {
         {...defaultProps}
         variant={HIERARCHICAL_VARIANT}
         inputConfig={inputData}
+        onAddItem={onAddItem}
       />
     );
 
@@ -1059,6 +1064,9 @@ describe(componentName, () => {
     expect(addButton);
     await act(() => userEvent.click(addButton));
 
+    //verify onAddItem callback is triggered
+    expect(onAddItem).toHaveBeenCalled();
+
     const regionOption = screen.getByRole('option', {
       name: 'Region',
     });
@@ -1087,6 +1095,9 @@ describe(componentName, () => {
     );
     expect(addSubGroupButton);
     await act(() => userEvent.click(addSubGroupButton));
+
+    //verify onAddItem callback is triggered
+    expect(onAddItem).toHaveBeenCalled();
 
     //add third condition
 
@@ -1120,6 +1131,7 @@ describe(componentName, () => {
         {...defaultProps}
         variant={HIERARCHICAL_VARIANT}
         inputConfig={inputData}
+        onAddItem={onAddItem}
       />
     );
 
@@ -1212,6 +1224,10 @@ describe(componentName, () => {
     );
     expect(addGroupButton);
     await act(() => userEvent.click(addGroupButton));
+
+    //verify onAddItem callback is triggered
+    expect(onAddItem).toHaveBeenCalled();
+
     //adding condition 1
 
     await act(() =>
@@ -1794,6 +1810,85 @@ describe(componentName, () => {
       user.hover(document.querySelector(`.${blockClass}__property-field`))
     );
     expect(screen.getByText('This is a tooltip')).toBeInTheDocument();
+  });
+
+  it('prevent adding a condition, subgroup and group when onAddItem returns preventAdd true', async () => {
+    const onAddItemWithPreventAdd = jest.fn(() => ({
+      preventAdd: true,
+    }));
+    render(
+      <ConditionBuilder
+        {...defaultProps}
+        variant={HIERARCHICAL_VARIANT}
+        inputConfig={inputData}
+        onAddItem={onAddItemWithPreventAdd}
+      />
+    );
+
+    await act(() => userEvent.click(screen.getByText('Add condition')));
+    //group 1
+    //adding condition 1
+
+    await act(() =>
+      userEvent.click(
+        screen.getByRole('option', {
+          name: 'Continent',
+        })
+      )
+    );
+
+    await act(() =>
+      userEvent.click(
+        screen.getByRole('option', {
+          name: 'is',
+        })
+      )
+    );
+
+    await act(() => userEvent.click(screen.getByText('Africa')));
+
+    //adding condition 2
+
+    let addButton = document.querySelector(`.${blockClass}__add-button`);
+    expect(addButton);
+    await act(() => userEvent.click(addButton));
+
+    expect(onAddItemWithPreventAdd).toHaveBeenCalled();
+    const container = document.querySelector(`.${blockClass}`);
+    await act(() => userEvent.click(container));
+
+    expect(
+      screen.queryByRole('button', { name: 'and' })
+    ).not.toBeInTheDocument();
+
+    //adding a subgroup
+
+    let addSubGroupButton = document.querySelector(
+      `.${blockClass}__add-condition-sub-group`
+    );
+    expect(addSubGroupButton);
+    await act(() => userEvent.click(addSubGroupButton));
+
+    expect(onAddItemWithPreventAdd).toHaveBeenCalled();
+    await act(() => userEvent.click(container));
+
+    const subGroups = screen.getAllByText('if');
+    expect(subGroups).toHaveLength(1);
+
+    //group 2
+
+    const addGroupButton = document.querySelector(
+      `.${blockClass}__add-condition-group`
+    );
+    expect(addGroupButton);
+    await act(() => userEvent.click(addGroupButton));
+
+    //verify onAddItem callback is triggered
+    expect(onAddItemWithPreventAdd).toHaveBeenCalled();
+    await act(() => userEvent.click(container));
+
+    const groupConnector = screen.queryAllByRole('button', { name: 'or' });
+    expect(groupConnector).toHaveLength(0);
   });
 
   // keyboard navigation tests

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.tsx
@@ -66,6 +66,7 @@ export let ConditionBuilder = React.forwardRef(
       actions,
       translateWithId,
       statementConfigCustom,
+      onAddItem,
       ...rest
     }: ConditionBuilderProps,
     ref: ForwardedRef<HTMLDivElement>
@@ -86,6 +87,7 @@ export let ConditionBuilder = React.forwardRef(
         translateWithId={translateWithId}
         conditionBuilderRef={conditionBuilderRef}
         statementConfigCustom={statementConfigCustom}
+        onAddItem={onAddItem}
       >
         <div
           {
@@ -260,6 +262,11 @@ ConditionBuilder.propTypes = {
       })
     ),
   }).isRequired,
+  /**
+   * this is an optional callback triggered before adding any condition , subgroup or group.
+   * User can optionally perform any validation and can stop add action if they return back {preventAdd:true}
+   */
+  onAddItem: PropTypes.func,
 
   /**
    * Provide an mandatory numeric value that will be used to enable search option in the popovers with list.

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.types.ts
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.types.ts
@@ -158,7 +158,12 @@ export type statementConfig = Item & {
   connector: 'and' | 'or';
   secondaryLabel?: string;
 };
-type AddItemType = 'add-condition' | 'add-subgroup' | 'add-group';
+type AddItemType = 'condition' | 'subgroup' | 'group';
+type AddItemConfig = {
+  type: AddItemType;
+  state: ConditionBuilderState;
+  group?: ConditionGroup;
+};
 
 export type ConditionBuilderProps = {
   inputConfig: inputConfig;
@@ -176,11 +181,7 @@ export type ConditionBuilderProps = {
   variant?: 'Non-Hierarchical' | 'Hierarchical';
   translateWithId: (id: string) => string;
   statementConfigCustom: statementConfig[];
-  onAddItem?: (
-    addItemType: AddItemType,
-    rootState: ConditionBuilderState,
-    group?: ConditionGroup
-  ) => { preventAdd: boolean };
+  onAddItem?: (config: AddItemConfig) => { preventAdd: boolean };
 };
 
 export type InitialState = {
@@ -208,9 +209,5 @@ export type ConditionBuilderContextProps = {
   setRootState?: Dispatch<SetStateAction<ConditionBuilderState>>;
   actionState?: Action[];
   setActionState?: Dispatch<SetStateAction<Action[]>>;
-  onAddItem?: (
-    addItemType: AddItemType,
-    rootState: ConditionBuilderState,
-    group?: ConditionGroup
-  ) => { preventAdd: boolean };
+  onAddItem?: (config: AddItemConfig) => { preventAdd: boolean };
 } & ConditionBuilderContextInputProps;

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.types.ts
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.types.ts
@@ -158,6 +158,7 @@ export type statementConfig = Item & {
   connector: 'and' | 'or';
   secondaryLabel?: string;
 };
+type AddItemType = 'add-condition' | 'add-subgroup' | 'add-group';
 
 export type ConditionBuilderProps = {
   inputConfig: inputConfig;
@@ -175,6 +176,11 @@ export type ConditionBuilderProps = {
   variant?: 'Non-Hierarchical' | 'Hierarchical';
   translateWithId: (id: string) => string;
   statementConfigCustom: statementConfig[];
+  onAddItem?: (
+    addItemType: AddItemType,
+    rootState: ConditionBuilderState,
+    group?: ConditionGroup
+  ) => { preventAdd: boolean };
 };
 
 export type InitialState = {
@@ -202,4 +208,9 @@ export type ConditionBuilderContextProps = {
   setRootState?: Dispatch<SetStateAction<ConditionBuilderState>>;
   actionState?: Action[];
   setActionState?: Dispatch<SetStateAction<Action[]>>;
+  onAddItem?: (
+    addItemType: AddItemType,
+    rootState: ConditionBuilderState,
+    group?: ConditionGroup
+  ) => { preventAdd: boolean };
 } & ConditionBuilderContextInputProps;

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderAdd/ConditionBuilderAdd.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderAdd/ConditionBuilderAdd.tsx
@@ -29,7 +29,7 @@ interface ConditionBuilderAddProps {
   enableSubGroup?: boolean;
   buttonLabel?: string;
   tabIndex?: number;
-  group: ConditionGroup;
+  group?: ConditionGroup;
 }
 const ConditionBuilderAdd = ({
   className,

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderAdd/ConditionBuilderAdd.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderAdd/ConditionBuilderAdd.tsx
@@ -55,8 +55,11 @@ const ConditionBuilderAdd = ({
 
   const onClickHandler = () => {
     const { preventAdd } =
-      onAddItem?.('add-condition', rootState as ConditionBuilderState, group) ??
-      {};
+      onAddItem?.({
+        type: 'condition',
+        state: rootState as ConditionBuilderState,
+        group,
+      }) ?? {};
     if (!preventAdd) {
       hideConditionPreviewHandler?.();
       onClick();
@@ -81,8 +84,11 @@ const ConditionBuilderAdd = ({
 
   const handleAddSubGroup = () => {
     const { preventAdd } =
-      onAddItem?.('add-subgroup', rootState as ConditionBuilderState, group) ??
-      {};
+      onAddItem?.({
+        type: 'subgroup',
+        state: rootState as ConditionBuilderState,
+        group,
+      }) ?? {};
     if (!preventAdd) {
       addConditionSubGroupHandler?.();
     }

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderAdd/ConditionBuilderAdd.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderAdd/ConditionBuilderAdd.tsx
@@ -5,13 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useContext } from 'react';
 import cx from 'classnames';
 import { AddAlt, TextNewLine } from '@carbon/react/icons';
 import { ConditionBuilderButton } from '../ConditionBuilderButton/ConditionBuilderButton';
 import PropTypes from 'prop-types';
 import { useTranslations } from '../utils/useTranslations';
 import { blockClass } from '../utils/util';
+import { ConditionBuilderContext } from '../ConditionBuilderContext/ConditionBuilderProvider';
+import {
+  ConditionBuilderState,
+  ConditionGroup,
+} from '../ConditionBuilder.types';
 
 interface ConditionBuilderAddProps {
   className?: string;
@@ -24,6 +29,7 @@ interface ConditionBuilderAddProps {
   enableSubGroup?: boolean;
   buttonLabel?: string;
   tabIndex?: number;
+  group: ConditionGroup;
 }
 const ConditionBuilderAdd = ({
   className,
@@ -36,6 +42,7 @@ const ConditionBuilderAdd = ({
   enableSubGroup,
   buttonLabel,
   tabIndex,
+  group,
 }: ConditionBuilderAddProps) => {
   const [addConditionText, addConditionRowText, addSubgroupText] =
     useTranslations([
@@ -44,9 +51,16 @@ const ConditionBuilderAdd = ({
       'addSubgroupText',
     ]);
 
+  const { onAddItem, rootState } = useContext(ConditionBuilderContext);
+
   const onClickHandler = () => {
-    hideConditionPreviewHandler?.();
-    onClick();
+    const { preventAdd } =
+      onAddItem?.('add-condition', rootState as ConditionBuilderState, group) ??
+      {};
+    if (!preventAdd) {
+      hideConditionPreviewHandler?.();
+      onClick();
+    }
   };
   const previewHandlers = () => {
     return enableSubGroup
@@ -64,6 +78,15 @@ const ConditionBuilderAdd = ({
     onFocus: showConditionSubGroupPreviewHandler,
     onBlur: hideConditionSubGroupPreviewHandler,
   });
+
+  const handleAddSubGroup = () => {
+    const { preventAdd } =
+      onAddItem?.('add-subgroup', rootState as ConditionBuilderState, group) ??
+      {};
+    if (!preventAdd) {
+      addConditionSubGroupHandler?.();
+    }
+  };
 
   const getAriaLabel = () => {
     return buttonLabel
@@ -99,7 +122,7 @@ const ConditionBuilderAdd = ({
       {enableSubGroup && (
         <ConditionBuilderButton
           renderIcon={TextNewLine}
-          onClick={addConditionSubGroupHandler}
+          onClick={handleAddSubGroup}
           className={cx(`${blockClass}__add-condition-sub-group`)}
           hideLabel
           label={addSubgroupText}

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderContent/ConditionBuilderContent.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderContent/ConditionBuilderContent.tsx
@@ -51,7 +51,7 @@ const ConditionBuilderContent = ({
   initialState,
   actions,
 }: ConditionBuilderContentProps) => {
-  const { rootState, setRootState, variant, actionState } =
+  const { rootState, setRootState, variant, actionState, onAddItem } =
     useContext<ConditionBuilderContextProps>(ConditionBuilderContext);
 
   const initialConditionState = useRef(
@@ -153,27 +153,31 @@ const ConditionBuilderContent = ({
   };
 
   const addConditionGroupHandler = () => {
-    const newGroup: ConditionGroup = {
-      statement: 'ifAll',
-      groupOperator: 'and',
-      id: uuidv4(),
-      conditions: [
-        {
-          property: undefined,
-          operator: '',
-          value: '',
-          popoverToOpen: 'propertyField',
-          id: uuidv4(),
-        },
-      ],
-    };
-    setRootState?.({
-      ...rootState,
-      groups:
-        rootState && rootState.groups
-          ? [...rootState.groups, newGroup]
-          : [newGroup],
-    });
+    const { preventAdd } =
+      onAddItem?.('add-group', rootState as ConditionBuilderState) ?? {};
+    if (!preventAdd) {
+      const newGroup: ConditionGroup = {
+        statement: 'ifAll',
+        groupOperator: 'and',
+        id: uuidv4(),
+        conditions: [
+          {
+            property: undefined,
+            operator: '',
+            value: '',
+            popoverToOpen: 'propertyField',
+            id: uuidv4(),
+          },
+        ],
+      };
+      setRootState?.({
+        ...rootState,
+        groups:
+          rootState && rootState.groups
+            ? [...rootState.groups, newGroup]
+            : [newGroup],
+      });
+    }
   };
 
   const getColorIndex = () => {

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderContent/ConditionBuilderContent.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderContent/ConditionBuilderContent.tsx
@@ -154,7 +154,10 @@ const ConditionBuilderContent = ({
 
   const addConditionGroupHandler = () => {
     const { preventAdd } =
-      onAddItem?.('add-group', rootState as ConditionBuilderState) ?? {};
+      onAddItem?.({
+        type: 'group',
+        state: rootState as ConditionBuilderState,
+      }) ?? {};
     if (!preventAdd) {
       const newGroup: ConditionGroup = {
         statement: 'ifAll',

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderContext/ConditionBuilderProvider.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderContext/ConditionBuilderProvider.tsx
@@ -61,6 +61,7 @@ export const ConditionBuilderProvider: React.FC<
     translateWithId: props.translateWithId,
     conditionBuilderRef: props.conditionBuilderRef,
     statementConfigCustom: props.statementConfigCustom,
+    onAddItem: props.onAddItem,
   };
 
   return (


### PR DESCRIPTION
Closes #7130 

This add support for a new callback prop 'onAddItem' that will be called before adding any condition , subgroup or group. 
User can prevent add if they return `{preventAdd : true}`

#### What did you change?
Added a new callback prop
```
onAddItem?: (
    addItemType: 'add-condition' | 'add-subgroup' | 'add-group',
    rootState: ConditionBuilderState,
    group?: ConditionGroup
  ) => { preventAdd: boolean };
```
#### How did you test and verify your work?
