### PR TITLE
fix: use carbon prefix directly from `@carbon/styles` package config

### DIFF
--- a/packages/ibm-products-styles/src/components/APIKeyModal/_api-key-modal.scss
+++ b/packages/ibm-products-styles/src/components/APIKeyModal/_api-key-modal.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2022
+// Copyright IBM Corp. 2021, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -10,19 +10,21 @@
 @use '@carbon/styles/scss/components/button/tokens' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as c4p-settings;
 
 $block-class: #{c4p-settings.$pkg-prefix}--apikey-modal;
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--modal-close {
+.#{$block-class} .#{config.$prefix}--modal-close {
   display: none;
 }
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--inline-loading {
+.#{$block-class} .#{config.$prefix}--inline-loading {
   min-block-size: 3rem; // increasing the height from 2 to 3 resolves an issue where the scroll bar bounces
 }
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--modal-content {
+.#{$block-class} .#{config.$prefix}--modal-content {
   padding-inline-end: $spacing-05;
 }
 

--- a/packages/ibm-products-styles/src/components/AboutModal/_about-modal.scss
+++ b/packages/ibm-products-styles/src/components/AboutModal/_about-modal.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2022
+// Copyright IBM Corp. 2020, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -9,6 +9,7 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/type';
 @use '@carbon/type/scss/font-family' as *;
+@use '@carbon/styles/scss/config';
 
 // Standard imports.
 @use '../../global/styles/project-settings' as c4p-settings;
@@ -16,7 +17,7 @@
 // The block part of our conventional BEM class names (blockClass__E--M).
 $block-class: #{c4p-settings.$pkg-prefix}--about-modal;
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--modal-container {
+.#{$block-class} .#{config.$prefix}--modal-container {
   grid-template-rows: auto auto 1fr auto;
 }
 
@@ -47,14 +48,13 @@ $block-class: #{c4p-settings.$pkg-prefix}--about-modal;
   padding-block-start: 0;
   padding-inline: $spacing-05 20%;
 
-  &:not(.#{c4p-settings.$carbon-prefix}--modal-scroll-content) {
+  &:not(.#{config.$prefix}--modal-scroll-content) {
     margin-block-end: $spacing-06;
     padding-block-end: 0;
   }
 }
 
-.#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--modal-content--overflow-indicator {
+.#{$block-class} .#{config.$prefix}--modal-content--overflow-indicator {
   background-image: linear-gradient(to bottom, #00000000, $layer-01);
   inset-block-end: #{$spacing-06};
 }

--- a/packages/ibm-products-styles/src/components/ActionSet/_action-set.scss
+++ b/packages/ibm-products-styles/src/components/ActionSet/_action-set.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2023
+// Copyright IBM Corp. 2021, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -10,6 +10,7 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/config';
 
 @use '../../global/styles/project-settings' as c4p-settings;
 
@@ -34,10 +35,10 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
   }
 }
 
-.#{$action-set-block-class}.#{c4p-settings.$carbon-prefix}--btn-set
-  .#{$action-set-block-class}__action-button.#{c4p-settings.$carbon-prefix}--btn.#{c4p-settings.$carbon-prefix}--btn--expressive,
-.#{$action-set-block-class}.#{c4p-settings.$carbon-prefix}--btn-set
-  .#{$action-set-block-class}__action-button.#{c4p-settings.$carbon-prefix}--btn {
+.#{$action-set-block-class}.#{config.$prefix}--btn-set
+  .#{$action-set-block-class}__action-button.#{config.$prefix}--btn.#{config.$prefix}--btn--expressive,
+.#{$action-set-block-class}.#{config.$prefix}--btn-set
+  .#{$action-set-block-class}__action-button.#{config.$prefix}--btn {
   max-inline-size: none;
 }
 
@@ -90,19 +91,19 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
 // or any non-ghosts in extra large or 2xl,
 // or row-quadruple (non-ghost),
 // buttons are 25% width with a 2xl of 232px
-.#{$action-set-block-class}.#{c4p-settings.$carbon-prefix}--btn-set.#{$action-set-block-class}--row-triple.#{$action-set-block-class}--lg
+.#{$action-set-block-class}.#{config.$prefix}--btn-set.#{$action-set-block-class}--row-triple.#{$action-set-block-class}--lg
   .#{$action-set-block-class}__action-button:not(
     .#{$action-set-block-class}__action-button--ghost
   ),
-.#{$action-set-block-class}.#{c4p-settings.$carbon-prefix}--btn-set.#{$action-set-block-class}--xl
+.#{$action-set-block-class}.#{config.$prefix}--btn-set.#{$action-set-block-class}--xl
   .#{$action-set-block-class}__action-button:not(
     .#{$action-set-block-class}__action-button--ghost
   ),
-.#{$action-set-block-class}.#{c4p-settings.$carbon-prefix}--btn-set.#{$action-set-block-class}--2xl
+.#{$action-set-block-class}.#{config.$prefix}--btn-set.#{$action-set-block-class}--2xl
   .#{$action-set-block-class}__action-button:not(
     .#{$action-set-block-class}__action-button--ghost
   ),
-.#{$action-set-block-class}.#{c4p-settings.$carbon-prefix}--btn-set.#{$action-set-block-class}--row-quadruple
+.#{$action-set-block-class}.#{config.$prefix}--btn-set.#{$action-set-block-class}--row-quadruple
   .#{$action-set-block-class}__action-button:not(
     .#{$action-set-block-class}__action-button--ghost
   ) {
@@ -111,14 +112,14 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
   max-inline-size: to-rem(232px);
 }
 
-.#{$action-set-block-class}.#{c4p-settings.$carbon-prefix}--btn-set.#{$action-set-block-class}--row-quadruple
+.#{$action-set-block-class}.#{config.$prefix}--btn-set.#{$action-set-block-class}--row-quadruple
   .#{$action-set-block-class}__action-button--ghost {
   flex: 1 1 25%;
 }
 
 .#{$action-set-block-class}
   .#{$action-set-block-class}__action-button
-  .#{c4p-settings.$carbon-prefix}--inline-loading {
+  .#{config.$prefix}--inline-loading {
   position: absolute;
   inline-size: $spacing-07;
   inset-block-start: 0;

--- a/packages/ibm-products-styles/src/components/AddSelect/_add-select.scss
+++ b/packages/ibm-products-styles/src/components/AddSelect/_add-select.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2022, 2022
+// Copyright IBM Corp. 2022, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -10,6 +10,7 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/type';
 @use '@carbon/type/scss/font-family' as *;
+@use '@carbon/styles/scss/config';
 
 // Standard imports.
 @use '../../global/styles/project-settings' as *;
@@ -60,7 +61,7 @@ $tearsheet-class: #{$pkg-prefix}--tearsheet;
     justify-content: center;
   }
 
-  &-dropdown .cds--dropdown {
+  &-dropdown .#{config.$prefix}--dropdown {
     background: transparent;
   }
 
@@ -120,8 +121,8 @@ $tearsheet-class: #{$pkg-prefix}--tearsheet;
     color: $interactive;
   }
 
-  button.#{$block-class}__selections-view-children.#{$carbon-prefix}--btn--ghost.#{$carbon-prefix}--btn--icon-only
-    .#{$carbon-prefix}--btn__icon
+  button.#{$block-class}__selections-view-children.#{config.$prefix}--btn--ghost.#{config.$prefix}--btn--icon-only
+    .#{config.$prefix}--btn__icon
     path {
     fill: currentColor;
   }
@@ -260,7 +261,7 @@ $tearsheet-class: #{$pkg-prefix}--tearsheet;
     display: flex;
   }
 
-  .#{$carbon-prefix}--overflow-menu {
+  .#{config.$prefix}--overflow-menu {
     border-block-end: 1px solid $border-strong-01;
   }
 }
@@ -359,11 +360,11 @@ button.#{$block-class}__global-filter-toggle {
 
 // overrides
 
-.#{$block-class}__selections .#{$carbon-prefix}--list-box__menu {
+.#{$block-class}__selections .#{config.$prefix}--list-box__menu {
   inset-inline-start: auto;
 }
 
-.#{$block-class}__tags .#{$carbon-prefix}--tag {
+.#{$block-class}__tags .#{config.$prefix}--tag {
   margin: 0;
 }
 
@@ -375,7 +376,7 @@ button.#{$block-class}__global-filter-toggle {
 
 .#{$block-class}.#{$tearsheet-class}.#{$tearsheet-class}--wide
   .#{$tearsheet-class}__content
-  .cds--dropdown {
+  .#{config.$prefix}--dropdown {
   background-color: transparent;
 }
 
@@ -389,7 +390,7 @@ button.#{$block-class}__global-filter-toggle {
 }
 
 .#{$block-class}.#{$block-class}__multi
-  .#{$pkg-prefix}--action-set.#{$carbon-prefix}--btn-set.#{$pkg-prefix}--action-set--max
+  .#{$pkg-prefix}--action-set.#{config.$prefix}--btn-set.#{$pkg-prefix}--action-set--max
   .#{$pkg-prefix}--action-set__action-button {
   max-inline-size: 11.25rem;
 }
@@ -399,27 +400,27 @@ button.#{$block-class}__global-filter-toggle {
 }
 
 .#{$block-class}
-  .#{$carbon-prefix}--modal-container--sm
-  .#{$carbon-prefix}--modal-content
+  .#{config.$prefix}--modal-container--sm
+  .#{config.$prefix}--modal-content
   p {
   padding-inline-end: 0;
 }
 
-.#{$block-class} .#{$carbon-prefix}--radio-button__appearance {
+.#{$block-class} .#{config.$prefix}--radio-button__appearance {
   margin: 0 $spacing-05 0 0;
 }
 
 .#{$block-class}
-  .#{$carbon-prefix}--radio-button-wrapper
-  .#{$carbon-prefix}--radio-button__label {
+  .#{config.$prefix}--radio-button-wrapper
+  .#{config.$prefix}--radio-button__label {
   justify-content: left;
 }
 
-.#{$block-class} .#{$carbon-prefix}--breadcrumb .#{$carbon-prefix}--link {
+.#{$block-class} .#{config.$prefix}--breadcrumb .#{config.$prefix}--link {
   cursor: pointer;
 }
 
-.#{$block-class} .#{$carbon-prefix}--accordion__item {
+.#{$block-class} .#{config.$prefix}--accordion__item {
   &:hover .#{$block-class}__sidebar-accordion-title button {
     opacity: 1;
   }
@@ -434,36 +435,36 @@ button.#{$block-class}__global-filter-toggle {
   max-inline-size: 16rem;
 }
 
-.#{$block-class} .#{$carbon-prefix}--accordion__arrow {
+.#{$block-class} .#{config.$prefix}--accordion__arrow {
   transform: rotate(0deg);
 }
 
 .#{$block-class}
-  .#{$carbon-prefix}--accordion__item--active
-  .#{$carbon-prefix}--accordion__arrow {
+  .#{config.$prefix}--accordion__item--active
+  .#{config.$prefix}--accordion__arrow {
   transform: rotate(90deg);
 }
 
 .#{$block-class}
-  .#{$carbon-prefix}--accordion--start
-  .#{$carbon-prefix}--accordion__arrow {
+  .#{config.$prefix}--accordion--start
+  .#{config.$prefix}--accordion__arrow {
   margin: 0 0 0 $spacing-05;
 }
 
 .#{$block-class}
-  .#{$carbon-prefix}--accordion--start
-  .#{$carbon-prefix}--accordion__title {
+  .#{config.$prefix}--accordion--start
+  .#{config.$prefix}--accordion__title {
   margin: 0 $spacing-05 0 $spacing-03;
 }
 
 .#{$block-class}
-  .#{$carbon-prefix}--accordion__item--active
-  .#{$carbon-prefix}--accordion__content {
+  .#{config.$prefix}--accordion__item--active
+  .#{config.$prefix}--accordion__content {
   margin-block-start: $spacing-03;
   padding-block: 0;
 }
 
-.#{$block-class} + div .#{$carbon-prefix}--tooltip,
-.#{$block-class} + div .#{$carbon-prefix}--overflow-menu-options {
+.#{$block-class} + div .#{config.$prefix}--tooltip,
+.#{$block-class} + div .#{config.$prefix}--overflow-menu-options {
   z-index: 9000;
 }

--- a/packages/ibm-products-styles/src/components/BreadcrumbWithOverflow/_breadcrumb-with-overflow.scss
+++ b/packages/ibm-products-styles/src/components/BreadcrumbWithOverflow/_breadcrumb-with-overflow.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2023
+// Copyright IBM Corp. 2020, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -9,6 +9,8 @@
 @use '@carbon/styles/scss/breakpoint' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/utilities';
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as c4p-settings;
 @use '../../global/styles/mixins' as *;
 
@@ -31,8 +33,7 @@ $_block-class: #{c4p-settings.$pkg-prefix}--breadcrumb-with-overflow;
     inline-size: 100%;
   }
 
-  .#{$_block-class}__breadcrumb-container
-    .#{c4p-settings.$carbon-prefix}--breadcrumb {
+  .#{$_block-class}__breadcrumb-container .#{config.$prefix}--breadcrumb {
     flex-wrap: nowrap;
     align-items: flex-start;
     inline-size: 100%;
@@ -47,22 +48,22 @@ $_block-class: #{c4p-settings.$pkg-prefix}--breadcrumb-with-overflow;
     display: none;
   }
 
-  .#{$_block-class}__back__button.#{c4p-settings.$carbon-prefix}--btn {
+  .#{$_block-class}__back__button.#{config.$prefix}--btn {
     padding: 0;
     min-block-size: revert;
   }
 
-  .#{$_block-class}__back__button.#{c4p-settings.$carbon-prefix}--btn--ghost:hover {
+  .#{$_block-class}__back__button.#{config.$prefix}--btn--ghost:hover {
     background-color: inherit;
   }
 
   @include breakpoint-down(md) {
-    .#{c4p-settings.$carbon-prefix}--breadcrumb-item {
+    .#{config.$prefix}--breadcrumb-item {
       display: none;
     }
 
     .#{$_block-class}__breadcrumb-back,
-    .#{c4p-settings.$carbon-prefix}--breadcrumb-item:last-child {
+    .#{config.$prefix}--breadcrumb-item:last-child {
       display: inline-flex;
       vertical-align: middle;
     }
@@ -74,7 +75,7 @@ $_block-class: #{c4p-settings.$pkg-prefix}--breadcrumb-with-overflow;
     }
   }
 
-  .#{c4p-settings.$carbon-prefix}--breadcrumb-item:last-child {
+  .#{config.$prefix}--breadcrumb-item:last-child {
     display: inline-flex; // flex instead of block due to spacing
   }
 
@@ -82,8 +83,7 @@ $_block-class: #{c4p-settings.$pkg-prefix}--breadcrumb-with-overflow;
     display: inline-flex; // flex instead of block due to spacing
   }
 
-  .#{$_block-class}__displayed-breadcrumb:last-child
-    .#{c4p-settings.$carbon-prefix}--link {
+  .#{$_block-class}__displayed-breadcrumb:last-child .#{config.$prefix}--link {
     display: inline-block;
     overflow: hidden;
     inline-size: 100%;

--- a/packages/ibm-products-styles/src/components/ButtonMenu/_button-menu.scss
+++ b/packages/ibm-products-styles/src/components/ButtonMenu/_button-menu.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2023
+// Copyright IBM Corp. 2021, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -8,9 +8,11 @@
 // Standard imports.
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/components/button/tokens' as *;
-@use '../../global/styles/project-settings' as c4p-settings;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config';
+
+@use '../../global/styles/project-settings' as c4p-settings;
 
 // TODO: @use(s) of Carbon settings and component styles and other
 // related component styles used by ButtonMenu
@@ -21,26 +23,26 @@ $block-class: #{c4p-settings.$pkg-prefix}--button-menu;
 .#{$block-class} {
   min-inline-size: 160px;
   &.#{$block-class}__wrapper--primary,
-  &.#{$block-class}__wrapper--primary.#{c4p-settings.$carbon-prefix}--overflow-menu.#{c4p-settings.$carbon-prefix}--overflow-menu--open {
+  &.#{$block-class}__wrapper--primary.#{config.$prefix}--overflow-menu.#{config.$prefix}--overflow-menu--open {
     background-color: $button-primary;
   }
-  &.#{c4p-settings.$carbon-prefix}--overflow-menu.#{$block-class}__wrapper--primary:hover {
+  &.#{config.$prefix}--overflow-menu.#{$block-class}__wrapper--primary:hover {
     background-color: $button-primary-hover;
   }
 
   &.#{$block-class}__wrapper--tertiary,
-  &.#{$block-class}__wrapper--tertiary.#{c4p-settings.$carbon-prefix}--overflow-menu.#{c4p-settings.$carbon-prefix}--overflow-menu--open {
+  &.#{$block-class}__wrapper--tertiary.#{config.$prefix}--overflow-menu.#{config.$prefix}--overflow-menu--open {
     background-color: $button-tertiary;
   }
-  &.#{c4p-settings.$carbon-prefix}--overflow-menu.#{$block-class}__wrapper--tertiary:hover {
+  &.#{config.$prefix}--overflow-menu.#{$block-class}__wrapper--tertiary:hover {
     background-color: $button-tertiary-hover;
   }
 
   &.#{$block-class}__wrapper--ghost,
-  &.#{$block-class}__wrapper--ghost.#{c4p-settings.$carbon-prefix}--overflow-menu.#{c4p-settings.$carbon-prefix}--overflow-menu--open {
+  &.#{$block-class}__wrapper--ghost.#{config.$prefix}--overflow-menu.#{config.$prefix}--overflow-menu--open {
     background-color: transparent;
   }
-  &.#{c4p-settings.$carbon-prefix}--overflow-menu.#{$block-class}__wrapper--ghost:hover {
+  &.#{config.$prefix}--overflow-menu.#{$block-class}__wrapper--ghost:hover {
     background-color: $layer-hover;
   }
 
@@ -55,6 +57,6 @@ $block-class: #{c4p-settings.$pkg-prefix}--button-menu;
   }
 }
 
-.#{$block-class}__options.#{c4p-settings.$carbon-prefix}--overflow-menu-options::after {
+.#{$block-class}__options.#{config.$prefix}--overflow-menu-options::after {
   content: initial;
 }

--- a/packages/ibm-products-styles/src/components/Card/_card.scss
+++ b/packages/ibm-products-styles/src/components/Card/_card.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2022
+// Copyright IBM Corp. 2020, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -12,8 +12,10 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/type' as *;
 @use '@carbon/styles/scss/motion' as *;
-@use '../../global/styles/project-settings' as c4p-settings;
 @use '@carbon/styles/scss/utilities';
+@use '@carbon/styles/scss/config';
+
+@use '../../global/styles/project-settings' as c4p-settings;
 
 $block-class: #{c4p-settings.$pkg-prefix}--card;
 
@@ -144,8 +146,8 @@ $block-class: #{c4p-settings.$pkg-prefix}--card;
   position: relative;
 }
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--slug,
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--ai-label {
+.#{$block-class} .#{config.$prefix}--slug,
+.#{$block-class} .#{config.$prefix}--ai-label {
   position: absolute;
   inset-block-start: $spacing-05;
   inset-inline-end: $spacing-05;
@@ -156,8 +158,8 @@ $block-class: #{c4p-settings.$pkg-prefix}--card;
   inset-block-start: $spacing-05;
   inset-inline-end: $spacing-05;
 
-  .#{c4p-settings.$carbon-prefix}--slug,
-  .#{c4p-settings.$carbon-prefix}--ai-label {
+  .#{config.$prefix}--slug,
+  .#{config.$prefix}--ai-label {
     position: relative;
     inset-block-start: unset;
     inset-inline-end: unset;
@@ -184,8 +186,8 @@ $block-class: #{c4p-settings.$pkg-prefix}--card;
   position: relative;
 }
 
-.#{$block-class}__clickable .#{c4p-settings.$carbon-prefix}--slug,
-.#{$block-class}__clickable .#{c4p-settings.$carbon-prefix}--slug-icon {
+.#{$block-class}__clickable .#{config.$prefix}--slug,
+.#{$block-class}__clickable .#{config.$prefix}--slug-icon {
   pointer-events: none;
 }
 
@@ -225,11 +227,11 @@ $block-class: #{c4p-settings.$pkg-prefix}--card;
   z-index: 1;
 }
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--slug-icon rect {
+.#{$block-class} .#{config.$prefix}--slug-icon rect {
   stroke: $icon-primary;
 }
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--slug-icon path {
+.#{$block-class} .#{config.$prefix}--slug-icon path {
   fill: $icon-primary;
 }
 

