### PR TITLE
chore: add deprecation notice to userprofileimage

### DIFF
--- a/e2e/components/UserProfileImage/UserProfileImage-test.avt.e2e.js
+++ b/e2e/components/UserProfileImage/UserProfileImage-test.avt.e2e.js
@@ -14,7 +14,7 @@ test.describe('UserProfileImage @avt', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'UserProfileImage',
-      id: 'patterns-prebuilt-patterns-userprofileimage--default',
+      id: 'deprecated-userprofileimage--default',
       globals: {
         carbonTheme: 'white',
       },

--- a/packages/ibm-products/src/components/UserProfileImage/UserProfileImage.docs-page.js
+++ b/packages/ibm-products/src/components/UserProfileImage/UserProfileImage.docs-page.js
@@ -13,7 +13,7 @@ const DocsPage = () => (
   <StoryDocsPage
     altGuidelinesHref={[]}
     // cspell:disable-next-line
-    deprecationNotice="This component will soon be deprecated, Please migrate to [UserAvatar](?path=/docs/ibm-products-components-user-avatar-useravatar--docs#migration-from-userprofileimage)."
+    deprecationNotice="This component is deprecated and will be removed in the next major version. Please migrate to [UserAvatar](?path=/docs/components-useravatar--docs#migration-from-userprofileimage)."
     blocks={[
       {
         story: stories.Default,

--- a/packages/ibm-products/src/components/UserProfileImage/UserProfileImage.stories.jsx
+++ b/packages/ibm-products/src/components/UserProfileImage/UserProfileImage.stories.jsx
@@ -19,7 +19,7 @@ const defaultArgs = {
 };
 
 export default {
-  title: 'Patterns/Prebuilt patterns/UserProfileImage',
+  title: 'Deprecated/UserProfileImage',
   component: UserProfileImage,
   tags: ['autodocs'],
   argTypes: {
@@ -69,6 +69,24 @@ export default {
       page: DocsPage,
     },
   },
+  decorators: [
+    (story) => (
+      <div>
+        <Annotation
+          type="deprecation-notice"
+          text={
+            <div>
+              This component is deprecated and will be removed in the next major
+              version. Please migrate to {/* cspell:disable-next-line */}
+              <a href="/?path=/docs/components-useravatar--docs">UserAvatar</a>.
+            </div>
+          }
+        >
+          {story()}
+        </Annotation>
+      </div>
+    ),
+  ],
 };
 
 const Template = (args) => {

--- a/packages/ibm-products/src/components/UserProfileImage/UserProfileImage.test.js
+++ b/packages/ibm-products/src/components/UserProfileImage/UserProfileImage.test.js
@@ -27,6 +27,10 @@ const renderComponent = ({ ...rest } = {}) =>
   render(<UserProfileImage {...{ kind, size, theme, ...rest }} />);
 
 describe(componentName, () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
   it('should return a circle with background color', async () => {
     const { container } = renderComponent({
       backgroundColor: 'light-cyan',

--- a/packages/ibm-products/src/components/UserProfileImage/UserProfileImage.tsx
+++ b/packages/ibm-products/src/components/UserProfileImage/UserProfileImage.tsx
@@ -98,6 +98,7 @@ export type UserProfileImageProps = UserProfileImageBaseProps & imageProps;
 
 /**
  * The user profile avatar allows for an image of the user to be displayed by passing in the image prop. By default the component will display a user icon on a blue background.
+ * @deprecated This component is deprecated.
  */
 export let UserProfileImage = React.forwardRef<
   HTMLDivElement,
@@ -226,6 +227,12 @@ export let UserProfileImage = React.forwardRef<
     );
   }
 );
+
+/**@ts-ignore*/
+UserProfileImage.deprecated = {
+  level: 'warn',
+  details: `Please replace ${componentName} with UserAvatar`,
+};
 
 // Return a placeholder if not released and not enabled by feature flag
 UserProfileImage = pkg.checkComponentEnabled(UserProfileImage, componentName);


### PR DESCRIPTION
Closes #4140 

Added deprecation notice to UserProfileImage

#### What did you change? e2e/components/UserProfileImage/UserProfileImage-test.avt.e2e.js
packages/ibm-products/src/components/UserProfileImage/UserProfileImage.docs-page.js
packages/ibm-products/src/components/UserProfileImage/UserProfileImage.stories.jsx
packages/ibm-products/src/components/UserProfileImage/UserProfileImage.tsx

#### How did you test and verify your work? yarn storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
