### PR TITLE
fix(rtl): minor updates to provide stronger rtl support

### DIFF
--- a/packages/ibm-products-styles/src/components/AboutModal/_about-modal.scss
+++ b/packages/ibm-products-styles/src/components/AboutModal/_about-modal.scss
@@ -25,9 +25,11 @@ $block-class: #{c4p-settings.$pkg-prefix}--about-modal;
 }
 
 .#{$block-class} .#{$block-class}__header {
-  padding: 0 20% 0 $spacing-05;
+  padding: 0;
   grid-row: auto;
   margin-block-end: 0;
+  padding-inline-end: 20%;
+  padding-inline-start: $spacing-05;
 }
 
 .#{$block-class} .#{$block-class}__title {

--- a/packages/ibm-products-styles/src/global/styles/_display-box.scss
+++ b/packages/ibm-products-styles/src/global/styles/_display-box.scss
@@ -41,10 +41,8 @@ $indicator-height: $spacing-04;
 }
 
 .sb-main-centered .#{$block-class}__message {
-  inset-inline-start: 50%;
-  min-inline-size: 100vh;
+  inline-size: inherit;
   text-align: center;
-  transform: translateX(-50%);
 }
 
 .#{$block-class}__indicator--left,

--- a/packages/ibm-products/src/components/NotificationsPanel/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/NotificationsPanel/_storybook-styles.scss
@@ -32,3 +32,8 @@ $storybook-block-class: #{c4p-settings.$pkg-prefix}--notifications-panel__story;
 .cds--header__global {
   z-index: 2;
 }
+
+// Mirror unread notification bell svg in RTL
+[dir='rtl'] .sb-unread-notification-icon {
+  transform: scaleX(-1);
+}

--- a/packages/ibm-products/src/components/NotificationsPanel/preview-components/UnreadNotificationBell.js
+++ b/packages/ibm-products/src/components/NotificationsPanel/preview-components/UnreadNotificationBell.js
@@ -16,6 +16,7 @@ const UnreadNotificationBell = () => {
       version="1.1"
       xmlns="http://www.w3.org/2000/svg"
       xmlnsXlink="http://www.w3.org/1999/xlink"
+      className="sb-unread-notification-icon"
     >
       <title>Unread notification bell</title>
       <g id="Group" transform="translate(-1.000000, 0.000000)">


### PR DESCRIPTION
Closes #6878 

Includes minor changes to provide stronger RTL support, most of the components flagged in #6878 were related to layout issues from the `DisplayBox` utility component used for overflow type stories (tagset, tag overflow, etc.).

An area that I did a little bit of research around was icon mirroring between LTR and RTL. From what I've found, icon mirroring should be supported except for cases where it may change the meaning of what the icon is used for. (ie "common icons such as the fast-forward and rewind icons in media players, use the same orientation in both LTR and RTL layouts"). To demonstrate how to support this, I included the mirroring support for the notification bell in `NotificationsPanel`. Most of the icons being used are symmetrical and won't require any additional changes to support mirroring.

#### What did you change?
```
packages/ibm-products-styles/src/components/AboutModal/_about-modal.scss
packages/ibm-products-styles/src/global/styles/_display-box.scss
packages/ibm-products/src/components/NotificationsPanel/_storybook-styles.scss
packages/ibm-products/src/components/NotificationsPanel/preview-components/UnreadNotificationBell.js
```
#### How did you test and verify your work?
Storybook via text direction toggling