### PR TITLE
feat(tearsheet): add decorator option

### DIFF
--- a/packages/ibm-products-web-components/src/components/tearsheet/tearsheet.scss
+++ b/packages/ibm-products-web-components/src/components/tearsheet/tearsheet.scss
@@ -102,8 +102,11 @@ $motion-duration: $duration-moderate-02;
   .#{$block-class}__influencer[wide] {
     @extend .#{$block-class}__influencer--wide;
   }
+  ::slotted([slot='decorator']),
   ::slotted(#{$carbon-prefix}-slug) {
+    position: absolute;
     display: flex;
+    inset-block-start: to-rem(10px);
     inset-inline-end: 0;
     /* stylelint-disable-next-line carbon/layout-use */
     margin-block: 6px;
@@ -171,7 +174,8 @@ $motion-duration: $duration-moderate-02;
   @extend .#{$carbon-prefix}--visually-hidden;
 }
 
-:host(#{$prefix}-tearsheet[slug]) {
+:host(#{$prefix}-tearsheet[slug]),
+:host(#{$prefix}-tearsheet[ai-label]) {
   --overlay-color: #{$ai-overlay};
 
   .#{$block-class}__container {
@@ -200,7 +204,13 @@ $motion-duration: $duration-moderate-02;
 
 :host(#{$prefix}-tearsheet[slug])
   .#{$prefix}--tearsheet__header[has-actions]
-  ::slotted(#{$prefix}-slug) {
+  ::slotted(#{$prefix}-slug),
+:host(#{$prefix}-tearsheet[ai-label])
+  .#{$prefix}--tearsheet__header[has-actions]
+  ::slotted(#{$prefix}-ai-label),
+:host(#{$prefix}-tearsheet[decorator])
+  .#{$prefix}--tearsheet__header[has-actions]
+  ::slotted([slot='decorator']) {
   inset-inline-end: 0;
 }
 
@@ -256,11 +266,13 @@ $motion-duration: $duration-moderate-02;
   }
 
   .#{$block-class}__header[has-close-icon],
-  .#{$block-class}__header[has-slug] {
+  .#{$block-class}__header[has-slug],
+  #{$block-class}__header[has-decorator] {
     padding-inline-end: $spacing-11;
   }
 
-  .#{$block-class}__header[has-close-icon][has-slug] {
+  .#{$block-class}__header[has-close-icon][has-slug],
+  .#{$block-class}__header[has-close-icon][has-decorator] {
     /* stylelint-disable-next-line carbon/layout-use */
     padding-inline-end: calc(#{$spacing-11 + $spacing-09});
   }

--- a/packages/ibm-products-web-components/src/components/tearsheet/tearsheet.stories.ts
+++ b/packages/ibm-products-web-components/src/components/tearsheet/tearsheet.stories.ts
@@ -21,6 +21,7 @@ import {
   getInfluencer,
   getContent,
   getSlug,
+  getDecorator,
   getLabel,
   getActionToolbarItems,
   getActionItems,
@@ -85,6 +86,12 @@ const slugs = {
   'With Slug': 1,
 };
 
+const decorators = {
+  'No Decorator': 0,
+  'With AI Label': 1,
+  'With non AI Label component': 2,
+};
+
 const contents = {
   Empty: 0,
   'Brief content': 1,
@@ -96,6 +103,7 @@ const labels = {
   'Shorter label': 1,
   'Longer label': 2,
 };
+
 export const Default = {
   args: {
     actionItems: 4,
@@ -110,6 +118,7 @@ export const Default = {
     selectorInitialFocus: '',
     width: TEARSHEET_WIDTH.WIDE,
     slug: 0,
+    decorator: 0,
     description: 'Description used to describe the flow if need be.',
     title: 'Title used to designate the overarching flow of the tearsheet.',
     headerNavigation: 0,
@@ -172,6 +181,11 @@ export const Default = {
       description: 'slug (AI slug)',
       options: slugs,
     },
+    decorator: {
+      control: 'select',
+      description: 'Slot(decorator)',
+      options: decorators,
+    },
     description: {
       control: 'text',
       description: 'description',
@@ -222,6 +236,9 @@ export const Default = {
 
         <!-- slotted action items cds-buttons -->
         ${getActionItems(args.actionItems)}
+
+        <!-- slotted Decorator -->
+        ${getDecorator(args.decorator)}
 
         <!-- slotted slug -->
         ${getSlug(args.slug)}

--- a/packages/ibm-products-web-components/src/components/tearsheet/tearsheet.ts
+++ b/packages/ibm-products-web-components/src/components/tearsheet/tearsheet.ts
@@ -137,6 +137,12 @@ class CDSTearsheet extends HostListenerMixin(LitElement) {
   _hasSlug = false;
 
   @state()
+  _hasDecorator = false;
+
+  @state()
+  _hasAILabel = false;
+
+  @state()
   _hasTitle = false;
 
   @state()
@@ -309,13 +315,33 @@ class CDSTearsheet extends HostListenerMixin(LitElement) {
 
   private _handleSlugChange(e: Event) {
     const childItems = (e.target as HTMLSlotElement).assignedElements();
-
     this._hasSlug = childItems.length > 0;
     if (this._hasSlug) {
       childItems[0].setAttribute('size', 'sm');
       this.setAttribute('slug', '');
     } else {
       this.removeAttribute('slug');
+    }
+  }
+  private _handleDecoratorChange(e: Event) {
+    this._hasAILabel = false;
+    const childItems = (e.target as HTMLSlotElement).assignedElements();
+    this._hasDecorator = childItems.length > 0;
+    if (this._hasDecorator) {
+      for (const item of childItems) {
+        if (item.tagName.toLowerCase() === 'cds-ai-label') {
+          this._hasAILabel = true;
+          break;
+        }
+      }
+    }
+    if (this._hasAILabel || this._hasDecorator) {
+      childItems[0].setAttribute('size', 'sm');
+      this.setAttribute(this._hasAILabel ? 'ai-label' : 'decorator', '');
+      this.removeAttribute(this._hasAILabel ? 'decorator' : 'ai-label');
+    } else {
+      this.removeAttribute('decorator');
+      this.removeAttribute('ai-label');
     }
   }
 
@@ -496,7 +522,6 @@ class CDSTearsheet extends HostListenerMixin(LitElement) {
     const indexOpen = CDSTearsheet._stack.all.indexOf(this._handleStackChange);
     CDSTearsheet._stack.open.splice(indexOpen, 1);
   }
-
   render() {
     const {
       closeIconDescription,
@@ -543,6 +568,7 @@ class CDSTearsheet extends HostListenerMixin(LitElement) {
       ?has-header-actions=${this._hasHeaderActions && this.width === 'wide'}
       ?has-actions=${this?._actionsCount > 0}
       ?has-slug=${this?._hasSlug}
+      ?has-decorator=${this?._hasDecorator}
       width=${width}
     >
       ${this.width === TEARSHEET_WIDTH.WIDE
@@ -560,6 +586,11 @@ class CDSTearsheet extends HostListenerMixin(LitElement) {
           @slotchange=${this._checkSetHasSlot}
         ></slot>
       </div>
+      <slot
+        name="decorator"
+        slot="ai-label"
+        @slotchange=${this._handleDecoratorChange}
+      ></slot>
       <slot name="slug" @slotchange=${this._handleSlugChange}></slot>
       ${this.hasCloseIcon || this?._actionsCount === 0
         ? html`<cds-modal-close-button

--- a/packages/ibm-products-web-components/src/components/tearsheet/utils.ts
+++ b/packages/ibm-products-web-components/src/components/tearsheet/utils.ts
@@ -13,6 +13,8 @@ import '@carbon/web-components/es/components/text-input/index.js';
 import '@carbon/web-components/es/components/textarea/index.js';
 import '@carbon/web-components/es/components/tabs/index.js';
 import '@carbon/web-components/es/components/slug/index.js';
+import '@carbon/web-components/es/components/ai-label/index.js';
+import '@carbon/web-components/es/components/toggle-tip/index.js';
 import '@carbon/web-components/es/components/dropdown/index.js';
 import '@carbon/web-components/es/components/progress-indicator/index.js';
 import '@carbon/web-components/es/components/progress-bar/index.js';
@@ -295,3 +297,40 @@ export const getSlug = (index) => {
       return null;
   }
 };
+// cspell: disable
+export const getDecorator = (decorator) => {
+  switch (decorator) {
+    case 1:
+      return html`
+        <cds-ai-label alignment="bottom-right" slot="decorator">
+          <div slot="body-text">
+            <p class="secondary">AI Explained</p>
+            <h2 class="ai-label-heading">84%</h2>
+            <p class="secondary bold">Confidence score</p>
+            <p class="secondary">
+              Lorem ipsum dolor sit amet, di os consectetur adipiscing elit, sed
+              do eiusmod tempor incididunt ut fsil labore et dolore magna
+              aliqua.
+            </p>
+            <hr />
+            <p class="secondary">Model type</p>
+            <p class="bold">Foundation model</p>
+          </div>
+        </cds-ai-label>
+      `;
+    case 2:
+      return html`
+        <cds-toggletip slot="decorator" alignment="bottom">
+          <p slot="body-text">
+            Lorem ipsum dolor sit amet, di os consectetur adipiscing elit, sed
+            do eiusmod tempor incididunt ut fsil labore et dolore magna aliqua.
+          </p>
+          <cds-link slot="actions">Test</cds-link>
+          <cds-button slot="actions">Button</cds-button>
+        </cds-toggletip>
+      `;
+    default:
+      return;
+  }
+};
+// cspell: enable


### PR DESCRIPTION
Closes #7331 

Add decorator prop to Tearsheet

#### What did you change?
Added support for `decorator` slot. This is then mapped to slot `ai-label` in Modal component.
Added decorator control in storybook 

#### How did you test and verify your work?
Storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
