### PR TITLE
fix(use-resize-observer): adds optional chain

### DIFF
--- a/packages/ibm-products/src/global/js/hooks/useResizeObserver.js
+++ b/packages/ibm-products/src/global/js/hooks/useResizeObserver.js
@@ -76,7 +76,7 @@ export const useResizeObserver = (ref, callback, deps = []) => {
     observer.observe(ref.current);
 
     return () => {
-      observer.disconnect();
+      observer?.disconnect();
       observer = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Closes #5729 

Adds an optional chain to remove null error

#### What did you change?
`packages/ibm-products/src/global/js/hooks/useResizeObserver.js`

