### PR TITLE
chore(release): ensure release tag is created before release PR creation

### DIFF
--- a/.github/workflows/create-release-tag-and-pr.yml
+++ b/.github/workflows/create-release-tag-and-pr.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Generate CHANGELOG.md
         # The tags are now guaranteed to exist before this step runs
         run: |
-          node ./scripts/get-changelog.js -f ${{ github.event.inputs.previous-tag }} -t ${{ github.event.inputs.tag }}
+          node ./scripts/get-changelog.js -f ${{ github.event.inputs.previous-tag }} -t ${{ github.event.inputs.tag }} -w true
 
       - name: Commit changelog
         run: |

--- a/.github/workflows/create-release-tag-and-pr.yml
+++ b/.github/workflows/create-release-tag-and-pr.yml
@@ -29,10 +29,30 @@ on:
         default: true
 
 jobs:
+  # This job creates the git tag for the release (ie. v2.47.0)
+  create-release-tag:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: '0'
+          token: ${{ secrets.GH_TOKEN_LERNA }} # https://github.com/lerna/lerna/issues/1957
+
+      # https://github.com/actions/checkout#push-a-commit-using-the-built-in-token
+      - run: |
+          git config --global user.email ${{ secrets.CARBON_BOT_EMAIL }}
+          git config --global user.name ${{ secrets.CARBON_BOT_NAME }}
+      - name: Create tag and push
+        run: |
+          git tag -a ${{ github.event.inputs.tag }} -m "Release ${{ github.event.inputs.tag }}"
+          git push origin ${{ github.event.inputs.tag }}
+
   create-pull-request:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     if: github.event.inputs.create-pr == 'true'
+    needs: create-release-tag
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -60,8 +80,9 @@ jobs:
           git checkout -b chore/${{ github.event.inputs.tag }}-release
 
       - name: Generate CHANGELOG.md
+        # The tags are now guaranteed to exist before this step runs
         run: |
-          node ./scripts/get-changelog.js -f ${{ github.event.inputs.previous-tag }} -t ${{ github.event.inputs.tag }} -w true
+          node ./scripts/get-changelog.js -f ${{ github.event.inputs.previous-tag }} -t ${{ github.event.inputs.tag }}
 
       - name: Commit changelog
         run: |
@@ -78,25 +99,6 @@ jobs:
             - [ ] Verify CI passes as expected'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # This job creates the git tag for the release (ie. v2.47.0)
-  create-release-tag:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: '0'
-          token: ${{ secrets.GH_TOKEN_LERNA }} # https://github.com/lerna/lerna/issues/1957
-
-      # https://github.com/actions/checkout#push-a-commit-using-the-built-in-token
-      - run: |
-          git config --global user.email ${{ secrets.CARBON_BOT_EMAIL }}
-          git config --global user.name ${{ secrets.CARBON_BOT_NAME }}
-      - name: Create tag and push
-        run: |
-          git tag -a ${{ github.event.inputs.tag }} -m "Release ${{ github.event.inputs.tag }}"
-          git push origin ${{ github.event.inputs.tag }}
 
   # This job creates the release with the git tag pushed from job above with the corresponding
   # release notes from the previous version to current


### PR DESCRIPTION
Closes #7437 

We need to ensure release tag is created before running the script for generating changelog. 

#### What did you change?
 I have moved up the `create-release-tag` job to run before pull request creation

#### How did you test and verify your work?
Can only be tested during the next release

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
