### PR TITLE
chore: change-logs repeated in all packages

### DIFF
--- a/.github/workflows/create-release-tag-and-pr.yml
+++ b/.github/workflows/create-release-tag-and-pr.yml
@@ -45,9 +45,29 @@ jobs:
 
       # Create a new branch off the release branch for the PR, we do this to ensure the release branch
       # is not affected
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20.x'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install
+
       - name: Create branch
         run: |
           git checkout -b chore/${{ github.event.inputs.tag }}-release
+
+      - name: Generate CHANGELOG.md
+        run: |
+          node ./scripts/get-changelog.js -f ${{ github.event.inputs.previous-tag }} -t ${{ github.event.inputs.tag }}
+
+      - name: Commit changelog
+        run: |
+          git add CHANGELOG.md
+          git commit -m "docs(changelog): update for ${{ github.event.inputs.tag }}" || echo "No changes to commit"
+
           git push origin chore/${{ github.event.inputs.tag }}-release
       # Create PR with the new branch
       - name: Create Pull Request

--- a/.github/workflows/create-release-tag-and-pr.yml
+++ b/.github/workflows/create-release-tag-and-pr.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Generate CHANGELOG.md
         run: |
-          node ./scripts/get-changelog.js -f ${{ github.event.inputs.previous-tag }} -t ${{ github.event.inputs.tag }}
+          node ./scripts/get-changelog.js -f ${{ github.event.inputs.previous-tag }} -t ${{ github.event.inputs.tag }} -w true
 
       - name: Commit changelog
         run: |

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,8 @@
   "command": {
     "version": {
       "conventionalCommits": true,
-      "message": "chore(release): publish [skip ci]"
+      "message": "chore(release): publish [skip ci]",
+      "changelog":false
     }
   },
   "ignoreChanges": [

--- a/scripts/get-changelog.js
+++ b/scripts/get-changelog.js
@@ -213,21 +213,25 @@ function generateLog() {
     './packages/ibm-products-web-components'
   );
   console.log(log);
-
+  //update changelog.md for packages/core
   getChangelog('@carbon/ibm-cloud-cognitive-core', './packages/core');
+
+  //update changelog.md for config/babel-preset-ibm-cloud-cognitive
   getChangelog(
     '@babel-preset-ibm-cloud-cognitive',
     './config/babel-preset-ibm-cloud-cognitive'
   );
+  //update changelog.md for config/jest-config-ibm-cloud-cognitive
   getChangelog(
     '@jest-config-ibm-cloud-cognitive',
     './config/jest-config-ibm-cloud-cognitive'
   );
+  //update changelog.md for config/storybook-addon-carbon-theme
   getChangelog(
     '@carbon/storybook-addon-theme',
     './config/storybook-addon-carbon-theme'
   );
-
+  // the log returned is used to create changelog in releases
   return log;
 }
 

--- a/scripts/get-changelog.js
+++ b/scripts/get-changelog.js
@@ -213,24 +213,29 @@ function generateLog() {
     './packages/ibm-products-web-components'
   );
   console.log(log);
-  //update changelog.md for packages/core
-  getChangelog('@carbon/ibm-cloud-cognitive-core', './packages/core');
+  if (writeChangelog) {
+    //these logs are not required for release page
 
-  //update changelog.md for config/babel-preset-ibm-cloud-cognitive
-  getChangelog(
-    '@babel-preset-ibm-cloud-cognitive',
-    './config/babel-preset-ibm-cloud-cognitive'
-  );
-  //update changelog.md for config/jest-config-ibm-cloud-cognitive
-  getChangelog(
-    '@jest-config-ibm-cloud-cognitive',
-    './config/jest-config-ibm-cloud-cognitive'
-  );
-  //update changelog.md for config/storybook-addon-carbon-theme
-  getChangelog(
-    '@carbon/storybook-addon-theme',
-    './config/storybook-addon-carbon-theme'
-  );
+    //update changelog.md for packages/core
+    getChangelog('@carbon/ibm-cloud-cognitive-core', './packages/core');
+
+    //update changelog.md for config/babel-preset-ibm-cloud-cognitive
+    getChangelog(
+      '@babel-preset-ibm-cloud-cognitive',
+      './config/babel-preset-ibm-cloud-cognitive'
+    );
+    //update changelog.md for config/jest-config-ibm-cloud-cognitive
+    getChangelog(
+      '@jest-config-ibm-cloud-cognitive',
+      './config/jest-config-ibm-cloud-cognitive'
+    );
+    //update changelog.md for config/storybook-addon-carbon-theme
+    getChangelog(
+      '@carbon/storybook-addon-theme',
+      './config/storybook-addon-carbon-theme'
+    );
+  }
+
   // the log returned is used to create changelog in releases
   return log;
 }


### PR DESCRIPTION
Closes #7437 

[Change-logs](https://github.com/carbon-design-system/ibm-products/pull/7524/files#diff-8f035289d274d6d70d7fcda70c304e870ea8163ef97c0c34e764bd38d6e389b4R6) seem to be accumulating and repeating since `v2.62.0` in all packages. Lerna used generate and update changelog.md during releases. Looks like some glitch happened after a subsequent RC release `2.62.0-rc.1`.

Now `changelog.md` is updated using a manual script `get-changelog.js` while running the workflow  `Create github tag and PR `during release. We are already using the same script for generating changelog in [release](https://github.com/carbon-design-system/ibm-products/releases) page. Now I am reusing this scripts to update `changelog.md` as well.

#### What did you change?
Updated `get-changelog.js` to include logic to write the logs to `changelog.md` files
Updated `Create github tag and PR` to include action to update changelogs
#### How did you test and verify your work?
Changelogs are generating in local as expected. But fullflow can be tested after merging.