### PR TITLE
fix(datagrid): last applied filter should be included for both panel and flyout

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
@@ -252,13 +252,6 @@ const FilterFlyout = ({
     reset(tableId);
   });
 
-  useEffect(
-    function reflectLastAppliedFiltersWhenReactTableUpdates() {
-      lastAppliedFilters.current = JSON.stringify(reactTableFiltersState);
-    },
-    [reactTableFiltersState, lastAppliedFilters]
-  );
-
   return (
     <div className={`${componentClass}__container`} ref={filterFlyoutRef}>
       <IconButton

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
@@ -523,6 +523,14 @@ const useFilters = ({
     filtersObjectArray,
   ]);
 
+  // This useEffect will update the last applied filters when the react-table filters change, this helps keeps all states in sync
+  useEffect(
+    function reflectLastAppliedFiltersWhenReactTableUpdates() {
+      lastAppliedFilters.current = JSON.stringify(reactTableFiltersState);
+    },
+    [reactTableFiltersState, lastAppliedFilters]
+  );
+
   const cancel = () => {
     // Reverting to previous filters only applies when using batch actions
     if (updateMethod === BATCH) {


### PR DESCRIPTION
Issue brought up by @wkeese 🎉 

> Hi Alexander, I’m looking at a Datagrid bug apparently from your commit https://github.com/wkeese/carbon-ibm-products/commit/fc9af2a67b1de33f8e941bea6353a67542c35af6.
> 1. Go to https://carbon-for-ibm-products.netlify.app/?path=/story/deprecated-datagrid-datagrid-filtering-panel--panel-batch&globals=viewport:basic,
> 2. Open filter panel, and check Password Strength / Normal.
> 3. -> Table filtered
> 4. Click “dismiss” button of the Normal filter tag (above the table).
> 5. Filter panel restored to original state, and all table rows displayed.
> 6. Check Password Strength / Critical in filter panel.
> 7. Click filter panel’s Cancel button
> 8. Filter panel restored to state from step 2 (Normal checked).   Expected: Nothing should be checked, because we dismissed the “Normal” filter in step 4.

The problem boils down to the lastAppliedFilters variable you added in https://github.com/wkeese/carbon-ibm-products/commit/fc9af2a67b1de33f8e941bea6353a67542c35af6.  Not sure why you needed that variable as it seems like we are now storing the filter in three separate variables.   But, if you do need a lastAppliedFilters variable, then doesn’t useFilters.js need the same code you added to FilterFlyout.js?
```
  useEffect(
    function reflectLastAppliedFiltersWhenReactTableUpdates() {
      lastAppliedFilters.current = JSON.stringify(reactTableFiltersState);
    },
    [reactTableFiltersState, lastAppliedFilters]
  );
```
In other words, lastAppliedFilters needs to reflect the filter change from clearing the Tag. (edited)
