### PR TITLE
fix(wc-tests): remove vi mock, no longer needed, causing flaky tests

### DIFF
--- a/packages/ibm-products-web-components/src/components/about-modal/about-modal.test.ts
+++ b/packages/ibm-products-web-components/src/components/about-modal/about-modal.test.ts
@@ -5,8 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-vi.mock('@carbon/icons/lib/close/20', () => vi.fn().mockReturnValue({}));
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { fixture, html } from '@open-wc/testing';
 import { render, TemplateResult } from 'lit';
 import './index';

--- a/packages/ibm-products-web-components/src/components/full-page-error/full-page-error.test.ts
+++ b/packages/ibm-products-web-components/src/components/full-page-error/full-page-error.test.ts
@@ -5,8 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-vi.mock('@carbon/icons/lib/close/20', () => vi.fn().mockReturnValue({}));
-import { describe, it, vi, expect } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { fixture, html, expect as owcExpect } from '@open-wc/testing';
 import { render } from 'lit';
 import { Kind } from './types';

--- a/packages/ibm-products-web-components/src/components/tearsheet/tearsheet.test.ts
+++ b/packages/ibm-products-web-components/src/components/tearsheet/tearsheet.test.ts
@@ -1,12 +1,11 @@
 /**
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-vi.mock('@carbon/icons/lib/close/20', () => vi.fn().mockReturnValue({}));
-import { describe, expect, it, vi, afterEach } from 'vitest';
+import { describe, expect, it, afterEach } from 'vitest';
 import { TemplateResult } from 'lit';
 import { fixture, html } from '@open-wc/testing';
 import './index';


### PR DESCRIPTION
The vite mock for the Carbon close icon that was previously needed may be the culprit for the flaky options-tile web component test. Basically the mock will cause vite to reload the test and can cause unexpected behavior.

```
[vite] (client) ✨ new dependencies optimized: @carbon/icons/lib/close/20
[vite] (client) ✨ optimized dependencies changed. reloading
[vitest] Vite unexpectedly reloaded a test. This may cause tests to fail, lead to flaky behaviour or duplicated test runs.
For a stable experience, please add mentioned dependencies to your config's `optimizeDeps.include` field manually.
```

After removing the mock, I do not see the above warnings anymore.

#### What did you change?
```
packages/ibm-products-web-components/src/components/about-modal/about-modal.test.ts
packages/ibm-products-web-components/src/components/full-page-error/full-page-error.test.ts
packages/ibm-products-web-components/src/components/tearsheet/tearsheet.test.ts
```
#### How did you test and verify your work?
Double checking tests running in CI within this PR