--- a/packages/ibm-products-styles/src/components/Checklist/_checklist.scss
+++ b/packages/ibm-products-styles/src/components/Checklist/_checklist.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2023, 2023
+// Copyright IBM Corp. 2023, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -11,6 +11,8 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/type' as *;
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as c4p-settings;
 
 @mixin ellipsis-2-lines {
@@ -80,7 +82,7 @@ $block-class: #{c4p-settings.$pkg-prefix}--checklist;
 // The <IconButton> itself (class="...__toggle") is embedded inside two more tags,
 // which do not accept any class names passed via the <IconButton>.
 // So, we have to refer to it via it's "tooltip" wrapper element. :/
-.#{$block-class}__header .#{c4p-settings.$carbon-prefix}--tooltip {
+.#{$block-class}__header .#{config.$prefix}--tooltip {
   block-size: 2rem;
   margin-block-start: calc(-1 * $spacing-03);
   margin-inline: auto calc(-1 * $spacing-03);
@@ -104,7 +106,7 @@ $block-class: #{c4p-settings.$pkg-prefix}--checklist;
 // Button to appear more like a link so it aligns better with the list text.
 // Override Primary button styling to appear more like a link.
 // "Unset" some settings to allow an inner div to enable multiple lines and an ellipsis if req'd.
-.#{$block-class}__button.#{c4p-settings.$carbon-prefix}--btn--primary {
+.#{$block-class}__button.#{config.$prefix}--btn--primary {
   @include type-style('body-short-01');
   // override bx--btn to allow two-line ellipsis
   /* stylelint-disable-next-line declaration-property-value-disallowed-list */
@@ -119,17 +121,17 @@ $block-class: #{c4p-settings.$pkg-prefix}--checklist;
 }
 // The CSS for the Carbon button's label is incompatible with two-line ellipsis,
 // but a div inside a Carbon button works.
-.#{$block-class}__button.#{c4p-settings.$carbon-prefix}--btn--primary div {
+.#{$block-class}__button.#{config.$prefix}--btn--primary div {
   @include ellipsis-2-lines();
 }
 
-.#{$block-class}__button.#{c4p-settings.$carbon-prefix}--btn--primary:hover {
+.#{$block-class}__button.#{config.$prefix}--btn--primary:hover {
   background: transparent;
   color: $link-primary-hover;
   text-decoration: underline;
 }
 
-.#{$block-class}__button.#{c4p-settings.$carbon-prefix}--btn--primary:active {
+.#{$block-class}__button.#{config.$prefix}--btn--primary:active {
   background: transparent;
   color: $text-primary;
   text-decoration: underline;

--- a/packages/ibm-products-styles/src/components/Coachmark/_coachmark-overlay.scss
+++ b/packages/ibm-products-styles/src/components/Coachmark/_coachmark-overlay.scss
@@ -1,7 +1,7 @@
 /* stylelint-disable function-no-unknown */
 /* stylelint-disable max-nesting-depth */
 //
-// Copyright IBM Corp. 2023, 2024
+// Copyright IBM Corp. 2023, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -13,14 +13,16 @@
 
 // Standard imports.
 @use '@carbon/layout/scss/convert' as *;
-@use '../../global/styles/project-settings' as c4p-settings;
-@use '../../global/styles/mixins';
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/colors' as *;
 @use '@carbon/styles/scss/components/button/tokens' as *;
 @use '@carbon/styles/scss/motion' as *;
+@use '@carbon/styles/scss/config';
+
+@use '../../global/styles/project-settings' as c4p-settings;
+@use '../../global/styles/mixins';
 // Define all component styles in a mixin which is then exported using
 // the Carbon import-once mechanism.
 
@@ -145,7 +147,7 @@ $draghandle-btn-class: #{$block-class}__handle;
 
   // BODY
   &__body {
-    .#{c4p-settings.$carbon-prefix}--btn--ghost {
+    .#{config.$prefix}--btn--ghost {
       color: $link-inverse;
 
       &:hover {
@@ -241,7 +243,7 @@ $draghandle-btn-class: #{$block-class}__handle;
   // THEME
   &__light {
     .#{$block-class}__body {
-      .#{c4p-settings.$carbon-prefix}--link {
+      .#{config.$prefix}--link {
         color: $link-inverse;
 
         &:hover {
@@ -257,7 +259,7 @@ $draghandle-btn-class: #{$block-class}__handle;
         }
       }
 
-      .#{c4p-settings.$carbon-prefix}--btn--ghost {
+      .#{config.$prefix}--btn--ghost {
         border-color: transparent !important;
         border-radius: 0;
         outline: 1px solid transparent;
@@ -304,7 +306,7 @@ $draghandle-btn-class: #{$block-class}__handle;
 
   &__dark {
     .#{$block-class}__body {
-      .#{c4p-settings.$carbon-prefix}--link {
+      .#{config.$prefix}--link {
         color: #0062fe;
 
         &:hover {
@@ -321,7 +323,7 @@ $draghandle-btn-class: #{$block-class}__handle;
         }
       }
 
-      .#{c4p-settings.$carbon-prefix}--btn--primary {
+      .#{config.$prefix}--btn--primary {
         &:focus {
           background-color: $button-primary-active;
           box-shadow:
@@ -330,7 +332,7 @@ $draghandle-btn-class: #{$block-class}__handle;
         }
       }
 
-      .#{c4p-settings.$carbon-prefix}--btn--ghost {
+      .#{config.$prefix}--btn--ghost {
         border-color: transparent;
 
         &:hover {

--- a/packages/ibm-products-styles/src/components/CoachmarkStack/_coachmark-stack.scss
+++ b/packages/ibm-products-styles/src/components/CoachmarkStack/_coachmark-stack.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2023, 2024
+// Copyright IBM Corp. 2023, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -8,14 +8,16 @@
 /* stylelint-disable max-nesting-depth */
 
 // Standard imports.
-@use '../../global/styles/project-settings' as c4p-settings;
-@use '../../global/styles/mixins';
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/motion' as *;
 @use '@carbon/styles/scss/colors' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/layout/scss/convert';
 @use '@carbon/styles/scss/components/button/tokens' as *;
+@use '@carbon/styles/scss/config';
+
+@use '../../global/styles/project-settings' as c4p-settings;
+@use '../../global/styles/mixins';
 // Other Carbon settings if needed
 // TODO: @use '@carbon/styles/scss/grid';
 // or
@@ -105,7 +107,7 @@ $stack-home-class: #{c4p-settings.$pkg-prefix}--coachmark-stacked-home;
   &__navLinkLabels-tooltip {
     max-inline-size: 100%;
 
-    .#{c4p-settings.$carbon-prefix}--tooltip-content {
+    .#{config.$prefix}--tooltip-content {
       color: $text-primary;
       margin-inline-start: calc($spacing-02 + $spacing-01);
       max-inline-size: 100%;

--- a/packages/ibm-products-styles/src/components/ComboButton/_combo-button.scss
+++ b/packages/ibm-products-styles/src/components/ComboButton/_combo-button.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2024
+// Copyright IBM Corp. 2020, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -8,6 +8,8 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/components/button/tokens' as *;
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as c4p-settings;
 
 .#{c4p-settings.$pkg-prefix}--combo-button {
@@ -35,23 +37,23 @@
 }
 
 .#{c4p-settings.$pkg-prefix}--combo-button
-  .#{c4p-settings.$pkg-prefix}--combo-button__overflow-menu.#{c4p-settings.$carbon-prefix}--overflow-menu:hover,
+  .#{c4p-settings.$pkg-prefix}--combo-button__overflow-menu.#{config.$prefix}--overflow-menu:hover,
 .#{c4p-settings.$pkg-prefix}--combo-button
-  .#{c4p-settings.$pkg-prefix}--combo-button__overflow-menu.#{c4p-settings.$carbon-prefix}--overflow-menu--open,
+  .#{c4p-settings.$pkg-prefix}--combo-button__overflow-menu.#{config.$prefix}--overflow-menu--open,
 .#{c4p-settings.$pkg-prefix}--combo-button
-  .#{c4p-settings.$carbon-prefix}--overflow-menu.#{c4p-settings.$carbon-prefix}--overflow-menu--open:hover,
+  .#{config.$prefix}--overflow-menu.#{config.$prefix}--overflow-menu--open:hover,
 .#{c4p-settings.$pkg-prefix}--combo-button
-  .#{c4p-settings.$carbon-prefix}--overflow-menu.#{c4p-settings.$carbon-prefix}--overflow-menu--open {
+  .#{config.$prefix}--overflow-menu.#{config.$prefix}--overflow-menu--open {
   background-color: $button-primary-hover;
 }
 
 .#{c4p-settings.$pkg-prefix}--combo-button
-  .cds--overflow-menu--flip.cds--overflow-menu-options[data-floating-menu-direction='bottom']::after {
+  .#{config.$prefix}--overflow-menu--flip.#{config.$prefix}--overflow-menu-options[data-floating-menu-direction='bottom']::after {
   block-size: 0;
   inline-size: 0;
 }
 
-.#{c4p-settings.$pkg-prefix}--combo-button__overflow-menu.#{c4p-settings.$carbon-prefix}--overflow-menu:active {
+.#{c4p-settings.$pkg-prefix}--combo-button__overflow-menu.#{config.$prefix}--overflow-menu:active {
   background-color: $button-primary-active;
 }
 
@@ -60,7 +62,7 @@
   pointer-events: none;
 }
 
-.#{c4p-settings.$pkg-prefix}--combo-button__overflow-menu__list.#{c4p-settings.$carbon-prefix}--overflow-menu-options {
+.#{c4p-settings.$pkg-prefix}--combo-button__overflow-menu__list.#{config.$prefix}--overflow-menu-options {
   inline-size: 100%;
   inset-inline-start: 0;
 }
@@ -69,7 +71,7 @@
   display: none;
 }
 
-.#{c4p-settings.$pkg-prefix}--combo-button__overflow-menu__item.#{c4p-settings.$carbon-prefix}--overflow-menu-options__btn {
+.#{c4p-settings.$pkg-prefix}--combo-button__overflow-menu__item.#{config.$prefix}--overflow-menu-options__btn {
   max-inline-size: 100%;
 }
 

--- a/packages/ibm-products-styles/src/components/CreateFullPage/_create-full-page.scss
+++ b/packages/ibm-products-styles/src/components/CreateFullPage/_create-full-page.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2023
+// Copyright IBM Corp. 2021, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -9,6 +9,8 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as c4p-settings;
 
 // CreateFullPage uses the following IBM Products components:
@@ -32,9 +34,7 @@ $step-block-class: #{c4p-settings.$pkg-prefix}--create-full-page__step;
   }
 }
 
-.#{$block-class}
-  .#{$block-class}__content
-  .#{c4p-settings.$carbon-prefix}--grid {
+.#{$block-class} .#{$block-class}__content .#{config.$prefix}--grid {
   margin-inline: 0;
   padding-block-start: $spacing-06;
 }
@@ -59,7 +59,7 @@ $step-block-class: #{c4p-settings.$pkg-prefix}--create-full-page__step;
   margin-block-end: $spacing-06;
 }
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--fieldset {
+.#{$block-class} .#{config.$prefix}--fieldset {
   margin-block-end: 0;
 }
 
@@ -67,7 +67,7 @@ $step-block-class: #{c4p-settings.$pkg-prefix}--create-full-page__step;
   margin-block-end: $spacing-05;
 }
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--modal-close {
+.#{$block-class} .#{config.$prefix}--modal-close {
   display: none;
 }
 
@@ -119,11 +119,11 @@ $step-block-class: #{c4p-settings.$pkg-prefix}--create-full-page__step;
   padding-block-end: $spacing-07;
 }
 
-.#{$block-class}__step .#{c4p-settings.$carbon-prefix}--css-grid {
+.#{$block-class}__step .#{config.$prefix}--css-grid {
   margin-inline-start: 0;
 }
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--side-nav--ux {
+.#{$block-class} .#{config.$prefix}--side-nav--ux {
   background-color: transparent;
   block-size: min-content;
   border-inline-end: 1px solid $border-subtle-01;
@@ -173,7 +173,7 @@ $step-block-class: #{c4p-settings.$pkg-prefix}--create-full-page__step;
 }
 
 .#{$block-class}
-  .#{$block-class}__progress-indicator.#{c4p-settings.$carbon-prefix}--progress {
+  .#{$block-class}__progress-indicator.#{config.$prefix}--progress {
   padding: $spacing-06;
 }
 

--- a/packages/ibm-products-styles/src/components/CreateModal/_create-modal.scss
+++ b/packages/ibm-products-styles/src/components/CreateModal/_create-modal.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2021
+// Copyright IBM Corp. 2021, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -10,15 +10,15 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/breakpoint' as *;
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as c4p-settings;
 
-.#{c4p-settings.$pkg-prefix}--create-modal
-  .#{c4p-settings.$carbon-prefix}--modal-close {
+.#{c4p-settings.$pkg-prefix}--create-modal .#{config.$prefix}--modal-close {
   display: none;
 }
 
-.#{c4p-settings.$pkg-prefix}--create-modal
-  .#{c4p-settings.$carbon-prefix}--modal-container {
+.#{c4p-settings.$pkg-prefix}--create-modal .#{config.$prefix}--modal-container {
   @include breakpoint(md) {
     max-block-size: 95%;
   }
@@ -27,8 +27,7 @@
   }
 }
 
-.#{c4p-settings.$pkg-prefix}--create-modal
-  .#{c4p-settings.$carbon-prefix}--modal-header {
+.#{c4p-settings.$pkg-prefix}--create-modal .#{config.$prefix}--modal-header {
   border-block-end: 1px solid $layer-accent-01;
   margin-block-end: 0;
   padding-block-end: $spacing-03;
@@ -36,8 +35,8 @@
 }
 
 .#{c4p-settings.$pkg-prefix}--create-modal
-  .#{c4p-settings.$carbon-prefix}--modal-footer
-  .#{c4p-settings.$carbon-prefix}--btn {
+  .#{config.$prefix}--modal-footer
+  .#{config.$prefix}--btn {
   max-inline-size: none;
 }
 
@@ -62,8 +61,7 @@
   padding-inline-end: calc(20% - #{$spacing-05});
 }
 
-.#{c4p-settings.$pkg-prefix}--create-modal__form
-  .#{c4p-settings.$carbon-prefix}--fieldset {
+.#{c4p-settings.$pkg-prefix}--create-modal__form .#{config.$prefix}--fieldset {
   margin-block-end: 0;
   min-inline-size: 100%;
 }

--- a/packages/ibm-products-styles/src/components/CreateSidePanel/_create-side-panel.scss
+++ b/packages/ibm-products-styles/src/components/CreateSidePanel/_create-side-panel.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2021
+// Copyright IBM Corp. 2021, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -9,6 +9,8 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as c4p-settings;
 @use '../SidePanel/side-panel-variables' as side-panel-vars;
 
@@ -24,11 +26,11 @@ $side-panel-block-class: #{c4p-settings.$pkg-prefix}--side-panel;
   padding-inline-end: calc(20% - #{$spacing-05});
 }
 
-.#{c4p-settings.$carbon-prefix}--form.#{$create-side-panel-block-class}__form {
+.#{config.$prefix}--form.#{$create-side-panel-block-class}__form {
   padding-block-start: $spacing-05;
 }
 
-.#{$create-side-panel-block-class}__form.#{c4p-settings.$carbon-prefix}--fieldset {
+.#{$create-side-panel-block-class}__form.#{config.$prefix}--fieldset {
   padding-block-start: $spacing-03;
 }
 
@@ -47,7 +49,7 @@ $side-panel-block-class: #{c4p-settings.$pkg-prefix}--side-panel;
 }
 
 .#{$create-side-panel-block-class}.#{$side-panel-block-class}
-  .#{c4p-settings.$carbon-prefix}--btn.#{$side-panel-block-class}__close-button {
+  .#{config.$prefix}--btn.#{$side-panel-block-class}__close-button {
   display: none;
 }
 

--- a/packages/ibm-products-styles/src/components/CreateTearsheet/_create-tearsheet.scss
+++ b/packages/ibm-products-styles/src/components/CreateTearsheet/_create-tearsheet.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2023
+// Copyright IBM Corp. 2021, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -12,6 +12,7 @@
 @use '@carbon/styles/scss/motion' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config';
 
 // Standard imports.
 @use '../../global/styles/project-settings' as c4p-settings;
@@ -55,7 +56,7 @@ $tearsheet-fieldset-class: #{c4p-settings.$pkg-prefix}--tearsheet-create__step--
   --#{$create-tearsheet-block-class}--total-width: 0;
 }
 
-.#{$step-block-class} .#{c4p-settings.$carbon-prefix}--css-grid {
+.#{$step-block-class} .#{config.$prefix}--css-grid {
   margin-inline-start: 0;
 }
 
@@ -90,13 +91,13 @@ $tearsheet-fieldset-class: #{c4p-settings.$pkg-prefix}--tearsheet-create__step--
 
 .#{$create-tearsheet-block-class}
   .#{$create-tearsheet-block-class}__content
-  .#{c4p-settings.$carbon-prefix}--form {
+  .#{config.$prefix}--form {
   block-size: inherit;
 }
 
 .#{$create-tearsheet-block-class}
   .#{$create-tearsheet-block-class}__content
-  .#{c4p-settings.$carbon-prefix}--grid {
+  .#{config.$prefix}--grid {
   padding: 0;
   margin: 0;
 }
@@ -107,13 +108,12 @@ $tearsheet-fieldset-class: #{c4p-settings.$pkg-prefix}--tearsheet-create__step--
 }
 
 .#{$create-tearsheet-block-class}
-  .#{c4p-settings.$carbon-prefix}--btn-set
-  .#{c4p-settings.$carbon-prefix}--btn.#{c4p-settings.$carbon-prefix}--btn--disabled {
+  .#{config.$prefix}--btn-set
+  .#{config.$prefix}--btn.#{config.$prefix}--btn--disabled {
   box-shadow: -0.0625rem 0 0 0 $button-separator;
 }
 
-.#{$create-tearsheet-block-class}
-  .#{c4p-settings.$carbon-prefix}--side-nav--ux {
+.#{$create-tearsheet-block-class} .#{config.$prefix}--side-nav--ux {
   position: initial;
   background-color: transparent;
 }
@@ -154,7 +154,7 @@ $tearsheet-fieldset-class: #{c4p-settings.$pkg-prefix}--tearsheet-create__step--
   margin-block-end: $spacing-06;
 }
 
-.#{$create-tearsheet-block-class} .#{c4p-settings.$carbon-prefix}--fieldset {
+.#{$create-tearsheet-block-class} .#{config.$prefix}--fieldset {
   margin-block-end: 0;
 }
 

--- a/packages/ibm-products-styles/src/components/CreateTearsheetNarrow/_create-tearsheet-narrow.scss
+++ b/packages/ibm-products-styles/src/components/CreateTearsheetNarrow/_create-tearsheet-narrow.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2021
+// Copyright IBM Corp. 2021, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -9,6 +9,8 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as c4p-settings;
 
 // CreateTearsheetNarrow uses the following IBM Products components:
