### PR TITLE
fix(percy): add global `waitForSelector` to validate that storybook has loaded

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -6,7 +6,7 @@ snapshot:
     - 1366
   minHeight: 1024
 discovery:
-  network_idle_timeout: 500
+  network_idle_timeout: 1500
 storybook:
   include: ['/IBM Products/']
   exclude: [

--- a/.percy.yml
+++ b/.percy.yml
@@ -12,7 +12,7 @@ storybook:
   # waits for data-carbon-theme attribute to exist before taking snapshot
   # if storybook is still loading, percy could take a snapshot of the storybook
   # loading spinner and cause flaky tests
-  waitForSelector: [data-carbon-theme]
+  waitForSelector: '[data-carbon-theme]'
   include: ['/IBM Products/']
   exclude: [
       '/Internal/',

--- a/.percy.yml
+++ b/.percy.yml
@@ -6,7 +6,7 @@ snapshot:
     - 1366
   minHeight: 1024
 discovery:
-  network_idle_timeout: 1500
+  network_idle_timeout: 750
 storybook:
   include: ['/IBM Products/']
   exclude: [

--- a/.percy.yml
+++ b/.percy.yml
@@ -8,6 +8,11 @@ snapshot:
 discovery:
   network_idle_timeout: 750
 storybook:
+  waitForTimeout: 1000
+  # waits for data-carbon-theme attribute to exist before taking snapshot
+  # if storybook is still loading, percy could take a snapshot of the storybook
+  # loading spinner and cause flaky tests
+  waitForSelector: [data-carbon-theme]
   include: ['/IBM Products/']
   exclude: [
       '/Internal/',


### PR DESCRIPTION
Closes #7513 

~I'm hoping increasing the network timeout for percy will resolve some of the flaky snapshots that get flagged as visual changes.~

Next attempt is to use the `waitForSelector` in the percy config to look for `[data-carbon-theme]` since that attribute is only added after storybook has finished loading.

Percy has flagged 8 visual differences which I think may be accurate. [This PR](https://github.com/carbon-design-system/ibm-products/pull/7447/files) contained changes to the breadcrumb row height which would explain the page header snapshots. And the other snapshot that was flagged was `NotificationPanel`, but it was just the 'n months ago' text. I'll approve the Percy snapshot changes and we can monitor new PRs for any Percy flakiness.

While storybook is loading (no `[data-carbon-theme]` attribute)
![Screenshot 2025-05-15 at 3 18 36 PM](https://github.com/user-attachments/assets/c9f63dc8-54d1-4572-91f0-aeeedafa4fac)

After storybook has loaded
![Screenshot 2025-05-15 at 3 19 09 PM](https://github.com/user-attachments/assets/edf8cf87-ec2c-49f6-aa97-4464e6b919bb)


#### What did you change?
- `.percy.yml`

#### How did you test and verify your work?
Will test via percy PR check run in this PR