### PR TITLE
refactor(useResizeObserver): migrate to TS and refactor tests to include resize validation

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.tsx
@@ -5,7 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useRef, MutableRefObject, useEffect, useState } from 'react';
+import React, {
+  useRef,
+  MutableRefObject,
+  useEffect,
+  useState,
+  RefObject,
+} from 'react';
 import PropTypes from 'prop-types';
 import {
   TableToolbar,
@@ -234,8 +240,8 @@ const DatagridToolbar = ({
   ariaToolbarLabel,
   ...datagridState
 }: DatagridToolbarProps & DataGridState) => {
-  const ref = useRef(null);
-  const { width } = useResizeObserver(ref);
+  const ref = useRef<HTMLDivElement | null>(null);
+  const { width } = useResizeObserver(ref as RefObject<HTMLDivElement>);
   const { DatagridActions, DatagridBatchActions, batchActions, rowSize } =
     datagridState;
   const getRowHeight = rowSize || 'lg';

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridVirtualBody.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridVirtualBody.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { MutableRefObject, useEffect, useRef } from 'react';
+import React, { MutableRefObject, RefObject, useEffect, useRef } from 'react';
 import { VariableSizeList } from 'react-window';
 import { TableBody } from '@carbon/react';
 import { pkg } from '../../../settings';
@@ -58,7 +58,7 @@ const DatagridVirtualBody = (datagridState: DataGridState) => {
     }
   };
 
-  useResizeObserver(gridRef, handleVirtualGridResize);
+  useResizeObserver(gridRef as RefObject<HTMLElement>, handleVirtualGridResize);
 
   useEffect(() => {
     handleResize?.();

--- a/packages/ibm-products/src/components/PageHeader/PageHeader.tsx
+++ b/packages/ibm-products/src/components/PageHeader/PageHeader.tsx
@@ -489,8 +489,7 @@ export let PageHeader = React.forwardRef(
     const localHeaderRef = useRef<HTMLDivElement | null>(null);
     const headerRef = (ref ||
       localHeaderRef) as MutableRefObject<HTMLElementStyled>;
-    const sizingContainerRef: MutableRefObject<HTMLDivElement | null> =
-      useRef(null);
+    const sizingContainerRef: RefObject<HTMLDivElement | null> = useRef(null);
     const offsetTopMeasuringRef = useRef(null);
     const overflowMenuRef = useRef<HTMLDivElement>(null);
 
@@ -893,7 +892,10 @@ export let PageHeader = React.forwardRef(
       headerRef,
     ]);
 
-    useResizeObserver(sizingContainerRef, handleResizeActionBarColumn);
+    useResizeObserver(
+      sizingContainerRef as RefObject<HTMLDivElement>,
+      handleResizeActionBarColumn
+    );
     useResizeObserver(headerRef, handleResize);
 
     // Determine what form of title to display in the breadcrumb

--- a/packages/ibm-products/src/components/TagSet/TagSet.tsx
+++ b/packages/ibm-products/src/components/TagSet/TagSet.tsx
@@ -9,6 +9,7 @@ import React, {
   JSX,
   PropsWithChildren,
   ReactNode,
+  RefObject,
   useCallback,
   useEffect,
   useRef,
@@ -411,12 +412,15 @@ export let TagSet = React.forwardRef<HTMLDivElement, TagSetProps>(
       setTimeout(() => launcherButton?.focus(), 0);
     };
 
-    useResizeObserver(sizingContainerRef, handleSizerTagsResize);
+    useResizeObserver(
+      sizingContainerRef as RefObject<HTMLDivElement>,
+      handleSizerTagsResize
+    );
 
     const resizeOption = containingElementRef
       ? containingElementRef
       : tagSetRef;
-    useResizeObserver(resizeOption, handleResize);
+    useResizeObserver(resizeOption as RefObject<HTMLElement>, handleResize);
 
     return (
       <div

--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
@@ -289,10 +289,10 @@ export const TearsheetShell = React.forwardRef(
     const bcModalHeader = `${carbonPrefix}--modal-header`;
     const renderPortalUse = usePortalTarget(portalTargetIn);
     const localRef = useRef(undefined);
-    const resizer = useRef(null);
+    const resizer = useRef<HTMLDivElement | null>(null);
     const modalBodyRef = useRef(null);
     const modalRef = (ref || localRef) as RefObject<HTMLDivElement>;
-    const { width } = useResizeObserver(resizer);
+    const { width } = useResizeObserver(resizer as RefObject<HTMLDivElement>);
     const prevOpen = usePreviousValue(open);
     const { keyDownListener, claimFocus } = useFocus(
       modalRef,

--- a/packages/ibm-products/src/global/js/hooks/__tests__/useResizeObserver.test.js
+++ b/packages/ibm-products/src/global/js/hooks/__tests__/useResizeObserver.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2025, 2025
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/ibm-products/src/global/js/hooks/useOverflowItems/useOverflowItems.ts
+++ b/packages/ibm-products/src/global/js/hooks/useOverflowItems/useOverflowItems.ts
@@ -55,7 +55,7 @@ export function useOverflowItems<T extends Item>(
     return node;
   };
 
-  useResizeObserver(containerRef, handleResize);
+  useResizeObserver(containerRef as RefObject<HTMLElement>, handleResize);
 
   const getMap = () => {
     if (!itemsRef.current) {

--- a/packages/ibm-products/src/global/js/hooks/useResizeObserver.ts
+++ b/packages/ibm-products/src/global/js/hooks/useResizeObserver.ts
@@ -1,37 +1,53 @@
 /**
- * Copyright IBM Corp. 2023, 2023
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { useRef, useState, useLayoutEffect, useEffect } from 'react';
+import { useRef, useState, useLayoutEffect, useEffect, RefObject } from 'react';
 
-export const useResizeObserver = (ref, callback, deps = []) => {
+export const useResizeObserver = (
+  ref: RefObject<HTMLElement>,
+  onResize?: (rect: DOMRectReadOnly) => void
+) => {
   const [width, setWidth] = useState(-1);
   const [height, setHeight] = useState(-1);
-  const entriesToHandle = useRef(null);
-  const cb = useRef(callback);
+  const entriesToHandle = useRef<ResizeObserverEntry[] | null>(null);
+  const cb = useRef(onResize);
 
   useEffect(() => {
-    // ref for callback removes it as dependency from useLayoutEffect
+    // ref for onResize removes it as dependency from useLayoutEffect
     // This significantly reduces repeated calls if a function is redefined on every
     // render
-    cb.current = callback;
-  }, [callback]);
+    cb.current = onResize;
+  }, [onResize]);
 
   useEffect(() => {
     const getInitialSize = () => {
       if (ref.current) {
         const refComputedStyle = window.getComputedStyle(ref.current);
+
         const initialWidth =
-          (ref.current?.offsetWidth || 0) -
-          (parseFloat(refComputedStyle?.paddingLeft || 0),
-          parseFloat(refComputedStyle?.paddingRight || 0));
+          (ref.current?.offsetWidth ?? 0) -
+          (typeof refComputedStyle?.paddingLeft === 'string' &&
+          refComputedStyle?.paddingLeft.length
+            ? parseFloat(refComputedStyle?.paddingLeft)
+            : 0) -
+          (typeof refComputedStyle?.paddingRight === 'string' &&
+          refComputedStyle?.paddingRight.length
+            ? parseFloat(refComputedStyle?.paddingRight)
+            : 0);
 
         const initialHeight =
-          (ref.current?.offsetHeight || 0) -
-          (parseFloat(refComputedStyle?.paddingTop || 0),
-          parseFloat(refComputedStyle?.paddingLeft || 0));
+          (ref.current?.offsetHeight ?? 0) -
+          (typeof refComputedStyle?.paddingTop === 'string' &&
+          refComputedStyle?.paddingTop.length
+            ? parseFloat(refComputedStyle?.paddingTop)
+            : 0) -
+          (typeof refComputedStyle?.paddingBottom === 'string' &&
+          refComputedStyle?.paddingBottom.length
+            ? parseFloat(refComputedStyle?.paddingBottom)
+            : 0);
 
         setWidth(initialWidth);
         setHeight(initialHeight);
@@ -41,8 +57,9 @@ export const useResizeObserver = (ref, callback, deps = []) => {
       return;
     }
     getInitialSize();
+    // Ignoring exhaustive-deps as we do NOT want to include the ref in dep array
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [width, height, ref.current, ...deps]);
+  }, [width, height]);
 
   useLayoutEffect(() => {
     if (!ref?.current) {
@@ -62,7 +79,7 @@ export const useResizeObserver = (ref, callback, deps = []) => {
       cb.current && cb.current(entry.contentRect);
     };
 
-    let observer = new ResizeObserver((entries) => {
+    const observer = new ResizeObserver((entries) => {
       // always update entriesToHandle
       entriesToHandle.current = entries;
 
@@ -76,10 +93,10 @@ export const useResizeObserver = (ref, callback, deps = []) => {
     observer.observe(ref.current);
 
     return () => {
-      observer?.disconnect();
-      observer = null;
+      observer.disconnect();
     };
+    // Ignoring exhaustive-deps as we do NOT want to include the ref in dep array
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ref.current, ...deps]);
+  }, []);
   return { width, height };
 };


### PR DESCRIPTION
Closes #7543 

Refactors `useResizeObserver` based on changes made when contributing to `@carbon/react`. The hook has been migrated to TS and the tests have also been simplified a lot. The tests also include test cases for the resizing logic of the hook by triggering a resize observer callback to validate that the `width` and `height` returned from the hook update as expected. I also removed the `deps` param from the hook since it isn't used anywhere in our library and adds extra complexity.

I also made small typescript updates in instances where this hook is called.

#### What did you change?
```
# Main changes
packages/ibm-products/src/global/js/hooks/__tests__/useResizeObserver.test.js
packages/ibm-products/src/global/js/hooks/useResizeObserver.ts

# Files requiring TS updates after hook was migrated to TS
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.tsx
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridVirtualBody.tsx
packages/ibm-products/src/components/PageHeader/PageHeader.tsx
packages/ibm-products/src/components/TagSet/TagSet.tsx
packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
packages/ibm-products/src/global/js/hooks/useOverflowItems/useOverflowItems.ts
```
#### How did you test and verify your work?