@@ -18,8 +20,8 @@
 // The block part of our conventional BEM class names (blockClass__E--M).
 $block-class: #{c4p-settings.$pkg-prefix}--create-tearsheet-narrow;
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--modal-header__heading,
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--modal-header__label,
+.#{$block-class} .#{config.$prefix}--modal-header__heading,
+.#{$block-class} .#{config.$prefix}--modal-header__label,
 .#{$block-class} .#{c4p-settings.$pkg-prefix}--tearsheet__header-description {
   max-inline-size: 100%;
   padding-inline-end: calc(20% - #{$spacing-05});

--- a/packages/ibm-products-styles/src/components/Datagrid/_datagrid.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/_datagrid.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2022, 2023
+// Copyright IBM Corp. 2022, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -8,6 +8,8 @@
 // Standard imports.
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as c4p-settings;
 @use '../../global/styles/mixins';
 
@@ -33,15 +35,15 @@ $block-class: #{c4p-settings.$pkg-prefix}--datagrid;
   display: block;
   inline-size: 100%;
 
-  :global(.#{c4p-settings.$carbon-prefix}--checkbox) {
+  :global(.#{config.$prefix}--checkbox) {
     display: none;
   }
 }
 
 .#{$block-class}
   .#{c4p-settings.$pkg-prefix}--datagrid__row-size-options-container
-  .#{c4p-settings.$carbon-prefix}--popover-container
-  .#{c4p-settings.$carbon-prefix}--btn--icon-only {
+  .#{config.$prefix}--popover-container
+  .#{config.$prefix}--btn--icon-only {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -65,7 +67,7 @@ $block-class: #{c4p-settings.$pkg-prefix}--datagrid;
 
   /* stylelint-disable-next-line */
   :global {
-    .#{c4p-settings.$carbon-prefix}--pagination {
+    .#{config.$prefix}--pagination {
       // newer version of carbon pagination has scroll which doesn't make any sense, removing it
       /* stylelint-disable-next-line declaration-property-value-disallowed-list */
       overflow-x: unset;
@@ -79,8 +81,6 @@ $block-class: #{c4p-settings.$pkg-prefix}--datagrid;
 
 // firefox fix for issue mentioned in 3442
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--menu-button__trigger:not(
-    .#{c4p-settings.$carbon-prefix}--btn--ghost
-  ) {
+  .#{config.$prefix}--menu-button__trigger:not(.#{config.$prefix}--btn--ghost) {
   min-inline-size: auto;
 }

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_datagrid.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2024
+// Copyright IBM Corp. 2020, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -10,8 +10,10 @@
 @use '@carbon/layout/scss/convert' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/components/button/tokens' as *;
-@use '../../../global/styles/project-settings' as c4p-settings;
 @use '@carbon/styles/scss/breakpoint';
+@use '@carbon/styles/scss/config';
+
+@use '../../../global/styles/project-settings' as c4p-settings;
 @use './variables' as *;
 
 .#{$block-class}__table-toolbar > section {
@@ -35,7 +37,7 @@
 
   &.#{$block-class}__vertical-align-center {
     .#{$block-class}__head {
-      .#{c4p-settings.$carbon-prefix}--table-header-label {
+      .#{config.$prefix}--table-header-label {
         display: flex;
         align-items: center;
         block-size: 100%;
@@ -54,8 +56,8 @@
       padding-block: 0;
     }
 
-    td.#{c4p-settings.$carbon-prefix}--table-column-checkbox,
-    th.#{c4p-settings.$carbon-prefix}--table-column-checkbox {
+    td.#{config.$prefix}--table-column-checkbox,
+    th.#{config.$prefix}--table-column-checkbox {
       /* stylelint-disable-next-line carbon/layout-use */
       padding-block-start: 0.6875rem;
 
@@ -72,7 +74,7 @@
     }
 
     .#{$block-class}__checkbox-cell {
-      th.#{c4p-settings.$carbon-prefix}--table-column-checkbox {
+      th.#{config.$prefix}--table-column-checkbox {
         display: flex;
         align-items: center;
         block-size: 100%;
@@ -81,22 +83,22 @@
     }
 
     &.#{$block-class}__variable-row-height {
-      &.#{c4p-settings.$carbon-prefix}--data-table--xs {
+      &.#{config.$prefix}--data-table--xs {
         .#{$block-class}__cell {
           padding-block: $spacing-01;
         }
       }
 
-      &.#{c4p-settings.$carbon-prefix}--data-table--sm,
-      &.#{c4p-settings.$carbon-prefix}--data-table--md {
+      &.#{config.$prefix}--data-table--sm,
+      &.#{config.$prefix}--data-table--md {
         .#{$block-class}__cell {
           /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
           padding-block: to-rem(7px) to-rem(6px);
         }
       }
 
-      &.#{c4p-settings.$carbon-prefix}--data-table--lg,
-      &.#{c4p-settings.$carbon-prefix}--data-table--xl {
+      &.#{config.$prefix}--data-table--lg,
+      &.#{config.$prefix}--data-table--xl {
         .#{$block-class}__cell {
           padding-block: $spacing-05;
         }
@@ -105,30 +107,30 @@
   }
 
   &.#{$block-class}__vertical-align-top {
-    &.#{c4p-settings.$carbon-prefix}--data-table--lg,
-    &.#{c4p-settings.$carbon-prefix}--data-table--xl {
+    &.#{config.$prefix}--data-table--lg,
+    &.#{config.$prefix}--data-table--xl {
       .#{$block-class}__cell {
         padding-block-start: $spacing-05;
       }
 
-      .#{c4p-settings.$carbon-prefix}--table-header-label {
+      .#{config.$prefix}--table-header-label {
         padding-block-start: $spacing-05;
       }
 
-      .#{c4p-settings.$carbon-prefix}--table-column-checkbox {
+      .#{config.$prefix}--table-column-checkbox {
         /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
         padding-block-start: to-rem(13px);
       }
     }
 
     &.#{$block-class}__variable-row-height {
-      &.#{c4p-settings.$carbon-prefix}--data-table--lg,
-      &.#{c4p-settings.$carbon-prefix}--data-table--xl {
+      &.#{config.$prefix}--data-table--lg,
+      &.#{config.$prefix}--data-table--xl {
         .#{$block-class}__cell {
           padding-block-end: $spacing-05;
         }
 
-        .#{c4p-settings.$carbon-prefix}--table-header-label {
+        .#{config.$prefix}--table-header-label {
           padding-block-end: $spacing-05;
         }
       }
@@ -162,11 +164,11 @@
 }
 
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
   tr.#{$block-class}__slug--row,
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
   tr.#{$block-class}__slug--row
   + .#{$block-class}__expanded-row {
@@ -176,7 +178,7 @@
 }
 
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
   tr.#{$block-class}__slug--row {
   /* stylelint-disable-next-line carbon/theme-use */
@@ -184,27 +186,27 @@
 }
 
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
   tr.#{$block-class}__slug--row:hover,
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
-  tr.#{$block-class}__slug--row.#{c4p-settings.$carbon-prefix}--data-table--selected:hover,
+  tr.#{$block-class}__slug--row.#{config.$prefix}--data-table--selected:hover,
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
   tr.#{$block-class}__slug--row.#{$block-class}__carbon-row-expanded:hover
   + .#{$block-class}__expanded-row,
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
   tr.#{$block-class}__expandable-row--hover.#{$block-class}__slug--row {
   @include ai-table-gradient('hover');
 }
 
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
   tr.#{$block-class}__expandable-row--hover.#{$block-class}__slug--row
   td {
@@ -212,15 +214,13 @@
 }
 
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
-  tr.#{$block-class}__slug--row.#{c4p-settings.$carbon-prefix}--data-table--selected {
+  tr.#{$block-class}__slug--row.#{config.$prefix}--data-table--selected {
   @include ai-table-gradient('selected');
 }
 
-.#{$block-class}
-  th.#{$block-class}__with-slug
-  .#{c4p-settings.$carbon-prefix}--slug {
+.#{$block-class} th.#{$block-class}__with-slug .#{config.$prefix}--slug {
   margin-inline-start: $spacing-03;
 }
 /* This section to be removed after support for slug dropped  - end */
@@ -235,11 +235,11 @@
 }
 
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
   tr.#{$block-class}__ai-label--row,
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
   tr.#{$block-class}__ai-label--row
   + .#{$block-class}__expanded-row {
@@ -249,34 +249,34 @@
 }
 
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
   tr.#{$block-class}__ai-label--row {
   box-shadow: inset 1px 0 $ai-border-strong;
 }
 
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
   tr.#{$block-class}__ai-label--row:hover,
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
-  tr.#{$block-class}__ai-label--row.#{c4p-settings.$carbon-prefix}--data-table--selected:hover,
+  tr.#{$block-class}__ai-label--row.#{config.$prefix}--data-table--selected:hover,
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
   tr.#{$block-class}__ai-label--row.#{$block-class}__carbon-row-expanded:hover
   + .#{$block-class}__expanded-row,
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
   tr.#{$block-class}__expandable-row--hover.#{$block-class}__ai-label--row {
   @include ai-table-gradient('hover');
 }
 
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
   tr.#{$block-class}__expandable-row--hover.#{$block-class}__ai-label--row
   td {
@@ -284,15 +284,13 @@
 }
 
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
-  tr.#{$block-class}__ai-label--row.#{c4p-settings.$carbon-prefix}--data-table--selected {
+  tr.#{$block-class}__ai-label--row.#{config.$prefix}--data-table--selected {
   @include ai-table-gradient('selected');
 }
 
-.#{$block-class}
-  th.#{$block-class}__with-ai-label
-  .#{c4p-settings.$carbon-prefix}--slug {
+.#{$block-class} th.#{$block-class}__with-ai-label .#{config.$prefix}--slug {
   margin-inline-start: $spacing-03;
 }
 
@@ -301,13 +299,13 @@
   inline-size: 100%;
   padding-block-start: 0;
 
-  .#{c4p-settings.$carbon-prefix}--data-table-header__description {
+  .#{config.$prefix}--data-table-header__description {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
-  .#{c4p-settings.$carbon-prefix}--data-table-header__title {
+  .#{config.$prefix}--data-table-header__title {
     overflow: hidden;
     max-inline-size: 80ch;
     text-overflow: ellipsis;
@@ -318,7 +316,7 @@
     }
   }
 
-  .#{c4p-settings.$carbon-prefix}--data-table-content {
+  .#{config.$prefix}--data-table-content {
     block-size: 100%;
     inline-size: 100%;
     overflow-x: auto;
@@ -330,7 +328,7 @@
 
   .#{$block-class}-filter-panel
     + .#{$block-class}__table-container-inner
-    .#{c4p-settings.$carbon-prefix}--data-table-content {
+    .#{config.$prefix}--data-table-content {
     block-size: fit-content;
   }
 
@@ -425,27 +423,27 @@
     background-color: $layer-hover-01;
   }
 
-  .#{c4p-settings.$carbon-prefix}--data-table--selected
+  .#{config.$prefix}--data-table--selected
     .#{$block-class}__left-sticky-column-cell,
-  .#{c4p-settings.$carbon-prefix}--data-table--selected
+  .#{config.$prefix}--data-table--selected
     .#{$block-class}__right-sticky-column-cell,
-  .#{c4p-settings.$carbon-prefix}--data-table--selected
+  .#{config.$prefix}--data-table--selected
     .#{$block-class}__checkbox-cell-sticky-left {
     /* stylelint-disable-next-line declaration-no-important */
     background-color: $layer-selected-01;
   }
 
-  .#{c4p-settings.$carbon-prefix}--select-input {
+  .#{config.$prefix}--select-input {
     -webkit-appearance: none; // could be fixed by post-css plugin
     appearance: none; // could be fixed by post-css plugin
   }
 
-  th.#{c4p-settings.$carbon-prefix}--table-column-checkbox {
+  th.#{config.$prefix}--table-column-checkbox {
     display: block;
   }
 
-  td.#{c4p-settings.$carbon-prefix}--table-column-checkbox,
-  th.#{c4p-settings.$carbon-prefix}--table-column-checkbox {
+  td.#{config.$prefix}--table-column-checkbox,
+  th.#{config.$prefix}--table-column-checkbox {
     /* stylelint-disable-next-line declaration-no-important */
     inline-size: $spacing-09 !important;
     /* stylelint-disable-next-line declaration-no-important */
@@ -463,7 +461,7 @@
 }
 
 .#{$block-class}__empty-state
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
   tr:not([data-child-row]):hover {
   background: inherit;
@@ -513,7 +511,7 @@
 }
 
 .#{$block-class}__grid-container
-  table.#{$block-class}__table-simple.#{c4p-settings.$carbon-prefix}--data-table.#{$block-class}__table-is-resizing {
+  table.#{$block-class}__table-simple.#{config.$prefix}--data-table.#{$block-class}__table-is-resizing {
   overflow-y: hidden;
   @supports (overflow-block: hidden) {
     overflow-block: hidden;
@@ -548,22 +546,22 @@
 .#{$block-class}
   .#{$block-class}__carbon-row
   .#{$block-class}__actions-column-cell-non-sticky
-  .#{c4p-settings.$carbon-prefix}--btn--icon-only {
+  .#{config.$prefix}--btn--icon-only {
   opacity: 0;
 }
 
 .#{$block-class}
   .#{$block-class}__carbon-row:hover
   .#{$block-class}__actions-column-cell-non-sticky
-  .#{c4p-settings.$carbon-prefix}--btn--icon-only,
+  .#{config.$prefix}--btn--icon-only,
 .#{$block-class}
   .#{$block-class}__carbon-row
   .#{$block-class}__actions-column-cell-non-sticky
-  .#{c4p-settings.$carbon-prefix}--btn--icon-only:focus,
+  .#{config.$prefix}--btn--icon-only:focus,
 .#{$block-class}
   .#{$block-class}__carbon-row
   .#{$block-class}__actions-column-cell-non-sticky
-  .#{c4p-settings.$carbon-prefix}--btn--icon-only[aria-expanded='true'] {
+  .#{config.$prefix}--btn--icon-only[aria-expanded='true'] {
   opacity: 1;
 }
 
@@ -694,7 +692,7 @@
   }
 }
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--data-table-header {
+.#{$block-class} .#{config.$prefix}--data-table-header {
   background: transparent;
 }
 
@@ -702,7 +700,7 @@
   display: flex;
   flex-wrap: wrap;
 
-  .#{c4p-settings.$carbon-prefix}--data-table-header {
+  .#{config.$prefix}--data-table-header {
     flex: 1 1 auto;
     padding-block-end: $spacing-05;
   }
@@ -713,11 +711,11 @@
     align-items: flex-end;
   }
 
-  .#{c4p-settings.$carbon-prefix}--table-toolbar {
+  .#{config.$prefix}--table-toolbar {
     background: transparent;
   }
 
-  .#{c4p-settings.$carbon-prefix}__table-container {
+  .#{config.$prefix}__table-container {
     flex: 1 1 100%;
   }
 
@@ -738,14 +736,12 @@
 }
 
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table--selected:not(
-    .#{$block-class}__active-row
-  ) {
+  .#{config.$prefix}--data-table--selected:not(.#{$block-class}__active-row) {
   position: relative;
 }
 
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table--selected:not(
+  .#{config.$prefix}--data-table--selected:not(
     .#{$block-class}__active-row
   )::before {
   position: absolute;
@@ -758,13 +754,13 @@
 }
 
 .#{c4p-settings.$pkg-prefix}--datagrid__table-toolbar
-  .#{c4p-settings.$carbon-prefix}--batch-summary__para {
+  .#{config.$prefix}--batch-summary__para {
   white-space: nowrap;
 }
 
 .#{c4p-settings.$pkg-prefix}--datagrid__table-toolbar
-  .#{c4p-settings.$carbon-prefix}--batch-actions
-  .#{c4p-settings.$carbon-prefix}--batch-actions--active {
+  .#{config.$prefix}--batch-actions
+  .#{config.$prefix}--batch-actions--active {
   overflow-x: hidden;
   @supports (overflow-inline: hidden) {
     /* stylelint-disable-next-line declaration-property-value-disallowed-list */
@@ -795,7 +791,7 @@
   inline-size: 100%;
   min-inline-size: $spacing-09;
 
-  .#{c4p-settings.$carbon-prefix}--btn__icon {
+  .#{config.$prefix}--btn__icon {
     margin: 0;
   }
 }
@@ -811,7 +807,7 @@
   inline-size: $spacing-09;
 }
 
-.#{$block-class}__customize-columns-checkbox-wrapper.#{c4p-settings.$carbon-prefix}--form-item {
+.#{$block-class}__customize-columns-checkbox-wrapper.#{config.$prefix}--form-item {
   flex: 0 0 auto;
   margin-inline-end: $spacing-03;
 }
@@ -831,7 +827,7 @@
 
 .#{$block-class}__virtualScrollContainer {
   inline-size: 100%;
-  .#{c4p-settings.$carbon-prefix}--data-table-content {
+  .#{config.$prefix}--data-table-content {
     // overrides default scroll overflow as we handle overflow in thead and tbody separately for virtualScrollContainer variant
     overflow-x: hidden;
     @supports (overflow-inline: hidden) {
@@ -841,23 +837,22 @@
   }
 }
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--modal {
+.#{$block-class} .#{config.$prefix}--modal {
   inline-size: 100%;
 }
 
-.#{c4p-settings.$carbon-prefix}--overflow-menu.#{$block-class}__toolbar-menu__trigger {
+.#{config.$prefix}--overflow-menu.#{$block-class}__toolbar-menu__trigger {
   flex-shrink: 0;
   background-color: $interactive;
 }
 
-.#{c4p-settings.$carbon-prefix}--overflow-menu.#{$block-class}__toolbar-menu__trigger
-  svg {
+.#{config.$prefix}--overflow-menu.#{$block-class}__toolbar-menu__trigger svg {
   fill: $background;
 }
 
-.#{c4p-settings.$carbon-prefix}--overflow-menu.#{$block-class}__toolbar-menu__trigger:hover,
-.#{c4p-settings.$carbon-prefix}--overflow-menu.#{$block-class}__toolbar-menu__trigger.#{c4p-settings.$carbon-prefix}--overflow-menu--open:hover,
-.#{c4p-settings.$carbon-prefix}--overflow-menu.#{$block-class}__toolbar-menu__trigger.#{c4p-settings.$carbon-prefix}--overflow-menu--open {
+.#{config.$prefix}--overflow-menu.#{$block-class}__toolbar-menu__trigger:hover,
+.#{config.$prefix}--overflow-menu.#{$block-class}__toolbar-menu__trigger.#{config.$prefix}--overflow-menu--open:hover,
+.#{config.$prefix}--overflow-menu.#{$block-class}__toolbar-menu__trigger.#{config.$prefix}--overflow-menu--open {
   background-color: $button-primary-hover;
 }
 
@@ -866,12 +861,11 @@
   background-color: $layer-02;
 }
 
-.#{$block-class}__toolbar-options.#{c4p-settings.$carbon-prefix}--overflow-menu-options::after {
+.#{$block-class}__toolbar-options.#{config.$prefix}--overflow-menu-options::after {
   background-color: transparent;
 }
 
-.#{$block-class}__mobile-toolbar-modal
-  .#{c4p-settings.$carbon-prefix}--modal-container {
+.#{$block-class}__mobile-toolbar-modal .#{config.$prefix}--modal-container {
   position: absolute;
 }
 
@@ -895,20 +889,16 @@
 }
 
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--action-list
-  .#{c4p-settings.$carbon-prefix}--btn.#{c4p-settings.$pkg-prefix}--button-menu {
+  .#{config.$prefix}--action-list
+  .#{config.$prefix}--btn.#{c4p-settings.$pkg-prefix}--button-menu {
   padding: 0;
 }
 
-.#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--noLabel
-  svg.#{c4p-settings.$carbon-prefix}--btn__icon {
+.#{$block-class} .#{config.$prefix}--noLabel svg.#{config.$prefix}--btn__icon {
   margin-inline-start: 0;
 }
 
