### PR TITLE
test: try `.story-wrapper` for percy waitForSelector

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -12,7 +12,7 @@ storybook:
   # waits for data-carbon-theme attribute to exist before taking snapshot
   # if storybook is still loading, percy could take a snapshot of the storybook
   # loading spinner and cause flaky tests
-  waitForSelector: '[data-carbon-theme]'
+  waitForSelector: '.story-wrapper'
   include: ['/IBM Products/']
   exclude: [
       '/Internal/',


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/ibm-products/issues/7513 (already closed, but I noticed Percy still took a snapshot of the storybook loading spinner for `Saving` so trying a different `waitForSelector`)

I updated the `waitForSelector` value to target the `.story-wrapper` element which doesn't even get included in the DOM until the story has loaded. I'm hoping switching to this selector helps because I noticed that in one of the Percy builds, the `Saving` component received a snapshot of the storybook loader which is not what we would expect.

#### What did you change?
`.percy.yml`
#### How did you test and verify your work?
Checking the percy flagged snapshots