### PR TITLE
feat(emptystate): automatically use right heading level

### DIFF
--- a/packages/ibm-products/src/components/EmptyStates/EmptyState.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyState.tsx
@@ -31,10 +31,9 @@ enum sizes {
 }
 
 // Default values for props
-export const defaults: { position: string; size: sizes; headingAs: string } = {
+export const defaults: { position: string; size: sizes } = {
   position: 'top',
   size: sizes.lg,
-  headingAs: 'h3',
 };
 
 export interface EmptyStateAction extends ButtonProps<React.ElementType> {
@@ -79,7 +78,9 @@ export interface EmptyStateProps {
   link?: CustomLink;
 
   /**
-   * Empty state headingAs allows you to customize the type of heading element
+   * Customize the heading element.  Set to "h1" when EmptyState is full page, i.e. there is no higher header.
+   * Otherwise, you normally don't need to specify this: EmptyState will automatically pick the right heading level
+   * (h2-h6) by leveraging Section and Heading.
    */
   headingAs?: (() => ReactNode) | string | ElementType;
 
@@ -124,7 +125,7 @@ export let EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
       illustrationPosition = defaults.position,
       link,
       size = defaults.size,
-      headingAs = defaults.headingAs,
+      headingAs,
       subtitle,
       title,
       ...rest

--- a/packages/ibm-products/src/components/EmptyStates/EmptyStateContent.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyStateContent.tsx
@@ -14,7 +14,7 @@ import { pkg } from '../../settings';
 import cx from 'classnames';
 
 // Carbon and package components we use.
-import { Button, Link, Section } from '@carbon/react';
+import { Button, Heading, Link, Section } from '@carbon/react';
 import { CustomLink, EmptyStateAction } from './EmptyState';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
@@ -51,17 +51,17 @@ export const EmptyStateContent = React.forwardRef<
   EmptyStateProps
 >((props) => {
   const { action, link, headingAs, size, subtitle, title } = props;
+  const HeadingComponent = headingAs ?? Heading;
 
   return (
-    <div className={`${blockClass}__content`}>
-      <Section
-        as={headingAs}
+    <Section className={`${blockClass}__content`}>
+      <HeadingComponent
         className={cx(`${blockClass}__header`, {
           [`${blockClass}__header--small`]: size === 'sm',
         })}
       >
         {title}
-      </Section>
+      </HeadingComponent>
       {subtitle && (
         <p
           className={cx(`${blockClass}__subtitle`, {
@@ -88,7 +88,7 @@ export const EmptyStateContent = React.forwardRef<
           {link.text}
         </Link>
       )}
-    </div>
+    </Section>
   );
 });
 

--- a/packages/ibm-products/src/components/EmptyStates/EmptyStates.stories.jsx
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyStates.stories.jsx
@@ -38,7 +38,6 @@ export default {
 };
 
 const emptyStateCommonProps = {
-  headingAs: 'h3',
   title: 'Start by adding data assets',
   subtitle: (
     <>

--- a/packages/ibm-products/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.tsx
@@ -52,7 +52,7 @@ export let ErrorEmptyState = React.forwardRef<
       illustrationTheme,
       link,
       size = defaults.size,
-      headingAs = defaults.headingAs,
+      headingAs,
       subtitle,
       title,
 

--- a/packages/ibm-products/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.tsx
@@ -52,7 +52,7 @@ export let NoDataEmptyState = React.forwardRef<
       illustrationDescription,
       link,
       size = defaults.size,
-      headingAs = defaults.headingAs,
+      headingAs,
       subtitle,
       title,
 

--- a/packages/ibm-products/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.tsx
@@ -52,7 +52,7 @@ export let NoTagsEmptyState = React.forwardRef<
       illustrationDescription,
       link,
       size = defaults.size,
-      headingAs = defaults.headingAs,
+      headingAs,
       subtitle,
       title,
 

--- a/packages/ibm-products/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.tsx
@@ -52,7 +52,7 @@ export let NotFoundEmptyState = React.forwardRef<
       illustrationDescription,
       link,
       size = defaults.size,
-      headingAs = defaults.headingAs,
+      headingAs,
       subtitle,
       title,
 

--- a/packages/ibm-products/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.tsx
@@ -52,7 +52,7 @@ export let NotificationsEmptyState = React.forwardRef<
       illustrationDescription,
       link,
       size = defaults.size,
-      headingAs = defaults.headingAs,
+      headingAs,
       subtitle,
       title,
 

--- a/packages/ibm-products/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.tsx
@@ -52,7 +52,7 @@ export let UnauthorizedEmptyState = React.forwardRef<
       illustrationDescription,
       link,
       size = defaults.size,
-      headingAs = defaults.headingAs,
+      headingAs,
       subtitle,
       title,
 


### PR DESCRIPTION
Closes #7459.

Enhance `EmptyState` to use the right heading level automatically, rather than forcing the application to specify `headingAs`.

Note that you still need to specify `headingAs="h1"` for full-page `EmptyState`, i.e. when there is no higher-level heading above the `EmptyState`.

These changes match the heading updates I've been making to other components to use `Section` and `Heading`.

Also, fix strange code in `EmptyStateContent` that was confused about when to use `Section` and when to use `Heading`.

#### What did you change?

`EmptyState`'s wrapper node is a `Section`, and it uses `Heading` for the heading.  Unless overridden by `headingAs`.

#### How did you test and verify your work?

Storybook, including a temporary change to explicitly specify `headingAs`.