### PR TITLE
chore: Renovate/reconfigure

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,33 +1,62 @@
 {
-  "extends": [
+  extends: [
     // https://docs.renovatebot.com/presets-config/#configjs-lib
-    "config:js-lib",
+    'config:js-lib',
 
     // https://docs.renovatebot.com/presets-default/#maintainlockfilesweekly
-    ":maintainLockFilesWeekly",
+    ':maintainLockFilesWeekly',
 
     // https://docs.renovatebot.com/presets-default/#preservesemverranges
-    ":preserveSemverRanges",
+    ':preserveSemverRanges',
 
     // https://docs.renovatebot.com/presets-npm/#npmunpublishsafe
-    "npm:unpublishSafe",
+    'npm:unpublishSafe',
   ],
-  "schedule": [
-    "after 10pm every weekday",
-    "before 5am every weekday",
-    "every weekend",
+  schedule: [
+    'after 10pm every weekday',
+    'before 5am every weekday',
+    'every weekend',
   ],
-  "vulnerabilityAlerts": {
-    "enabled": true
+  vulnerabilityAlerts: {
+    enabled: true,
   },
-  "rebaseWhen": "never",
+  rebaseWhen: 'never',
   // Batch all Carbon package dependency upgrades together
-  "packageRules": [
+  packageRules: [
     {
-      "matchPackageNames": ["@carbon/**"],
-      "groupName": "Carbon core packages",
+      matchPackageNames: ['@carbon/**'],
+      groupName: 'Carbon core packages',
       // Update at 4:00 UTC on the 1st and 15th of every month
-      "schedule": "* 4 1,15 * *"
-    }
-  ]
+      schedule: '* 4 1,15 * *',
+    },
+  ],
+  major: {
+    ignoreDeps: [
+      // Ignore @testing-library/** packages
+      '@testing-library/dom',
+      '@testing-library/react',
+      '@testing-library/react-hooks',
+      '@testing-library/user-event',
+      '@testing-library/jest-dom',
+
+      // Ignore react packages
+      'react',
+      'react-dom',
+
+      // Ignore Carbon packages
+      '@carbon/react',
+      '@carbon/grid',
+      '@carbon/layout',
+      '@carbon/motion',
+      '@carbon/themes',
+      '@carbon/type',
+      '@carbon/feature-flags',
+      '@carbon/utilities',
+      '@carbon/icons',
+      '@carbon/icons-helpers',
+
+      // Ignore misc packages
+      'commander',
+    ],
+  },
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,11 +12,7 @@
     // https://docs.renovatebot.com/presets-npm/#npmunpublishsafe
     'npm:unpublishSafe',
   ],
-  schedule: [
-    'after 10pm every weekday',
-    'before 5am every weekday',
-    'every weekend',
-  ],
+  schedule: ['after 10pm every weekday', 'before 5am every weekday'],
   vulnerabilityAlerts: {
     enabled: true,
   },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,6 +25,11 @@
       // Update at 4:00 UTC on the 1st and 15th of every month
       schedule: '* 4 1,15 * *',
     },
+    {
+      matchPackageNames: ['react', 'react-dom'],
+      groupName: 'React packages',
+      allowedVersions: '< 19.0.0',
+    },
   ],
   major: {
     ignoreDeps: [

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "sync": "carbon-cli sync",
     "update-gallery-config": "node scripts/example-gallery-builder/index.js; prettier examples/carbon-for-ibm-products/**/src/**/*.{js,jsx,md,mdx,scss,json} --write --loglevel=silent",
     "//upgrade:dependencies:top": "# don't upgrade carbon (done globally), react/react-dom (not tested)",
-    "upgrade:dependencies:top": "npm-check-updates -u --dep dev,peer,prod --reject '/(carbon|^react$|^react-dom$|^@testing-library|^commander)/'",
+    "upgrade:dependencies:top": "npm-check-updates -u --dep dev,peer,prod --reject '/(carbon|^react$|^react-dom$|^@testing-library)/'",
     "upgrade:dependencies:packages": "yarn run-all --no-sort --concurrency 1 upgrade-dependencies",
     "upgrade:dependencies:examples": "npm-check-updates -u --dep dev,peer,prod --color --target minor --packageFile 'scripts/example-gallery-builder/update-example/**/package.json'",
     "upgrade:automatic": "run-s -s 'upgrade:dependencies:*'",
@@ -157,4 +157,3 @@
   },
   "packageManager": "yarn@4.9.1"
 }
-

--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -97,7 +97,6 @@
     "@babel/runtime": "^7.26.10",
     "@carbon/feature-flags": "^0.24.0",
     "@carbon/ibm-products-styles": "^2.61.0-rc.0",
-    "@carbon/telemetry": "^0.1.0",
     "@carbon/utilities": "^0.4.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1841,7 +1841,6 @@ __metadata:
     "@babel/runtime": "npm:^7.26.10"
     "@carbon/feature-flags": "npm:^0.24.0"
     "@carbon/ibm-products-styles": "npm:^2.61.0-rc.0"
-    "@carbon/telemetry": "npm:^0.1.0"
     "@carbon/utilities": "npm:^0.4.0"
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/modifiers": "npm:^9.0.0"
@@ -2100,15 +2099,6 @@ __metadata:
     sass:
       optional: true
   checksum: 10/3b5eb23e08e8781798f2e6f70cdd065ba6dc99e84e63eeac51e550b0da45e24e5b04bea2f595cce416fa2a2ae8c54625a4e24303887a5d32f9012090d27bd922
-  languageName: node
-  linkType: hard
-
-"@carbon/telemetry@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@carbon/telemetry@npm:0.1.0"
-  bin:
-    carbon-telemetry: bin/carbon-telemetry.js
-  checksum: 10/4a803573ab2ff78088d972a6b5570cc8bce3230306882d58eee99a37bbf98b167143401cb1435c0c5b607436de603e23fe3cdd9bb39d41e56a172bedcde8c1f3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #7309 

This PR ignores major releases of the following packages:

- **@testing-library/\*\* packages** 
- `@testing-library/dom`
- `@testing-library/react`
- `@testing-library/react-hooks`
- `@testing-library/user-event`
- `@testing-library/jest-dom`

- **React packages**:
  - `react`
  - `react-dom`

- **Carbon packages**:
  - `@carbon/react`
  - `@carbon/grid`
  - `@carbon/layout`
  - `@carbon/motion`
  - `@carbon/themes`
  - `@carbon/type`
  - `@carbon/feature-flags`
  - `@carbon/utilities`
  - `@carbon/icons`
  - `@carbon/icons-helpers`

- **Miscellaneous packages**:
  - `commander`

Also removes `@carbon/telemetry` since it is unused

#### How did you test and verify your work?

