### PR TITLE
fix(tearsheet): incorrect color layering i

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
@@ -523,6 +523,7 @@ export const TearsheetShell = React.forwardRef(
               ref={modalBodyRef}
               className={`${carbonPrefix}--modal-content ${bc}__body`}
             >
+              {/* Left influencer */}
               <Wrap
                 className={cx({
                   [`${bc}__influencer`]: true,
@@ -534,6 +535,7 @@ export const TearsheetShell = React.forwardRef(
                 {influencer}
               </Wrap>
               <Wrap className={`${bc}__right`}>
+                {/* Main area */}
                 <Wrap className={`${bc}__main`} alwaysRender={includeActions}>
                   <Wrap
                     className={`${bc}__content`}
@@ -542,8 +544,9 @@ export const TearsheetShell = React.forwardRef(
                     }
                     element={SectionLevel3}
                   >
-                    {children}
+                    <Wrap element={!wide ? Layer : undefined}>{children}</Wrap>
                   </Wrap>
+                  {/* Right influencer */}
                   <Wrap
                     className={cx({
                       [`${bc}__influencer`]: true,


### PR DESCRIPTION
Closes #3856 


#### What did you change?

1. Input fields in Narrow Tearsheet are missing their background / match the panel's background
<img width="1092" alt="Screenshot 2025-06-25 at 2 52 02 PM" src="https://github.com/user-attachments/assets/b2a6b17c-fe7d-4beb-a434-081c7901d4b6" />



#### How did you test and verify your work?

- storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
