### PR TITLE
chore(sidepanel): leverage IconButton

### DIFF
--- a/packages/ibm-products/src/components/SidePanel/SidePanel.test.js
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.test.js
@@ -179,9 +179,7 @@ describe('SidePanel', () => {
     const pageContent = container.querySelector(selectorPageContentValue);
     const style = getComputedStyle(pageContent);
     expect(style.marginInlineStart).toBe('30rem');
-    const closeIconButton = container.querySelector(
-      `.${blockClass}__close-button`
-    );
+    const closeIconButton = screen.getByRole('button', { name: 'Close' });
     await act(() => userEvent.click(closeIconButton));
     await act(() => rerender(<SlideIn placement="left" open={false} />));
     const updatedStyles = getComputedStyle(pageContent);
@@ -193,9 +191,7 @@ describe('SidePanel', () => {
     const pageContent = container.querySelector(selectorPageContentValue);
     const style = getComputedStyle(pageContent);
     expect(style.marginInlineEnd).toBe('30rem');
-    const closeIconButton = container.querySelector(
-      `.${blockClass}__close-button`
-    );
+    const closeIconButton = screen.getByRole('button', { name: 'Close' });
     const outerElement = container.querySelector(`.${blockClass}`);
     await act(() => userEvent.click(closeIconButton));
     await act(() => fireEvent.animationStart(outerElement));
@@ -218,9 +214,7 @@ describe('SidePanel', () => {
     const pageContent = container.querySelector(selectorPageContentValue);
     const style = getComputedStyle(pageContent);
     expect(style.marginInlineEnd).toBe('30rem');
-    const closeIconButton = container.querySelector(
-      `.${blockClass}__close-button`
-    );
+    const closeIconButton = screen.getByRole('button', { name: 'Close' });
     const outerElement = container.querySelector(`.${blockClass}`);
     await act(() => userEvent.click(closeIconButton));
     await act(() => fireEvent.animationStart(outerElement));
@@ -236,9 +230,7 @@ describe('SidePanel', () => {
     const { container, rerender } = renderSidePanel({
       includeOverlay: true,
     });
-    const closeIconButton = container.querySelector(
-      `.${blockClass}__close-button`
-    );
+    const closeIconButton = screen.getByRole('button', { name: 'Close' });
     const overlayElement = container.querySelector(`.${blockClass}__overlay`);
     await act(() => userEvent.click(closeIconButton));
     await act(() =>
@@ -376,9 +368,7 @@ describe('SidePanel', () => {
     const { container } = renderSidePanel({
       currentStep: 1,
     });
-    const navigationAction = container.querySelector(
-      `.${blockClass}__navigation-back-button`
-    );
+    const navigationAction = screen.getByRole('button', { name: 'Back' });
     expect(navigationAction).toBeTruthy();
   });
 
@@ -504,9 +494,7 @@ describe('SidePanel', () => {
   it('should call the onRequestClose event handler', async () => {
     const { click } = userEvent;
     const { container } = renderSidePanel();
-    const closeIconButton = container.querySelector(
-      `.${blockClass}__close-button`
-    );
+    const closeIconButton = screen.getByRole('button', { name: 'Close' });
     await act(() => click(closeIconButton));
     expect(onRequestCloseFn).toHaveBeenCalled();
   });
@@ -568,9 +556,7 @@ describe('SidePanel', () => {
     );
     const outerElement = container.querySelector(`.${blockClass}`);
     fireEvent.animationEnd(outerElement);
-    const closeIconButton = container.querySelector(
-      `.${blockClass}__close-button`
-    );
+    const closeIconButton = screen.getByRole('button', { name: 'Close' });
     await waitFor(() => {
       expect(closeIconButton).toHaveFocus();
     });
@@ -615,9 +601,7 @@ describe('SidePanel', () => {
     const launchButtonEl = getByText('Open');
     expect(launchButtonEl).toBeInTheDocument();
 
-    const closeIconButton = container.querySelector(
-      `.${blockClass}__close-button`
-    );
+    const closeIconButton = screen.getByRole('button', { name: 'Close' });
     await act(() => userEvent.click(closeIconButton));
     expect(mockCloseFn).toHaveBeenCalledTimes(1);
 

--- a/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
@@ -763,16 +763,16 @@ export let SidePanel = React.forwardRef(
         >
           {/* back button */}
           {currentStep > 0 && (
-            <Button
+            <IconButton
               kind="ghost"
               size={closeSize}
-              disabled={false}
-              renderIcon={(props) => <ArrowLeft size={20} {...props} />}
-              iconDescription={navigationBackIconDescription}
+              align="bottom"
+              label={navigationBackIconDescription}
               className={`${blockClass}__navigation-back-button`}
               onClick={onNavigationBack}
-              aria-label={navigationBackIconDescription}
-            />
+            >
+              <ArrowLeft />
+            </IconButton>
           )}
           {/* label */}
           {title && title.length && labelText && labelText.length && (
@@ -790,8 +790,6 @@ export let SidePanel = React.forwardRef(
               label={closeIconDescription}
               onClick={onRequestClose}
               onKeyDown={slideIn ? undefined : handleEscapeKey}
-              title={closeIconDescription}
-              aria-label={closeIconDescription}
               ref={closeRef}
               align="left"
             >


### PR DESCRIPTION
Refs #7174 and 9bc927a75f0a3ecc90076fd270b52aa98c66d22a.

Leverage IconButton to display back button.

Also:

- Remove redundant title and aria-label from close button.
- Update tests to find buttons semantically, rather than by CSS class.
- Fix back button tooltip.  It wasn't showing up before.

#### How did you test and verify your work?

Jest and storybook.