### PR TITLE
chore(renovate): disables major upgrades for some packages

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,44 +12,46 @@
     // https://docs.renovatebot.com/presets-npm/#npmunpublishsafe
     'npm:unpublishSafe',
   ],
+
   schedule: ['after 10pm every weekday', 'before 5am every weekday'],
+
   vulnerabilityAlerts: {
     enabled: true,
   },
+
   rebaseWhen: 'never',
+
   // Batch all Carbon package dependency upgrades together
   packageRules: [
     {
       matchPackageNames: ['@carbon/**'],
       groupName: 'Carbon core packages',
       // Update at 4:00 UTC on the 1st and 15th of every month
-      schedule: '* 4 1,15 * *',
-    }
+      schedule: ['* 4 1,15 * *'],
+    },
+    {
+      matchPackageNames: [
+        '@testing-library/dom',
+        '@testing-library/react',
+        '@testing-library/react-hooks',
+        '@testing-library/user-event',
+        '@testing-library/jest-dom',
+        'react',
+        'react-dom',
+        '@carbon/react',
+        '@carbon/grid',
+        '@carbon/layout',
+        '@carbon/motion',
+        '@carbon/themes',
+        '@carbon/type',
+        '@carbon/feature-flags',
+        '@carbon/utilities',
+        '@carbon/icons',
+        '@carbon/icons-helpers',
+      ],
+      matchUpdateTypes: ['major'],
+      enabled: false,
+      groupName: 'prevent major upgrades',
+    },
   ],
-  major: {
-    ignoreDeps: [
-      // Ignore @testing-library/** packages
-      '@testing-library/dom',
-      '@testing-library/react',
-      '@testing-library/react-hooks',
-      '@testing-library/user-event',
-      '@testing-library/jest-dom',
-
-      // Ignore react packages
-      'react',
-      'react-dom',
-
-      // Ignore Carbon packages
-      '@carbon/react',
-      '@carbon/grid',
-      '@carbon/layout',
-      '@carbon/motion',
-      '@carbon/themes',
-      '@carbon/type',
-      '@carbon/feature-flags',
-      '@carbon/utilities',
-      '@carbon/icons',
-      '@carbon/icons-helpers',
-    ],
-  },
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,33 +1,55 @@
 {
-  "extends": [
+  extends: [
     // https://docs.renovatebot.com/presets-config/#configjs-lib
-    "config:js-lib",
+    'config:js-lib',
 
     // https://docs.renovatebot.com/presets-default/#maintainlockfilesweekly
-    ":maintainLockFilesWeekly",
+    ':maintainLockFilesWeekly',
 
     // https://docs.renovatebot.com/presets-default/#preservesemverranges
-    ":preserveSemverRanges",
+    ':preserveSemverRanges',
 
     // https://docs.renovatebot.com/presets-npm/#npmunpublishsafe
-    "npm:unpublishSafe",
+    'npm:unpublishSafe',
   ],
-  "schedule": [
-    "after 10pm every weekday",
-    "before 5am every weekday",
-    "every weekend",
-  ],
-  "vulnerabilityAlerts": {
-    "enabled": true
+  schedule: ['after 10pm every weekday', 'before 5am every weekday'],
+  vulnerabilityAlerts: {
+    enabled: true,
   },
-  "rebaseWhen": "never",
+  rebaseWhen: 'never',
   // Batch all Carbon package dependency upgrades together
-  "packageRules": [
+  packageRules: [
     {
-      "matchPackageNames": ["@carbon/**"],
-      "groupName": "Carbon core packages",
+      matchPackageNames: ['@carbon/**'],
+      groupName: 'Carbon core packages',
       // Update at 4:00 UTC on the 1st and 15th of every month
-      "schedule": "* 4 1,15 * *"
+      schedule: '* 4 1,15 * *',
     }
-  ]
+  ],
+  major: {
+    ignoreDeps: [
+      // Ignore @testing-library/** packages
+      '@testing-library/dom',
+      '@testing-library/react',
+      '@testing-library/react-hooks',
+      '@testing-library/user-event',
+      '@testing-library/jest-dom',
+
+      // Ignore react packages
+      'react',
+      'react-dom',
+
+      // Ignore Carbon packages
+      '@carbon/react',
+      '@carbon/grid',
+      '@carbon/layout',
+      '@carbon/motion',
+      '@carbon/themes',
+      '@carbon/type',
+      '@carbon/feature-flags',
+      '@carbon/utilities',
+      '@carbon/icons',
+      '@carbon/icons-helpers',
+    ],
+  },
 }


### PR DESCRIPTION
Closes #7309 

This PR ignores major releases of the following packages:

- **@testing-library/\*\* packages** 
- `@testing-library/dom`
- `@testing-library/react`
- `@testing-library/react-hooks`
- `@testing-library/user-event`
- `@testing-library/jest-dom`

- **React packages**:
  - `react`
  - `react-dom`

- **Carbon packages**:
  - `@carbon/react`
  - `@carbon/grid`
  - `@carbon/layout`
  - `@carbon/motion`
  - `@carbon/themes`
  - `@carbon/type`
  - `@carbon/feature-flags`
  - `@carbon/utilities`
  - `@carbon/icons`
  - `@carbon/icons-helpers`

- **Miscellaneous packages**:
  - `commander`

Also removes `@carbon/telemetry` since it is unused

#### How did you test and verify your work?
Dependency Dashboard