-.#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--action-list
-  .#{c4p-settings.$carbon-prefix}--btn__icon {
+.#{$block-class} .#{config.$prefix}--action-list .#{config.$prefix}--btn__icon {
   margin-block-start: 0;
 }
 

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_useExpandedRow.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_useExpandedRow.scss
@@ -1,13 +1,15 @@
 /**
- * Copyright IBM Corp. 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-@use '../../../global/styles/project-settings' as c4p-settings;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/config';
+
+@use '../../../global/styles/project-settings' as c4p-settings;
 @use './variables';
 
 @mixin shared-pseudo-styles() {
@@ -46,7 +48,7 @@
   padding-inline-end: 0;
 }
 
-.#{variables.$block-class}__row-expander.#{c4p-settings.$carbon-prefix}--btn {
+.#{variables.$block-class}__row-expander.#{config.$prefix}--btn {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -60,7 +62,7 @@
 }
 
 .#{variables.$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
   tr:hover
   + .#{variables.$block-class}__expanded-row,
@@ -73,29 +75,29 @@
 }
 
 .#{variables.$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   tbody
   tr:hover
   td.#{variables.$block-class}__expanded-row-cell-wrapper,
 .#{variables.$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   td.#{variables.$block-class}__expanded-row-cell-wrapper,
 .#{variables.$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   .#{variables.$block-class}__carbon-row-expanded
   td.#{variables.$block-class}__expandable-row-cell {
   border: none;
 }
 
 .#{variables.$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   .#{variables.$block-class}__carbon-row-expanded:hover
   td:not(.#{variables.$block-class}__expandable-row-cell) {
   border-block-end: 1px solid $border-subtle-02;
 }
 
 .#{variables.$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   td.#{variables.$block-class}__expanded-row-cell-wrapper {
   padding: 0;
 }

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_useInlineEdit.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_useInlineEdit.scss
@@ -1,15 +1,17 @@
 /**
- * Copyright IBM Corp. 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-@use '../../../global/styles/project-settings' as c4p-settings;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/components/button/tokens' as *;
+@use '@carbon/styles/scss/config';
 @use '@carbon/type' as *;
+
+@use '../../../global/styles/project-settings' as c4p-settings;
 @use './variables';
 
 $row-heights: (
@@ -23,32 +25,32 @@ $row-heights: (
 @each $size, $size-value in $row-heights {
   .#{variables.$block-class}
     .#{variables.$block-class}__inline-edit--outer-cell-button--#{$size}
-    .#{c4p-settings.$carbon-prefix}--text-input,
+    .#{config.$prefix}--text-input,
   .#{variables.$block-class}
     .#{variables.$block-class}__inline-edit--outer-cell-button--#{$size}
-    .#{c4p-settings.$carbon-prefix}--number
+    .#{config.$prefix}--number
     input[type='number'],
   .#{variables.$block-class}
     .#{variables.$block-class}__inline-edit--outer-cell-button--#{$size}
     .#{variables.$block-class}__inline-edit--select
-    .#{c4p-settings.$carbon-prefix}--list-box.#{c4p-settings.$carbon-prefix}--dropdown,
+    .#{config.$prefix}--list-box.#{config.$prefix}--dropdown,
   .#{variables.$block-class}
     .#{variables.$block-class}__inline-edit--date.#{variables.$block-class}__inline-edit--date-#{$size}
-    .#{c4p-settings.$carbon-prefix}--date-picker__input {
+    .#{config.$prefix}--date-picker__input {
     block-size: $size-value;
   }
   .#{variables.$block-class}
     .#{variables.$block-class}__inline-edit--outer-cell-button--#{$size}
-    .#{c4p-settings.$carbon-prefix}--number__control-btn::before,
+    .#{config.$prefix}--number__control-btn::before,
   .#{variables.$block-class}
     .#{variables.$block-class}__inline-edit--outer-cell-button--#{$size}
-    .#{c4p-settings.$carbon-prefix}--number__control-btn::after {
+    .#{config.$prefix}--number__control-btn::after {
     block-size: calc(#{$size-value} - 0.25rem);
   }
   .#{variables.$block-class}
     .#{variables.$block-class}__inline-edit--outer-cell-button--#{$size}
     .#{variables.$block-class}__inline-edit--select
-    .#{c4p-settings.$carbon-prefix}--list-box {
+    .#{config.$prefix}--list-box {
     max-block-size: none;
   }
 }
@@ -80,7 +82,7 @@ $row-heights: (
 }
 
 .#{variables.$block-class}__inline-edit--outer-cell-checkbox-focus
-  .cds--checkbox-label::before {
+  .#{config.$prefix}--checkbox-label::before {
   outline: $spacing-01 solid $focus;
   outline-offset: 1px;
 }
@@ -196,9 +198,9 @@ $row-heights: (
 }
 
 .#{variables.$block-class}__inline-edit--outer-cell-button
-  .#{c4p-settings.$carbon-prefix}--text-input,
+  .#{config.$prefix}--text-input,
 .#{variables.$block-class}__inline-edit--outer-cell-button
-  .#{c4p-settings.$carbon-prefix}--number
+  .#{config.$prefix}--number
   input[type='number'] {
   block-size: $spacing-09;
 }
@@ -208,7 +210,7 @@ $row-heights: (
   inset-inline-end: $spacing-05;
 }
 
-.#{variables.$block-class}__table-with-inline-edit.#{c4p-settings.$carbon-prefix}--data-table
+.#{variables.$block-class}__table-with-inline-edit.#{config.$prefix}--data-table
   .#{variables.$block-class}__cell-inline-edit {
   position: relative;
   padding: 0;
@@ -216,7 +218,7 @@ $row-heights: (
     padding-inline-start: $spacing-05;
   }
 
-  .#{c4p-settings.$carbon-prefix}--number input[type='number'] {
+  .#{config.$prefix}--number input[type='number'] {
     min-inline-size: auto;
     padding-inline-end: $spacing-05;
   }
@@ -228,28 +230,27 @@ $row-heights: (
   padding-inline-start: $spacing-05;
 }
 
-.#{variables.$block-class}__inline-edit--select.#{c4p-settings.$carbon-prefix}--dropdown,
-.#{variables.$block-class}__inline-edit--date
-  .#{c4p-settings.$carbon-prefix}--date-picker {
+.#{variables.$block-class}__inline-edit--select.#{config.$prefix}--dropdown,
+.#{variables.$block-class}__inline-edit--date .#{config.$prefix}--date-picker {
   inline-size: inherit;
 }
 
-.#{variables.$block-class}__inline-edit--select.#{c4p-settings.$carbon-prefix}--dropdown,
+.#{variables.$block-class}__inline-edit--select.#{config.$prefix}--dropdown,
 .#{variables.$block-class}__inline-edit--date
-  .#{c4p-settings.$carbon-prefix}--date-picker.#{c4p-settings.$carbon-prefix}--date-picker--single
-  .#{c4p-settings.$carbon-prefix}--date-picker__input {
+  .#{config.$prefix}--date-picker.#{config.$prefix}--date-picker--single
+  .#{config.$prefix}--date-picker__input {
   block-size: $spacing-09; // default row height
   inline-size: 100%;
   max-block-size: none;
 }
 
 .#{variables.$block-class}__inline-edit--date
-  .#{c4p-settings.$carbon-prefix}--date-picker-container {
+  .#{config.$prefix}--date-picker-container {
   inline-size: inherit;
 }
 
-.#{variables.$block-class}__inline-edit--date.#{c4p-settings.$carbon-prefix}--date-picker.#{c4p-settings.$carbon-prefix}--date-picker--single
-  .#{c4p-settings.$carbon-prefix}--date-picker__input {
+.#{variables.$block-class}__inline-edit--date.#{config.$prefix}--date-picker.#{config.$prefix}--date-picker--single
+  .#{config.$prefix}--date-picker__input {
   overflow: hidden;
   inline-size: 100%;
   max-inline-size: none;
@@ -259,7 +260,7 @@ $row-heights: (
 }
 
 .#{variables.$block-class}
-  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{config.$prefix}--data-table
   .#{variables.$block-class}__carbon-row-hover-active
   td {
   background-color: $layer-hover;
@@ -299,7 +300,7 @@ $row-heights: (
 
 .#{variables.$block-class}
   .#{variables.$block-class}__grid-container-active
-  .#{c4p-settings.$carbon-prefix}--data-table-content::before {
+  .#{config.$prefix}--data-table-content::before {
   position: absolute;
   z-index: 2;
   background-color: $link-inverse;
@@ -334,11 +335,11 @@ $row-heights: (
 .#{variables.$block-class}
   .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
   [data-invalid]
-  ~ .#{c4p-settings.$carbon-prefix}--form-requirement,
+  ~ .#{config.$prefix}--form-requirement,
 .#{variables.$block-class}
   .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
   [data-invalid]
-  .#{c4p-settings.$carbon-prefix}--form-requirement {
+  .#{config.$prefix}--form-requirement {
   position: absolute;
   z-index: 3;
   padding: $spacing-03 $spacing-06 $spacing-03 $spacing-03;
@@ -352,20 +353,20 @@ $row-heights: (
 
 .#{variables.$block-class}
   .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
-  .#{c4p-settings.$carbon-prefix}--list-box[data-invalid]:focus-within
-  ~ .#{c4p-settings.$carbon-prefix}--form-requirement {
+  .#{config.$prefix}--list-box[data-invalid]:focus-within
+  ~ .#{config.$prefix}--form-requirement {
   outline: $spacing-01 solid $focus;
 }
 
 .#{variables.$block-class}
   .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
-  .#{c4p-settings.$carbon-prefix}--list-box__invalid-icon,
+  .#{config.$prefix}--list-box__invalid-icon,
 .#{variables.$block-class}
   .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
-  .#{c4p-settings.$carbon-prefix}--text-input__invalid-icon,
+  .#{config.$prefix}--text-input__invalid-icon,
 .#{variables.$block-class}
   .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
-  .#{c4p-settings.$carbon-prefix}--number__invalid {
+  .#{config.$prefix}--number__invalid {
   z-index: 4;
   inset-block-start: calc(100% + #{$spacing-04} + #{$spacing-01});
   inset-inline-end: $spacing-03;
@@ -373,13 +374,13 @@ $row-heights: (
 
 .#{variables.$block-class}
   .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
-  .#{c4p-settings.$carbon-prefix}--number__invalid {
+  .#{config.$prefix}--number__invalid {
   inset-block-start: calc(100% + #{$spacing-02} + #{$spacing-01});
 }
 
 .#{variables.$block-class}
   .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
-  .#{c4p-settings.$carbon-prefix}--form-requirement::before {
+  .#{config.$prefix}--form-requirement::before {
   position: absolute;
   background-color: $layer-01;
   block-size: $spacing-01;
@@ -390,7 +391,7 @@ $row-heights: (
 }
 
 .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
-  .#{c4p-settings.$carbon-prefix}--form-requirement::after {
+  .#{config.$prefix}--form-requirement::after {
   position: absolute;
   background-color: $layer-accent-01;
   block-size: 1px;
@@ -402,11 +403,11 @@ $row-heights: (
 
 .#{variables.$block-class} tbody tr:hover {
   .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
-    .#{c4p-settings.$carbon-prefix}--form-requirement::before {
+    .#{config.$prefix}--form-requirement::before {
     background-color: $layer-accent-01;
   }
   .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
-    .#{c4p-settings.$carbon-prefix}--form-requirement::after {
+    .#{config.$prefix}--form-requirement::after {
     background-color: transparent;
   }
 }
@@ -414,32 +415,32 @@ $row-heights: (
 // Keep input focus states using $support-01 when inline edit cell is invalid
 .#{variables.$block-class}
   .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
-  .#{c4p-settings.$carbon-prefix}--text-input:focus,
+  .#{config.$prefix}--text-input:focus,
 .#{variables.$block-class}
   .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
-  .#{c4p-settings.$carbon-prefix}--number
+  .#{config.$prefix}--number
   input[type='number']:focus,
 .#{variables.$block-class}
   .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
-  .#{c4p-settings.$carbon-prefix}--number
+  .#{config.$prefix}--number
   input[type='number']:focus
-  ~ .#{c4p-settings.$carbon-prefix}--number__controls
-  .#{c4p-settings.$carbon-prefix}--number__control-btn:hover,
+  ~ .#{config.$prefix}--number__controls
+  .#{config.$prefix}--number__control-btn:hover,
 .#{variables.$block-class}
   .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
-  .#{c4p-settings.$carbon-prefix}--number__control-btn:focus {
+  .#{config.$prefix}--number__control-btn:focus {
   outline-color: $support-error;
 }
 
-.#{variables.$block-class} .#{c4p-settings.$carbon-prefix}--text-input:focus {
+.#{variables.$block-class} .#{config.$prefix}--text-input:focus {
   background: $field-01;
 }
 
 .#{variables.$block-class}
   .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
-  .#{c4p-settings.$carbon-prefix}--number
+  .#{config.$prefix}--number
   input[type='number'][data-invalid]:focus
-  ~ .#{c4p-settings.$carbon-prefix}--number__controls
-  .#{c4p-settings.$carbon-prefix}--number__control-btn.up-icon::after {
+  ~ .#{config.$prefix}--number__controls
+  .#{config.$prefix}--number__control-btn.up-icon::after {
   background-color: $support-error;
 }

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_useNestedRows.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_useNestedRows.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,12 +7,13 @@
 
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
-@use '../../../global/styles/project-settings' as c4p-settings;
+@use '@carbon/styles/scss/config';
 @use '@carbon/styles/scss/motion' as *;
+
+@use '../../../global/styles/project-settings' as c4p-settings;
 @use './variables' as *;
 
-.#{c4p-settings.$carbon-prefix}--data-table
-  tr.#{$block-class}__carbon-nested-row {
+.#{config.$prefix}--data-table tr.#{$block-class}__carbon-nested-row {
   border-inline-start: 1px solid transparent;
 
   .#{$block-class}__cell {
@@ -58,35 +59,32 @@
   }
 }
 
-.#{c4p-settings.$carbon-prefix}--data-table
-  td.#{$block-class}__expandable-row-cell {
+.#{config.$prefix}--data-table td.#{$block-class}__expandable-row-cell {
   padding-inline-start: $spacing-03;
 }
 
-.#{c4p-settings.$carbon-prefix}--data-table
-  td.#{$block-class}__expandable-row-cell
-  + td,
-.#{c4p-settings.$carbon-prefix}--data-table
+.#{config.$prefix}--data-table td.#{$block-class}__expandable-row-cell + td,
+.#{config.$prefix}--data-table
   .#{$block-class}__carbon-nested-row:not(
     .#{$block-class}__carbon-row-expandable
   )
   td.#{$block-class}__cell:nth-of-type(2),
-.#{c4p-settings.$carbon-prefix}--data-table
+.#{config.$prefix}--data-table
   .#{$block-class}__carbon-nested-row
   td.#{$block-class}__cell:nth-of-type(2)
   + td {
   position: relative;
 }
 
-.#{c4p-settings.$carbon-prefix}--data-table
+.#{config.$prefix}--data-table
   td.#{$block-class}__expandable-row-cell.#{$block-class}__expandable-row-cell--is-expanded
   + td::before,
-.#{c4p-settings.$carbon-prefix}--data-table
+.#{config.$prefix}--data-table
   .#{$block-class}__carbon-nested-row:not(
     .#{$block-class}__carbon-row-expandable
   ):not(.#{$block-class}__carbon-row-expandable--async)
   td.#{$block-class}__cell:nth-of-type(2)::before,
-.#{c4p-settings.$carbon-prefix}--data-table
+.#{config.$prefix}--data-table
   .#{$block-class}__carbon-nested-row
   td.#{$block-class}__expandable-row-cell
   + td::before {
@@ -101,19 +99,19 @@
   transition: background-color $duration-fast-01 motion(entrance, productive);
 }
 
-.#{c4p-settings.$carbon-prefix}--data-table
+.#{config.$prefix}--data-table
   tr:hover
   td.#{$block-class}__expandable-row-cell.#{$block-class}__expandable-row-cell--is-expanded
   + td::before,
-.#{c4p-settings.$carbon-prefix}--data-table
+.#{config.$prefix}--data-table
   .#{$block-class}__carbon-nested-row:hover
   td.#{$block-class}__expandable-row-cell
   + td::before,
-.#{c4p-settings.$carbon-prefix}--data-table
+.#{config.$prefix}--data-table
   .#{$block-class}__expandable-row--hover
   td.#{$block-class}__expandable-row-cell
   + td::before,
-.#{c4p-settings.$carbon-prefix}--data-table
+.#{config.$prefix}--data-table
   .#{$block-class}__carbon-nested-row:hover:not(
     .#{$block-class}__carbon-row-expandable
   )

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_useNestedTable.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_useNestedTable.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,12 +7,14 @@
 
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/config';
+
 @use '../../../global/styles/project-settings' as c4p-settings;
 @use './variables';
 
 // used for tables within a expandable row
 .#{variables.$block-class}__expanded-row
-  .#{c4p-settings.$carbon-prefix}--data-table-container {
+  .#{config.$prefix}--data-table-container {
   border-inline-start: 2px solid $background-brand;
   inline-size: calc(100% - #{$spacing-07});
   margin-inline-start: $spacing-07;
@@ -28,7 +30,7 @@
 }
 
 .#{variables.$block-class}__expanded-row
-  .#{c4p-settings.$carbon-prefix}--data-table-container
+  .#{config.$prefix}--data-table-container
   th {
   background-color: $layer-accent-01;
   border-block-start-color: $layer-accent-01;

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_useSelectAllToggle.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_useSelectAllToggle.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2023
+// Copyright IBM Corp. 2021, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -7,6 +7,8 @@
 
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/config';
+
 @use './variables';
 @use '../../../global/styles/project-settings' as c4p-settings;
 
@@ -32,6 +34,6 @@ th.#{variables.$block-class}__select-all-toggle-on.button {
   margin-inline-start: $spacing-01;
 }
 
-.#{variables.$block-class}__select-all-toggle-overflow.#{c4p-settings.$carbon-prefix}--overflow-menu-options--sm.#{c4p-settings.$carbon-prefix}--overflow-menu-options[data-floating-menu-direction='bottom']::after {
+.#{variables.$block-class}__select-all-toggle-overflow.#{config.$prefix}--overflow-menu-options--sm.#{config.$prefix}--overflow-menu-options[data-floating-menu-direction='bottom']::after {
   inline-size: $spacing-13;
 }

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_useSortableColumns.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_useSortableColumns.scss
@@ -1,33 +1,33 @@
 /**
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 @use '@carbon/styles/scss/theme' as *;
-@use '../../../global/styles/project-settings' as c4p-settings;
+@use '@carbon/styles/scss/config';
 @use '@carbon/styles/scss/spacing' as *;
+
+@use '../../../global/styles/project-settings' as c4p-settings;
 @use './variables' as *;
 
 .#{$block-class}__sortableColumn {
   /* stylelint-disable-next-line declaration-no-important */
   padding-inline: $spacing-05 !important;
 
-  .#{c4p-settings.$carbon-prefix}--table-header-label .header-title {
+  .#{config.$prefix}--table-header-label .header-title {
     display: inline-block;
     inline-size: auto;
   }
-  .#{c4p-settings.$carbon-prefix}--table-header-label {
+  .#{config.$prefix}--table-header-label {
     display: block;
     block-size: 100%;
     inline-size: 100%;
   }
-  .#{c4p-settings.$carbon-prefix}--table-header-label
-    .#{c4p-settings.$carbon-prefix}--table-sort:focus,
-  .#{c4p-settings.$carbon-prefix}--table-header-label
-    .#{c4p-settings.$carbon-prefix}--table-sort:active,
-  .#{c4p-settings.$carbon-prefix}--table-header-label
+  .#{config.$prefix}--table-header-label .#{config.$prefix}--table-sort:focus,
+  .#{config.$prefix}--table-header-label .#{config.$prefix}--table-sort:active,
+  .#{config.$prefix}--table-header-label
     button:focus
     .#{$block-class}__sortable-icon {
     /* stylelint-disable-next-line declaration-no-important */
@@ -36,17 +36,14 @@
     color: $text-primary !important;
   }
 
-  .#{c4p-settings.$carbon-prefix}--table-header-label
-    .#{c4p-settings.$carbon-prefix}--table-sort:focus,
-  .#{c4p-settings.$carbon-prefix}--table-header-label
-    .#{c4p-settings.$carbon-prefix}--table-sort:active {
+  .#{config.$prefix}--table-header-label .#{config.$prefix}--table-sort:focus,
+  .#{config.$prefix}--table-header-label .#{config.$prefix}--table-sort:active {
     + .#{$block-class}__resizer {
       z-index: -1;
     }
   }
 
-  .#{c4p-settings.$carbon-prefix}--table-header-label
-    .#{c4p-settings.$carbon-prefix}--table-sort {
+  .#{config.$prefix}--table-header-label .#{config.$prefix}--table-sort {
     padding: 0 $spacing-05;
     border: none;
     /* stylelint-disable-next-line declaration-no-important */
@@ -57,15 +54,15 @@
     inline-size: 100%;
     min-inline-size: 100%;
   }
-  .#{c4p-settings.$carbon-prefix}--table-header-label
-    .#{c4p-settings.$carbon-prefix}--table-sort
+  .#{config.$prefix}--table-header-label
+    .#{config.$prefix}--table-sort
     .#{$block-class}__sortable-icon {
     fill: $text-primary;
     opacity: 0;
     visibility: hidden;
   }
 
-  .#{c4p-settings.$carbon-prefix}--table-sort.#{$block-class}--table-sort {
+  .#{config.$prefix}--table-sort.#{$block-class}--table-sort {
     align-items: inherit;
     margin: 0 calc(-1 * #{$spacing-05}); // fill width of parent table column header
     inline-size: calc(100% + #{$spacing-07}); // offset due to inner label
@@ -75,8 +72,7 @@
 .#{$block-class}__sortableColumn:hover,
 .#{$block-class}__sortableColumn:focus-within,
 .#{$block-class}__sortableColumn.#{$block-class}__isSorted {
-  .#{c4p-settings.$carbon-prefix}--table-header-label
-    .#{$block-class}__sortable-icon {
+  .#{config.$prefix}--table-header-label .#{$block-class}__sortable-icon {
     opacity: 1;
     visibility: visible;
   }

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_CustomizeColumnsTearsheet.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_CustomizeColumnsTearsheet.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2022, 2022
+// Copyright IBM Corp. 2022, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -13,6 +13,7 @@
 @use '@carbon/type/scss/font-family';
 @use '@carbon/layout' as *;
 @use '@carbon/layout/scss/convert';
+@use '@carbon/styles/scss/config';
 
 @use '../../../../global/styles/project-settings' as c4p-settings;
 @use '../variables';
@@ -31,7 +32,7 @@
   padding-inline-start: spacing.$spacing-09;
 }
 
