### PR TITLE
fix(stories): remove extra carbon style imports

### DIFF
--- a/packages/core/src/welcome/_storybook-styles.scss
+++ b/packages/core/src/welcome/_storybook-styles.scss
@@ -6,7 +6,6 @@
 //
 
 @use 'ALIAS_STORY_STYLE_CONFIG' as c4p-settings;
-@use '@carbon/styles';
 @use '@carbon/styles/scss/type';
 @use '@carbon/styles/scss/colors';
 @use '@carbon/styles/scss/spacing' as *;

--- a/packages/ibm-products-styles/src/global/styles/_display-box.scss
+++ b/packages/ibm-products-styles/src/global/styles/_display-box.scss
@@ -1,11 +1,11 @@
 //
-// Copyright IBM Corp. 2022, 2022
+// Copyright IBM Corp. 2022, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
 
-@use '@carbon/styles' as *;
+@use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/type' as *;
 @use '../../global/styles/project-settings' as *;

--- a/packages/ibm-products/.storybook/carbon.scss
+++ b/packages/ibm-products/.storybook/carbon.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2022
+// Copyright IBM Corp. 2021, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -7,5 +7,8 @@
 
 // a build of carbon css with our required feature flags set
 
+@use '@carbon/styles/scss/config' with (
+  $font-path: '@ibm/plex'
+);
 @use '@carbon/styles';
 @use '../../ibm-products-styles/src/global/styles/project-settings';


### PR DESCRIPTION
Closes #7646 

The extra import of `@carbon/styles` from the welcome page and the display box utility component were overriding the `$font-path` that is now configured in `.storybook/index.scss`. This caused the errors in the console regarding plex woff/woff2 files not loading, and also imported the entirety of Carbon's styles 2 extra times within our storybook.

#### What did you change?
```
packages/core/src/welcome/_storybook-styles.scss
packages/ibm-products-styles/src/global/styles/_display-box.scss
packages/ibm-products/.storybook/carbon.scss
```
#### How did you test and verify your work?
Ran storybook locally

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
