### PR TITLE
fix(Interstitial): pass forwarded refs

### DIFF
--- a/packages/ibm-products/src/components/EmptyStates/EmptyStateContent.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyStateContent.tsx
@@ -46,10 +46,8 @@ interface EmptyStateProps {
    */
   title: string | ReactNode;
 }
-export const EmptyStateContent = React.forwardRef<
-  HTMLDivElement,
-  EmptyStateProps
->((props) => {
+
+export const EmptyStateContent = (props: EmptyStateProps) => {
   const { action, link, headingAs, size, subtitle, title } = props;
   const HeadingComponent = headingAs ?? Heading;
 
@@ -90,7 +88,7 @@ export const EmptyStateContent = React.forwardRef<
       )}
     </Section>
   );
-});
+};
 
 // The display name of the component, used by React. Note that displayName
 // is used in preference to relying on function.name.

--- a/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreenBody.tsx
+++ b/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreenBody.tsx
@@ -46,7 +46,7 @@ export interface InterstitialScreenBodyProps {
 const InterstitialScreenBody = React.forwardRef<
   HTMLDivElement,
   InterstitialScreenBodyProps
->((props) => {
+>((props, ref) => {
   const { className = '', contentRenderer, ...rest } = props;
   const blockClass = `${pkg.prefix}--interstitial-screen`;
   const bodyBlockClass = `${blockClass}--internal-body`;
@@ -122,7 +122,7 @@ const InterstitialScreenBody = React.forwardRef<
   const renderBody = () => (
     <div
       className={`${blockClass}--body ${className}`}
-      ref={bodyScrollRef}
+      ref={bodyScrollRef ?? ref}
       {...rest}
     >
       <div className={`${blockClass}--content`}>
@@ -146,7 +146,9 @@ const InterstitialScreenBody = React.forwardRef<
   return isFullScreen ? (
     renderBody()
   ) : (
-    <ModalBody className={bodyBlockClass}>{renderBody()}</ModalBody>
+    <ModalBody ref={ref} className={bodyBlockClass}>
+      {renderBody()}
+    </ModalBody>
   );
 });
 

--- a/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreenFooter.tsx
+++ b/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreenFooter.tsx
@@ -61,7 +61,7 @@ export interface InterstitialScreenFooterProps {
 const InterstitialScreenFooter = React.forwardRef<
   HTMLDivElement,
   InterstitialScreenFooterProps
->((props) => {
+>((props, ref) => {
   const {
     className = '',
     skipButtonLabel = 'Skip',
@@ -128,7 +128,7 @@ const InterstitialScreenFooter = React.forwardRef<
   }, [loadingAction, isMultiStep, progStep, progStepCeil]);
 
   const getFooterContent = () => (
-    <div className={`${blockClass}--footer ${className}`}>
+    <div ref={ref} className={`${blockClass}--footer ${className}`}>
       {isMultiStep && skipButtonLabel !== '' && (
         <Button
           className={`${blockClass}--skip-btn`}
@@ -204,7 +204,7 @@ const InterstitialScreenFooter = React.forwardRef<
   return isFullScreen ? (
     getFooterContent()
   ) : (
-    <ModalFooter>{getFooterContent()}</ModalFooter>
+    <ModalFooter ref={ref}>{getFooterContent()}</ModalFooter>
   );
 });
 

--- a/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreenHeader.tsx
+++ b/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreenHeader.tsx
@@ -53,7 +53,7 @@ export type EnrichedChildren = {
 const InterstitialScreenHeader = React.forwardRef<
   HTMLDivElement,
   InterstitialScreenHeaderProps
->((props) => {
+>((props, ref) => {
   const {
     className = '',
     headerTitle,
@@ -107,6 +107,7 @@ const InterstitialScreenHeader = React.forwardRef<
   };
   return isFullScreen ? (
     <header
+      ref={ref}
       className={cx(headerBlockClass, className, {
         [`${headerBlockClass}--has-title`]:
           headerTitle || headerSubTitle || children,
@@ -116,6 +117,7 @@ const InterstitialScreenHeader = React.forwardRef<
     </header>
   ) : (
     <ModalHeader
+      ref={ref}
       className={cx(headerBlockClass, className, {
         [`${headerBlockClass}--has-title`]:
           headerTitle || headerSubTitle || children,


### PR DESCRIPTION
Closes #7587 

It appears that the Interstitial sub-components never used the `ref` from `forwardRef` when initially created, this causes warning within the console and when running tests with our library. I also removed `forwardRef` from `EmptyStateContent` which also had the same issue but we do not need to include `forwardRef` support since that is an internal component.

#### What did you change?
```
packages/ibm-products/src/components/EmptyStates/EmptyStateContent.tsx
packages/ibm-products/src/components/InterstitialScreen/InterstitialScreenBody.tsx
packages/ibm-products/src/components/InterstitialScreen/InterstitialScreenFooter.tsx
packages/ibm-products/src/components/InterstitialScreen/InterstitialScreenHeader.tsx
```
#### How did you test and verify your work?
Verified no longer seeing these warning/errors in console