### PR TITLE
fix: canary release workflow

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           registry-url: https://registry.npmjs.org
           cache: 'yarn'
 
@@ -47,7 +47,5 @@ jobs:
 
       # Publish release with canary tag to NPM using Lerna
       - name: Publish canary release of packages
-        env:
-          NPM_CONFIG_PROVENANCE: false
         run: |
           yarn lerna publish --canary --preid canary --dist-tag canary --yes

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           registry-url: https://registry.npmjs.org
           cache: 'yarn'
 

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -48,7 +48,6 @@ jobs:
       # Publish release with canary tag to NPM using Lerna
       - name: Publish canary release of packages
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN_LERNA }}
-          NODE_AUTH_TOKEN: ${{ secrets.CARBON_BOT_NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: false
         run: |
           yarn lerna publish --canary --preid canary --dist-tag canary --yes

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -47,5 +47,8 @@ jobs:
 
       # Publish release with canary tag to NPM using Lerna
       - name: Publish canary release of packages
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_LERNA }}
+          NODE_AUTH_TOKEN: ${{ secrets.CARBON_BOT_NPM_TOKEN }}
         run: |
           yarn lerna publish --canary --preid canary --dist-tag canary --yes


### PR DESCRIPTION
Closes #6729

the last several [canary release failures ](https://github.com/carbon-design-system/ibm-products/actions/workflows/release-canary.yml)show the following in the publish log

```
lerna WARN notice Package failed to publish: @carbon/ibm-products-styles
lerna ERR! E422 Error verifying sigstore provenance bundle: Failed to validate the provenance subject against the package name, version and tarball integrity. Please try re-publishing with the latest stable version of npm
```

unfortunately i'm unable to find anything with this error message specifically. right now the only thing i'm attempting to do is up update the node version used in the canary publish workflow from 20 to 24