### PR TITLE
fix: supress sass deprecation warnings

### DIFF
--- a/packages/ibm-products-web-components/tools/rollup-plugin-lit-scss.js
+++ b/packages/ibm-products-web-components/tools/rollup-plugin-lit-scss.js
@@ -76,6 +76,8 @@ export default function LitSCSS({
         ...options,
         file: id,
         data: finalContent,
+        quietDeps: true,
+        silenceDeprecations: ['mixed-decls', 'global-builtin', 'legacy-js-api'],
       });
 
       return {

--- a/packages/ibm-products-web-components/vite.config.ts
+++ b/packages/ibm-products-web-components/vite.config.ts
@@ -40,4 +40,13 @@ export default defineConfig({
       reporter: ['text', 'html', 'json'],
     },
   },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: 'modern',
+        quietDeps: true,
+        silenceDeprecations: ['mixed-decls', 'global-builtin', 'legacy-js-api'],
+      },
+    },
+  },
 });

--- a/packages/ibm-products/.storybook/main.js
+++ b/packages/ibm-products/.storybook/main.js
@@ -94,6 +94,19 @@ export default {
           ),
         },
       },
+      css: {
+        preprocessorOptions: {
+          scss: {
+            api: 'modern',
+            quietDeps: true,
+            silenceDeprecations: [
+              'mixed-decls',
+              'global-builtin',
+              'legacy-js-api',
+            ],
+          },
+        },
+      },
     });
   },
 


### PR DESCRIPTION
Closes #7512 

configures `sass` to stop with all the tedious messaging caused by deprecation warnings and from our carbon dependencies

<img width="1840" alt="Screenshot 2025-05-15 at 5 15 06 PM" src="https://github.com/user-attachments/assets/7a45451f-52e1-4268-9b59-60e7b9200480" />

in the screenshot above you can see how when you run the storybook commands that you're not inundated with large amounts of messages from sass