### PR TITLE
docs: update installation detail in readme and welcome story

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,50 @@ see the Carbon
 and the Carbon for IBM Products
 [v2 migration guide](https://github.com/carbon-design-system/ibm-products/blob/main/docs/guides/v2.md).
 
+### Installation
+
+Using npm:</br> `npm install @carbon/ibm-products`
+
+If you prefer Yarn:</br> `yarn add @carbon/ibm-products`
+
+#### Styles
+
+The `@carbon/ibm-products` package provides several options for importing the
+package styles:
+
+_// Include all the styles, including Carbon and experimental styles_</br>
+`@use '@carbon/ibm-products/css/index.min.css';`
+
+_// Include only styles from @carbon/ibm-products_</br>
+`@use '@carbon/ibm-products/css/index-without-carbon.css';`
+
+_// Include only styles from @carbon/ibm-products, excluding experimental
+styles_</br>
+`@use '@carbon/ibm-products/css/index-without-carbon-released-only.css';`
+
+_// Include all styles from carbon_</br>
+`@use '@carbon/ibm-products/css/index-full-carbon.css';`
+
+To include the styles for a specific component:
+
+_// Bring in the styles for one component_</br>
+`@use '@carbon/ibm-products/scss/components/AboutModal';`
+
+You can also leverage the Carbon for IBM Products styles independently of the
+React package using the
+[@carbon/ibm-products-styles](https://github.com/carbon-design-system/ibm-products/tree/main/packages/ibm-products-styles)
+package.
+
+#### Usage
+
+```
+import { AboutModal } from '@carbon/ibm-products';
+
+const App = () => {
+  return <AboutModal />;
+};
+```
+
 ## 🙌 Contributing
 
 This project is made possible by several community members who have invested

--- a/packages/core/src/welcome/Welcome.js
+++ b/packages/core/src/welcome/Welcome.js
@@ -110,6 +110,14 @@ const Welcome = () => {
             >
               v1 to v2 migration guide
             </Link>
+            <Link
+              href="https://pages.github.ibm.com/carbon/ibm-products/developing/get-started/"
+              className="welcome__link"
+              renderIcon={ArrowRight}
+              size="lg"
+            >
+              Get started
+            </Link>
           </div>
         </div>
         <div className="welcome__col--right">


### PR DESCRIPTION
Closes #7399 

Add Install, Styles, Usage section as in [website](https://pages.github.ibm.com/carbon/ibm-products/developing/get-started/) in repo [readme.md](https://github.com/carbon-design-system/ibm-products)

Include the missing detail in readme. `To include all Carbon index-full-carbon`

Add Get started link in storybook welcome page, this should go to packages/ibm-products/README.md



#### How did you test and verify your work?
local

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
