### PR TITLE
docs(pr-template): add pr readiness checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,3 +5,21 @@ Closes #
 #### What did you change?
 
 #### How did you test and verify your work?
+
+#### PR Checklist
+
+<!--
+  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
+-->
+
+As the author of this PR, before marking ready for review, confirm you:
+
+- [ ] Reviewed every line of the diff
+- [ ] Updated documentation and storybook examples
+- [ ] Wrote passing tests that cover this change
+- [ ] Addressed any impact on accessibility (a11y)
+- [ ] Tested for cross-browser consistency
+- [ ] Validated that this code is ready for review and status checks should pass
+
+More details can be found in the [pull request](./CONTRIBUTING.md) section of
+our contributing docs.


### PR DESCRIPTION
Adds a PR readiness checklist for PR authors when opening a new PR.

#### What did you change?
```
.github/PULL_REQUEST_TEMPLATE.md
```
#### How did you test and verify your work?
N/A