### PR TITLE
feat(about Modal): add test coverage

### DIFF
--- a/packages/ibm-products-web-components/src/components/about-modal/about-modal.test.ts
+++ b/packages/ibm-products-web-components/src/components/about-modal/about-modal.test.ts
@@ -7,7 +7,10 @@
 
 vi.mock('@carbon/icons/lib/close/20', () => vi.fn().mockReturnValue({}));
 import { describe, expect, it, vi } from 'vitest';
-import { render, html, TemplateResult } from 'lit';
+import { fixture, html, expect as owcExpect } from '@open-wc/testing';
+import { render, TemplateResult } from 'lit';
+import './index';
+import CDSAboutModal from './about-modal';
 
 const logo = html`
   <img
@@ -41,6 +44,12 @@ grants you a non-exclusive, non-transferable, limited permission to access and
 display the Web pages within this site as a customer or potential customer of
 IBM provided you comply with these Terms of Use, and all copyright, trademark,
 and other proprietary notices remain intact.`;
+const links: TemplateResult[] = [];
+const index = 3;
+for (let i = 0; i < index; i++) {
+  const link = html`<cds-link href="#"> Link action </cds-link>`;
+  links.push(link);
+}
 const defaultProps = {
   closeIconDescription: 'close',
   copyrightText: 'Copyright © IBM Corp. 2020, 2023',
@@ -49,14 +58,8 @@ const defaultProps = {
   version: 'Version 0.0.0',
   additionalInfo: additionalInfo,
   content: content,
-  links: false,
+  links: links,
 };
-const links: TemplateResult[] = [];
-const index = 3;
-for (let i = 0; i < index; i++) {
-  const link = html`<cds-link href="#"> Link action </cds-link>`;
-  links.push(link);
-}
 const template = (props = defaultProps) => html`
   <c4p-about-modal
     open
@@ -75,9 +78,133 @@ const template = (props = defaultProps) => html`
 
 describe('c4p-about-modal', () => {
   it('should render about modal', async () => {
-    render(template(), document.body);
-    await Promise.resolve();
-    const elem = document.body.querySelector('c4p-about-modal' as any);
-    expect(elem).toBeDefined();
+    const element = render(template(), document.body);
+    expect(element).toBeDefined();
+  });
+
+  it('renders a title', async () => {
+    const element: CDSAboutModal = await fixture(template());
+    expect(element.title).toBe(defaultProps.title);
+    const headingElement =
+      element.shadowRoot?.querySelector('cds-modal-heading');
+    expect(headingElement).toBeTruthy();
+    expect(headingElement?.shadowRoot).toBeTruthy();
+    const slot = headingElement?.shadowRoot?.querySelector('slot');
+    expect(slot).toBeTruthy();
+    const assignedNodes = slot?.assignedNodes({ flatten: true }) ?? [];
+    const slottedText = assignedNodes
+      .filter((node) => node.nodeType === Node.TEXT_NODE)
+      .map((node) => node.textContent?.trim())
+      .join('');
+    expect(slottedText).toBe(defaultProps.title);
+  });
+  it('renders version', async () => {
+    const element: CDSAboutModal = await fixture(template());
+    expect(element.version).toBe(defaultProps.version);
+    const modalBody = element.shadowRoot?.querySelector('cds-modal-body');
+    expect(modalBody).toBeTruthy();
+    expect(modalBody?.shadowRoot).toBeTruthy();
+    const slot = modalBody?.shadowRoot?.querySelector('slot');
+    expect(slot).toBeTruthy();
+    const assignedElements = slot?.assignedElements({ flatten: true }) ?? [];
+    const modalVersion = assignedElements
+      .map((el) => el.querySelector('.c4p--about-modal__version'))
+      .find((el) => el !== null);
+    expect(modalVersion).toBeTruthy();
+    expect(modalVersion?.textContent?.trim()).toBe(defaultProps.version);
+  });
+  it('renders copyright text', async () => {
+    const element: CDSAboutModal = await fixture(template());
+    expect(element.copyrightText).toBe(defaultProps.copyrightText);
+    const modalBody = element.shadowRoot?.querySelector('cds-modal-body');
+    expect(modalBody).toBeTruthy();
+    expect(modalBody?.shadowRoot).toBeTruthy();
+    const slot = modalBody?.shadowRoot?.querySelector('slot');
+    expect(slot).toBeTruthy();
+    const assignedElements = slot?.assignedElements({ flatten: true }) ?? [];
+    const modalCopyRight = assignedElements
+      .map((el) => el.querySelector('.c4p--about-modal__copyright-text'))
+      .find((el) => el !== null);
+    expect(modalCopyRight).toBeTruthy();
+    expect(modalCopyRight?.textContent?.trim()).toBe(
+      defaultProps.copyrightText
+    );
+  });
+  it('renders links', async () => {
+    const element: CDSAboutModal = await fixture(template());
+    const modalBody = element.shadowRoot?.querySelector('cds-modal-body');
+    expect(modalBody).toBeTruthy();
+    expect(modalBody?.shadowRoot).toBeTruthy();
+    const slot = modalBody?.shadowRoot?.querySelector('slot');
+    expect(slot).toBeTruthy();
+    const assignedElements = slot?.assignedElements({ flatten: true }) ?? [];
+    if (element.links.length > 0) {
+      const modalLinkContainer = assignedElements
+        .map((el) => el.querySelector('.c4p--about-modal__links-container'))
+        .find((el) => el !== null);
+      expect(modalLinkContainer).toBeTruthy();
+      const links = modalLinkContainer?.querySelectorAll('cds-link');
+      expect(links?.length == element?.links.length).toBeTruthy();
+    }
+  });
+  it('renders additional info', async () => {
+    const element: CDSAboutModal = await fixture(template());
+    if (element.additionalInfo) {
+      const modalFooter = element.shadowRoot?.querySelector('cds-modal-footer');
+      expect(modalFooter).toBeTruthy();
+    }
+  });
+  it('closes modal on clicking close button', async () => {
+    const element: CDSAboutModal = await fixture(template());
+    const modalClose = element.shadowRoot?.querySelector(
+      'cds-modal-close-button'
+    );
+    expect(modalClose).toBeTruthy();
+    expect(element.open).toBe(true);
+    (modalClose as HTMLElement)?.click();
+    expect(element.open).toBe(false);
+  });
+  it('Scrollable body with overflowing content', async () => {
+    const element: CDSAboutModal = await fixture(template());
+    const container = element.shadowRoot?.querySelector(
+      'cds-modal-body'
+    ) as HTMLElement;
+    // Simulate overflow: content fits
+    Object.defineProperty(container, 'scrollHeight', {
+      value: 200,
+      configurable: true,
+    });
+    Object.defineProperty(container, 'clientHeight', {
+      value: 100,
+      configurable: true,
+    });
+    // Manually call _checkOverflow to force the overflow check
+    element['_checkOverflow']();
+    await element.updateComplete;
+    expect(
+      container.classList.contains('c4p--about-modal-scroll-content')
+    ).toBe(true);
+  });
+  it('No scrollable body if content fits', async () => {
+    const element: CDSAboutModal = await fixture(template());
+    const container = element.shadowRoot?.querySelector(
+      'cds-modal-body'
+    ) as HTMLElement;
+    // Simulate non-overflow: content fits
+    Object.defineProperty(container, 'scrollHeight', {
+      value: 100,
+      configurable: true,
+    });
+    Object.defineProperty(container, 'clientHeight', {
+      value: 200,
+      configurable: true,
+    });
+    // Manually call _checkOverflow to force the overflow check
+    element['_checkOverflow']();
+    await element.updateComplete;
+
+    expect(
+      container.classList.contains('c4p--about-modal-scroll-content')
+    ).toBe(false);
   });
 });

--- a/packages/ibm-products-web-components/src/components/about-modal/defs.ts
+++ b/packages/ibm-products-web-components/src/components/about-modal/defs.ts
@@ -1,8 +1,0 @@
-/**
- * @license
- *
- * Copyright IBM Corp. 2025
- *
- * This source code is licensed under the Apache-2.0 license found in the
- * LICENSE file in the root directory of this source tree.
- */


### PR DESCRIPTION
Closes #7008

Add test coverage for About Modal in web components

#### What did you change?

- Updated the test cases with `@open-wc/testing` as done with the rest of the WC Components. 
- Removed `def.ts` file since it doesn't have any type definitions and was affecting the test coverage even though the file was empty except license statements

#### How did you test and verify your work?
By running `yarn test:c4p-wc` and `yarn wc-coverage` in local.