-.#{c4p-settings.$carbon-prefix}--form-item.#{c4p-settings.$carbon-prefix}--checkbox-wrapper.#{variables.$block-class}__customize-columns-checkbox {
+.#{config.$prefix}--form-item.#{config.$prefix}--checkbox-wrapper.#{variables.$block-class}__customize-columns-checkbox {
   display: flex;
   flex: initial;
   align-items: center;
@@ -39,7 +40,7 @@
 }
 
 .#{variables.$block-class}__customize-columns-column-list
-  .#{variables.$block-class}__customize-columns-checkbox-wrapper.#{c4p-settings.$carbon-prefix}--form-item {
+  .#{variables.$block-class}__customize-columns-checkbox-wrapper.#{config.$prefix}--form-item {
   margin-block-end: 0;
 }
 
@@ -63,7 +64,7 @@
   inset-block-start: 0;
   padding-inline-start: spacing.$spacing-08;
 
-  .#{c4p-settings.$carbon-prefix}--checkbox-label-text {
+  .#{config.$prefix}--checkbox-label-text {
     @include font-family.font-weight('semibold');
   }
 }

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_FilterFlyout.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_FilterFlyout.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2022, 2024
+// Copyright IBM Corp. 2022, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -12,6 +12,7 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type' as *;
 @use '@carbon/layout' as *;
+@use '@carbon/styles/scss/config';
 
 @use '../../../../global/styles/project-settings' as c4p-settings;
 @use '../variables';
@@ -86,22 +87,21 @@ $action-set-height: to-rem(64px);
 }
 
 // Carbon overrides
-.#{variables.$block-class}-filter-flyout__trigger.#{c4p-settings.$carbon-prefix}--btn {
+.#{variables.$block-class}-filter-flyout__trigger.#{config.$prefix}--btn {
   display: flex;
   justify-content: center;
   block-size: 3rem;
   inline-size: 3rem;
 }
 
-.#{variables.$block-class}-filter-flyout__trigger--open.#{c4p-settings.$carbon-prefix}--btn.#{c4p-settings.$carbon-prefix}--btn--icon-only {
+.#{variables.$block-class}-filter-flyout__trigger--open.#{config.$prefix}--btn.#{config.$prefix}--btn--icon-only {
   position: relative;
   background-color: $layer-02;
   /* stylelint-disable-next-line -- to-rem carbon replacement for rem */
   box-shadow: 0 1px to-rem(8px) 0 rgba(0, 0, 0, 0.25);
 }
 
-.#{variables.$block-class}-filter-flyout
-  .#{c4p-settings.$carbon-prefix}--fieldset {
+.#{variables.$block-class}-filter-flyout .#{config.$prefix}--fieldset {
   margin-block-end: 0;
 }
 

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_FilterPanel.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_FilterPanel.scss
@@ -1,16 +1,18 @@
 //
-// Copyright IBM Corp. 2022, 2024
+// Copyright IBM Corp. 2022, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
 
-@use '../variables' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/layout/scss/convert' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/type' as *;
 @use '@carbon/styles/scss/motion' as *;
+@use '@carbon/styles/scss/config';
+
+@use '../variables' as *;
 @use '../../../../global/styles/project-settings' as c4p-settings;
 @use './animations' as *;
 
@@ -182,29 +184,26 @@ $block-class-component: #{$block-class}-filter-panel;
 }
 
 // Overrides
-.#{$block-class-component}__container
-  .#{c4p-settings.$carbon-prefix}--accordion__title {
+.#{$block-class-component}__container .#{config.$prefix}--accordion__title {
   margin: 0;
 }
 
-.#{$block-class-component}__container
-  .#{c4p-settings.$carbon-prefix}--accordion__arrow {
+.#{$block-class-component}__container .#{config.$prefix}--accordion__arrow {
   margin: $spacing-01 0 0;
 }
 
-.#{$block-class-component}__container
-  .#{c4p-settings.$carbon-prefix}--accordion__content {
+.#{$block-class-component}__container .#{config.$prefix}--accordion__content {
   padding-inline: 0;
 }
 
 // Makes sure every child (filter) inside the accordion content has space in between
 .#{$block-class-component}__container
-  .#{c4p-settings.$carbon-prefix}--accordion__content
+  .#{config.$prefix}--accordion__content
   > *:not(:last-child) {
   margin-block-end: $spacing-05;
 }
 
-.#{c4p-settings.$carbon-prefix}--btn.#{$block-class-component}-open-button {
+.#{config.$prefix}--btn.#{$block-class-component}-open-button {
   display: flex;
   justify-content: center;
   block-size: 3rem;
@@ -213,6 +212,6 @@ $block-class-component: #{$block-class}-filter-panel;
   inline-size: 3rem;
 }
 
-.#{c4p-settings.$carbon-prefix}--btn.#{$block-class-component}__view-all-button {
+.#{config.$prefix}--btn.#{$block-class-component}__view-all-button {
   margin-inline-start: -$spacing-05;
 }

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_RowSizeDropdown.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_RowSizeDropdown.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,6 +7,8 @@
 
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/config';
+
 @use '../../../../global/styles/project-settings' as c4p-settings;
 @use '../variables';
 
@@ -20,24 +22,24 @@
 
 .#{variables.$block-class}
   .#{variables.$block-class}__row-size-radio-button
-  .#{c4p-settings.$carbon-prefix}--radio-button__label {
+  .#{config.$prefix}--radio-button__label {
   color: $text-primary;
 }
 
 .#{variables.$block-class}
   .#{variables.$block-class}__row-size-toggle-tip
-  .#{c4p-settings.$carbon-prefix}--popover-caret {
+  .#{config.$prefix}--popover-caret {
   background-color: $layer-02;
 }
 
 .#{variables.$block-class}
-  .#{c4p-settings.$carbon-prefix}--popover--bottom-right.#{variables.$block-class}__row-height-settings-popover
-  .#{c4p-settings.$carbon-prefix}--popover-caret {
+  .#{config.$prefix}--popover--bottom-right.#{variables.$block-class}__row-height-settings-popover
+  .#{config.$prefix}--popover-caret {
   // Used to fix layout issue with IconButton caret inside of Popover component
   inset-inline-start: -$spacing-02;
 }
 
-.#{variables.$block-class}__row-size-toggle-tip-button.#{c4p-settings.$carbon-prefix}--toggletip-button {
+.#{variables.$block-class}__row-size-toggle-tip-button.#{config.$prefix}--toggletip-button {
   display: flex;
   justify-content: center;
   block-size: $spacing-09;
@@ -46,10 +48,10 @@
 
 // Top align cell content for xl row size
 .#{variables.$block-class}
-  table.#{c4p-settings.$carbon-prefix}--data-table--xl.#{variables.$block-class}__vertical-align-center
+  table.#{config.$prefix}--data-table--xl.#{variables.$block-class}__vertical-align-center
   td,
 .#{variables.$block-class}
-  table.#{c4p-settings.$carbon-prefix}--data-table--xl.#{variables.$block-class}__vertical-align-top
+  table.#{config.$prefix}--data-table--xl.#{variables.$block-class}__vertical-align-top
   td {
   align-items: flex-start;
   padding-block: $spacing-05;
@@ -61,34 +63,34 @@
 
 // Top align header content for xl row size
 .#{variables.$block-class}
-  table.#{c4p-settings.$carbon-prefix}--data-table--xl.#{variables.$block-class}__vertical-align-center
+  table.#{config.$prefix}--data-table--xl.#{variables.$block-class}__vertical-align-center
   th,
 .#{variables.$block-class}
-  table.#{c4p-settings.$carbon-prefix}--data-table--xl.#{variables.$block-class}__vertical-align-top
+  table.#{config.$prefix}--data-table--xl.#{variables.$block-class}__vertical-align-top
   th {
-  .#{c4p-settings.$carbon-prefix}--table-header-label {
+  .#{config.$prefix}--table-header-label {
     align-items: flex-start;
   }
 }
 
 // Top align checkbox row header for xl row size
 .#{variables.$block-class}
-  table.#{c4p-settings.$carbon-prefix}--data-table--xl.#{variables.$block-class}__vertical-align-center
+  table.#{config.$prefix}--data-table--xl.#{variables.$block-class}__vertical-align-center
   .#{variables.$block-class}__checkbox-cell
-  th.cds--table-column-checkbox {
+  th.#{config.$prefix}--table-column-checkbox {
   align-items: flex-start;
   padding-block-start: $spacing-04;
 }
 
-.#{variables.$block-class}__row-size__row-settings-trigger--open.#{c4p-settings.$carbon-prefix}--btn--ghost {
+.#{variables.$block-class}__row-size__row-settings-trigger--open.#{config.$prefix}--btn--ghost {
   background-color: $layer-02;
 }
 
 .#{variables.$block-class}
-  table.#{c4p-settings.$carbon-prefix}--data-table--xl.#{variables.$block-class}__vertical-align-center
+  table.#{config.$prefix}--data-table--xl.#{variables.$block-class}__vertical-align-center
   td.#{variables.$block-class}__expandable-row-cell,
 .#{variables.$block-class}
-  table.#{c4p-settings.$carbon-prefix}--data-table--xl.#{variables.$block-class}__vertical-align-top
+  table.#{config.$prefix}--data-table--xl.#{variables.$block-class}__vertical-align-top
   td.#{variables.$block-class}__expandable-row-cell {
   padding-block-start: $spacing-03;
 }

--- a/packages/ibm-products-styles/src/components/DescriptionList/_description-list.scss
+++ b/packages/ibm-products-styles/src/components/DescriptionList/_description-list.scss
@@ -1,20 +1,22 @@
 //
-// Copyright IBM Corp. 2024, 2024
+// Copyright IBM Corp. 2024, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
 
 // Standard imports.
-@use '../../global/styles/project-settings' as c4p-settings;
-@use '../../global/styles/mixins';
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/type' as *;
 @use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/config';
+
+@use '../../global/styles/project-settings' as c4p-settings;
+@use '../../global/styles/mixins';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 $block-class: #{c4p-settings.$pkg-prefix}--description-list;
-$carbon-block-class: #{c4p-settings.$carbon-prefix}--structured-list;
+$carbon-block-class: #{config.$prefix}--structured-list;
 
 .#{$block-class} .#{$carbon-block-class} {
   margin-block-end: $spacing-07;

--- a/packages/ibm-products-styles/src/components/EditInPlace/_edit-in-place.scss
+++ b/packages/ibm-products-styles/src/components/EditInPlace/_edit-in-place.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2022, 2022
+// Copyright IBM Corp. 2022, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -8,12 +8,14 @@
 // Standard imports.
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
-@use '../../global/styles/project-settings' as *;
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/motion' as *;
+@use '@carbon/styles/scss/config';
+
+@use '../../global/styles/project-settings' as *;
 
 $block-class: #{$pkg-prefix}--edit-in-place;
-$carbon-input: #{$carbon-prefix}--text-input;
+$carbon-input: #{config.$prefix}--text-input;
 
 .#{$block-class} {
   --#{$block-class}--size: #{$spacing-07};
@@ -100,12 +102,6 @@ $carbon-input: #{$carbon-prefix}--text-input;
   cursor: pointer;
   outline: none;
 }
-
-// .#{$block-class}-readonly .#{$block-class}__text-input.#{$carbon-input},
-// .#{$block-class}-readonly
-//   .#{$carbon-prefix}--btn.#{$carbon-prefix}--btn--icon-only.#{$carbon-prefix}--tooltip__trigger {
-//   cursor: not-allowed;
-// }
 
 .#{$block-class}__text-input.#{$carbon-input}:focus,
 .#{$block-class}__text-input.#{$carbon-input}:active {

--- a/packages/ibm-products-styles/src/components/EditSidePanel/_edit-side-panel.scss
+++ b/packages/ibm-products-styles/src/components/EditSidePanel/_edit-side-panel.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2022
+// Copyright IBM Corp. 2021, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -8,6 +8,8 @@
 // Standard imports.
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as c4p-settings;
 @use '../../global/styles/mixins' as *;
 
@@ -19,11 +21,11 @@ $block-class: #{c4p-settings.$pkg-prefix}--edit-side-panel;
 $side-panel-block-class: #{c4p-settings.$pkg-prefix}--side-panel;
 
 .#{$block-class} {
-  .#{c4p-settings.$carbon-prefix}--form.#{$block-class}__form {
+  .#{config.$prefix}--form.#{$block-class}__form {
     padding-block-start: $spacing-05;
   }
 
-  .#{$block-class}__form.#{c4p-settings.$carbon-prefix}--fieldset {
+  .#{$block-class}__form.#{config.$prefix}--fieldset {
     padding-block-start: $spacing-03;
   }
 
@@ -42,7 +44,7 @@ $side-panel-block-class: #{c4p-settings.$pkg-prefix}--side-panel;
   }
 
   &.#{$side-panel-block-class}
-    .#{c4p-settings.$carbon-prefix}--btn.#{$side-panel-block-class}__close-button {
+    .#{config.$prefix}--btn.#{$side-panel-block-class}__close-button {
     display: none;
   }
 }

--- a/packages/ibm-products-styles/src/components/EditTearsheet/_edit-tearsheet.scss
+++ b/packages/ibm-products-styles/src/components/EditTearsheet/_edit-tearsheet.scss
@@ -10,6 +10,7 @@
 @use '@carbon/styles/scss/components/button/tokens' as *;
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/motion';
+@use '@carbon/styles/scss/config';
 
 // Standard imports.
 @use '../../global/styles/project-settings' as c4p-settings;
@@ -74,9 +75,7 @@ $tearsheet-fieldset-class: #{c4p-settings.$pkg-prefix}--tearsheet-edit__form--fi
   padding-block: $spacing-06;
 }
 
-.#{$block-class}
-  .#{$block-class}__content
-  .#{c4p-settings.$carbon-prefix}--css-grid {
+.#{$block-class} .#{$block-class}__content .#{config.$prefix}--css-grid {
   margin-inline-start: 0;
   padding-inline: $spacing-03;
 }
@@ -86,23 +85,23 @@ $tearsheet-fieldset-class: #{c4p-settings.$pkg-prefix}--tearsheet-edit__form--fi
 }
 
 .#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--btn-set
-  .#{c4p-settings.$carbon-prefix}--btn.#{c4p-settings.$carbon-prefix}--btn--disabled {
+  .#{config.$prefix}--btn-set
+  .#{config.$prefix}--btn.#{config.$prefix}--btn--disabled {
   box-shadow: -0.0625rem 0 0 0 $button-separator;
 }
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--side-nav--ux {
+.#{$block-class} .#{config.$prefix}--side-nav--ux {
   position: initial;
   background-color: transparent;
   inline-size: 100%;
   max-inline-size: 100%;
 }
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--side-nav__link:hover {
+.#{$block-class} .#{config.$prefix}--side-nav__link:hover {
   cursor: pointer;
 }
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--side-nav__overlay-active {
+.#{$block-class} .#{config.$prefix}--side-nav__overlay-active {
   display: none;
 }
 
@@ -125,7 +124,7 @@ $tearsheet-fieldset-class: #{c4p-settings.$pkg-prefix}--tearsheet-edit__form--fi
   margin-block-end: $spacing-06;
 }
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--fieldset {
+.#{$block-class} .#{config.$prefix}--fieldset {
   margin-block-end: 0;
 }
 

--- a/packages/ibm-products-styles/src/components/ExportModal/_export-modal.scss
+++ b/packages/ibm-products-styles/src/components/ExportModal/_export-modal.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -8,18 +8,17 @@
 // Standard imports.
 @use '@carbon/styles/scss/components/button/tokens' as *;
 @use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as c4p-settings;
 
 $block-class: #{c4p-settings.$pkg-prefix}--export-modal;
 
-.#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--modal-footer
-  .#{c4p-settings.$carbon-prefix}--btn {
+.#{$block-class} .#{config.$prefix}--modal-footer .#{config.$prefix}--btn {
   max-inline-size: none;
 }
 
-.#{$block-class}.#{c4p-settings.$carbon-prefix}--modal
-  .#{c4p-settings.$carbon-prefix}--modal-content {
+.#{$block-class}.#{config.$prefix}--modal .#{config.$prefix}--modal-content {
   padding-inline-end: $spacing-05;
 }
 

--- a/packages/ibm-products-styles/src/components/FilterPanel/_filter-panel-accordion-item.scss
+++ b/packages/ibm-products-styles/src/components/FilterPanel/_filter-panel-accordion-item.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2024, 2024
+// Copyright IBM Corp. 2024, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -9,15 +9,16 @@
 /* stylelint-disable max-nesting-depth */
 
 // Standard imports.
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as c4p-settings;
 @use '../../global/styles/mixins';
 
-@use '@carbon/styles/scss/spacing' as *;
-@use '@carbon/styles/scss/type';
-
 // The block part of our conventional BEM class names (blockClass__E--M).
 $block-class: #{c4p-settings.$pkg-prefix}--filter-panel-accordion-item;
-$carbon: #{c4p-settings.$carbon-prefix};
+$carbon: #{config.$prefix};
 
 // Remove top and bottom borders.
 html .#{$block-class} {

--- a/packages/ibm-products-styles/src/components/FilterPanel/_filter-panel-checkbox-with-overflow.scss
+++ b/packages/ibm-products-styles/src/components/FilterPanel/_filter-panel-checkbox-with-overflow.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2024, 2024
+// Copyright IBM Corp. 2024, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -9,15 +9,16 @@
 /* stylelint-disable max-nesting-depth */
 
 // Standard imports.
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as c4p-settings;
 @use '../../global/styles/mixins';
 
-@use '@carbon/styles/scss/spacing' as *;
-@use '@carbon/styles/scss/theme' as *;
-
 // The block part of our conventional BEM class names (blockClass__E--M).
 $block-class: #{c4p-settings.$pkg-prefix}--filter-panel-checkbox-with-overflow;
-$carbon: #{c4p-settings.$carbon-prefix};
+$carbon: #{config.$prefix};
 
 .#{$block-class} {
   position: relative;

--- a/packages/ibm-products-styles/src/components/FilterPanel/_filter-panel-checkbox.scss
+++ b/packages/ibm-products-styles/src/components/FilterPanel/_filter-panel-checkbox.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2024, 2024
+// Copyright IBM Corp. 2024, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -8,16 +8,17 @@
 /* stylelint-disable max-nesting-depth */
 
 // Standard imports.
-@use '../../global/styles/project-settings' as c4p-settings;
-@use '../../global/styles/mixins';
-
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config';
+
+@use '../../global/styles/project-settings' as c4p-settings;
+@use '../../global/styles/mixins';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 $block-class: #{c4p-settings.$pkg-prefix}--filter-panel-checkbox;
 $label: #{c4p-settings.$pkg-prefix}--filter-panel-label;
-$carbon: #{c4p-settings.$carbon-prefix};
+$carbon: #{config.$prefix};
 
 // UNDO Carbon's concept that a Checkbox is always a list item (":last-of-type").
 // This also allows the TruncatedList to calculate the correct height for expanding/collapsing the list.

--- a/packages/ibm-products-styles/src/components/FilterPanel/_filter-panel.scss
+++ b/packages/ibm-products-styles/src/components/FilterPanel/_filter-panel.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2024, 2024
+// Copyright IBM Corp. 2024, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -8,12 +8,13 @@
 /* stylelint-disable max-nesting-depth */
 
 // Standard imports.
-@use '../../global/styles/project-settings' as c4p-settings;
-@use '../../global/styles/mixins';
-
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config';
+
+@use '../../global/styles/project-settings' as c4p-settings;
+@use '../../global/styles/mixins';
 
 // FilterPanel uses the following Carbon for IBM Products components:
 // TODO: @use(s) of IBM Products component styles used by FilterPanel
@@ -21,7 +22,7 @@
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 $block-class: #{c4p-settings.$pkg-prefix}--filter-panel;
-$carbon: #{c4p-settings.$carbon-prefix};
+$carbon: #{config.$prefix};
 
 .#{$block-class}__title {
   @include type.type-style('body-compact-01');

--- a/packages/ibm-products-styles/src/components/FilterSummary/_filter-summary.scss
+++ b/packages/ibm-products-styles/src/components/FilterSummary/_filter-summary.scss
@@ -1,14 +1,16 @@
 //
-// Copyright IBM Corp. 2022, 2023
+// Copyright IBM Corp. 2022, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-@use '../../global/styles/project-settings' as *;
 @use '@carbon/layout/scss/convert' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/motion' as *;
