### PR TITLE
fix(notification panel): clickoutside return focus to trigger button

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -171,6 +171,7 @@
     "skipnav",
     "slotchange",
     "spacebar",
+    "spinbutton",
     "stackable",
     "stackblitz",
     "statusicon",

--- a/e2e/components/NotificationsPanel/NotificationsPanel-test.avt.e2e.js
+++ b/e2e/components/NotificationsPanel/NotificationsPanel-test.avt.e2e.js
@@ -38,6 +38,7 @@ test.describe('NotificationsPanel @avt', () => {
       `#${pkg.prefix}--notifications-panel`
     );
     await expect(notificationPanel).toBeVisible();
+
     for (let i = 0; i < 10; i++) {
       await page.keyboard.press('Tab');
       await expect(notificationPanel).toContainText(
@@ -76,7 +77,7 @@ test.describe('NotificationsPanel @avt', () => {
         (el) => el === document.activeElement
       );
       expect(isFocused).toBeTruthy();
-    }).toPass({ timeout: 2000 }); // Wait up to 2 seconds
+    }).toPass({ timeout: 2000 });
   });
   test('@avt-notification-panel-doesn-not-focus-return-to-trigger-when-clicked-on-actionable-elements', async ({
     page,

--- a/e2e/components/NotificationsPanel/NotificationsPanel-test.avt.e2e.js
+++ b/e2e/components/NotificationsPanel/NotificationsPanel-test.avt.e2e.js
@@ -38,7 +38,6 @@ test.describe('NotificationsPanel @avt', () => {
       `#${pkg.prefix}--notifications-panel`
     );
     await expect(notificationPanel).toBeVisible();
-
     for (let i = 0; i < 10; i++) {
       await page.keyboard.press('Tab');
       await expect(notificationPanel).toContainText(
@@ -52,5 +51,57 @@ test.describe('NotificationsPanel @avt', () => {
       name: 'Notifications',
     });
     await expect(notificationTrigger).toBeFocused();
+  });
+  test('@avt-notification-panel-focus-return-to-trigger', async ({ page }) => {
+    await visitStory(page, {
+      component: 'NotificationsPanel',
+      id: 'ibm-products-components-notifications-panel-notificationspanel--default',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    const notificationPanel = await page.locator(
+      `#${pkg.prefix}--notifications-panel`
+    );
+    await expect(notificationPanel).toBeVisible();
+    const notificationTrigger = page.locator(
+      'button[aria-label="Open notifications"]'
+    );
+    await page.evaluate(() => {
+      document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await expect(notificationPanel).not.toBeVisible({ timeout: 2000 });
+    await expect(async () => {
+      const isFocused = await notificationTrigger.evaluate(
+        (el) => el === document.activeElement
+      );
+      expect(isFocused).toBeTruthy();
+    }).toPass({ timeout: 2000 }); // Wait up to 2 seconds
+  });
+  test('@avt-notification-panel-doesn-not-focus-return-to-trigger-when-clicked-on-actionable-elements', async ({
+    page,
+  }) => {
+    await visitStory(page, {
+      component: 'NotificationsPanel',
+      id: 'ibm-products-components-notifications-panel-notificationspanel--default',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    const notificationPanel = await page.locator(
+      `#${pkg.prefix}--notifications-panel`
+    );
+    await expect(notificationPanel).toBeVisible();
+    const notificationTrigger = page.locator(
+      'button[aria-label="Open notifications"]'
+    );
+    const addNotificationButton = page.getByRole('button', {
+      name: 'Add new notification',
+      exact: true,
+    });
+    await addNotificationButton.click();
+    await expect(notificationPanel).not.toBeVisible({ timeout: 2000 });
+    await expect(notificationTrigger).not.toBeFocused();
+    await expect(addNotificationButton).toBeFocused({ timeout: 2000 });
   });
 });

--- a/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.test.js
+++ b/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.test.js
@@ -9,7 +9,7 @@
 
 import { fireEvent, render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-
+import { waitFor } from '@testing-library/react';
 import React from 'react';
 
 import uuidv4 from '../../global/js/utils/uuidv4';
@@ -255,6 +255,38 @@ describe('Notifications', () => {
     container.querySelector(`.${blockClass}`).focus();
     await act(() => userEvent.keyboard('{Escape}'));
     expect(onClickOutside).toHaveBeenCalled();
+  });
+
+  it('should return focus to trigger button when clicking outside and not on actionable element', async () => {
+    const triggerButtonRef = React.createRef();
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    triggerButtonRef.current = button;
+    renderNotifications({
+      triggerButtonRef,
+      open: true,
+      data: [],
+    });
+    await userEvent.click(document.body);
+    await waitFor(() => {
+      expect(document.activeElement).toBe(button);
+    });
+  });
+  it('should not return focus to trigger button when clicking outside but on an actionable element', async () => {
+    const triggerButtonRef = React.createRef();
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    const buttonAction = document.createElement('button');
+    document.body.appendChild(buttonAction);
+    triggerButtonRef.current = button;
+    renderNotifications({
+      triggerButtonRef,
+      open: true,
+      data: [],
+    });
+    await userEvent.click(buttonAction);
+    expect(document.activeElement).not.toBe(button);
+    expect(document.activeElement).toBe(buttonAction);
   });
 
   it('should not render a notifications panel when open is false', async () => {

--- a/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.tsx
+++ b/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.tsx
@@ -409,7 +409,13 @@ export let NotificationsPanel = React.forwardRef(
       setAllNotifications(data);
     }, [data]);
 
-    useClickOutside(ref || notificationPanelRef, () => {
+    useClickOutside(ref || notificationPanelRef, (target) => {
+      const element = target as HTMLElement;
+      if (!isActionableElement(element)) {
+        setTimeout(() => {
+          triggerButtonRef?.current?.focus();
+        }, 100);
+      }
       onClickOutside?.();
     });
 
@@ -680,6 +686,45 @@ export let NotificationsPanel = React.forwardRef(
             <Close size={16} />
           </IconButton>
         </Section>
+      );
+    };
+
+    const isActionableElement = (el: HTMLElement | null): boolean => {
+      if (!el) {
+        return false;
+      }
+      const interactiveRoles = new Set([
+        'button',
+        'link',
+        'textbox',
+        'checkbox',
+        'radio',
+        'slider',
+        'spinbutton',
+        'combobox',
+        'switch',
+        'menuitem',
+      ]);
+
+      const actionableAncestor = el.closest<HTMLElement>(
+        'button, a, input, select, textarea, [tabindex], [contenteditable="true"], [role]'
+      );
+
+      if (!actionableAncestor) {
+        return false;
+      }
+
+      return (
+        actionableAncestor instanceof HTMLButtonElement ||
+        actionableAncestor instanceof HTMLAnchorElement ||
+        actionableAncestor instanceof HTMLInputElement ||
+        actionableAncestor instanceof HTMLSelectElement ||
+        actionableAncestor instanceof HTMLTextAreaElement ||
+        actionableAncestor.tabIndex >= 0 ||
+        actionableAncestor.isContentEditable ||
+        interactiveRoles.has(
+          actionableAncestor.getAttribute('role')?.toLowerCase() ?? ''
+        )
       );
     };
 


### PR DESCRIPTION
Closes #7377

When clicked outside the notification panel, the focus should return to trigger button only if the clicked element is not an actionable element like a button, input, link etc.

#### What did you change?

- Modified the `useClickOutside` hook callback to check if the clicked element is an actionable element and focus return to trigger based on that.
- Added a function to check if the clicked element is actionable.
- Updated Unit test for the change.
- updated avt test to match the change.

#### How did you test and verify your work?

Storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
