### PR TITLE
chore: add global mocks to jest setup

### DIFF
--- a/config/jest-config-ibm-cloud-cognitive/setup/setupFiles.js
+++ b/config/jest-config-ibm-cloud-cognitive/setup/setupFiles.js
@@ -27,6 +27,27 @@ if (global.window) {
       disconnect: jest.fn(),
     };
   });
+
+  window.matchMedia = jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // Deprecated
+    removeListener: jest.fn(), // Deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }));
+
+  window.IntersectionObserver = jest.fn().mockImplementation(() => ({
+    root: null,
+    rootMargin: '',
+    thresholds: [],
+    disconnect: () => null,
+    observe: () => null,
+    takeRecords: () => [],
+    unobserve: () => null,
+  }));
 }
 
 if (global.HTMLElement) {

--- a/packages/ibm-products/src/__tests__/index-all-enabled.test.js
+++ b/packages/ibm-products/src/__tests__/index-all-enabled.test.js
@@ -20,7 +20,6 @@ pkg._silenceWarnings(true);
 pkg.setAllComponents(true);
 
 describe(name, () => {
-  const { ResizeObserver } = window;
   let mockError, mockWarn;
 
   beforeEach(() => {
@@ -29,32 +28,12 @@ describe(name, () => {
     // conditions not met, and for the purposes of these tests we don't care.
     mockError = jest.spyOn(console, 'error').mockImplementation(() => {});
     mockWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
-    window.matchMedia = jest.fn().mockImplementation((query) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addListener: jest.fn(), // Deprecated
-      removeListener: jest.fn(), // Deprecated
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
-      dispatchEvent: jest.fn(),
-    }));
-    window.IntersectionObserver = jest.fn(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-    }));
   });
 
   afterEach(() => {
     mockError.mockRestore();
     mockWarn.mockRestore();
     jest.restoreAllMocks();
-    window.ResizeObserver = ResizeObserver;
   });
 
   for (const key in components) {

--- a/packages/ibm-products/src/__tests__/index.test.js
+++ b/packages/ibm-products/src/__tests__/index.test.js
@@ -18,7 +18,6 @@ const name = 'JS export checks';
 pkg.setAllComponents();
 
 describe(name, () => {
-  const { ResizeObserver } = window;
   let mockError, mockWarn;
 
   beforeEach(() => {
@@ -27,18 +26,12 @@ describe(name, () => {
     // conditions not met, and for the purposes of these tests we don't care.
     mockError = jest.spyOn(console, 'error').mockImplementation(() => {});
     mockWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
   });
 
   afterEach(() => {
     mockError.mockRestore();
     mockWarn.mockRestore();
     jest.restoreAllMocks();
-    window.ResizeObserver = ResizeObserver;
   });
 
   for (const key in components) {

--- a/packages/ibm-products/src/components/AboutModal/AboutModal.test.js
+++ b/packages/ibm-products/src/components/AboutModal/AboutModal.test.js
@@ -74,20 +74,6 @@ const renderComponent = ({ ...rest } = {}) =>
   );
 
 describe(componentName, () => {
-  const { ResizeObserver } = window;
-
-  beforeEach(() => {
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
-  });
-
-  afterEach(() => {
-    window.ResizeObserver = ResizeObserver;
-  });
-
   it('renders a component AboutModal', async () => {
     renderComponent({ open: true });
     expect(screen.getByRole('presentation')).toHaveClass(blockClass);

--- a/packages/ibm-products/src/components/ActionBar/ActionBar.test.js
+++ b/packages/ibm-products/src/components/ActionBar/ActionBar.test.js
@@ -88,21 +88,14 @@ const testSizes = (el, property) => {
 };
 
 describe(ActionBar.displayName, () => {
-  const { ResizeObserver } = window;
   let mockElement;
 
   beforeEach(() => {
     mockElement = mockHTMLElement(mockSizes());
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
   });
 
   afterEach(() => {
     mockElement.mockRestore();
-    window.ResizeObserver = ResizeObserver;
   });
 
   it('Renders an action bar', async () => {

--- a/packages/ibm-products/src/components/AddSelect/AddSelect.test.js
+++ b/packages/ibm-products/src/components/AddSelect/AddSelect.test.js
@@ -46,19 +46,11 @@ const initialDefaultPortalTargetBody = pkg.isFeatureEnabled(
 );
 
 describe(componentName, () => {
-  const { ResizeObserver } = window;
-
   beforeEach(() => {
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
     pkg.feature['default-portal-target-body'] = false;
   });
 
   afterEach(() => {
-    window.ResizeObserver = ResizeObserver;
     pkg.feature['default-portal-target-body'] = initialDefaultPortalTargetBody;
   });
 

--- a/packages/ibm-products/src/components/AddSelect/AddSelectBody.test.js
+++ b/packages/ibm-products/src/components/AddSelect/AddSelectBody.test.js
@@ -221,22 +221,15 @@ const itemWithAvatar = {
 };
 
 describe(componentName, () => {
-  const { ResizeObserver } = window;
   let warn;
 
   beforeEach(() => {
     warn = jest.spyOn(console, 'warn').mockImplementation(jest.fn());
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
     pkg.feature['default-portal-target-body'] = false;
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
-    window.ResizeObserver = ResizeObserver;
     pkg.feature['default-portal-target-body'] = initialDefaultPortalTargetBody;
     warn.mockRestore();
   });

--- a/packages/ibm-products/src/components/AddSelect/AddSelectBreadcrumbs.test.js
+++ b/packages/ibm-products/src/components/AddSelect/AddSelectBreadcrumbs.test.js
@@ -22,21 +22,6 @@ const defaultProps = {
 };
 
 describe(componentName, () => {
-  const { ResizeObserver } = window;
-
-  beforeEach(() => {
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-    window.ResizeObserver = ResizeObserver;
-  });
-
   it('renders', async () => {
     render(<AddSelectBreadcrumbs {...defaultProps} />);
   });

--- a/packages/ibm-products/src/components/AddSelect/AddSelectMetaPanel.test.js
+++ b/packages/ibm-products/src/components/AddSelect/AddSelectMetaPanel.test.js
@@ -20,21 +20,6 @@ const defaultProps = {
 };
 
 describe(componentName, () => {
-  const { ResizeObserver } = window;
-
-  beforeEach(() => {
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-    window.ResizeObserver = ResizeObserver;
-  });
-
   it('renders', async () => {
     render(<AddSelectMetaPanel {...defaultProps} />);
   });

--- a/packages/ibm-products/src/components/AddSelect/AddSelectSort.test.js
+++ b/packages/ibm-products/src/components/AddSelect/AddSelectSort.test.js
@@ -15,21 +15,6 @@ const blockClass = `${pkg.prefix}--add-select-sort`;
 const componentName = AddSelectSort.name;
 
 describe(componentName, () => {
-  const { ResizeObserver } = window;
-
-  beforeEach(() => {
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-    window.ResizeObserver = ResizeObserver;
-  });
-
   it('renders', async () => {
     render(<AddSelectSort sortByLabel="test sort title" />);
   });

--- a/packages/ibm-products/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.test.js
+++ b/packages/ibm-products/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.test.js
@@ -48,7 +48,6 @@ const TestBreadcrumbWithOverflow = ({ width, ...rest }) => {
 };
 
 describe(BreadcrumbWithOverflow.displayName, () => {
-  const { ResizeObserver } = window;
   let mockElement;
 
   beforeEach(() => {
@@ -87,17 +86,11 @@ describe(BreadcrumbWithOverflow.displayName, () => {
         },
       },
     });
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
   });
 
   afterEach(() => {
     mockElement.mockRestore();
     jest.restoreAllMocks();
-    window.ResizeObserver = ResizeObserver;
   });
 
   const { click } = fireEvent;

--- a/packages/ibm-products/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.test.js
+++ b/packages/ibm-products/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.test.js
@@ -33,7 +33,6 @@ const blockClass = `${pkg.prefix}--button-set-with-overflow`;
 const buttonWidth = 200;
 
 describe(ButtonSetWithOverflow.displayName, () => {
-  const { ResizeObserver } = window;
   let mockElement;
 
   beforeEach(() => {
@@ -52,16 +51,10 @@ describe(ButtonSetWithOverflow.displayName, () => {
         },
       },
     });
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
   });
 
   afterEach(() => {
     mockElement.mockRestore();
-    window.ResizeObserver = ResizeObserver;
   });
 
   it('Works with button shape array', async () => {

--- a/packages/ibm-products/src/components/Carousel/Carousel.test.js
+++ b/packages/ibm-products/src/components/Carousel/Carousel.test.js
@@ -22,14 +22,6 @@ const className = `class-${uuidv4()}`;
 const dataTestId = uuidv4();
 
 describe(componentName, () => {
-  // The Carousel component uses IntersectionObserver.
-  beforeEach(() => {
-    window.IntersectionObserver = jest.fn().mockImplementation(() => ({
-      observe: () => null,
-      unobserve: () => null,
-    }));
-  });
-
   it('renders a component Carousel', () => {
     render(<Carousel data-testid={dataTestId}> </Carousel>);
     expect(screen.getByTestId(dataTestId)).toHaveClass(blockClass);

--- a/packages/ibm-products/src/components/CoachmarkFixed/CoachmarkFixed.test.js
+++ b/packages/ibm-products/src/components/CoachmarkFixed/CoachmarkFixed.test.js
@@ -57,24 +57,6 @@ const renderCoachmarkFixed = ({ ...rest } = {}) =>
 describe(componentName, () => {
   beforeEach(() => {
     jest.spyOn(console, 'warn').mockImplementation(() => {});
-
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: jest.fn().mockImplementation((query) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: jest.fn(), // Deprecated
-        removeListener: jest.fn(), // Deprecated
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
-    });
-    window.IntersectionObserver = jest.fn().mockImplementation(() => ({
-      observe: () => null,
-      unobserve: () => null,
-    }));
   });
   it('renders a component CoachmarkFixed', () => {
     renderCoachmarkFixed({

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.test.js
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.test.js
@@ -176,18 +176,6 @@ const renderFullPageWithStepChildrenOutside = ({ ...rest } = {}) =>
   );
 
 describe(componentName, () => {
-  const { ResizeObserver } = window;
-  beforeEach(() => {
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
-  });
-  afterEach(() => {
-    window.ResizeObserver = ResizeObserver;
-  });
-
   it('has no accessibility violations', async () => {
     const { container } = renderComponent({ ...defaultFullPageProps });
 

--- a/packages/ibm-products/src/components/CreateSidePanel/CreateSidePanel.test.js
+++ b/packages/ibm-products/src/components/CreateSidePanel/CreateSidePanel.test.js
@@ -49,33 +49,6 @@ const renderComponent = ({ ...rest } = {}, children = <p>test</p>) =>
   );
 
 describe(componentName, () => {
-  const { ResizeObserver } = window;
-
-  beforeEach(() => {
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: jest.fn().mockImplementation((query) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: jest.fn(), // Deprecated
-        removeListener: jest.fn(), // Deprecated
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
-    });
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
-  });
-
-  afterEach(() => {
-    window.ResizeObserver = ResizeObserver;
-  });
-
   it('renders the side panel', async () => {
     renderComponent();
     expect(screen.getByRole('complementary')).toHaveClass(blockClass);

--- a/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.test.js
+++ b/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.test.js
@@ -177,29 +177,12 @@ const initialDefaultPortalTargetBody = pkg.isFeatureEnabled(
 );
 
 describe(CreateTearsheet.displayName, () => {
-  const { ResizeObserver } = window;
-
   beforeEach(() => {
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
-    window.IntersectionObserver = jest.fn().mockImplementation(() => ({
-      root: null,
-      rootMargin: '',
-      thresholds: [],
-      disconnect: () => null,
-      observe: () => null,
-      takeRecords: () => [],
-      unobserve: () => null,
-    }));
     jest.useFakeTimers();
     pkg.feature['default-portal-target-body'] = false;
   });
 
   afterEach(() => {
-    window.ResizeObserver = ResizeObserver;
     jest.useRealTimers();
     pkg.feature['default-portal-target-body'] = initialDefaultPortalTargetBody;
   });

--- a/packages/ibm-products/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.test.js
+++ b/packages/ibm-products/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.test.js
@@ -50,20 +50,12 @@ const initialDefaultPortalTargetBody = pkg.isFeatureEnabled(
 );
 
 describe(componentName, () => {
-  const { ResizeObserver } = window;
-
   beforeAll(() => {
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
     pkg.feature['default-portal-target-body'] = false;
   });
 
   afterAll(() => {
     jest.restoreAllMocks();
-    window.ResizeObserver = ResizeObserver;
     pkg.feature['default-portal-target-body'] = initialDefaultPortalTargetBody;
   });
 

--- a/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid.test.js
@@ -972,27 +972,10 @@ describe(componentName, () => {
     jest.spyOn(global.console, 'warn').mockImplementation(() => {});
     jest.useFakeTimers();
     jest.spyOn(global, 'setTimeout');
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: jest.fn().mockImplementation((query) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
-    });
   });
 
   afterEach(() => {
     jest.useRealTimers();
-    window.ResizeObserver = ResizeObserver;
   });
 
   it('check total column count', () => {
@@ -2939,16 +2922,10 @@ describe('batch action testing', () => {
           },
         },
       });
-      window.ResizeObserver = jest.fn().mockImplementation(() => ({
-        observe: jest.fn(),
-        unobserve: jest.fn(),
-        disconnect: jest.fn(),
-      }));
     });
 
     afterEach(() => {
       mockElement.mockRestore();
-      window.ResizeObserver = ResizeObserver;
     });
 
     it('renders batch action and checks for the appropriate rendering based on the current mocked widths', async () => {

--- a/packages/ibm-products/src/components/EditSidePanel/EditSidePanel.test.js
+++ b/packages/ibm-products/src/components/EditSidePanel/EditSidePanel.test.js
@@ -53,32 +53,8 @@ const renderEditPanel = ({ ...rest } = {}, children = childrenContent) =>
   );
 
 describe(componentName, () => {
-  const { ResizeObserver } = window;
-
   beforeEach(() => {
     jest.spyOn(console, 'warn').mockImplementation(() => {});
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: jest.fn().mockImplementation((query) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: jest.fn(), // Deprecated
-        removeListener: jest.fn(), // Deprecated
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
-    });
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
-  });
-
-  afterEach(() => {
-    window.ResizeObserver = ResizeObserver;
   });
 
   it('renders a component EditSidePanel', async () => {

--- a/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.test.js
+++ b/packages/ibm-products/src/components/EditTearsheet/EditTearsheet.test.js
@@ -95,36 +95,10 @@ const initialDefaultPortalTargetBody = pkg.isFeatureEnabled(
 );
 
 describe(componentName, () => {
-  const { ResizeObserver } = window;
-
   beforeEach(() => {
     jest.spyOn(console, 'warn').mockImplementation(() => {});
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
-    window.IntersectionObserver = jest.fn().mockImplementation(() => ({
-      root: null,
-      rootMargin: '',
-      thresholds: [],
-      disconnect: () => null,
-      observe: () => null,
-      takeRecords: () => [],
-      unobserve: () => null,
-    }));
     jest.useFakeTimers();
     pkg.feature['default-portal-target-body'] = false;
-    window.matchMedia = jest.fn().mockImplementation((query) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addListener: jest.fn(), // Deprecated
-      removeListener: jest.fn(), // Deprecated
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
-      dispatchEvent: jest.fn(),
-    }));
 
     //todo: remove once carbon fixes issue on side nav
     jest.spyOn(console, 'error').mockImplementation((msg) => {
@@ -139,7 +113,6 @@ describe(componentName, () => {
   });
 
   afterEach(() => {
-    window.ResizeObserver = ResizeObserver;
     jest.useRealTimers();
     pkg.feature['default-portal-target-body'] = initialDefaultPortalTargetBody;
     console.error.mockRestore();

--- a/packages/ibm-products/src/components/FilterPanel/FilterPanelAccordion/FilterPanelAccordion.test.js
+++ b/packages/ibm-products/src/components/FilterPanel/FilterPanelAccordion/FilterPanelAccordion.test.js
@@ -36,15 +36,6 @@ describe(componentName, () => {
   beforeEach(() => {
     jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
-  const { getComputedStyle } = window;
-
-  beforeEach(() => {
-    window.getComputedStyle = jest.fn();
-  });
-
-  afterEach(() => {
-    window.getComputedStyle = getComputedStyle;
-  });
 
   it('renders a component FilterPanelAccordion', async () => {
     const { container } = renderComponent();

--- a/packages/ibm-products/src/components/FilterSummary/FilterSummary.test.js
+++ b/packages/ibm-products/src/components/FilterSummary/FilterSummary.test.js
@@ -38,20 +38,13 @@ const renderComponent = ({ ...rest } = {}) =>
   render(<FilterSummaryWrapper {...rest} />);
 
 describe(componentName, () => {
-  const { ResizeObserver } = window;
   let warn;
 
   beforeEach(() => {
     warn = jest.spyOn(console, 'warn').mockImplementation(jest.fn());
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
   });
 
   afterEach(() => {
-    window.ResizeObserver = ResizeObserver;
     warn.mockRestore();
   });
 

--- a/packages/ibm-products/src/components/Guidebanner/Guidebanner.test.js
+++ b/packages/ibm-products/src/components/Guidebanner/Guidebanner.test.js
@@ -50,14 +50,6 @@ const renderComponent = (customProps = {}) => {
 };
 
 describe(componentName, () => {
-  // The Carousel component uses IntersectionObserver.
-  beforeEach(() => {
-    window.IntersectionObserver = jest.fn().mockImplementation(() => ({
-      observe: () => null,
-      unobserve: () => null,
-    }));
-  });
-
   it('renders a component Guidebanner', () => {
     const { container } = renderComponent();
     const guidebanner = container.getElementsByClassName(blockClass);

--- a/packages/ibm-products/src/components/MultiAddSelect/MultiAddSelect.test.js
+++ b/packages/ibm-products/src/components/MultiAddSelect/MultiAddSelect.test.js
@@ -39,21 +39,6 @@ const defaultProps = {
 };
 
 describe(componentName, () => {
-  const { ResizeObserver } = window;
-
-  beforeEach(() => {
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-    window.ResizeObserver = ResizeObserver;
-  });
-
   it('renders', async () => {
     render(<MultiAddSelect {...defaultProps} />);
   });

--- a/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.test.js
+++ b/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.test.js
@@ -48,22 +48,6 @@ const renderNotifications = ({ ...rest } = {}) =>
   );
 
 describe('Notifications', () => {
-  beforeEach(() => {
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: jest.fn().mockImplementation((query) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: jest.fn(), // Deprecated
-        removeListener: jest.fn(), // Deprecated
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
-    });
-  });
-
   it('renders the notification panel', async () => {
     const { animationStart, animationEnd } = fireEvent;
     const { container, rerender } = renderNotifications({

--- a/packages/ibm-products/src/components/OptionsTile/OptionsTile.test.js
+++ b/packages/ibm-products/src/components/OptionsTile/OptionsTile.test.js
@@ -38,20 +38,6 @@ let originalAnimateFunction;
 
 describe(componentName, () => {
   beforeAll(() => {
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: jest.fn().mockImplementation((query) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: jest.fn(), // Deprecated
-        removeListener: jest.fn(), // Deprecated
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
-    });
-
     originalAnimateFunction = HTMLDivElement.prototype.animate;
 
     const obj = {
@@ -245,20 +231,6 @@ describe(componentName, () => {
   });
 
   it('expands and collapses with usePrefersReducedMotion', async () => {
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: jest.fn().mockImplementation((query) => ({
-        matches: true,
-        media: query,
-        onchange: null,
-        addListener: jest.fn(), // Deprecated
-        removeListener: jest.fn(), // Deprecated
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
-    });
-
     const { container } = render(<OptionsTile {...props} />);
     const summaryEl = container.querySelector('summary');
     const detailsEl = container.querySelector('details');

--- a/packages/ibm-products/src/components/PageHeader/PageHeader.test.js
+++ b/packages/ibm-products/src/components/PageHeader/PageHeader.test.js
@@ -199,10 +199,8 @@ const testPropsUserDefined = {
 };
 
 describe('PageHeader', () => {
-  const { ResizeObserver } = window;
-  let mockElement;
   const mocks = [];
-  let warn;
+  let mockElement, warn;
 
   window.innerWidth = 2000;
   window.innerHeight = 1080;
@@ -226,21 +224,6 @@ describe('PageHeader', () => {
       id: 'uuidv4',
       mock: uuidv4.mockImplementation(() => 'test-id'),
     });
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
-    window.matchMedia = jest.fn().mockImplementation((query) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addListener: jest.fn(), // Deprecated
-      removeListener: jest.fn(), // Deprecated
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
-      dispatchEvent: jest.fn(),
-    }));
   });
 
   afterEach(() => {
@@ -248,7 +231,6 @@ describe('PageHeader', () => {
       mock.mock.mockRestore();
     });
     mockElement.mockRestore();
-    window.ResizeObserver = ResizeObserver;
     warn.mockRestore();
   });
 

--- a/packages/ibm-products/src/components/ScrollGradient/ScrollGradient.test.js
+++ b/packages/ibm-products/src/components/ScrollGradient/ScrollGradient.test.js
@@ -40,15 +40,6 @@ const renderComponent = ({ ...rest } = {}, children = childrenContent) =>
   render(<ScrollGradient {...rest}>{children}</ScrollGradient>);
 
 describe(componentName, () => {
-  beforeEach(() => {
-    const observe = jest.fn();
-    const unobserve = jest.fn();
-    window.IntersectionObserver = jest.fn(() => ({
-      observe,
-      unobserve,
-    }));
-  });
-
   it('renders a component ScrollGradient', async () => {
     renderComponent({ 'data-testid': dataTestId });
     expect(screen.getByTestId(dataTestId)).toHaveClass(blockClass);

--- a/packages/ibm-products/src/components/SidePanel/SidePanel.test.js
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.test.js
@@ -102,33 +102,6 @@ const SlideIn = ({
 };
 
 describe('SidePanel', () => {
-  const { ResizeObserver } = window;
-
-  beforeEach(() => {
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: jest.fn().mockImplementation((query) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: jest.fn(), // Deprecated
-        removeListener: jest.fn(), // Deprecated
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
-    });
-  });
-
-  afterEach(() => {
-    window.ResizeObserver = ResizeObserver;
-  });
-
   it('renders the side panel', async () => {
     const subtitle = uuidv4();
     const labelText = uuidv4();

--- a/packages/ibm-products/src/components/SimpleHeader/SimpleHeader.test.js
+++ b/packages/ibm-products/src/components/SimpleHeader/SimpleHeader.test.js
@@ -13,18 +13,6 @@ const componentName = SimpleHeader.displayName;
 const blockClass = `${pkg.prefix}--simple-header`;
 
 describe(componentName, () => {
-  const { ResizeObserver } = window;
-  beforeEach(() => {
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
-  });
-  afterEach(() => {
-    window.ResizeObserver = ResizeObserver;
-  });
-
   const renderComponent = (args) => render(<SimpleHeader {...args} />);
 
   beforeAll(() => {

--- a/packages/ibm-products/src/components/SingleAddSelect/SingleAddSelect.test.js
+++ b/packages/ibm-products/src/components/SingleAddSelect/SingleAddSelect.test.js
@@ -39,21 +39,6 @@ const defaultProps = {
 };
 
 describe(componentName, () => {
-  const { ResizeObserver } = window;
-
-  beforeEach(() => {
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-    window.ResizeObserver = ResizeObserver;
-  });
-
   it('renders', async () => {
     render(<SingleAddSelect {...defaultProps} />);
   });

--- a/packages/ibm-products/src/components/TagOverflow/TagOverflow.test.js
+++ b/packages/ibm-products/src/components/TagOverflow/TagOverflow.test.js
@@ -27,24 +27,15 @@ const tagOverflowProps = {
 };
 
 describe(componentName, () => {
-  const { ResizeObserver } = window;
   let warn;
 
   beforeEach(() => {
     warn = jest.spyOn(console, 'warn').mockImplementation(jest.fn());
-
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
-
     window.innerWidth = 500;
     fireEvent(window, new Event('resize'));
   });
 
   afterEach(() => {
-    window.ResizeObserver = ResizeObserver;
     warn.mockRestore();
   });
 

--- a/packages/ibm-products/src/components/TagSet/TagSet.test.js
+++ b/packages/ibm-products/src/components/TagSet/TagSet.test.js
@@ -65,16 +65,10 @@ describe(TagSet.displayName, () => {
         },
       },
     });
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
   });
 
   afterEach(() => {
     mockElement.mockRestore();
-    window.ResizeObserver = ResizeObserver;
     warn.mockRestore();
   });
 

--- a/packages/ibm-products/src/components/Tearsheet/Tearsheet.test.js
+++ b/packages/ibm-products/src/components/Tearsheet/Tearsheet.test.js
@@ -374,29 +374,11 @@ const initialDefaultPortalTargetBody = pkg.isFeatureEnabled(
 );
 
 describe(componentName, () => {
-  const { ResizeObserver } = window;
-
   beforeAll(() => {
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
     pkg.feature['default-portal-target-body'] = false;
-    window.matchMedia = jest.fn().mockImplementation((query) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addListener: jest.fn(), // Deprecated
-      removeListener: jest.fn(), // Deprecated
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
-      dispatchEvent: jest.fn(),
-    }));
   });
 
   afterAll(() => {
-    window.ResizeObserver = ResizeObserver;
     pkg.feature['default-portal-target-body'] = initialDefaultPortalTargetBody;
   });
 
@@ -451,19 +433,7 @@ describe(componentName, () => {
 });
 
 describe(componentNameNarrow, () => {
-  const { ResizeObserver } = window;
-
-  beforeAll(() => {
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
-    pkg.feature['default-portal-target-body'] = false;
-  });
-
   afterAll(() => {
-    window.ResizeObserver = ResizeObserver;
     pkg.feature['default-portal-target-body'] = initialDefaultPortalTargetBody;
   });
 
@@ -471,20 +441,8 @@ describe(componentNameNarrow, () => {
 });
 
 describe(componentNameCreateNarrow, () => {
-  const { ResizeObserver } = window;
-
   beforeAll(() => {
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
     pkg.feature['default-portal-target-body'] = false;
-  });
-
-  afterAll(() => {
-    window.ResizeObserver = ResizeObserver;
-    pkg.feature['default-portal-target-body'] = initialDefaultPortalTargetBody;
   });
 
   commonTests(


### PR DESCRIPTION
Closes #5029 

this adds `matchMedia` and `IntersectionObserver` into the jest `setupFiles` config so that they don't have to be declared in every test that requires them. `ResizeObserver` was already set in the config, so this also removes unnecessary `ResizeObserver` mocks.