+@use '@carbon/styles/scss/config';
+
+@use '../../global/styles/project-settings' as *;
 
 $block-class: #{$pkg-prefix}--filter-summary;
 
@@ -44,7 +46,7 @@ $block-class: #{$pkg-prefix}--filter-summary;
 }
 
 .#{$block-class}__expanded
-  .#{$block-class}__clear-all-button.#{$carbon-prefix}--btn {
+  .#{$block-class}__clear-all-button.#{config.$prefix}--btn {
   margin-inline-end: $spacing-07;
 }
 

--- a/packages/ibm-products-styles/src/components/Guidebanner/_guidebanner.scss
+++ b/packages/ibm-products-styles/src/components/Guidebanner/_guidebanner.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2023, 2023
+// Copyright IBM Corp. 2023, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -30,6 +30,8 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/themes';
 @use '@carbon/styles/scss/type' as *;
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as c4p-settings;
 
 // Guidebanner uses the following Carbon for IBM Products components:
@@ -158,7 +160,7 @@ $purple-3: #7433e3;
 }
 
 // Button with crossroads icon
-.#{$block-class}__carousel .#{c4p-settings.$carbon-prefix}--btn--tertiary {
+.#{$block-class}__carousel .#{config.$prefix}--btn--tertiary {
   border-color: $white-0;
   color: $white-0;
 
@@ -181,7 +183,7 @@ $purple-3: #7433e3;
   }
 }
 
-.#{$block-class}__carousel .#{c4p-settings.$carbon-prefix}--btn--ghost {
+.#{$block-class}__carousel .#{config.$prefix}--btn--ghost {
   color: $blue-30;
   margin-inline-start: calc(-1 * $spacing-05);
 

--- a/packages/ibm-products-styles/src/components/ImportModal/_import-modal.scss
+++ b/packages/ibm-products-styles/src/components/ImportModal/_import-modal.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2021
+// Copyright IBM Corp. 2021, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -9,34 +9,30 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as c4p-settings;
 
 $block-class: #{c4p-settings.$pkg-prefix}--import-modal;
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--modal-close {
+.#{$block-class} .#{config.$prefix}--modal-close {
   display: none;
 }
 
-.#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--modal-footer
-  .#{c4p-settings.$carbon-prefix}--btn {
+.#{$block-class} .#{config.$prefix}--modal-footer .#{config.$prefix}--btn {
   max-inline-size: none;
 }
 
-.#{$block-class}.#{c4p-settings.$carbon-prefix}--modal
-  .#{c4p-settings.$carbon-prefix}--modal-content {
+.#{$block-class}.#{config.$prefix}--modal .#{config.$prefix}--modal-content {
   padding-inline-end: $spacing-05;
 }
 
-.#{c4p-settings.$carbon-prefix}--file
-  .#{c4p-settings.$carbon-prefix}--file-container,
-.#{c4p-settings.$carbon-prefix}--file
-  ~ .#{c4p-settings.$carbon-prefix}--file-container {
+.#{config.$prefix}--file .#{config.$prefix}--file-container,
+.#{config.$prefix}--file ~ .#{config.$prefix}--file-container {
   margin-block-start: 0;
 }
 
-.#{c4p-settings.$carbon-prefix}--modal-container--sm
-  .#{c4p-settings.$carbon-prefix}--modal-header {
+.#{config.$prefix}--modal-container--sm .#{config.$prefix}--modal-header {
   padding-inline-end: calc(20% - #{$spacing-05});
 }
 
@@ -44,7 +40,7 @@ $block-class: #{c4p-settings.$pkg-prefix}--import-modal;
   display: flex;
 }
 
-.#{$block-class}__import-button.#{c4p-settings.$carbon-prefix}--btn {
+.#{$block-class}__import-button.#{config.$prefix}--btn {
   margin-inline-start: $spacing-03;
 }
 
@@ -68,15 +64,15 @@ $block-class: #{c4p-settings.$pkg-prefix}--import-modal;
   padding-inline-end: calc(20% - #{$spacing-05});
 }
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--file__selected-file {
+.#{$block-class} .#{config.$prefix}--file__selected-file {
   background: $layer-02;
   max-inline-size: none;
 }
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--file {
+.#{$block-class} .#{config.$prefix}--file {
   margin-block-end: $spacing-05;
 }
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--text-input:disabled {
+.#{$block-class} .#{config.$prefix}--text-input:disabled {
   background: $layer-02;
 }

--- a/packages/ibm-products-styles/src/components/InterstitialScreen/_interstitial-screen.scss
+++ b/packages/ibm-products-styles/src/components/InterstitialScreen/_interstitial-screen.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2024, 2024
+// Copyright IBM Corp. 2024, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -9,13 +9,15 @@
 /* stylelint-disable declaration-no-important */
 
 // Standard imports.
-@use '../../global/styles/project-settings' as c4p-settings;
-@use '../../global/styles/mixins';
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/breakpoint' as *;
 @use '@carbon/styles/scss/colors' as *;
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config';
+
+@use '../../global/styles/project-settings' as c4p-settings;
+@use '../../global/styles/mixins';
 
 // InterstitialScreen uses the following Carbon for IBM Products components:
 @use '../Carousel/carousel';
@@ -121,7 +123,7 @@ $one-grid-column: calc(100% / 16);
       max-inline-size: none;
       padding-inline-start: $spacing-07 !important;
     }
-    .#{c4p-settings.$carbon-prefix}--inline-loading {
+    .#{config.$prefix}--inline-loading {
       position: absolute;
       inline-size: $spacing-07;
       inset-block-start: 0;

--- a/packages/ibm-products-styles/src/components/NotificationsPanel/_notifications-panel.scss
+++ b/packages/ibm-products-styles/src/components/NotificationsPanel/_notifications-panel.scss
@@ -11,8 +11,10 @@
 @use '@carbon/styles/scss/motion' as *;
 @use '@carbon/styles/scss/type';
 @use '@carbon/type/scss/font-family' as *;
-@use '../../global/styles/project-settings' as c4p-settings;
+@use '@carbon/styles/scss/config';
 @use '@carbon/styles/scss/utilities';
+
+@use '../../global/styles/project-settings' as c4p-settings;
 
 // NotificationsPanel uses the following IBM Products components:
 // NotificationsEmptyState
@@ -120,7 +122,7 @@ $block-size: 38.5rem;
     .#{$block-class}__do-not-disturb-toggle {
       padding-block-end: $spacing-03;
 
-      .#{c4p-settings.$carbon-prefix}--toggle__label-text {
+      .#{config.$prefix}--toggle__label-text {
         @include utilities.visually-hidden;
       }
     }
@@ -236,7 +238,7 @@ $block-size: 38.5rem;
         padding: 0;
         min-inline-size: 5.5rem;
 
-        .#{c4p-settings.$carbon-prefix}--btn__icon {
+        .#{config.$prefix}--btn__icon {
           // stylelint-disable-next-line carbon/motion-easing-use
           transition: transform $duration-moderate-02 ease;
           /* stylelint-disable-next-line max-nesting-depth */
@@ -245,18 +247,18 @@ $block-size: 38.5rem;
           }
         }
         &.#{$block-class}__notification-read-more-button {
-          .#{c4p-settings.$carbon-prefix}--btn__icon {
+          .#{config.$prefix}--btn__icon {
             transform: rotate(0deg);
           }
         }
         &.#{$block-class}__notification-read-less-button {
-          .#{c4p-settings.$carbon-prefix}--btn__icon {
+          .#{config.$prefix}--btn__icon {
             transform: rotate(180deg);
           }
         }
       }
     }
-    .#{c4p-settings.$carbon-prefix}--popover-container {
+    .#{config.$prefix}--popover-container {
       position: initial;
     }
     .#{$block-class}__dismiss-single-button {
@@ -342,8 +344,7 @@ $block-size: 38.5rem;
       min-block-size: 2.5rem;
       min-inline-size: 2.5rem;
     }
-    .#{$block-class}__settings-button
-      .#{c4p-settings.$carbon-prefix}--btn__icon {
+    .#{$block-class}__settings-button .#{config.$prefix}--btn__icon {
       margin: 0;
     }
   }

--- a/packages/ibm-products-styles/src/components/OptionsTile/_options-tile.scss
+++ b/packages/ibm-products-styles/src/components/OptionsTile/_options-tile.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2022
+// Copyright IBM Corp. 2021, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -11,6 +11,8 @@
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/motion' as *;
 @use '@carbon/styles/scss/colors' as *;
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as c4p-settings;
 @use '../../global/styles/mixins' as *;
 
@@ -42,12 +44,12 @@ $block-class: #{c4p-settings.$pkg-prefix}--options-tile;
 }
 
 .#{$block-class}__toggle
-  .#{c4p-settings.$carbon-prefix}--toggle-input__label
-  .#{c4p-settings.$carbon-prefix}--toggle__switch {
+  .#{config.$prefix}--toggle-input__label
+  .#{config.$prefix}--toggle__switch {
   margin: 0;
 }
 
-.#{$block-class}__toggle .#{c4p-settings.$carbon-prefix}--toggle__label-text {
+.#{$block-class}__toggle .#{config.$prefix}--toggle__label-text {
   @include visually-hidden;
 }
 
@@ -153,8 +155,8 @@ $block-class: #{c4p-settings.$pkg-prefix}--options-tile;
 }
 
 .#{$block-class}__content
-  > .#{c4p-settings.$carbon-prefix}--fieldset
-  > .#{c4p-settings.$carbon-prefix}--label:empty {
+  > .#{config.$prefix}--fieldset
+  > .#{config.$prefix}--label:empty {
   display: none;
 }
 

--- a/packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
+++ b/packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2023
+// Copyright IBM Corp. 2020, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -13,6 +13,7 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/utilities';
+@use '@carbon/styles/scss/config';
 
 // Standard imports.
 @use '../../global/styles/project-settings' as *;
@@ -328,18 +329,18 @@ $duration: 1000ms;
     }
   }
 
-  .#{$block-class}__breadcrumb .#{$carbon-prefix}--breadcrumb-item {
+  .#{$block-class}__breadcrumb .#{config.$prefix}--breadcrumb-item {
     margin-inline-end: $spacing-02;
   }
 
-  .#{$block-class}__breadcrumb .#{$carbon-prefix}--breadcrumb-item::after {
+  .#{$block-class}__breadcrumb .#{config.$prefix}--breadcrumb-item::after {
     margin-inline-start: $spacing-02;
   }
 
-  .#{$block-class}__breadcrumb .#{$carbon-prefix}--breadcrumb-item,
+  .#{$block-class}__breadcrumb .#{config.$prefix}--breadcrumb-item,
   .#{$block-class}__breadcrumb
-    .#{$carbon-prefix}--breadcrumb-item
-    .#{$carbon-prefix}--link {
+    .#{config.$prefix}--breadcrumb-item
+    .#{config.$prefix}--link {
     @include type.type-style('label-01');
   }
 
@@ -504,8 +505,8 @@ $duration: 1000ms;
   }
 
   .#{$block-class}__page-actions
-    .#{$carbon-prefix}--btn-set
-    .#{$carbon-prefix}--btn {
+    .#{config.$prefix}--btn-set
+    .#{config.$prefix}--btn {
     inline-size: initial;
   }
 
@@ -563,14 +564,14 @@ $duration: 1000ms;
     @include type.type-style('body-01');
   }
 
-  .#{$block-class}__subtitle-tooltip .#{$carbon-prefix}--definition-term {
+  .#{$block-class}__subtitle-tooltip .#{config.$prefix}--definition-term {
     border-block-end: 0;
     letter-spacing: inherit;
   }
 
   // overwrites the existing styles to make the popover bigger because in some cases the narrow space can be too constricting for the header
   .#{$block-class}__subtitle-tooltip
-    .#{$carbon-prefix}--popover-content.#{$carbon-prefix}--definition-tooltip {
+    .#{config.$prefix}--popover-content.#{config.$prefix}--definition-tooltip {
     max-inline-size: fit-content;
   }
 
@@ -605,13 +606,13 @@ $duration: 1000ms;
     flex-wrap: wrap-reverse;
     margin-block-start: 0;
 
-    .#{$carbon-prefix}--content-switcher {
+    .#{config.$prefix}--content-switcher {
       box-sizing: content-box;
       padding-block-end: $spacing-05;
     }
   }
 
-  .#{$block-class}__navigation-row .#{$carbon-prefix}--tab-content {
+  .#{$block-class}__navigation-row .#{config.$prefix}--tab-content {
     display: none; /* need to figure out how to handle the tab content */
   }
 
@@ -657,7 +658,7 @@ $duration: 1000ms;
     text-align: initial;
   }
 
-  .#{$block-class}__navigation-row .#{$carbon-prefix}--content-switcher-btn {
+  .#{$block-class}__navigation-row .#{config.$prefix}--content-switcher-btn {
     background-color: $background;
   }
 
@@ -668,7 +669,7 @@ $duration: 1000ms;
     inset-inline-end: 0;
   }
 
-  .#{$block-class}__collapse-expand-toggle .#{$carbon-prefix}--btn__icon {
+  .#{$block-class}__collapse-expand-toggle .#{config.$prefix}--btn__icon {
     // transform: rotate(-90deg); // accordion does this, but it feels odd in page header
     transition: all $duration-slow-01 motion(standard, productive);
   }
@@ -690,17 +691,17 @@ $duration: 1000ms;
   inset-block-start: var(--#{$block-class}--tagset-tooltip-offset) !important;
 }
 
-.#{$block-class}__navigation-tags-overflow.#{$carbon-prefix}--tooltip {
+.#{$block-class}__navigation-tags-overflow.#{config.$prefix}--tooltip {
   z-index: $z-index-header-minus;
 }
 
-.#{$block-class}__action-bar-menu-options.#{$carbon-prefix}--overflow-menu-options,
-.#{$carbon-prefix}--breadcrumb-menu-options.#{$carbon-prefix}--overflow-menu-options,
-.#{$block-class}__button-set-menu-options.#{$carbon-prefix}--overflow-menu-options {
+.#{$block-class}__action-bar-menu-options.#{config.$prefix}--overflow-menu-options,
+.#{config.$prefix}--breadcrumb-menu-options.#{config.$prefix}--overflow-menu-options,
+.#{$block-class}__button-set-menu-options.#{config.$prefix}--overflow-menu-options {
   z-index: $z-index-header-minus;
 }
 
 .#{$block-class}__button-set-menu-options
-  > button.#{$carbon-prefix}--menu-button__trigger {
+  > button.#{config.$prefix}--menu-button__trigger {
   min-inline-size: 0;
 }

--- a/packages/ibm-products-styles/src/components/RemoveModal/_remove-modal.scss
+++ b/packages/ibm-products-styles/src/components/RemoveModal/_remove-modal.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2022
+// Copyright IBM Corp. 2020, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -7,17 +7,16 @@
 
 // Standard imports.
 @use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/config';
 @use '../../global/styles/project-settings' as c4p-settings;
 
 $block-class: #{c4p-settings.$pkg-prefix}--remove-modal;
 
-.#{$block-class}
-  .#{c4p-settings.$carbon-prefix}--modal-footer
-  .#{c4p-settings.$carbon-prefix}--btn {
+.#{$block-class} .#{config.$prefix}--modal-footer .#{config.$prefix}--btn {
   max-inline-size: none;
 }
 
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--modal-content {
+.#{$block-class} .#{config.$prefix}--modal-content {
   padding-inline-end: $spacing-05;
 }
 

--- a/packages/ibm-products-styles/src/components/Saving/_saving.scss
+++ b/packages/ibm-products-styles/src/components/Saving/_saving.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2022
+// Copyright IBM Corp. 2021, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -9,6 +9,8 @@
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/components/button/tokens' as *;
 @use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as c4p-settings;
 
 $block-class: #{c4p-settings.$pkg-prefix}--saving;
@@ -34,7 +36,7 @@ $block-class: #{c4p-settings.$pkg-prefix}--saving;
 }
 
 .#{$block-class}__buttons
-  .#{c4p-settings.$carbon-prefix}--btn
-  .#{c4p-settings.$carbon-prefix}--inline-loading {
+  .#{config.$prefix}--btn
+  .#{config.$prefix}--inline-loading {
   min-block-size: auto;
 }

--- a/packages/ibm-products-styles/src/components/SearchBar/_search-bar.scss
+++ b/packages/ibm-products-styles/src/components/SearchBar/_search-bar.scss
@@ -1,15 +1,16 @@
 //
-// Copyright IBM Corp. 2024, 2024
+// Copyright IBM Corp. 2024, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
 
 // Standard imports.
+@use '@carbon/styles/scss/utilities' as *;
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as c4p-settings;
 @use '../../global/styles/mixins';
-
-@use '@carbon/styles/scss/utilities' as *;
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 $block-class: #{c4p-settings.$pkg-prefix}--search-bar;
@@ -19,7 +20,7 @@ $block-class: #{c4p-settings.$pkg-prefix}--search-bar;
   display: flex;
 
   .#{c4p-settings.$pkg-prefix}--search-bar__scopes {
-    .#{c4p-settings.$carbon-prefix}--label {
+    .#{config.$prefix}--label {
       position: absolute;
     }
   }

--- a/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
+++ b/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
@@ -16,6 +16,7 @@
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/breakpoint' as *;
 @use '@carbon/styles/scss/utilities';
+@use '@carbon/styles/scss/config';
 
 // Standard imports.
 @use '../../global/styles/project-settings' as c4p-settings;
@@ -228,10 +229,8 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
       padding-block-start: $spacing-07;
     }
 
-    &:has(
-        .#{$block-class}__navigation-back-button.#{c4p-settings.$carbon-prefix}--btn--md
-      ),
-    &.#{$block-class}__header--has-navigation-back.#{c4p-settings.$carbon-prefix}--btn--md {
+    &:has(.#{$block-class}__navigation-back-button.#{config.$prefix}--btn--md),
+    &.#{$block-class}__header--has-navigation-back.#{config.$prefix}--btn--md {
       padding-block-start: $spacing-08;
     }
 
@@ -263,7 +262,7 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
     }
 
     &.#{$block-class}__header--on-detail-step
-      .#{$block-class}__navigation-back-button.#{c4p-settings.$carbon-prefix}--btn--md
+      .#{$block-class}__navigation-back-button.#{config.$prefix}--btn--md
       ~ .#{$block-class}__collapsed-title-text {
       inset-block-start: $spacing-06;
     }
@@ -421,14 +420,14 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
     margin-inline-end: $spacing-03;
   }
 
-  .#{c4p-settings.$carbon-prefix}--btn.#{$block-class}__navigation-back-button {
+  .#{config.$prefix}--btn.#{$block-class}__navigation-back-button {
     position: fixed;
     z-index: 5;
     inset-block-start: 0;
     inset-inline-start: 0;
   }
-  .#{c4p-settings.$carbon-prefix}--btn.#{$block-class}__navigation-back-button,
-  .#{c4p-settings.$carbon-prefix}--btn.#{$block-class}__close-button {
+  .#{config.$prefix}--btn.#{$block-class}__navigation-back-button,
+  .#{config.$prefix}--btn.#{$block-class}__close-button {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -449,8 +448,8 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
     }
   }
 
-  .#{c4p-settings.$carbon-prefix}--btn--md.#{$block-class}__navigation-back-button,
-  .#{c4p-settings.$carbon-prefix}--btn--md.#{$block-class}__close-button {
+  .#{config.$prefix}--btn--md.#{$block-class}__navigation-back-button,
+  .#{config.$prefix}--btn--md.#{$block-class}__close-button {
     block-size: $spacing-08;
     inline-size: $spacing-08;
   }
@@ -504,15 +503,15 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
 }
 
 // form fields should receive correct background color
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--text-input,
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--text-area,
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--search-input,
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--select-input,
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--multi-select,
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--dropdown,
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--dropdown-list,
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--number input[type='number'],
-.#{$block-class} .#{c4p-settings.$carbon-prefix}--date-picker__input {
+.#{$block-class} .#{config.$prefix}--text-input,
+.#{$block-class} .#{config.$prefix}--text-area,
+.#{$block-class} .#{config.$prefix}--search-input,
+.#{$block-class} .#{config.$prefix}--select-input,
+.#{$block-class} .#{config.$prefix}--multi-select,
+.#{$block-class} .#{config.$prefix}--dropdown,
+.#{$block-class} .#{config.$prefix}--dropdown-list,
+.#{$block-class} .#{config.$prefix}--number input[type='number'],
+.#{$block-class} .#{config.$prefix}--date-picker__input {
   background-color: $field-02;
 }
 

