### PR TITLE
feat(openStackblitz): about modal and export Modal

### DIFF
--- a/packages/ibm-products/src/components/AboutModal/AboutModal.mdx
+++ b/packages/ibm-products/src/components/AboutModal/AboutModal.mdx
@@ -1,0 +1,48 @@
+import { Story, Controls, Source, Canvas } from '@storybook/addon-docs';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
+import { AboutModal } from '.';
+import * as AboutModalStories from './AboutModal.stories';
+import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
+
+# About Modal
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Example usage](#example-usage)
+- [Component API](#component-api)
+
+## Overview
+
+The About modal component conveys product information, including the version number, copyright information, and license details.
+The About modal is triggered by a user’s action which appears on top of the main page content and is persistent until dismissed. 
+The purpose of this modal should be immediately apparent to the user, with a clear and obvious path to completion.
+
+### About Modal
+
+<Canvas
+  of={AboutModalStories.aboutModal}
+  additionalActions={[
+      {
+        title: 'Open in Stackblitz',
+        onClick: () => stackblitzPrefillConfig(AboutModalStories.aboutModal,[],[]),
+      },
+    ]}>
+</Canvas>
+
+
+### About Modal With All Props Set
+
+<Canvas
+  of={AboutModalStories.aboutModalWithAllPropsSet}
+  additionalActions={[
+      {
+        title: 'Open in Stackblitz',
+        onClick: () => stackblitzPrefillConfig(AboutModalStories.aboutModalWithAllPropsSet,[],[]),
+      },
+    ]}>
+</Canvas>
+
+## Component API
+
+<Controls />

--- a/packages/ibm-products/src/components/AboutModal/AboutModal.stories.jsx
+++ b/packages/ibm-products/src/components/AboutModal/AboutModal.stories.jsx
@@ -23,7 +23,7 @@ import styles from './_storybook-styles.scss?inline';
 
 const blockClass = `${pkg.prefix}--about-modal`;
 
-import DocsPage from './AboutModal.docs-page';
+import mdx from './AboutModal.mdx';
 
 export default {
   title: 'IBM Products/Components/About modal/AboutModal',
@@ -32,7 +32,7 @@ export default {
   parameters: {
     styles,
     docs: {
-      page: DocsPage,
+      page: mdx,
     },
     controls: { sort: 'requiredFirst' },
   },
@@ -167,16 +167,12 @@ const logo = (
   />
 );
 
-const Template = (storyName, storyInitiallyOpen, args, context) => {
+const Template = (args, context) => {
   const [open, setOpen] = useState(context.viewMode !== 'docs');
-  const [beenOpen, setBeenOpen] = useState(false);
-  useEffect(() => setBeenOpen(beenOpen || open), [open, beenOpen]);
 
   return (
     <>
-      <Button onClick={() => setOpen(true)}>
-        {beenOpen ? 'Reopen the' : 'Open the'} {storyName}
-      </Button>
+      <Button onClick={() => setOpen(true)}>{'Open Modal'}</Button>
 
       <style>{`.${blockClass} { opacity: 0; }`};</style>
       <AboutModal
@@ -198,9 +194,7 @@ const commonArgs = {
   copyrightText: 'Copyright © IBM Corp. 2020, 2023',
 };
 
-const aboutModalStoryName = 'About modal';
-export const aboutModal = Template.bind({}, aboutModalStoryName, true);
-aboutModal.storyName = aboutModalStoryName;
+export const aboutModal = Template.bind({});
 aboutModal.args = {
   title: 2,
   links: 0,
@@ -209,13 +203,7 @@ aboutModal.args = {
   ...commonArgs,
 };
 
-const fullyLoadedStoryName = 'About modal with all props set';
-export const aboutModalWithAllPropsSet = Template.bind(
-  {},
-  fullyLoadedStoryName,
-  false
-);
-aboutModalWithAllPropsSet.storyName = fullyLoadedStoryName;
+export const aboutModalWithAllPropsSet = Template.bind({});
 aboutModalWithAllPropsSet.args = {
   title: 2,
   links: 3,

--- a/packages/ibm-products/src/components/ExportModal/ExportModal.mdx
+++ b/packages/ibm-products/src/components/ExportModal/ExportModal.mdx
@@ -1,0 +1,63 @@
+import { Story, Controls, Source, Canvas } from '@storybook/addon-docs';
+import { CodesandboxLink } from '../../global/js/utils/story-helper';
+import { ExportModal } from '.';
+import * as ExportModalStories from './ExportModal.stories';
+import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
+import wait from '../../global/js/utils/wait';
+
+export const customFunctionArr = [
+  wait,
+];
+
+# About Modal
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Example usage](#example-usage)
+- [Component API](#component-api)
+
+## Overview
+
+Modal dialog version of the export pattern.
+
+### Standard
+
+<Canvas
+  of={ExportModalStories.Standard}
+  additionalActions={[
+      {
+        title: 'Open in Stackblitz',
+        onClick: () => stackblitzPrefillConfig(ExportModalStories.Standard,[],customFunctionArr),
+      },
+    ]}>
+</Canvas>
+
+
+### With Extension Validation
+
+<Canvas
+  of={ExportModalStories.WithExtensionValidation}
+  additionalActions={[
+      {
+        title: 'Open in Stackblitz',
+        onClick: () => stackblitzPrefillConfig(ExportModalStories.WithExtensionValidation,[],customFunctionArr),
+      },
+    ]}>
+</Canvas>
+
+### With Preformatted Extensions
+
+<Canvas
+  of={ExportModalStories.WithPreformattedExtensions}
+  additionalActions={[
+      {
+        title: 'Open in Stackblitz',
+        onClick: () => stackblitzPrefillConfig(ExportModalStories.WithPreformattedExtensions,[],customFunctionArr),
+      },
+    ]}>
+</Canvas>
+
+## Component API
+
+<Controls />

--- a/packages/ibm-products/src/components/ExportModal/ExportModal.stories.jsx
+++ b/packages/ibm-products/src/components/ExportModal/ExportModal.stories.jsx
@@ -9,7 +9,7 @@ import React, { useState, useRef } from 'react';
 import { Button } from '@carbon/react';
 import { ExportModal } from '.';
 import wait from '../../global/js/utils/wait';
-import { StoryDocsPage } from '../../global/js/utils/StoryDocsPage';
+import mdx from './ExportModal.mdx';
 
 export default {
   title: 'IBM Products/Components/Export/ExportModal',
@@ -17,24 +17,7 @@ export default {
   tags: ['autodocs'],
   parameters: {
     docs: {
-      page: () => (
-        <StoryDocsPage
-          altGuidelinesHref={[
-            {
-              href: 'https://pages.github.ibm.com/carbon/ibm-products/components/export/usage/',
-              label: 'Export usage guidelines',
-            },
-            {
-              href: 'https://www.carbondesignsystem.com/components/modal/usage',
-              label: 'Carbon Modal usage guidelines',
-            },
-            {
-              href: 'https://react.carbondesignsystem.com/?path=/docs/components-modal',
-              label: 'Carbon Modal documentation',
-            },
-          ]}
-        />
-      ),
+      page: mdx,
     },
   },
   argTypes: {
@@ -47,10 +30,6 @@ export default {
         },
       },
       options: [0, 1],
-      mapping: {
-        0: [],
-        1: ['pdf'],
-      },
     },
     preformattedExtensions: {
       control: {
@@ -61,19 +40,6 @@ export default {
         },
       },
       options: [0, 1],
-      mapping: {
-        0: [],
-        1: [
-          {
-            extension: 'YAML',
-            description: 'best for IBM managed cloud',
-          },
-          {
-            extension: 'BAR',
-            description: 'best for integration server',
-          },
-        ],
-      },
     },
   },
 };
@@ -91,7 +57,31 @@ const defaultProps = {
   successful: true,
 };
 
-const Template = ({ storyInitiallyOpen = false, ...args }, context) => {
+const Template = ({ storyInitiallyOpen, ...args }, context) => {
+  const { preformattedExtensions, validExtensions } = args;
+  const getPreformattedExtensions = (value) => {
+    if (value === 1) {
+      return [
+        {
+          extension: 'YAML',
+          description: 'best for IBM managed cloud',
+        },
+        {
+          extension: 'BAR',
+          description: 'best for integration server',
+        },
+      ];
+    }
+    return [];
+  };
+
+  const getValidations = (value) => {
+    if (value === 1) {
+      return ['pdf'];
+    }
+    return [];
+  };
+
   const [open, setOpen] = useState(
     context.viewMode !== 'docs' && storyInitiallyOpen
   );
@@ -128,6 +118,10 @@ const Template = ({ storyInitiallyOpen = false, ...args }, context) => {
       {RenderButton(triggerButtonRef)}
       <ExportModal
         {...args}
+        validExtensions={getValidations(validExtensions)}
+        preformattedExtensions={getPreformattedExtensions(
+          preformattedExtensions
+        )}
         open={open}
         onClose={onCloseHandler}
         onRequestSubmit={onSubmitHandler}


### PR DESCRIPTION
Closes #7175

Implemented open stackblitz in About Modal and Export Modal

#### What did you change? 
Created 
packages/ibm-products/src/components/AboutModal/AboutModal.mdx and 
packages/ibm-products/src/components/ExportModal/ExportModal.mdx

Updated
packages/ibm-products/src/components/AboutModal/AboutModal.stories.jsx
packages/ibm-products/src/components/ExportModal/ExportModal.stories.jsx

#### How did you test and verify your work? yarn storybook and open stackblitz (Without the changes to codePreviewer.tsx from [7365](https://github.com/carbon-design-system/ibm-products/pull/7365), this PR cannot be tested in the deployment preview.)

**Note: This PR should only be merged after [7365](https://github.com/carbon-design-system/ibm-products/pull/7365)**
Therefore, marking it as a draft until [7365](https://github.com/carbon-design-system/ibm-products/pull/7365) is merged.