### PR TITLE
fix(Tearsheet): fix keyboard scroll for non-interactive tearsheet

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
@@ -538,7 +538,6 @@ export const TearsheetShell = React.forwardRef(
                     alwaysRender={
                       !!(influencer && influencerPosition === 'right')
                     }
-                    tabIndex={-1}
                     element={SectionLevel3}
                   >
                     {children}


### PR DESCRIPTION
Closes #7521.

Most browsers automatically allow tab navigation to scrollable nodes without interactive content.  Unfortunately, Tearsheet sabotaged that behavior by explicitly setting tabIndex={-1}.

#### What did you change?

This simply removes that tabIndex setting.

#### How did you test and verify your work?

Storybook.