### PR TITLE
fix: remove usage of local carbon prefix in component files

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.tsx
@@ -1,5 +1,5 @@
 // /**
-//  * Copyright IBM Corp. 2022, 2024
+//  * Copyright IBM Corp. 2022, 2025
 //  *
 //  * This source code is licensed under the Apache-2.0 license found in the
 //  * LICENSE file in the root directory of this source tree.
@@ -7,8 +7,8 @@
 import '../../../feature-flags';
 import { FilterContext, FilterPanel } from './addons/Filtering';
 import React, { useContext, ForwardedRef, useRef, useEffect } from 'react';
-import { Table, TableContainer } from '@carbon/react';
-import { carbon, pkg } from '../../../settings';
+import { Table, TableContainer, usePrefix } from '@carbon/react';
+import { pkg } from '../../../settings';
 import {
   CLEAR_FILTERS,
   CLEAR_SINGLE_FILTER,
@@ -82,6 +82,7 @@ export const DatagridContent = ({
   const contentRows = ((DatagridPagination && page) || rows) as DatagridRow[];
   const gridAreaRef: ForwardedRef<HTMLDivElement> = useRef(null);
   const multiKeyTrackingRef: ForwardedRef<HTMLDivElement> = useRef(null);
+  const carbonPrefix = usePrefix();
 
   const enableEditableCell = useFeatureFlag('enable-datagrid-useEditableCell');
   const enableInlineEdit = useFeatureFlag('enable-datagrid-useInlineEdit');
@@ -161,6 +162,7 @@ export const DatagridContent = ({
                   state: inlineEditState,
                   usingMac,
                   ref: multiKeyTrackingRef,
+                  carbonPrefix,
                 })),
             onFocus:
               withInlineEdit &&
@@ -194,7 +196,7 @@ export const DatagridContent = ({
       `#${tableId}`
     );
     const tableHeader = gridElement?.querySelector(
-      `.${carbon.prefix}--data-table-header`
+      `.${carbonPrefix}--data-table-header`
     );
     gridElement?.style?.setProperty(
       `--${blockClass}--grid-width`,
@@ -206,7 +208,14 @@ export const DatagridContent = ({
         px(tableHeader?.clientHeight || 0)
       );
     }
-  }, [withInlineEdit, tableId, totalColumnsWidth, datagridState, gridActive]);
+  }, [
+    withInlineEdit,
+    tableId,
+    totalColumnsWidth,
+    datagridState,
+    gridActive,
+    carbonPrefix,
+  ]);
 
   useSubscribeToEventEmitter(CLEAR_SINGLE_FILTER, (id) =>
     clearSingleFilter(id, setAllFilters, state, contextTableId)

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.tsx
@@ -1,16 +1,16 @@
 /**
- * Copyright IBM Corp. 2020, 2024
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import React, { isValidElement } from 'react';
-import { TableRow, TableCell, SkeletonText } from '@carbon/react';
+import { TableRow, TableCell, SkeletonText, usePrefix } from '@carbon/react';
 import { px } from '@carbon/layout';
 import { selectionColumnId } from '../common-column-ids';
 import cx from 'classnames';
-import { pkg, carbon } from '../../../settings';
+import { pkg } from '../../../settings';
 import { DatagridAILabel } from './addons/AiLabel/DatagridAiLabel';
 import { DataGridState } from '../types';
 
@@ -40,6 +40,8 @@ const DatagridRow = (datagridState: DataGridState) => {
     visibleColumns,
     getAsyncSubRows,
   } = datagridState;
+
+  const carbonPrefix = usePrefix();
 
   const getVisibleNestedRowCount = ({ isExpanded, subRows }) => {
     let size = 0;
@@ -141,7 +143,7 @@ const DatagridRow = (datagridState: DataGridState) => {
     [`${blockClass}__carbon-row-expandable`]: row.canExpand,
     [`${blockClass}__carbon-row-expandable--async`]:
       getAsyncSubRows && row.depth > 0,
-    [`${carbon.prefix}--data-table--selected`]: row.isSelected,
+    [`${carbonPrefix}--data-table--selected`]: row.isSelected,
     [`${blockClass}__slug--row`]: isValidElement(row?.original?.slug),
     [`${blockClass}__ai-label--row`]: isValidElement(row?.original?.aiLabel),
   });

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.tsx
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2023
+ * Copyright IBM Corp. 2021, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,9 +19,10 @@ import {
   TableBatchAction,
   MenuButton,
   MenuItem,
+  usePrefix,
 } from '@carbon/react';
 import { useResizeObserver } from '../../../global/js/hooks/useResizeObserver';
-import { pkg, carbon } from '../../../settings';
+import { pkg } from '../../../settings';
 import cx from 'classnames';
 import { handleSelectAllRowData } from './addons/stateReducer';
 import { DataGridState, DatagridRowProps } from '../types';
@@ -53,6 +54,7 @@ const DatagridBatchActionsToolbar = (
     batchActionMenuButtonLabel,
     translateWithIdBatchActions,
   } = datagridState;
+  const carbonPrefix = usePrefix();
   const [availableRowsCount, setAvailableRowsCount] = useState(rows.length);
 
   const batchActionMenuButtonLabelText = batchActionMenuButtonLabel ?? 'More';
@@ -74,23 +76,23 @@ const DatagridBatchActionsToolbar = (
   useEffect(() => {
     if (totalSelected === 1 && !receivedInitialWidth) {
       const batchActionListWidth = ref?.current?.querySelector(
-        `.${carbon.prefix}--action-list`
+        `.${carbonPrefix}--action-list`
       ).offsetWidth;
       setInitialListWidth(batchActionListWidth);
       setReceivedInitialWidth(true);
     }
-  }, [totalSelected, receivedInitialWidth, ref]);
+  }, [totalSelected, receivedInitialWidth, ref, carbonPrefix]);
 
   useEffect(() => {
     const summaryWidth = ref?.current.querySelector(
-      `.${carbon.prefix}--batch-summary`
+      `.${carbonPrefix}--batch-summary`
     ).offsetWidth;
     if (width < summaryWidth + initialListWidth + 32) {
       setDisplayAllInMenu(true);
     } else {
       setDisplayAllInMenu(false);
     }
-  }, [width, ref, initialListWidth]);
+  }, [width, ref, initialListWidth, carbonPrefix]);
 
   const getSelectedRowData = () => {
     if (selectedKeys.length === 0) {
@@ -220,7 +222,7 @@ const DatagridBatchActionsToolbar = (
                 renderIcon={batchAction.renderIcon}
                 onClick={(event) => onClickHandler(event, batchAction)}
                 className={cx({
-                  [`${carbon.prefix}--noLabel`]:
+                  [`${carbonPrefix}--noLabel`]:
                     !batchAction.label || batchAction.label === '',
                 })}
                 iconDescription={batchAction.label}

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/handleGridKeyPress.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/handleGridKeyPress.js
@@ -1,11 +1,11 @@
 /**
- * Copyright IBM Corp. 2022, 2023
+ * Copyright IBM Corp. 2022, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import { carbon, pkg } from '../../../../../settings';
+import { pkg } from '../../../../../settings';
 import { handleMultipleKeys } from './handleMultipleKeys';
 import { getCellIdAsObject } from './InlineEditContext/getCellIdAsObject';
 
@@ -19,6 +19,7 @@ export const handleGridKeyPress = ({
   keysPressedList,
   usingMac,
   ref,
+  carbonPrefix,
 }) => {
   const { key } = event;
   const { gridActive, activeCellId, editId } = state;
@@ -70,7 +71,7 @@ export const handleGridKeyPress = ({
   // Checks if the date picker is open
   const datePickerIsActive = () => {
     const focusedCalendarElement = document.querySelector(
-      `.${carbon.prefix}--date-picker__input.flatpickr-input.active`
+      `.${carbonPrefix}--date-picker__input.flatpickr-input.active`
     );
     if (
       focusedCalendarElement ||

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/RowSize/RowSizeDropdown.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/RowSize/RowSizeDropdown.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2023
+ * Copyright IBM Corp. 2021, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -8,10 +8,16 @@
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Settings } from '@carbon/react/icons';
-import { IconButton, Layer, Popover, PopoverContent } from '@carbon/react';
+import {
+  IconButton,
+  Layer,
+  Popover,
+  PopoverContent,
+  usePrefix,
+} from '@carbon/react';
 import cx from 'classnames';
 import RowSizeRadioGroup from './RowSizeRadioGroup';
-import { pkg, carbon } from '../../../../../settings';
+import { pkg } from '../../../../../settings';
 
 const blockClass = `${pkg.prefix}--datagrid__row-size`;
 
@@ -23,6 +29,7 @@ const RowSizeDropdown = ({
 }) => {
   const radioGroupRef = useRef(undefined);
   const [isOpen, setIsOpen] = React.useState(false);
+  const carbonPrefix = usePrefix();
 
   const onCloseHandler = () => {
     setIsOpen(false);
@@ -44,7 +51,7 @@ const RowSizeDropdown = ({
     if (isOpen) {
       const radioGroupParentElement = radioGroupRef?.current;
       const checkedRadioChild = radioGroupParentElement?.querySelector(
-        `.${carbon.prefix}--radio-button:checked`
+        `.${carbonPrefix}--radio-button:checked`
       );
       checkedRadioChild?.focus();
     }

--- a/packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
+++ b/packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 /**
- * Copyright IBM Corp. 2020, 2024
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,13 +9,15 @@
 import React, { useRef } from 'react';
 import { ChevronRight } from '@carbon/react/icons';
 import cx from 'classnames';
-import { pkg, carbon } from '../../settings';
+import { pkg } from '../../settings';
 import { useFocusRowExpander } from './useFocusRowExpander';
 import { handleDynamicRowCheck } from './Datagrid/addons/stateReducer';
+import { usePrefix } from '@carbon/react';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
 const useNestedRowExpander = (hooks) => {
+  const carbonPrefix = usePrefix();
   const tempState = useRef(undefined);
   const lastExpandedRowIndex = useRef(undefined);
   const useInstance = (instance) => {
@@ -83,8 +85,8 @@ const useNestedRowExpander = (hooks) => {
             aria-label={expanderTitle}
             className={cx(
               `${blockClass}__row-expander`,
-              `${carbon.prefix}--btn`,
-              `${carbon.prefix}--btn--ghost`
+              `${carbonPrefix}--btn`,
+              `${carbonPrefix}--btn--ghost`
             )}
             {...expanderButtonProps}
           >

--- a/packages/ibm-products/src/components/Datagrid/useOnRowClick.ts
+++ b/packages/ibm-products/src/components/Datagrid/useOnRowClick.ts
@@ -1,16 +1,18 @@
 /**
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { Hooks, TableInstance } from 'react-table';
-import { pkg, carbon } from '../../settings';
+import { pkg } from '../../settings';
 import { DataGridState } from './types';
+import { usePrefix } from '@carbon/react';
 
 const useOnRowClick = (hooks: Hooks) => {
   const useInstance = (rowInstance: TableInstance) => {
+    const carbonPrefix = usePrefix();
     const { onRowClick } = rowInstance as DataGridState;
     const getRowProps = (props, datagridState) => {
       const { isFetching, row, instance } = datagridState;
@@ -23,15 +25,15 @@ const useOnRowClick = (hooks: Hooks) => {
 
           // Remove selected class from all other clickable rows as only one clickable row can be selected at a time
           const clickableSelectedRows = document.querySelectorAll(
-            `#${tableId}.${pkg.prefix}--datagrid .${carbon.prefix}--data-table--selected:not(.${pkg.prefix}--datagrid__active-row)`
+            `#${tableId}.${pkg.prefix}--datagrid .${carbonPrefix}--data-table--selected:not(.${pkg.prefix}--datagrid__active-row)`
           );
           if (clickableSelectedRows.length) {
             Array.from(clickableSelectedRows).forEach((row) => {
-              row.classList.remove(`${carbon.prefix}--data-table--selected`);
+              row.classList.remove(`${carbonPrefix}--data-table--selected`);
             });
           }
           const closestRow = event.currentTarget.closest('tr');
-          closestRow.classList.add(`${carbon.prefix}--data-table--selected`);
+          closestRow.classList.add(`${carbonPrefix}--data-table--selected`);
 
           if (!withSelectRows) {
             if (instance.selectedFlatRows) {

--- a/packages/ibm-products/src/components/Datagrid/useRowExpander.js
+++ b/packages/ibm-products/src/components/Datagrid/useRowExpander.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 /**
- * Copyright IBM Corp. 2020, 2024
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -8,9 +8,10 @@
 
 import React, { useRef } from 'react';
 import { ChevronDown, ChevronUp } from '@carbon/react/icons';
-import { pkg, carbon } from '../../settings';
+import { pkg } from '../../settings';
 import cx from 'classnames';
 import { useFocusRowExpander } from './useFocusRowExpander';
+import { usePrefix } from '@carbon/react';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
@@ -20,6 +21,7 @@ const useRowExpander = (hooks) => {
   const useInstance = (instance) => {
     tempState.current = instance;
   };
+  const carbonPrefix = usePrefix();
 
   useFocusRowExpander({
     instance: tempState?.current,
@@ -55,8 +57,8 @@ const useRowExpander = (hooks) => {
               aria-label={expanderTitle}
               className={cx(
                 `${blockClass}__row-expander`,
-                `${carbon.prefix}--btn`,
-                `${carbon.prefix}--btn--ghost`
+                `${carbonPrefix}--btn`,
+                `${carbonPrefix}--btn--ghost`
               )}
               {...expanderButtonProps}
             >

--- a/packages/ibm-products/src/components/Datagrid/useSelectRows.tsx
+++ b/packages/ibm-products/src/components/Datagrid/useSelectRows.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2023
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,10 +7,10 @@
 
 import React, { useCallback, useLayoutEffect, useState } from 'react';
 import cx from 'classnames';
-import { TableSelectRow } from '@carbon/react';
+import { TableSelectRow, usePrefix } from '@carbon/react';
 import { SelectAll } from './Datagrid/DatagridSelectAll';
 import { selectionColumnId } from './common-column-ids';
-import { pkg, carbon } from '../../settings';
+import { pkg } from '../../settings';
 import { handleToggleRowSelected } from './Datagrid/addons/stateReducer';
 import { ColumnInstance, Hooks, TableInstance } from 'react-table';
 import { DataGridState } from './types';
@@ -64,6 +64,7 @@ const useSelectRows = (hooks: Hooks) => {
 };
 
 const useHighlightSelection = (hooks) => {
+  const carbonPrefix = usePrefix();
   const getRowProps = (props, { row }) => {
     const { checked } = row.getToggleRowSelectedProps();
     return [
@@ -72,7 +73,7 @@ const useHighlightSelection = (hooks) => {
         className: cx([
           `${blockClass}__carbon-row`,
           {
-            [`${carbon.prefix}--data-table--selected`]: checked,
+            [`${carbonPrefix}--data-table--selected`]: checked,
             [`${blockClass}__active-row`]: checked,
           },
         ]),

--- a/packages/ibm-products/src/components/Datagrid/useSortableColumns.tsx
+++ b/packages/ibm-products/src/components/Datagrid/useSortableColumns.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2024
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,8 +7,8 @@
 
 import React from 'react';
 import cx from 'classnames';
-import { pkg, carbon } from '../../settings';
-import { Button } from '@carbon/react';
+import { pkg } from '../../settings';
+import { Button, usePrefix } from '@carbon/react';
 import { ArrowUp, ArrowDown, ArrowsVertical } from '@carbon/react/icons';
 import { SelectAll } from './Datagrid/DatagridSelectAll';
 import { DatagridAILabel } from './Datagrid/addons/AiLabel/DatagridAiLabel';
@@ -60,12 +60,13 @@ const getAriaPressedValue = (col) => {
 };
 
 const useSortableColumns = (hooks: Hooks) => {
+  const carbonPrefix = usePrefix();
   const sortableVisibleColumns = (visibleColumns, { instance }) => {
     const { onSort } = instance;
     const onSortClick = (event, column) => {
       const aiLabel =
-        event.target.classList.contains(`${carbon.prefix}--slug`) ||
-        event.target.closest(`.${carbon.prefix}--slug`);
+        event.target.classList.contains(`${carbonPrefix}--slug`) ||
+        event.target.closest(`.${carbonPrefix}--slug`);
       // Do not continue with sorting if we find a slug
       if (aiLabel) {
         event.stopPropagation();
@@ -84,7 +85,7 @@ const useSortableColumns = (hooks: Hooks) => {
         const iconProps = {
           size: 16,
           ...props,
-          className: `${blockClass}__sortable-icon ${carbon.prefix}--btn__icon`,
+          className: `${blockClass}__sortable-icon ${carbonPrefix}--btn__icon`,
         };
         if (col?.isSorted) {
           switch (col.isSortedDesc) {
@@ -134,7 +135,7 @@ const useSortableColumns = (hooks: Hooks) => {
             }}
             id={column?.id}
             className={cx(
-              `${carbon.prefix}--table-sort ${blockClass}--table-sort`,
+              `${carbonPrefix}--table-sort ${blockClass}--table-sort`,
               {
                 [`${blockClass}--table-sort--desc`]:
                   headerProp?.column.isSortedDesc,

--- a/packages/ibm-products/src/components/EditFullPage/EditFullPage.stories.jsx
+++ b/packages/ibm-products/src/components/EditFullPage/EditFullPage.stories.jsx
@@ -31,6 +31,7 @@ import {
   Column,
   Grid,
   DefinitionTooltip,
+  usePrefix,
 } from '@carbon/react';
 import DocsPage from './EditFullPage.docs-page';
 
@@ -91,10 +92,11 @@ const Template = ({ ...args }) => {
   const [simulatedDelay] = useState(750);
   const [shouldIncludeAdditionalStep, setShouldIncludeAdditionalStep] =
     useState(false);
+  const carbonPrefix = usePrefix();
 
   return (
     <>
-      <style>{`.${carbon.prefix}--modal { opacity: 0; }`};</style>
+      <style>{`.${carbonPrefix}--modal { opacity: 0; }`};</style>
       <CreateFullPage {...args}>
         <CreateFullPageStep
           className={`${storyClass}__step-fieldset--no-label`}
@@ -282,10 +284,11 @@ const TemplateWithSections = ({ ...args }) => {
   const [shouldReject, setShouldReject] = useState(false);
   const [isInvalid, setIsInvalid] = useState(false);
   const [simulatedDelay] = useState(750);
+  const carbonPrefix = usePrefix();
 
   return (
     <>
-      <style>{`.${carbon.prefix}--modal { opacity: 0; }`};</style>
+      <style>{`.${carbonPrefix}--modal { opacity: 0; }`};</style>
       <CreateFullPage className={`${blockClass}`} {...args}>
         <CreateFullPageStep
           title="Partition"

--- a/packages/ibm-products/src/components/EditInPlace/EditInPlace.tsx
+++ b/packages/ibm-products/src/components/EditInPlace/EditInPlace.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -13,9 +13,9 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { carbon, pkg } from '../../settings';
+import { pkg } from '../../settings';
 
-import { IconButton } from '@carbon/react';
+import { IconButton, usePrefix } from '@carbon/react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
@@ -163,6 +163,7 @@ export let EditInPlace = forwardRef<HTMLDivElement, EditInplaceProps>(
     const inputRef = useRef<HTMLInputElement>(null);
     const canSave = value !== initialValue && !invalid;
     const escaping = useRef(false);
+    const carbonPrefix = usePrefix();
 
     const tipAlignIsObject = typeof tooltipAlignment === 'object';
     const tipAlignments: { [key: string]: AlignPropType } = [
@@ -290,8 +291,8 @@ export let EditInPlace = forwardRef<HTMLDivElement, EditInplaceProps>(
             id={id}
             className={cx(
               `${blockClass}__text-input`,
-              `${carbon.prefix}--text-input`,
-              `${carbon.prefix}--text-input--${size}`
+              `${carbonPrefix}--text-input`,
+              `${carbonPrefix}--text-input--${size}`
             )}
             type="text"
             placeholder={placeholder}

--- a/packages/ibm-products/src/components/ExportModal/ExportModal.tsx
+++ b/packages/ibm-products/src/components/ExportModal/ExportModal.tsx
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -18,6 +18,7 @@ import {
   RadioButtonGroup,
   TextInput,
   unstable_FeatureFlags as FeatureFlags,
+  usePrefix,
 } from '@carbon/react';
 import { CheckmarkFilled, ErrorFilled } from '@carbon/react/icons';
 import React, {
@@ -32,7 +33,7 @@ import React, {
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
-import { pkg, carbon } from '../../settings';
+import { pkg } from '../../settings';
 import { usePortalTarget } from '../../global/js/hooks/usePortalTarget';
 import uuidv4 from '../../global/js/utils/uuidv4';
 
@@ -200,6 +201,7 @@ export let ExportModal = forwardRef(
     // by default (if it exists) use the first extension in the extension array
     const [extension, setExtension] = useState('');
     const renderPortalUse = usePortalTarget(portalTargetIn);
+    const carbonPrefix = usePrefix();
 
     useEffect(() => {
       setName(filename);
@@ -215,11 +217,11 @@ export let ExportModal = forwardRef(
     useEffect(() => {
       if (successful) {
         const button: HTMLButtonElement | null = document.querySelector(
-          `.${blockClass} .${carbon.prefix}--modal-close-button button`
+          `.${blockClass} .${carbonPrefix}--modal-close-button button`
         );
         button?.focus();
       }
-    }, [successful, blockClass]);
+    }, [successful, blockClass, carbonPrefix]);
 
     const onNameChangeHandler = (evt) => {
       setName(evt.target.value);

--- a/packages/ibm-products/src/components/ScrollGradient/ScrollGradient.js
+++ b/packages/ibm-products/src/components/ScrollGradient/ScrollGradient.js
@@ -5,22 +5,21 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Import portions of React that are needed.
 import React, { useState, useRef, useEffect } from 'react';
-// Other standard imports.
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
-import { pkg, carbon } from '../../settings';
+import { pkg } from '../../settings';
 import { ScrollStates, useIsOverflow } from './constants';
 import { useIsomorphicEffect } from '../../global/js/hooks';
+import { usePrefix } from '@carbon/react';
+
 const blockClass = `${pkg.prefix}--scroll-gradient`;
 const componentName = 'ScrollGradient';
 
 // Default values for props
 const defaults = {
-  color: `var(--${carbon.prefix}-layer-01)`,
   hideStartGradient: false,
   onScroll: () => {},
   getScrollElementRef: () => {},
@@ -34,7 +33,7 @@ export let ScrollGradient = React.forwardRef(
     {
       children,
       className,
-      color = defaults.color,
+      color,
       onScroll = defaults.onScroll,
       scrollElementClassName,
       getScrollElementRef = defaults.getScrollElementRef,
@@ -47,6 +46,9 @@ export let ScrollGradient = React.forwardRef(
     const intersectionEndRef = useRef();
     const intersectionLeftRef = useRef();
     const intersectionRightRef = useRef();
+
+    const carbonPrefix = usePrefix();
+    const fallbackColor = `var(--${carbonPrefix}-layer-01)`;
 
     const scrollContainer = useRef(undefined);
     const contentChildrenContainer = useRef(undefined);
@@ -74,18 +76,18 @@ export let ScrollGradient = React.forwardRef(
     useIsomorphicEffect(() => {
       // start vertical styles
       startVerticalRef.current.style.right = gradientRight;
-      startVerticalRef.current.style.backgroundImage = `linear-gradient(0deg, transparent, ${color} 90%)`;
+      startVerticalRef.current.style.backgroundImage = `linear-gradient(0deg, transparent, ${color ?? fallbackColor} 90%)`;
       // start horizontal styles
-      startHorizontalRef.current.backgroundImage = `linear-gradient(-90deg, transparent, ${color} 90%)`;
+      startHorizontalRef.current.backgroundImage = `linear-gradient(-90deg, transparent, ${color ?? fallbackColor} 90%)`;
       startHorizontalRef.current.bottom = gradientBottom;
       // end vertical styles
       endVerticalRef.current.style.right = gradientRight;
       endVerticalRef.current.style.bottom = gradientBottom;
-      endVerticalRef.current.style.backgroundImage = `linear-gradient(0deg, ${color} 10%, transparent)`;
+      endVerticalRef.current.style.backgroundImage = `linear-gradient(0deg, ${color ?? fallbackColor} 10%, transparent)`;
       // end horizontal styles
       endHorizontalRef.current.style.right = gradientRight;
       endHorizontalRef.current.style.bottom = gradientBottom;
-      endHorizontalRef.current.style.backgroundImage = `linear-gradient(-90deg, ${color} 10%, transparent)`;
+      endHorizontalRef.current.style.backgroundImage = `linear-gradient(-90deg, ${color ?? fallbackColor} 10%, transparent)`;
     }, [color, gradientRight, gradientBottom]);
 
     const setGradientOnIntersection = (entry, gradientRef) => {

--- a/packages/ibm-products/src/components/TruncatedList/TruncatedList.tsx
+++ b/packages/ibm-products/src/components/TruncatedList/TruncatedList.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -14,10 +14,10 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { carbon, pkg } from '../../settings';
+import { pkg } from '../../settings';
 
 // Carbon and package components we use.
-import { Button } from '@carbon/react';
+import { Button, usePrefix } from '@carbon/react';
 // Other standard imports.
 import PropTypes from 'prop-types';
 import cx from 'classnames';
@@ -109,6 +109,7 @@ export let TruncatedList = React.forwardRef<HTMLDivElement, TruncatedListProps>(
     //   (difference of the guessed height to rendered height - a few pixels)
     const [listHeight, setListHeight] = useState(minItems * 16);
     const listRef = useRef<HTMLElement | undefined>(undefined);
+    const carbonPrefix = usePrefix();
 
     const handleToggle = () => {
       setIsCollapsed((prev) => !prev);
@@ -171,7 +172,7 @@ export let TruncatedList = React.forwardRef<HTMLDivElement, TruncatedListProps>(
           <Button
             className={cx(
               `${blockClass}__button`,
-              `${carbon.prefix}--link`,
+              `${carbonPrefix}--link`,
               buttonClassName
             )}
             kind="ghost"

--- a/packages/ibm-products/src/global/js/utils/wrapFocus.js
+++ b/packages/ibm-products/src/global/js/utils/wrapFocus.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,7 +10,6 @@ import {
   DOCUMENT_POSITION_BROAD_FOLLOWING,
   selectorTabbable,
 } from './keyboardNavigation';
-import { carbon } from '../../../settings';
 
 /**
  * @param {Node} node A DOM node.
@@ -20,10 +19,11 @@ import { carbon } from '../../../settings';
 function elementOrParentIsFloatingMenu(
   node,
   selectorsFloatingMenus = [
-    `.${carbon.prefix}--overflow-menu-options`,
-    `.${carbon.prefix}--tooltip`,
+    `.${prefix}--overflow-menu-options`,
+    `.${prefix}--tooltip`,
     '.flatpickr-calendar',
-  ]
+  ],
+  prefix
 ) {
   if (node && typeof node.closest === 'function') {
     return selectorsFloatingMenus.some((selector) => node.closest(selector));
@@ -47,13 +47,18 @@ function wrapFocus({
   currentActiveNode,
   oldActiveNode,
   selectorsFloatingMenus,
+  carbonPrefix = 'cds',
 }) {
   if (
     bodyNode &&
     currentActiveNode &&
     oldActiveNode &&
     !bodyNode.contains(currentActiveNode) &&
-    !elementOrParentIsFloatingMenu(currentActiveNode, selectorsFloatingMenus)
+    !elementOrParentIsFloatingMenu(
+      currentActiveNode,
+      selectorsFloatingMenus,
+      carbonPrefix
+    )
   ) {
     const comparisonResult =
       oldActiveNode.compareDocumentPosition(currentActiveNode);

--- a/packages/ibm-products/src/global/js/utils/wrapFocus.js
+++ b/packages/ibm-products/src/global/js/utils/wrapFocus.js
@@ -10,6 +10,7 @@ import {
   DOCUMENT_POSITION_BROAD_FOLLOWING,
   selectorTabbable,
 } from './keyboardNavigation';
+import { carbon } from '../../../settings';
 
 /**
  * @param {Node} node A DOM node.
@@ -19,11 +20,10 @@ import {
 function elementOrParentIsFloatingMenu(
   node,
   selectorsFloatingMenus = [
-    `.${prefix}--overflow-menu-options`,
-    `.${prefix}--tooltip`,
+    `.${carbon.prefix}--overflow-menu-options`,
+    `.${carbon.prefix}--tooltip`,
     '.flatpickr-calendar',
-  ],
-  prefix
+  ]
 ) {
   if (node && typeof node.closest === 'function') {
     return selectorsFloatingMenus.some((selector) => node.closest(selector));
@@ -47,18 +47,13 @@ function wrapFocus({
   currentActiveNode,
   oldActiveNode,
   selectorsFloatingMenus,
-  carbonPrefix = 'cds',
 }) {
   if (
     bodyNode &&
     currentActiveNode &&
     oldActiveNode &&
     !bodyNode.contains(currentActiveNode) &&
-    !elementOrParentIsFloatingMenu(
-      currentActiveNode,
-      selectorsFloatingMenus,
-      carbonPrefix
-    )
+    !elementOrParentIsFloatingMenu(currentActiveNode, selectorsFloatingMenus)
   ) {
     const comparisonResult =
       oldActiveNode.compareDocumentPosition(currentActiveNode);


### PR DESCRIPTION
Closes #7641 

This is a complementary PR to #7640 but focuses on removing any usage of our local `carbon.prefix` in favor of `usePrefix()` from Carbon. The only place it still makes sense to use our locally defined Carbon prefix variable is within our test files, otherwise there will be clashes with custom prefixing.

#### What did you change?
```
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridContent.tsx
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridRow.tsx
packages/ibm-products/src/components/Datagrid/Datagrid/DatagridToolbar.tsx
packages/ibm-products/src/components/Datagrid/Datagrid/addons/InlineEdit/handleGridKeyPress.js
packages/ibm-products/src/components/Datagrid/Datagrid/addons/RowSize/RowSizeDropdown.js
packages/ibm-products/src/components/Datagrid/useNestedRowExpander.js
packages/ibm-products/src/components/Datagrid/useOnRowClick.ts
packages/ibm-products/src/components/Datagrid/useRowExpander.js
packages/ibm-products/src/components/Datagrid/useSelectRows.tsx
packages/ibm-products/src/components/Datagrid/useSortableColumns.tsx
packages/ibm-products/src/components/EditFullPage/EditFullPage.stories.jsx
packages/ibm-products/src/components/EditInPlace/EditInPlace.tsx
packages/ibm-products/src/components/ExportModal/ExportModal.tsx
packages/ibm-products/src/components/ScrollGradient/ScrollGradient.js
packages/ibm-products/src/components/TruncatedList/TruncatedList.tsx
packages/ibm-products/src/global/js/utils/wrapFocus.js
```
#### How did you test and verify your work?
Verified components within storybook, ran tests

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
