### PR TITLE
refactor(instrumentation): replace amplitude with autotrack

### DIFF
--- a/packages/ibm-products-web-components/.storybook/main.ts
+++ b/packages/ibm-products-web-components/.storybook/main.ts
@@ -1,6 +1,7 @@
 import { mergeConfig } from 'vite';
 import { litStyleLoader, litTemplateLoader } from '@mordech/vite-lit-loader';
 import glob from 'fast-glob';
+import { getAutoTrack } from '../../../scripts/get-auto-track-script';
 
 const stories = glob.sync(
   [
@@ -39,16 +40,7 @@ const config = {
       ${head}
       ${
         process.env.NODE_ENV !== 'development'
-          ? `
-        <script src="https://cdn.amplitude.com/script/f6f1d9025934f04f5a2a8bebb74abf2f.js"></script>
-          <script>
-            window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));
-            window.amplitude.init('f6f1d9025934f04f5a2a8bebb74abf2f', {
-              "fetchRemoteConfig":true,
-              "autocapture":true
-            });
-          </script>
-        `
+          ? getAutoTrack('ibm-products-web-components-storybook')
           : ''
       }
     `;

--- a/packages/ibm-products-web-components/tsconfig.json
+++ b/packages/ibm-products-web-components/tsconfig.json
@@ -8,8 +8,7 @@
       "src/typings",
       "tests/typings",
       "node_modules/@types",
-      "../../node_modules/@types",
-      "./storybook/typings"
+      "../../node_modules/@types"
     ],
     "declaration": true,
     "skipLibCheck": true,

--- a/packages/ibm-products-web-components/tsconfig.json
+++ b/packages/ibm-products-web-components/tsconfig.json
@@ -8,10 +8,10 @@
       "src/typings",
       "tests/typings",
       "node_modules/@types",
-      "../../node_modules/@types"
+      "../../node_modules/@types",
+      "./storybook/typings"
     ],
     "declaration": true,
-    "rootDir": ".",
     "skipLibCheck": true,
     "sourceMap": true,
     "stripInternal": true,

--- a/packages/ibm-products/.storybook/main.js
+++ b/packages/ibm-products/.storybook/main.js
@@ -6,6 +6,7 @@
  */
 import { dirname, join, resolve } from 'path';
 import remarkGfm from 'remark-gfm';
+import { getAutoTrack } from '../../../scripts/get-auto-track-script';
 
 const stories = [
   '../src/**/!(*.internal).stories.*',
@@ -62,15 +63,7 @@ export default {
       ${head}
       ${
         process.env.NODE_ENV !== 'development'
-          ? `
-          <script src="https://cdn.amplitude.com/script/f6f1d9025934f04f5a2a8bebb74abf2f.js"></script>
-          <script>
-            window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));
-            window.amplitude.init('f6f1d9025934f04f5a2a8bebb74abf2f', {
-              "fetchRemoteConfig":true,
-              "autocapture":true
-            });
-          </script>`
+          ? getAutoTrack('ibm-products-react-storybook')
           : ''
       }
     `;

--- a/scripts/get-auto-track-script.ts
+++ b/scripts/get-auto-track-script.ts
@@ -33,7 +33,8 @@ export const getAutoTrack = (source: string) => `
               productTitle: 'Carbon for IBM Products',
             },
             pageProperties: {
-              // NO REQUIRED PROPERTIES
+              productCode: 'C4IP',
+              productTitle: 'Carbon for IBM Products',
             },
           },
         },

--- a/scripts/get-auto-track-script.ts
+++ b/scripts/get-auto-track-script.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright IBM Corp. 2025, 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//cspell: disable
+export const getAutoTrack = (source: string) => `
+  <script>
+    window._ibmAnalytics = {
+      settings: {
+        name: '${source}',
+        isSpa: false,
+        tealiumProfileName: 'in-app-usage-growth',
+      },
+      onLoad: [['ibmStats.pageview', []]],
+    };
+
+    window.digitalData = {
+      page: {
+        pageInfo: {
+          ibm: {
+            siteId: ${`IBM_${(window as any)._ibmAnalytics.settings.name}`},
+          },
+          segment: {
+            enabled: true,
+            env: 'test',
+            key: 'aWg1ug3bDNcSTnde9iwvg1OcvVRzf0JC',
+            coremetrics: false,
+            commonProperties: {
+              UT30: 'C4IP',
+              productCode: 'C4IP',
+              productCodeType: 'C4IP',
+              productTitle: 'carbon-for-ibm-products',
+              instanceId: 'carbon-for-ibm-products',
+            },
+            pageProperties: {
+              // NO REQUIRED PROPERTIES
+            },
+          },
+        },
+        category: {
+          primaryCategory: 'PC110',
+        },
+      },
+    };
+  </script>
+  <script
+    src="//1.www.s81c.com/common/stats/ibm-common.js"
+    type="text/javascript"
+    async="async"></script>
+  <script
+    type="text/javascript"
+    async="async"
+    src="//1.www.s81c.com/common/carbon/autotrack.min.js"></script>`;

--- a/scripts/get-auto-track-script.ts
+++ b/scripts/get-auto-track-script.ts
@@ -21,7 +21,7 @@ export const getAutoTrack = (source: string) => `
       page: {
         pageInfo: {
           ibm: {
-            siteId: ${`IBM_${(window as any)._ibmAnalytics.settings.name}`},
+            siteId: ${`IBM_${source}`},
           },
           segment: {
             enabled: true,

--- a/scripts/get-auto-track-script.ts
+++ b/scripts/get-auto-track-script.ts
@@ -29,11 +29,8 @@ export const getAutoTrack = (source: string) => `
             key: 'aWg1ug3bDNcSTnde9iwvg1OcvVRzf0JC',
             coremetrics: false,
             commonProperties: {
-              UT30: 'C4IP',
               productCode: 'C4IP',
-              productCodeType: 'C4IP',
-              productTitle: 'carbon-for-ibm-products',
-              instanceId: 'carbon-for-ibm-products',
+              productTitle: 'Carbon for IBM Products',
             },
             pageProperties: {
               // NO REQUIRED PROPERTIES


### PR DESCRIPTION
Closes #7690 

Replaces the amplitude auto-capture setup with carbon autotrack.

#### What did you change?
```
packages/ibm-products-web-components/.storybook/main.ts
packages/ibm-products-web-components/tsconfig.json
packages/ibm-products/.storybook/main.js
scripts/get-auto-track-script.ts
```

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [X] Updated documentation and storybook examples
- [X] Wrote passing tests that cover this change
- [X] Addressed any impact on accessibility (a11y)
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