--- a/packages/ibm-products-styles/src/components/SimpleHeader/_simple-header.scss
+++ b/packages/ibm-products-styles/src/components/SimpleHeader/_simple-header.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2023, 2023
+// Copyright IBM Corp. 2023, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -8,6 +8,7 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config';
 
 @use '../../global/styles/project-settings' as *;
 
@@ -29,9 +30,9 @@ $block-class: #{$pkg-prefix}--simple-header;
   margin-block-start: $spacing-02;
 }
 
-.#{$block-class}__breadcrumbs .#{$carbon-prefix}--breadcrumb-item,
+.#{$block-class}__breadcrumbs .#{config.$prefix}--breadcrumb-item,
 .#{$block-class}__breadcrumbs
-  .#{$carbon-prefix}--breadcrumb-item
-  .#{$carbon-prefix}--link {
+  .#{config.$prefix}--breadcrumb-item
+  .#{config.$prefix}--link {
   @include type.type-style('label-01');
 }

--- a/packages/ibm-products-styles/src/components/StatusIcon/_status-icon.scss
+++ b/packages/ibm-products-styles/src/components/StatusIcon/_status-icon.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2022
+// Copyright IBM Corp. 2021, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -9,6 +9,8 @@
 
 // Standard imports.
 @use '@carbon/styles/scss/colors' as *;
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as *;
 
 $colors: (
@@ -115,9 +117,9 @@ $block-class: #{$pkg-prefix}--status-icon;
 @each $theme in $themes {
   @each $icon in $icons {
     @each $theme-key in $themes {
-      .#{$carbon-prefix}--btn--ghost:not([disabled])
+      .#{config.$prefix}--btn--ghost:not([disabled])
         .#{$block-class}--#{$theme}.#{$block-class}--#{$theme-key}-#{$icon},
-      .#{$carbon-prefix}--btn.#{$carbon-prefix}--btn--icon-only.#{$carbon-prefix}--tooltip__trigger
+      .#{config.$prefix}--btn.#{config.$prefix}--btn--icon-only.#{config.$prefix}--tooltip__trigger
         .#{$block-class}--#{$theme}.#{$block-class}--#{$theme-key}-#{$icon},
       .#{$block-class}--#{$theme}.#{$block-class}--#{$theme-key}-#{$icon} {
         @if $icon == in-progress {

--- a/packages/ibm-products-styles/src/components/StatusIndicator/_status-indicator.scss
+++ b/packages/ibm-products-styles/src/components/StatusIndicator/_status-indicator.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2024, 2024
+// Copyright IBM Corp. 2024, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -19,6 +19,7 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/themes';
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 $block-class: #{c4p-settings.$pkg-prefix}--status-indicator;
@@ -69,8 +70,7 @@ $block-class-step: #{c4p-settings.$pkg-prefix}--status-indicator-step;
 .#{$block-class-step}--active .#{$block-class-step}__icon {
   margin-inline-end: 0;
 }
-.#{$block-class-step}--active
-  .#{c4p-settings.$carbon-prefix}--inline-loading__animation {
+.#{$block-class-step}--active .#{config.$prefix}--inline-loading__animation {
   margin-inline-end: to-rem(7px);
 }
 // /Override

--- a/packages/ibm-products-styles/src/components/StringFormatter/_string-formatter.scss
+++ b/packages/ibm-products-styles/src/components/StringFormatter/_string-formatter.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2024, 2024
+// Copyright IBM Corp. 2024, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -10,6 +10,7 @@
 @use '../../global/styles/mixins';
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/config';
 // Other Carbon settings if needed
 // TODO: @use '@carbon/styles/scss/grid';
 // or
@@ -20,7 +21,7 @@
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 $block-class: #{c4p-settings.$pkg-prefix}--string-formatter;
-$popover-block-class: #{c4p-settings.$carbon-prefix}--popover;
+$popover-block-class: #{config.$prefix}--popover;
 
 .#{$block-class} {
   display: inline-block;
@@ -34,12 +35,12 @@ $popover-block-class: #{c4p-settings.$carbon-prefix}--popover;
     word-break: break-word;
   }
 
-  button.cds--definition-term {
+  button.#{config.$prefix}--definition-term {
     border-block-end: none;
     letter-spacing: inherit;
   }
 
-  .cds--popover-container {
+  .#{config.$prefix}--popover-container {
     display: flex;
   }
 }

--- a/packages/ibm-products-styles/src/components/TagOverflow/_tag-overflow.scss
+++ b/packages/ibm-products-styles/src/components/TagOverflow/_tag-overflow.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2024, 2024
+// Copyright IBM Corp. 2024, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -12,6 +12,7 @@
 @use '@carbon/styles/scss/breakpoint' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config';
 
 // Other Carbon settings if needed
 // TODO: @use '@carbon/styles/scss/grid';
@@ -63,20 +64,18 @@ $block-class-modal: #{$block-class}-modal;
   max-inline-size: $spacing-09;
 }
 
-.#{c4p-settings.$carbon-prefix}--popover
-  .#{c4p-settings.$carbon-prefix}--popover-content {
+.#{config.$prefix}--popover .#{config.$prefix}--popover-content {
   white-space: normal;
 }
 
 .#{$block-class-overflow} {
   display: inline-block;
   vertical-align: bottom;
-  .#{c4p-settings.$carbon-prefix}--tag.#{c4p-settings.$carbon-prefix}--tag--interactive {
+  .#{config.$prefix}--tag.#{config.$prefix}--tag--interactive {
     border: 0;
   }
 
-  .#{c4p-settings.$carbon-prefix}--popover
-    .#{c4p-settings.$carbon-prefix}--popover-content {
+  .#{config.$prefix}--popover .#{config.$prefix}--popover-content {
     padding: $spacing-05;
   }
 }
@@ -100,15 +99,15 @@ $block-class-modal: #{$block-class}-modal;
     font-family: inherit;
   }
 
-  .#{$block-class-overflow}__show-all-tags-link.#{c4p-settings.$carbon-prefix}--link:visited {
+  .#{$block-class-overflow}__show-all-tags-link.#{config.$prefix}--link:visited {
     display: inline-block;
     margin: $spacing-03 0 $spacing-02; // to match the tags
     color: $link-inverse;
   }
 
-  .#{c4p-settings.$carbon-prefix}--link:active,
-  .#{c4p-settings.$carbon-prefix}--link:active:visited,
-  .#{c4p-settings.$carbon-prefix}--link:active:visited:hover {
+  .#{config.$prefix}--link:active,
+  .#{config.$prefix}--link:active:visited,
+  .#{config.$prefix}--link:active:visited:hover {
     color: $text-inverse;
   }
 
@@ -123,13 +122,13 @@ $block-class-modal: #{$block-class}-modal;
   }
 
   .#{$block-class-overflow}__tag-item.#{$block-class-overflow}__tag-item--tag
-    .#{c4p-settings.$carbon-prefix}--tag {
+    .#{config.$prefix}--tag {
     background-color: $background-inverse-hover;
   }
 
   .#{$block-class-overflow}__tag-item.#{$block-class-overflow}__tag-item--default,
   .#{$block-class-overflow}__tag-item.#{$block-class-overflow}__tag-item--default
-    .#{c4p-settings.$carbon-prefix}--tag {
+    .#{config.$prefix}--tag {
     @include type.type-style('body-compact-01');
 
     display: block;
@@ -143,25 +142,21 @@ $block-class-modal: #{$block-class}-modal;
     min-inline-size: initial;
   }
 
-  .#{$block-class-overflow}__tag
-    .#{c4p-settings.$carbon-prefix}--tag__close-icon {
-    // undo override by .#{c4p-settings.$carbon-prefix}--tooltip button
+  .#{$block-class-overflow}__tag .#{config.$prefix}--tag__close-icon {
+    // undo override by .#{config.$prefix}--tooltip button
     padding: 0;
   }
 
-  .#{$block-class-overflow}__tag
-    .#{c4p-settings.$carbon-prefix}--tag--high-contrast {
+  .#{$block-class-overflow}__tag .#{config.$prefix}--tag--high-contrast {
     background-color: $background;
     color: $text-primary;
   }
 
-  .#{$block-class-overflow}__tag
-    .#{c4p-settings.$carbon-prefix}--tag__close-icon:hover {
+  .#{$block-class-overflow}__tag .#{config.$prefix}--tag__close-icon:hover {
     background-color: $background-hover;
   }
 
-  .#{$block-class-overflow}__tag
-    .#{c4p-settings.$carbon-prefix}--tag__close-icon:focus {
+  .#{$block-class-overflow}__tag .#{config.$prefix}--tag__close-icon:focus {
     box-shadow: inset 0 0 0 $spacing-01 $focus;
   }
 }

--- a/packages/ibm-products-styles/src/components/TagSet/_tag-set.scss
+++ b/packages/ibm-products-styles/src/components/TagSet/_tag-set.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -10,6 +10,8 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/breakpoint' as *;
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as *;
 @use '../../global/styles/mixins' as *;
 
@@ -55,11 +57,11 @@ $block-class-modal: #{$_block-class}-modal;
   .#{$block-class-overflow} {
     display: inline-block;
     vertical-align: bottom;
-    .#{$carbon-prefix}--tag.#{$carbon-prefix}--tag--interactive {
+    .#{config.$prefix}--tag.#{config.$prefix}--tag--interactive {
       border: 0;
     }
 
-    .#{$carbon-prefix}--popover .#{$carbon-prefix}--popover-content {
+    .#{config.$prefix}--popover .#{config.$prefix}--popover-content {
       padding: $spacing-05;
     }
   }
@@ -108,15 +110,15 @@ $block-class-modal: #{$_block-class}-modal;
     font-family: inherit;
   }
 
-  .#{$block-class-overflow}__show-all-tags-link.#{$carbon-prefix}--link:visited {
+  .#{$block-class-overflow}__show-all-tags-link.#{config.$prefix}--link:visited {
     display: inline-block;
     margin: $spacing-03 0 $spacing-02; // to match the tags
     color: $link-inverse;
   }
 
-  .#{$carbon-prefix}--link:active,
-  .#{$carbon-prefix}--link:active:visited,
-  .#{$carbon-prefix}--link:active:visited:hover {
+  .#{config.$prefix}--link:active,
+  .#{config.$prefix}--link:active:visited,
+  .#{config.$prefix}--link:active:visited:hover {
     color: $text-inverse;
   }
 
@@ -131,13 +133,13 @@ $block-class-modal: #{$_block-class}-modal;
   }
 
   .#{$block-class-overflow}__tag-item.#{$block-class-overflow}__tag-item--tag
-    .#{$carbon-prefix}--tag {
+    .#{config.$prefix}--tag {
     background-color: $background-inverse-hover;
   }
 
   .#{$block-class-overflow}__tag-item.#{$block-class-overflow}__tag-item--default,
   .#{$block-class-overflow}__tag-item.#{$block-class-overflow}__tag-item--default
-    .#{$carbon-prefix}--tag {
+    .#{config.$prefix}--tag {
     @include type.type-style('body-compact-01');
 
     display: block;
@@ -153,21 +155,21 @@ $block-class-modal: #{$_block-class}-modal;
     white-space: nowrap;
   }
 
-  .#{$block-class-overflow}__tag .#{$carbon-prefix}--tag__close-icon {
-    // undo override by .#{$carbon-prefix}--tooltip button
+  .#{$block-class-overflow}__tag .#{config.$prefix}--tag__close-icon {
+    // undo override by .#{config.$prefix}--tooltip button
     padding: 0;
   }
 
-  .#{$block-class-overflow}__tag .#{$carbon-prefix}--tag--high-contrast {
+  .#{$block-class-overflow}__tag .#{config.$prefix}--tag--high-contrast {
     background-color: $background;
     color: $text-primary;
   }
 
-  .#{$block-class-overflow}__tag .#{$carbon-prefix}--tag__close-icon:hover {
+  .#{$block-class-overflow}__tag .#{config.$prefix}--tag__close-icon:hover {
     background-color: $background-hover;
   }
 
-  .#{$block-class-overflow}__tag .#{$carbon-prefix}--tag__close-icon:focus {
+  .#{$block-class-overflow}__tag .#{config.$prefix}--tag__close-icon:focus {
     box-shadow: inset 0 0 0 $spacing-01 $focus;
   }
 }

--- a/packages/ibm-products-styles/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/ibm-products-styles/src/components/Tearsheet/_tearsheet.scss
@@ -1,7 +1,7 @@
 // stylelint-disable carbon/motion-duration-use, carbon/motion-easing-use
 
 //
-// Copyright IBM Corp. 2020, 2023
+// Copyright IBM Corp. 2020, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -15,6 +15,8 @@
 @use '@carbon/styles/scss/breakpoint' as *;
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/utilities';
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as *;
 @use '../../global/styles/mixins' as *;
 
@@ -238,8 +240,8 @@ $motion-duration: $duration-moderate-02;
 
   // buttons inside button sets in the header action area have 8px gap
   .#{$block-class}__header-actions
-    .#{$carbon-prefix}--btn-set
-    .#{$carbon-prefix}--btn:not(:first-of-type) {
+    .#{config.$prefix}--btn-set
+    .#{config.$prefix}--btn:not(:first-of-type) {
     margin-inline-start: $spacing-03;
   }
 
@@ -248,7 +250,7 @@ $motion-duration: $duration-moderate-02;
   }
 
   &.#{$block-class}--wide
-    .#{$carbon-prefix}--modal-header__heading.#{$block-class}__heading {
+    .#{config.$prefix}--modal-header__heading.#{$block-class}__heading {
     @include type.type-style('heading-04');
   }
 
@@ -382,27 +384,27 @@ $motion-duration: $duration-moderate-02;
   &.#{$block-class}--wide .#{$block-class}__content {
     // Specific to the Tearsheet *and* radio buttons,
     // `readOnly` styling is not applying a grey outline.
-    .#{$carbon-prefix}--radio-button[readonly]
-      + .#{$carbon-prefix}--radio-button__label
-      .#{$carbon-prefix}--radio-button__appearance {
+    .#{config.$prefix}--radio-button[readonly]
+      + .#{config.$prefix}--radio-button__label
+      .#{config.$prefix}--radio-button__appearance {
       border-color: $icon-disabled;
     }
 
-    .#{$carbon-prefix}--select--inline .#{$carbon-prefix}--select-input {
+    .#{config.$prefix}--select--inline .#{config.$prefix}--select-input {
       background-color: transparent;
     }
 
     // and restore the 'light' prop in case light fields are wanted
-    .#{$carbon-prefix}--text-input--light,
-    .#{$carbon-prefix}--text-area--light,
-    .#{$carbon-prefix}--search--light .#{$carbon-prefix}--search-input,
-    .#{$carbon-prefix}--select--light .#{$carbon-prefix}--select-input,
-    .#{$carbon-prefix}--dropdown--light,
-    .#{$carbon-prefix}--dropdown--light .#{$carbon-prefix}--dropdown-list,
+    .#{config.$prefix}--text-input--light,
+    .#{config.$prefix}--text-area--light,
+    .#{config.$prefix}--search--light .#{config.$prefix}--search-input,
+    .#{config.$prefix}--select--light .#{config.$prefix}--select-input,
+    .#{config.$prefix}--dropdown--light,
+    .#{config.$prefix}--dropdown--light .#{config.$prefix}--dropdown-list,
     /* stylelint-disable-next-line prettier/prettier */
-    .#{$carbon-prefix}--number--light input[type='number'],
-    .#{$carbon-prefix}--date-picker--light
-      .#{$carbon-prefix}--date-picker__input {
+    .#{config.$prefix}--number--light input[type='number'],
+    .#{config.$prefix}--date-picker--light
+      .#{config.$prefix}--date-picker__input {
       background-color: $field-02;
     }
   }
@@ -433,9 +435,9 @@ $motion-duration: $duration-moderate-02;
   }
 
   &.#{$block-class}--has-slug:not(.#{$block-class}--has-close)
-    .#{$carbon-prefix}--slug,
+    .#{config.$prefix}--slug,
   &.#{$block-class}--has-ai-label:not(.#{$block-class}--has-close)
-    .#{$carbon-prefix}--slug {
+    .#{config.$prefix}--slug {
     inset-inline-end: 0;
     /* stylelint-disable-next-line carbon/layout-use */
     margin-block: 6px;

--- a/packages/ibm-products-styles/src/components/Toolbar/_toolbar.scss
+++ b/packages/ibm-products-styles/src/components/Toolbar/_toolbar.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2021
+// Copyright IBM Corp. 2021, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -8,6 +8,8 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/breakpoint' as *;
 @use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as *;
 
 $block-class: #{$pkg-prefix}--toolbar;
@@ -48,7 +50,7 @@ $toolbar-dimensions: $spacing-08;
 }
 
 .#{$block-class}--vertical > .#{$block-class}__group:last-of-type,
-.#{$block-class} .#{$carbon-prefix}--dropdown {
+.#{$block-class} .#{config.$prefix}--dropdown {
   border-block-end-width: 0;
 }
 

--- a/packages/ibm-products-styles/src/components/TruncatedList/_truncated-list.scss
+++ b/packages/ibm-products-styles/src/components/TruncatedList/_truncated-list.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2024, 2024
+// Copyright IBM Corp. 2024, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -12,6 +12,7 @@
 // Other Carbon settings if needed
 @use '@carbon/styles/scss/motion' as *;
 @use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/config';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 $block-class: #{c4p-settings.$pkg-prefix}--truncated-list;
@@ -40,12 +41,12 @@ $block-class: #{c4p-settings.$pkg-prefix}--truncated-list;
   }
 }
 
-.#{c4p-settings.$carbon-prefix}--btn.#{$block-class}__button {
+.#{config.$prefix}--btn.#{$block-class}__button {
   padding: 0;
   inline-size: 100%;
   margin-block-start: $spacing-02;
   min-block-size: auto;
 }
-.#{c4p-settings.$carbon-prefix}--btn.#{$block-class}__button:hover {
+.#{config.$prefix}--btn.#{$block-class}__button:hover {
   background: transparent;
 }

--- a/packages/ibm-products-styles/src/components/UserAvatar/_user-avatar.scss
+++ b/packages/ibm-products-styles/src/components/UserAvatar/_user-avatar.scss
@@ -14,6 +14,7 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config';
 
 $block-class: #{$pkg-prefix}--user-avatar;
 
@@ -71,16 +72,16 @@ $sizes: (
 //this mixin allows you to set background color based on the lighter themes such as g10 and white
 @mixin setLightBg($order, $color) {
   :root .#{$block-class}--#{$order},
-  .#{$carbon-prefix}--g10 .#{$block-class}--#{$order},
-  .#{$carbon-prefix}--white .#{$block-class}--#{$order} {
+  .#{config.$prefix}--g10 .#{$block-class}--#{$order},
+  .#{config.$prefix}--white .#{$block-class}--#{$order} {
     @include setBgColor($color);
   }
 }
 
 //this mixin allows you to set background color based on the darker themes such as g90 and g100
 @mixin setDarkBg($order, $color) {
-  .#{$carbon-prefix}--g90 .#{$block-class}--#{$order},
-  .#{$carbon-prefix}--g100 .#{$block-class}--#{$order} {
+  .#{config.$prefix}--g90 .#{$block-class}--#{$order},
+  .#{config.$prefix}--g100 .#{$block-class}--#{$order} {
     @include setBgColor($color);
   }
 }

--- a/packages/ibm-products-styles/src/components/UserProfileImage/_user-profile-image.scss
+++ b/packages/ibm-products-styles/src/components/UserProfileImage/_user-profile-image.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2021
+// Copyright IBM Corp. 2021, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -12,6 +12,8 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/type';
 @use '@carbon/type/scss/font-family';
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as *;
 @use './color-map' as *;
 
@@ -72,8 +74,8 @@ $theme-keys: map-keys($themes);
   }
 }
 
-.#{$carbon-prefix}--tooltip__trigger.#{$block-class}__tooltip,
-.#{$block-class}__tooltip.#{$carbon-prefix}--btn--ghost:not([disabled]) svg {
+.#{config.$prefix}--tooltip__trigger.#{$block-class}__tooltip,
+.#{$block-class}__tooltip.#{config.$prefix}--btn--ghost:not([disabled]) svg {
   /* stylelint-disable-next-line max-nesting-depth */
   &:hover,
   &:focus {
@@ -93,19 +95,19 @@ $theme-keys: map-keys($themes);
   text-transform: uppercase;
 }
 
-.#{$block-class}__tooltip.#{$carbon-prefix}--btn--md.#{$carbon-prefix}--btn--icon-only {
+.#{$block-class}__tooltip.#{config.$prefix}--btn--md.#{config.$prefix}--btn--icon-only {
   padding: 0;
   border-radius: 50%;
   min-block-size: auto;
 }
 
