### PR TITLE
fix: adds nullish checker back into create tearsheet first step logic

### DIFF
--- a/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.tsx
+++ b/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.tsx
@@ -241,7 +241,7 @@ export let CreateTearsheet = forwardRef(
 
     useEffect(() => {
       const firstItem =
-        stepData.findIndex((item) => item.shouldIncludeStep === true) + 1;
+        stepData.findIndex((item) => item?.shouldIncludeStep) + 1;
       const lastItem = lastIndexInArray(stepData, 'shouldIncludeStep', true);
       if (firstItem !== firstIncludedStep) {
         setCurrentStep(firstItem);


### PR DESCRIPTION
Closes #6859 

confirmed that this change doesn't revert the original bug fix