### PR TITLE
Fix resizable side panel a11y

### DIFF
--- a/e2e/components/SidePanel/SidePanel-test.avt.e2e.js
+++ b/e2e/components/SidePanel/SidePanel-test.avt.e2e.js
@@ -106,6 +106,8 @@ test.describe('SidePanel @avt', () => {
         carbonTheme: 'white',
       },
     });
-    await expect(page).toHaveNoACViolations('SidePanel @avt-default-state');
+    await expect(page).toHaveNoACViolations(
+      'SidePanel @avt-resizer-feature-enabled'
+    );
   });
 });

--- a/e2e/components/SidePanel/SidePanel-test.avt.e2e.js
+++ b/e2e/components/SidePanel/SidePanel-test.avt.e2e.js
@@ -97,4 +97,15 @@ test.describe('SidePanel @avt', () => {
     await page.getByRole('button', { name: 'Open side panel' }).click();
     await expect(page.getByLabel('Close')).toBeFocused();
   });
+
+  test('@avt-resizer-feature-enabled', async ({ page }) => {
+    await visitStory(page, {
+      component: 'SidePanel',
+      id: 'ibm-products-components-side-panel-sidepanel--slide-over&args=jsFlags[0]:enableSidepanelResizer',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('SidePanel @avt-default-state');
+  });
 });

--- a/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
@@ -391,23 +391,36 @@ const SidePanelBase = React.forwardRef(
       [placement, sidePanelRef, sidePanelWidth]
     );
 
+    const getPanelWidthPercent = useCallback(
+      (customWidth?: string) => {
+        if (customWidth) {
+          const remValue = parseFloat(customWidth);
+          const remInPixels =
+            remValue *
+            parseFloat(getComputedStyle(document.documentElement).fontSize);
+          return Math.round((remInPixels / window.innerWidth) * 100);
+        }
+        return Math.round(
+          ((sidePanelRef.current?.clientWidth || 0) / window.innerWidth) * 100
+        );
+      },
+      [sidePanelRef]
+    );
+
     const onResizeEnd = useCallback(
       (_, ref) => {
         accumulatedDeltaRef.current = 0;
         sidePanelRef.current?.style?.removeProperty('transition');
-
-        const percent = Math.round(
-          ((sidePanelRef.current.clientWidth || 0) / window.innerWidth) * 100
-        );
         // custom a11y announcements
         ref.current.setAttribute(
           'aria-label',
-          `side panel is covering ${percent}% of screen`
+          `side panel is covering ${getPanelWidthPercent()}% of screen`
         );
+        ref.current.setAttribute('aria-valuenow', getPanelWidthPercent());
 
         sidePanelWidth.current = sidePanelRef.current?.clientWidth;
       },
-      [sidePanelRef]
+      [sidePanelRef, getPanelWidthPercent]
     );
 
     const onDoubleClick = useCallback(() => {
@@ -1019,7 +1032,9 @@ const SidePanelBase = React.forwardRef(
             <Resizer
               className={`${blockClass}__resizer`}
               orientation="vertical"
-              aria-valuenow={sidePanelWidth.current}
+              aria-valuemin={getPanelWidthPercent(SIDE_PANEL_SIZES['xs'])}
+              aria-valuemax={75}
+              aria-valuenow={getPanelWidthPercent()}
               onResize={onResize}
               onResizeEnd={onResizeEnd}
               onDoubleClick={onDoubleClick}


### PR DESCRIPTION
contributes to #7250 

fixes a11y issue when we enable the resize feature, by providing 
aria-valuemin, aria-valuemax, aria-valuenow which updates with resizing.
<img width="450" alt="Screenshot 2025-06-19 at 1 36 45 PM" src="https://github.com/user-attachments/assets/0e1b1627-bd00-4500-b2e7-0eab6aeec08c" />

#### What did you change?
side panel, added a function to get panel size by % and setting it on aria-valuenow
aria-valuemax is always 75% as per the guidance
aria-valuemin is calculated by getPanelWidthPercent(SIDE_PANEL_SIZES['xs'])

#### How did you test and verify your work?
storybook accessibility tab with feature enabled, doesn't show any violation

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