-.#{$carbon-prefix}--btn--ghost.#{$block-class}__tooltip:focus {
+.#{config.$prefix}--btn--ghost.#{$block-class}__tooltip:focus {
   border: 0;
   box-shadow: 0 0 0 $spacing-02 $focus;
 }
 
-.#{$carbon-prefix}--tooltip__trigger .#{$block-class} svg,
-.#{$block-class}__tooltip.#{$carbon-prefix}--btn--ghost:not([disabled]) svg {
+.#{config.$prefix}--tooltip__trigger .#{$block-class} svg,
+.#{$block-class}__tooltip.#{config.$prefix}--btn--ghost:not([disabled]) svg {
   fill: $layer-01;
 }
 

--- a/packages/ibm-products-styles/src/components/WebTerminal/_web-terminal.scss
+++ b/packages/ibm-products-styles/src/components/WebTerminal/_web-terminal.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2022
+// Copyright IBM Corp. 2020, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -11,6 +11,8 @@
 @use '@carbon/styles/scss/motion' as *;
 @use '@carbon/styles/scss/themes' as *;
 @use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/config';
+
 @use '../../global/styles/project-settings' as *;
 
 $web-terminal-width: 40rem; // 640px
@@ -90,7 +92,7 @@ $block-class: #{$pkg-prefix}--web-terminal;
 }
 
 .#{$block-class}__documentation-overflow
-  .#{$carbon-prefix}--overflow-menu-options__btn {
+  .#{config.$prefix}--overflow-menu-options__btn {
   text-decoration: none;
 }
 

--- a/packages/ibm-products-web-components/src/components/about-modal/about-modal.scss
+++ b/packages/ibm-products-web-components/src/components/about-modal/about-modal.scss
@@ -1,5 +1,5 @@
 /*
-* Copyright IBM Corp. 2025
+* Copyright IBM Corp. 2025, 2025
 *
 * This source code is licensed under the Apache-2.0 license found in the
 * LICENSE file in the root directory of this source tree.
@@ -11,7 +11,7 @@ $css--plex: true !default;
 @use '@carbon/styles' as styles;
 @use '@carbon/styles/scss/reset';
 @use '@carbon/styles/scss/breakpoint' as *;
-@use '@carbon/styles/scss/config' as *;
+@use '@carbon/styles/scss/config';
 @use '@carbon/styles/scss/motion' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/themes/scss/themes';
@@ -24,7 +24,6 @@ $css--plex: true !default;
 @use 'sass:map';
 
 $prefix: 'c4p';
-$carbon-prefix: 'cds';
 
 @use '@carbon/ibm-products-styles/scss/components/AboutModal/index' as *;
 
@@ -32,12 +31,12 @@ $carbon-prefix: 'cds';
   .#{$prefix}--about-modal__logo {
     margin: $spacing-05 $spacing-05 $spacing-07 $spacing-05;
   }
-  #{$carbon-prefix}-modal-header {
+  #{config.$prefix}-modal-header {
     padding: 0 20% 0 $spacing-05;
     grid-row: auto;
     margin-block-end: 0;
   }
-  #{$carbon-prefix}-modal-body {
+  #{config.$prefix}-modal-body {
     @include type.type-style('body-compact-02');
 
     overflow: hidden auto;
@@ -50,11 +49,11 @@ $carbon-prefix: 'cds';
       padding-block-end: 0;
     }
     &.#{$prefix}--about-modal-scroll-content {
-      @extend .#{$carbon-prefix}--modal-scroll-content;
+      @extend .#{config.$prefix}--modal-scroll-content;
     }
   }
 
-  #{$carbon-prefix}-modal-heading {
+  #{config.$prefix}-modal-heading {
     @include type.type-style('heading-04');
 
     color: $text-primary;
@@ -81,20 +80,20 @@ $carbon-prefix: 'cds';
   .#{$prefix}--about-modal__copyright-text:first-child {
     margin-block-start: $spacing-07;
   }
-  #{$carbon-prefix}-link {
+  #{config.$prefix}-link {
     display: inline-flex;
   }
   .#{$prefix}--about-modal__links-container {
     @include type.type-style('body-compact-01');
 
     margin-block-start: $spacing-06;
-    #{$carbon-prefix}-link + #{$carbon-prefix}-link {
+    #{config.$prefix}-link + #{config.$prefix}-link {
       border-inline-start: 1px solid $border-strong-01;
       margin-inline-start: $spacing-03;
       padding-inline-start: $spacing-03;
     }
   }
-  #{$carbon-prefix}-modal-footer {
+  #{config.$prefix}-modal-footer {
     @include styles.theme(styles.$g100);
 
     display: block;

--- a/packages/ibm-products-web-components/src/components/full-page-error/full-page-error.scss
+++ b/packages/ibm-products-web-components/src/components/full-page-error/full-page-error.scss
@@ -19,7 +19,6 @@ $css--plex: true !default;
 
 // Local vars
 $prefix: 'c4p';
-$carbon-prefix: 'cds';
 $block-class: #{$prefix}--side-panel;
 
 :host(#{$prefix}-full-page-error) {

--- a/packages/ibm-products-web-components/src/components/options-tile/options-tile.scss
+++ b/packages/ibm-products-web-components/src/components/options-tile/options-tile.scss
@@ -12,9 +12,9 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/reset';
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/config';
 
 $prefix: 'c4p';
-$carbon-prefix: 'cds';
 $block-class: #{$prefix}--options-tile;
 
 :host(#{$prefix}-options-tile) {

--- a/packages/ibm-products-web-components/src/components/side-panel/side-panel.scss
+++ b/packages/ibm-products-web-components/src/components/side-panel/side-panel.scss
@@ -1,5 +1,5 @@
 /*
-* Copyright IBM Corp. 2023, 2024
+* Copyright IBM Corp. 2023, 2025
 *
 * This source code is licensed under the Apache-2.0 license found in the
 * LICENSE file in the root directory of this source tree.
@@ -16,9 +16,9 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/utilities/ai-gradient' as *;
 @use '@carbon/styles/scss/utilities/convert' as *;
+@use '@carbon/styles/scss/config';
 
 $prefix: 'c4p';
-$carbon-prefix: 'cds';
 @use '@carbon/ibm-products-styles/scss/components/ActionSet/index' as *;
 @use '@carbon/ibm-products-styles/scss/components/SidePanel/index' as *;
 @use '@carbon/ibm-products-styles/scss/components/SidePanel/side-panel-variables'
@@ -164,7 +164,7 @@ $block-class-action-set: #{$prefix}--action-set;
 
   .#{$block-class}__subtitle-text {
     &[hidden] {
-      @extend .#{$carbon-prefix}--visually-hidden !optional;
+      @extend .#{config.$prefix}--visually-hidden !optional;
     }
   }
 
@@ -173,12 +173,12 @@ $block-class-action-set: #{$prefix}--action-set;
     padding-inline-start: 0;
 
     &[hidden] {
-      @extend .#{$carbon-prefix}--visually-hidden !optional;
+      @extend .#{config.$prefix}--visually-hidden !optional;
     }
   }
 
   .#{$block-class} .#{$block-class}__action-toolbar[hidden] {
-    @extend .#{$carbon-prefix}--visually-hidden !optional;
+    @extend .#{config.$prefix}--visually-hidden !optional;
   }
 
   .#{$block-class}[has-slug] {
@@ -209,14 +209,14 @@ $block-class-action-set: #{$prefix}--action-set;
     }
 
     ::slotted(#{$prefix}-button[hidden]) {
-      @extend .#{$carbon-prefix}--visually-hidden !optional;
+      @extend .#{config.$prefix}--visually-hidden !optional;
 
       display: none;
     }
 
     // -1 in @container query is for 1px left border
     @container (width <= #{map.get(spv.$side-panel-sizes, lg)}) {
-      &:not([actions-multiple='triple']) ::slotted(#{$carbon-prefix}-button) {
+      &:not([actions-multiple='triple']) ::slotted(#{config.$prefix}-button) {
         // double and single on lg use 50%
         flex: 0 1 50%;
         max-inline-size: none;
@@ -227,12 +227,12 @@ $block-class-action-set: #{$prefix}--action-set;
     @container (width <= #{map.get(spv.$side-panel-sizes, md)}) {
       // md is 50% for two and 100% for one
       // column for triple
-      &[actions-multiple] ::slotted(#{$carbon-prefix}-button) {
+      &[actions-multiple] ::slotted(#{config.$prefix}-button) {
         flex: 0 0 100%;
         max-inline-size: none;
       }
 
-      &[actions-multiple='double'] ::slotted(#{$carbon-prefix}-button) {
+      &[actions-multiple='double'] ::slotted(#{config.$prefix}-button) {
         flex: 0 1 50%;
         max-inline-size: none;
       }
@@ -240,7 +240,7 @@ $block-class-action-set: #{$prefix}--action-set;
       &[actions-multiple='triple'] {
         --flex-direction: column;
 
-        ::slotted(#{$carbon-prefix}-button) {
+        ::slotted(#{config.$prefix}-button) {
           flex: initial;
           inline-size: 100%;
           max-inline-size: none;
@@ -252,7 +252,7 @@ $block-class-action-set: #{$prefix}--action-set;
     @container (width <= #{map.get(spv.$side-panel-sizes, sm)}) {
       --flex-direction: column;
 
-      ::slotted(#{$carbon-prefix}-button) {
+      ::slotted(#{config.$prefix}-button) {
         flex: initial;
         inline-size: 100%;
         max-inline-size: none;
@@ -267,12 +267,12 @@ $block-class-action-set: #{$prefix}--action-set;
     display: flex;
     inline-size: 100%;
 
-    ::slotted(#{$carbon-prefix}-button) {
+    ::slotted(#{config.$prefix}-button) {
       @extend .#{$block-class-action-set}__action-button;
     }
 
     &[hidden] {
-      @extend .#{$carbon-prefix}--visually-hidden !optional;
+      @extend .#{config.$prefix}--visually-hidden !optional;
 
       display: none;
     }
@@ -280,7 +280,7 @@ $block-class-action-set: #{$prefix}--action-set;
     $multiples: 'single' 'double' 'triple';
     @each $m in $multiples {
       &[actions-multiple='#{$m}'] {
-        @extend .#{$carbon-prefix}--action-set--row-#{$m} !optional;
+        @extend .#{config.$prefix}--action-set--row-#{$m} !optional;
       }
     }
 
@@ -293,7 +293,7 @@ $block-class-action-set: #{$prefix}--action-set;
   }
 
   .sentinel {
-    @extend .#{$carbon-prefix}--visually-hidden !optional;
+    @extend .#{config.$prefix}--visually-hidden !optional;
   }
 
   .#{$block-class}__close-button {

--- a/packages/ibm-products-web-components/src/components/tearsheet/tearsheet.scss
+++ b/packages/ibm-products-web-components/src/components/tearsheet/tearsheet.scss
@@ -1,5 +1,5 @@
 /*
-* Copyright IBM Corp. 2023, 2024
+* Copyright IBM Corp. 2023, 2025
 *
 * This source code is licensed under the Apache-2.0 license found in the
 * LICENSE file in the root directory of this source tree.
@@ -10,7 +10,6 @@ $css--plex: true !default;
 /* Other Carbon settings. */
 @use '@carbon/styles/scss/reset';
 @use '@carbon/styles/scss/breakpoint' as *;
-@use '@carbon/styles/scss/config' as *;
 @use '@carbon/styles/scss/motion' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
@@ -19,10 +18,11 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/utilities/ai-gradient' as *;
 @use '@carbon/styles/scss/components/modal' as *;
 @use '@carbon/styles/scss/utilities/convert' as *;
+@use '@carbon/styles/scss/config';
+
 @use 'sass:map';
 
 $prefix: 'c4p';
-$carbon-prefix: 'cds';
 
 @use '@carbon/ibm-products-styles/scss/components/Tearsheet/index' as *;
 @use '@carbon/ibm-products-styles/scss/components/ActionSet/index' as *;
@@ -34,7 +34,7 @@ $motion-duration: $duration-moderate-02;
 :host(#{$prefix}-tearsheet) {
   --content-padding: #{$spacing-05};
 
-  @extend .#{$carbon-prefix}--modal;
+  @extend .#{config.$prefix}--modal;
   @extend .#{$prefix}--tearsheet;
 
   .#{$block-class}__header,
@@ -75,12 +75,12 @@ $motion-duration: $duration-moderate-02;
   }
 
   .#{$block-class}__buttons[hidden] {
-    @extend .#{$carbon-prefix}--visually-hidden;
+    @extend .#{config.$prefix}--visually-hidden;
 
     display: none;
   }
 
-  .#{$block-class}__buttons ::slotted(#{$carbon-prefix}-button) {
+  .#{$block-class}__buttons ::slotted(#{config.$prefix}-button) {
     @extend .#{$block-class-action-set}__action-button;
 
     flex: 0 1 25%;
@@ -88,13 +88,13 @@ $motion-duration: $duration-moderate-02;
     max-inline-size: to-rem(232px);
   }
 
-  .#{$block-class}__buttons ::slotted(#{$carbon-prefix}-button[kind='ghost']) {
+  .#{$block-class}__buttons ::slotted(#{config.$prefix}-button[kind='ghost']) {
     flex: 1 1 25%;
     max-inline-size: none;
   }
 
-  .#{$block-class}__buttons ::slotted(#{$carbon-prefix}-button[hidden]) {
-    @extend .#{$carbon-prefix}--visually-hidden;
+  .#{$block-class}__buttons ::slotted(#{config.$prefix}-button[hidden]) {
+    @extend .#{config.$prefix}--visually-hidden;
 
     display: none;
   }
@@ -102,7 +102,7 @@ $motion-duration: $duration-moderate-02;
   .#{$block-class}__influencer[wide] {
     @extend .#{$block-class}__influencer--wide;
   }
-  ::slotted(#{$carbon-prefix}-slug) {
+  ::slotted(#{config.$prefix}-slug) {
     display: flex;
     inset-inline-end: 0;
     /* stylelint-disable-next-line carbon/layout-use */
@@ -168,7 +168,7 @@ $motion-duration: $duration-moderate-02;
 }
 
 :host(#{$prefix}-tearsheet[hidden]) {
-  @extend .#{$carbon-prefix}--visually-hidden;
+  @extend .#{config.$prefix}--visually-hidden;
 }
 
 :host(#{$prefix}-tearsheet[slug]) {
@@ -250,7 +250,7 @@ $motion-duration: $duration-moderate-02;
     }
   }
 
-  .#{$carbon-prefix}--modal-header__heading.#{$block-class}__heading {
+  .#{config.$prefix}--modal-header__heading.#{$block-class}__heading {
     @include type.type-style('heading-04');
   }
 
@@ -271,34 +271,34 @@ $motion-duration: $duration-moderate-02;
 
   .#{$block-class}__content {
     // Revert background color overridden by Carbon's modal - https://github.com/carbon-design-system/carbon/blob/main/packages/styles/scss/components/modal/_modal.scss#L54
-    .#{$carbon-prefix}--pagination,
-    .#{$carbon-prefix}--pagination__control-buttons,
-    .#{$carbon-prefix}--text-input,
-    .#{$carbon-prefix}--text-area,
-    .#{$carbon-prefix}--search-input,
-    .#{$carbon-prefix}--select-input,
-    .#{$carbon-prefix}--dropdown,
-    .#{$carbon-prefix}--dropdown-list,
-    .#{$carbon-prefix}--number input[type='number'],
-    .#{$carbon-prefix}--date-picker__input {
+    .#{config.$prefix}--pagination,
+    .#{config.$prefix}--pagination__control-buttons,
+    .#{config.$prefix}--text-input,
+    .#{config.$prefix}--text-area,
+    .#{config.$prefix}--search-input,
+    .#{config.$prefix}--select-input,
+    .#{config.$prefix}--dropdown,
+    .#{config.$prefix}--dropdown-list,
+    .#{config.$prefix}--number input[type='number'],
+    .#{config.$prefix}--date-picker__input {
       background-color: $field;
     }
 
-    .#{$carbon-prefix}--select--inline .#{$carbon-prefix}--select-input {
+    .#{config.$prefix}--select--inline .#{config.$prefix}--select-input {
       background-color: transparent;
     }
 
     // and restore the 'light' prop in case light fields are wanted
-    .#{$carbon-prefix}--text-input--light,
-  .#{$carbon-prefix}--text-area--light,
-  .#{$carbon-prefix}--search--light .#{$carbon-prefix}--search-input,
-  .#{$carbon-prefix}--select--light .#{$carbon-prefix}--select-input,
-  .#{$carbon-prefix}--dropdown--light,
-  .#{$carbon-prefix}--dropdown--light .#{$carbon-prefix}--dropdown-list,
+    .#{config.$prefix}--text-input--light,
+  .#{config.$prefix}--text-area--light,
+  .#{config.$prefix}--search--light .#{config.$prefix}--search-input,
+  .#{config.$prefix}--select--light .#{config.$prefix}--select-input,
+  .#{config.$prefix}--dropdown--light,
+  .#{config.$prefix}--dropdown--light .#{config.$prefix}--dropdown-list,
   /* stylelint-disable-next-line prettier/prettier */
-  .#{$carbon-prefix}--number--light input[type='number'],
-  .#{$carbon-prefix}--date-picker--light
-    .#{$carbon-prefix}--date-picker__input {
+  .#{config.$prefix}--number--light input[type='number'],
+  .#{config.$prefix}--date-picker--light
+    .#{config.$prefix}--date-picker__input {
       background-color: $field-02;
     }
   }
@@ -310,10 +310,10 @@ $motion-duration: $duration-moderate-02;
 
 :host(#{$prefix}-tearsheet[width='narrow'])
   .#{$block-class}__buttons[actions-multiple='single']
-  ::slotted(#{$carbon-prefix}-button),
+  ::slotted(#{config.$prefix}-button),
 :host(#{$prefix}-tearsheet[width='narrow'])
   .#{$block-class}__buttons[actions-multiple='double']
-  ::slotted(#{$carbon-prefix}-button) {
+  ::slotted(#{config.$prefix}-button) {
   // double and single on lg use 50%
   flex: 0 1 50%;
   max-inline-size: none;
@@ -321,7 +321,7 @@ $motion-duration: $duration-moderate-02;
 
 :host(#{$prefix}-tearsheet[width='narrow'])
   .#{$block-class}__buttons
-  ::slotted(#{$carbon-prefix}-button) {
+  ::slotted(#{config.$prefix}-button) {
   block-size: $spacing-10;
 }
 :host(#{$prefix}-tearsheet[width='narrow']) {

--- a/packages/ibm-products-web-components/src/components/user-avatar/user-avatar.scss
+++ b/packages/ibm-products-web-components/src/components/user-avatar/user-avatar.scss
@@ -23,7 +23,6 @@ $css--plex: true !default;
 @use '@carbon/ibm-products-styles/scss/components/UserAvatar' as *;
 
 $prefix: 'c4p';
-$carbon-prefix: 'cds';
 
 $block-class: #{$prefix}--user-avatar;
 

--- a/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.test.js
+++ b/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.test.js
@@ -642,13 +642,13 @@ describe(CreateTearsheet.displayName, () => {
 
     expect(
       influencerSteps.childNodes[0].classList.contains(
-        'cds--progress-step--complete'
+        `${carbon.prefix}--progress-step--complete`
       )
     ).toBe(true);
 
     expect(
       influencerSteps.childNodes[1].classList.contains(
-        'cds--progress-step--current'
+        `${carbon.prefix}--progress-step--current`
       )
     ).toBe(true);
   });


### PR DESCRIPTION
Closes #7639 

Our current approach of directly referencing `c4p-settings.$carbon-prefix` causes our library to not support custom prefixing with Carbon. If someone attempts to add custom prefixing with base Carbon, the custom prefix won't be applied to any of the Carbon components that we reference directly within our component styles.

Instead, we should be accessing the carbon styles config module directly so that if the prefix is being passed a custom value, we're also using it.

#### What did you change?
Any sass file in our project that uses `c4p-settings.$carbon-prefix`
#### How did you test and verify your work?
Manually added a custom Carbon prefix to our storybook
`packages/ibm-products/.storybook/preview.js`
![Screenshot 2025-06-09 at 11 02 30 AM](https://github.com/user-attachments/assets/3ee4b162-ec7f-44d7-9d72-d62c1f013270)
`packages/ibm-products/.storybook/index.scss`
![Screenshot 2025-06-09 at 11 02 19 AM](https://github.com/user-attachments/assets/58a91eba-2d8f-448a-b182-9802bc9562e0)

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] Wrote passing tests that cover this change, will investigate the best way to test for this
- [ ] ~Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
