### PR TITLE
fix(avt): update notification panel avt story urls and fix percy config issue

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -13,7 +13,7 @@ storybook:
   # if storybook is still loading, percy could take a snapshot of the storybook
   # loading spinner and cause flaky tests
   waitForSelector: '.story-wrapper'
-  include: ['/IBM Products/']
+  include: ['/Components/', '/Patterns/', '/Utilities/']
   exclude: [
       '/Internal/',
       '/Datagrid/*',

--- a/e2e/components/NotificationsPanel/NotificationsPanel-test.avt.e2e.js
+++ b/e2e/components/NotificationsPanel/NotificationsPanel-test.avt.e2e.js
@@ -56,7 +56,7 @@ test.describe('NotificationsPanel @avt', () => {
   test('@avt-notification-panel-focus-return-to-trigger', async ({ page }) => {
     await visitStory(page, {
       component: 'NotificationsPanel',
-      id: 'ibm-products-components-notifications-panel-notificationspanel--default',
+      id: 'components-notificationspanel--default',
       globals: {
         carbonTheme: 'white',
       },
@@ -84,7 +84,7 @@ test.describe('NotificationsPanel @avt', () => {
   }) => {
     await visitStory(page, {
       component: 'NotificationsPanel',
-      id: 'ibm-products-components-notifications-panel-notificationspanel--default',
+      id: 'components-notificationspanel--default',
       globals: {
         carbonTheme: 'white',
       },


### PR DESCRIPTION
Updates urls for two avt tests from `NotificationsPanel`, these are causing avt tests to fail after the storybook IA changes. Also noticed that in our `percy.yml` config file, we were still only including snapshots within `IBM Products` directory, which doesn't exist after the storybook IA changes (this is what is causing the `vrt-runner` to fail). I've updated it to include snapshots for `Components`, `Patterns`, and `Utilities`.

#### What did you change?
```
e2e/components/NotificationsPanel/NotificationsPanel-test.avt.e2e.js
```
#### How did you test and verify your work?
Will verify in this PR
#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
