### PR TITLE
fix(stackblitz examples): updated version in about modal and fullpage

### DIFF
--- a/packages/ibm-products-web-components/examples/about-modal/package.json
+++ b/packages/ibm-products-web-components/examples/about-modal/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf node_modules dist .cache"
   },
   "dependencies": {
-    "@carbon/ibm-products-web-components": "^0.10.0-rc.0",
+    "@carbon/ibm-products-web-components": "^0.14.0-rc.0",
     "lit": "^3.2.1",
     "sass": "^1.64.1"
   },

--- a/packages/ibm-products-web-components/examples/full-page-error/package.json
+++ b/packages/ibm-products-web-components/examples/full-page-error/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf node_modules dist .cache"
   },
   "dependencies": {
-    "@carbon/ibm-products-web-components": "^0.10.0-rc.0",
+    "@carbon/ibm-products-web-components": "^0.14.0-rc.0",
     "lit": "^3.2.1",
     "sass": "^1.64.1"
   },


### PR DESCRIPTION
Closes #7390 

Update `ibm-products-web-components` package version in About Modal and Full page error examples

#### What did you change?
Updated version  to `0.14.0-rc.0` in both examples             

#### How did you test and verify your work?
In the existing example the problem was solved by forking the example and updating the version to `0.14.0-rc.0`.
Te same is done here.
[About Modal Stackblitz Example from the PR Branch](https://stackblitz.com/github/sangeethababu9223/ibm-products/tree/fix/stackblitz-example-version-update/packages/ibm-products-web-components/examples/about-modal?file=src%2Findex.js)
[Full Page Error Stackblitz Example from the PR branch](https://stackblitz.com/github/sangeethababu9223/ibm-products/tree/fix/stackblitz-example-version-update/packages/ibm-products-web-components/examples/full-page-error?file=src%2Findex.js)