### PR TITLE
feat(page-header): add sticky support, web component

### DIFF
--- a/packages/ibm-products-web-components/src/components/page-header/_story-assets/_storybook-styles.scss
+++ b/packages/ibm-products-web-components/src/components/page-header/_story-assets/_storybook-styles.scss
@@ -1,0 +1,9 @@
+@use '@carbon/styles/scss/spacing';
+
+#main-content {
+  margin-block-start: spacing.$spacing-09;
+}
+
+.tabs-demo {
+  block-size: 200vh;
+}

--- a/packages/ibm-products-web-components/src/components/page-header/_story-assets/_storybook-styles.scss
+++ b/packages/ibm-products-web-components/src/components/page-header/_story-assets/_storybook-styles.scss
@@ -1,3 +1,10 @@
+//
+// Copyright IBM Corp. 2025, 2025
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
 @use '@carbon/styles/scss/spacing';
 
 .page-header--docs-demo .docs-story div:first-child {

--- a/packages/ibm-products-web-components/src/components/page-header/_story-assets/_storybook-styles.scss
+++ b/packages/ibm-products-web-components/src/components/page-header/_story-assets/_storybook-styles.scss
@@ -1,9 +1,28 @@
 @use '@carbon/styles/scss/spacing';
 
-#main-content {
-  margin-block-start: spacing.$spacing-09;
+.page-header--docs-demo .docs-story div:first-child {
+  padding: 0;
 }
 
 .tabs-demo {
   block-size: 200vh;
+}
+
+.page-header--docs-demo .tabs-demo {
+  block-size: 100%;
+}
+
+#main-content main {
+  margin-block-start: spacing.$spacing-09;
+}
+
+.page-header--docs-demo .innerZoomElementWrapper > * {
+  /* Used to override storybook styling from a dynamically generated class in the canvas preview */
+  /* stylelint-disable-next-line declaration-no-important */
+  border: 0 !important;
+}
+
+.page-header--docs-demo .ui-shell--header {
+  /* stylelint-disable-next-line carbon/layout-use */
+  transform: translateY(-48px);
 }

--- a/packages/ibm-products-web-components/src/components/page-header/page-header.mdx
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header.mdx
@@ -30,7 +30,7 @@ import '@carbon/web-components/es/components/button/index.js';
 
 The `c4p-page-header` is a large family of components, composed of three zones; the Breadcrumb, Content, and Tabs.
 
-<Canvas of={PageHeaderStories.Default} />
+<Canvas className='page-header--docs-demo' of={PageHeaderStories.Default} />
 
 ## Breadcrumb
 
@@ -41,7 +41,7 @@ the breadcrumb content.
 
 ## Content
 
-<Canvas of={PageHeaderStories.ContentWithContextualActionsAndPageActions} />
+<Canvas className='page-header--docs-demo' of={PageHeaderStories.ContentWithContextualActionsAndPageActions} />
 
 The `c4p-page-header-content` component defines the primary content area of the Page header, including the title, subtitle, and
 any supporting text or contextual actions. It accepts a `title` attribute to display the main heading and has an `icon` slot
@@ -71,7 +71,7 @@ To support use cases such as tags, `contextual-actions` slot can be to render co
 
 ### Content With Hero Image
 
-<Canvas of={PageHeaderStories.ContentWithHeroImage} />
+<Canvas className='page-header--docs-demo' of={PageHeaderStories.ContentWithHeroImage} />
 
 When including a hero image within the Page header, the Carbon Grid classes will need to be utilized. In addition,
 the `withinGrid` attribute has to be set in the `c4p-page-header-content` and `c4p-page-header-breadcrumb` components.
@@ -149,7 +149,7 @@ as within its `tabs` slot. Then set up the corresponding tab panel elements outs
 
 ### Tabs With Tags
 
-<Canvas of={PageHeaderStories.TabBarWithTabsAndTags} />
+<Canvas className='page-header--docs-demo' of={PageHeaderStories.TabBarWithTabsAndTags} />
 
 The `c4p-page-header-tabs` component has a `tags` slot for tag components.
 

--- a/packages/ibm-products-web-components/src/components/page-header/page-header.scss
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header.scss
@@ -26,9 +26,13 @@ $carbon-prefix: 'cds';
   // TODO: remove above styles when styles from React have been migrated
   // and use the extend below
   // @extend .#{$prefix}--page-header;
+  position: sticky;
   display: block;
   background-color: $layer-01;
   border-block-end: 1px solid $border-subtle-01;
+  /* custom css property used from calculation of header offset */
+  /* stylelint-disable-next-line carbon/layout-use */
+  inset-block-start: var(--c4p-page-header-header-top);
 }
 
 :host(#{$prefix}-page-header-breadcrumb),
@@ -40,7 +44,13 @@ $carbon-prefix: 'cds';
 }
 
 :host(#{$prefix}-page-header-breadcrumb) {
+  position: sticky;
+  background-color: $layer-01;
   block-size: convert.to-rem(40px);
+
+  /* custom css property used from calculation of breadcrumb offset */
+  /* stylelint-disable-next-line carbon/layout-use */
+  inset-block-start: var(--c4p-page-header-breadcrumb-top);
   // TODO: remove above styles when styles from React have been migrated
   // and use the extend below
   // @extend .#{$prefix}--page-header__breadcrumb-bar;

--- a/packages/ibm-products-web-components/src/components/page-header/page-header.scss
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header.scss
@@ -47,6 +47,7 @@ $carbon-prefix: 'cds';
   position: sticky;
   background-color: $layer-01;
   block-size: convert.to-rem(40px);
+  border-block-end: $border-subtle;
 
   /* custom css property used from calculation of breadcrumb offset */
   /* stylelint-disable-next-line carbon/layout-use */

--- a/packages/ibm-products-web-components/src/components/page-header/page-header.stories.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header.stories.ts
@@ -8,15 +8,16 @@
  */
 
 import { html } from 'lit';
-import { prefix } from '../../globals/settings';
 import './index';
 import '@carbon/web-components/es/components/tag/index.js';
 import '@carbon/web-components/es/components/icon-button/index.js';
 import '@carbon/web-components/es/components/button/index.js';
 import '@carbon/web-components/es/components/tabs/index.js';
 import '@carbon/web-components/es/components/breadcrumb/index.js';
+import '@carbon/web-components/es/components/ui-shell/index.js';
 import image1 from './_story-assets/2x1.jpg';
 import image2 from './_story-assets/3x2.jpg';
+import styles from './_story-assets/_storybook-styles.scss?lit';
 import { breakpoints } from '@carbon/layout';
 import Add16 from '@carbon/web-components/es/icons/add/16.js';
 import Bee32 from '@carbon/web-components/es/icons/bee/32.js';
@@ -24,6 +25,10 @@ import Bee16 from '@carbon/web-components/es/icons/bee/16.js';
 import Activity16 from '@carbon/web-components/es/icons/activity/16.js';
 import AiGenerate16 from '@carbon/web-components/es/icons/ai-generate/16.js';
 import CloudFoundry16 from '@carbon/web-components/es/icons/cloud-foundry--1/16.js';
+import {
+  TAG_SIZE,
+  TAG_TYPE,
+} from '@carbon/web-components/es/components/tag/defs.js';
 
 const tags = [
   {
@@ -107,9 +112,17 @@ export const Default = {
       renderBreadcrumbIcon,
     } = args ?? {};
     return html`
+      <style>
+        ${styles}
+      </style>
+      <cds-header aria-label="IBM Platform Name">
+        <cds-header-name href="javascript:void 0" prefix="IBM"
+          >[Platform]</cds-header-name
+        >
+      </cds-header>
       <c4p-page-header>
         <c4p-page-header-breadcrumb
-          border="${border}"
+          ?border="${border}"
           ?page-actions-flush="${pageActionsFlush}"
           ?content-actions-flush="${contentActionsFlush}"
         >
@@ -217,130 +230,156 @@ export const Default = {
 
 export const ContentWithContextualActions = {
   render: () =>
-    html`<c4p-page-header>
-      <c4p-page-header-breadcrumb>
-        ${Bee16({ slot: 'icon' })}
-        <cds-breadcrumb>
-          <cds-breadcrumb-item>
-            <cds-breadcrumb-link href="#">Breadcrumb 1</cds-breadcrumb-link>
-          </cds-breadcrumb-item>
-          <cds-breadcrumb-item>
-            <cds-breadcrumb-link href="#">Breadcrumb 2</cds-breadcrumb-link>
-          </cds-breadcrumb-item>
-        </cds-breadcrumb>
-        <cds-icon-button
-          slot="page-actions"
-          kind="ghost"
-          size="md"
-          align="bottom"
+    html` <style>
+        ${styles}
+      </style>
+      <cds-header aria-label="IBM Platform Name">
+        <cds-header-name href="javascript:void 0" prefix="IBM"
+          >[Platform]</cds-header-name
         >
-          ${Activity16({ slot: 'icon' })}
-          <span slot="tooltip-content">action 1</span>
-        </cds-icon-button>
-        <cds-icon-button
-          slot="page-actions"
-          kind="ghost"
-          size="md"
-          align="bottom"
+      </cds-header>
+      <c4p-page-header>
+        <c4p-page-header-breadcrumb>
+          ${Bee16({ slot: 'icon' })}
+          <cds-breadcrumb>
+            <cds-breadcrumb-item>
+              <cds-breadcrumb-link href="#">Breadcrumb 1</cds-breadcrumb-link>
+            </cds-breadcrumb-item>
+            <cds-breadcrumb-item>
+              <cds-breadcrumb-link href="#">Breadcrumb 2</cds-breadcrumb-link>
+            </cds-breadcrumb-item>
+          </cds-breadcrumb>
+          <cds-icon-button
+            slot="page-actions"
+            kind="ghost"
+            size="md"
+            align="bottom"
+          >
+            ${Activity16({ slot: 'icon' })}
+            <span slot="tooltip-content">action 1</span>
+          </cds-icon-button>
+          <cds-icon-button
+            slot="page-actions"
+            kind="ghost"
+            size="md"
+            align="bottom"
+          >
+            ${AiGenerate16({ slot: 'icon' })}
+            <span slot="tooltip-content">action 2</span>
+          </cds-icon-button>
+          <cds-icon-button
+            slot="page-actions"
+            kind="ghost"
+            size="md"
+            align="bottom"
+          >
+            ${CloudFoundry16({ slot: 'icon' })}
+            <span slot="tooltip-content">action 3</span>
+          </cds-icon-button>
+        </c4p-page-header-breadcrumb>
+        <c4p-page-header-content
+          title="Virtual-Machine-DAL-really-long-title-example-that-goes-at-least-2-lines-long"
         >
-          ${AiGenerate16({ slot: 'icon' })}
-          <span slot="tooltip-content">action 2</span>
-        </cds-icon-button>
-        <cds-icon-button
-          slot="page-actions"
-          kind="ghost"
-          size="md"
-          align="bottom"
-        >
-          ${CloudFoundry16({ slot: 'icon' })}
-          <span slot="tooltip-content">action 3</span>
-        </cds-icon-button>
-      </c4p-page-header-breadcrumb>
-      <c4p-page-header-content
-        title="Virtual-Machine-DAL-really-long-title-example-that-goes-at-least-2-lines-long"
-      >
-        <div slot="contextual-actions">
-          <cds-tag type="blue" size="lg">Tag</cds-tag>
-        </div>
-        <c4p-page-header-content-text subtitle="Subtitle">
-          Built for modern teams, our technology platform simplifies complexity
-          with powerful APIs, real-time collaboration tools, and seamless
-          integration. From deployment to monitoring, we help you ship faster,
-          scale efficiently, and stay in control every step of the way.
-        </c4p-page-header-content-text>
-      </c4p-page-header-content>
-    </c4p-page-header>`,
+          <div slot="contextual-actions">
+            <cds-tag type="blue" size="lg">Tag</cds-tag>
+          </div>
+          <c4p-page-header-content-text subtitle="Subtitle">
+            Built for modern teams, our technology platform simplifies
+            complexity with powerful APIs, real-time collaboration tools, and
+            seamless integration. From deployment to monitoring, we help you
+            ship faster, scale efficiently, and stay in control every step of
+            the way.
+          </c4p-page-header-content-text>
+        </c4p-page-header-content>
+      </c4p-page-header>`,
 };
 
 export const ContentWithContextualActionsAndPageActions = {
   render: () =>
-    html`<c4p-page-header>
-      <c4p-page-header-breadcrumb>
-        ${Bee16({ slot: 'icon' })}
-        <cds-breadcrumb>
-          <cds-breadcrumb-item>
-            <cds-breadcrumb-link href="#">Breadcrumb 1</cds-breadcrumb-link>
-          </cds-breadcrumb-item>
-          <cds-breadcrumb-item>
-            <cds-breadcrumb-link href="#">Breadcrumb 2</cds-breadcrumb-link>
-          </cds-breadcrumb-item>
-        </cds-breadcrumb>
-        <cds-icon-button
-          slot="page-actions"
-          kind="ghost"
-          size="md"
-          align="bottom"
+    html` <style>
+        ${styles}
+      </style>
+      <cds-header aria-label="IBM Platform Name">
+        <cds-header-name href="javascript:void 0" prefix="IBM"
+          >[Platform]</cds-header-name
         >
-          ${Activity16({ slot: 'icon' })}
-          <span slot="tooltip-content">action 1</span>
-        </cds-icon-button>
-        <cds-icon-button
-          slot="page-actions"
-          kind="ghost"
-          size="md"
-          align="bottom"
-        >
-          ${AiGenerate16({ slot: 'icon' })}
-          <span slot="tooltip-content">action 2</span>
-        </cds-icon-button>
-        <cds-icon-button
-          slot="page-actions"
-          kind="ghost"
-          size="md"
-          align="bottom"
-        >
-          ${CloudFoundry16({ slot: 'icon' })}
-          <span slot="tooltip-content">action 3</span>
-        </cds-icon-button>
-      </c4p-page-header-breadcrumb>
-      <c4p-page-header-content
-        title="Virtual-Machine-DAL-really-long-title-example-that-goes-at-least-2-lines-long"
-      >
-        <div slot="contextual-actions">
-          <cds-tag type="blue" size="lg">Tag</cds-tag>
-        </div>
-        <div slot="page-actions">
-          <cds-button size="md"
-            >Primary action ${Add16({ slot: 'icon' })}</cds-button
+      </cds-header>
+      <c4p-page-header>
+        <c4p-page-header-breadcrumb>
+          ${Bee16({ slot: 'icon' })}
+          <cds-breadcrumb>
+            <cds-breadcrumb-item>
+              <cds-breadcrumb-link href="#">Breadcrumb 1</cds-breadcrumb-link>
+            </cds-breadcrumb-item>
+            <cds-breadcrumb-item>
+              <cds-breadcrumb-link href="#">Breadcrumb 2</cds-breadcrumb-link>
+            </cds-breadcrumb-item>
+          </cds-breadcrumb>
+          <cds-icon-button
+            slot="page-actions"
+            kind="ghost"
+            size="md"
+            align="bottom"
           >
-        </div>
-        <c4p-page-header-content-text subtitle="Subtitle">
-          Built for modern teams, our technology platform simplifies complexity
-          with powerful APIs, real-time collaboration tools, and seamless
-          integration. From deployment to monitoring, we help you ship faster,
-          scale efficiently, and stay in control every step of the way.
-        </c4p-page-header-content-text>
-      </c4p-page-header-content>
-    </c4p-page-header>`,
+            ${Activity16({ slot: 'icon' })}
+            <span slot="tooltip-content">action 1</span>
+          </cds-icon-button>
+          <cds-icon-button
+            slot="page-actions"
+            kind="ghost"
+            size="md"
+            align="bottom"
+          >
+            ${AiGenerate16({ slot: 'icon' })}
+            <span slot="tooltip-content">action 2</span>
+          </cds-icon-button>
+          <cds-icon-button
+            slot="page-actions"
+            kind="ghost"
+            size="md"
+            align="bottom"
+          >
+            ${CloudFoundry16({ slot: 'icon' })}
+            <span slot="tooltip-content">action 3</span>
+          </cds-icon-button>
+        </c4p-page-header-breadcrumb>
+        <c4p-page-header-content
+          title="Virtual-Machine-DAL-really-long-title-example-that-goes-at-least-2-lines-long"
+        >
+          <div slot="contextual-actions">
+            <cds-tag type="blue" size="lg">Tag</cds-tag>
+          </div>
+          <div slot="page-actions">
+            <cds-button size="md"
+              >Primary action ${Add16({ slot: 'icon' })}</cds-button
+            >
+          </div>
+          <c4p-page-header-content-text subtitle="Subtitle">
+            Built for modern teams, our technology platform simplifies
+            complexity with powerful APIs, real-time collaboration tools, and
+            seamless integration. From deployment to monitoring, we help you
+            ship faster, scale efficiently, and stay in control every step of
+            the way.
+          </c4p-page-header-content-text>
+        </c4p-page-header-content>
+      </c4p-page-header>`,
 };
 
 export const ContentWithHeroImage = {
   render: () =>
     html`
+    <style>
+        ${styles}
+      </style>
+      <cds-header aria-label="IBM Platform Name">
+        <cds-header-name href="javascript:void 0" prefix="IBM"
+          >[Platform]</cds-header-name
+        >
+      </cds-header>
     <c4p-page-header>
       <div class="cds--css-grid">
         <div class="cds--sm:col-span-4 cds--md:col-span-4 cds--lg:col-span-8 cds--css-grid-column">
-          <c4p-page-header-breadcrumb border=false within-grid>
+          <c4p-page-header-breadcrumb ?border=${false} within-grid>
         ${Bee16({ slot: 'icon' })}
         <cds-breadcrumb>
           <cds-breadcrumb-item>
@@ -386,62 +425,79 @@ export const ContentWithHeroImage = {
 
 export const ContentWithIcon = {
   render: () =>
-    html`<c4p-page-header>
-      <c4p-page-header-breadcrumb>
-        ${Bee16({ slot: 'icon' })}
-        <cds-breadcrumb>
-          <cds-breadcrumb-item>
-            <cds-breadcrumb-link href="#">Breadcrumb 1</cds-breadcrumb-link>
-          </cds-breadcrumb-item>
-          <cds-breadcrumb-item>
-            <cds-breadcrumb-link href="#">Breadcrumb 2</cds-breadcrumb-link>
-          </cds-breadcrumb-item>
-        </cds-breadcrumb>
-        <cds-icon-button
-          slot="page-actions"
-          kind="ghost"
-          size="md"
-          align="bottom"
+    html` <style>
+        ${styles}
+      </style>
+      <cds-header aria-label="IBM Platform Name">
+        <cds-header-name href="javascript:void 0" prefix="IBM"
+          >[Platform]</cds-header-name
         >
-          ${Activity16({ slot: 'icon' })}
-          <span slot="tooltip-content">action 1</span>
-        </cds-icon-button>
-        <cds-icon-button
-          slot="page-actions"
-          kind="ghost"
-          size="md"
-          align="bottom"
+      </cds-header>
+      <c4p-page-header>
+        <c4p-page-header-breadcrumb>
+          ${Bee16({ slot: 'icon' })}
+          <cds-breadcrumb>
+            <cds-breadcrumb-item>
+              <cds-breadcrumb-link href="#">Breadcrumb 1</cds-breadcrumb-link>
+            </cds-breadcrumb-item>
+            <cds-breadcrumb-item>
+              <cds-breadcrumb-link href="#">Breadcrumb 2</cds-breadcrumb-link>
+            </cds-breadcrumb-item>
+          </cds-breadcrumb>
+          <cds-icon-button
+            slot="page-actions"
+            kind="ghost"
+            size="md"
+            align="bottom"
+          >
+            ${Activity16({ slot: 'icon' })}
+            <span slot="tooltip-content">action 1</span>
+          </cds-icon-button>
+          <cds-icon-button
+            slot="page-actions"
+            kind="ghost"
+            size="md"
+            align="bottom"
+          >
+            ${AiGenerate16({ slot: 'icon' })}
+            <span slot="tooltip-content">action 2</span>
+          </cds-icon-button>
+          <cds-icon-button
+            slot="page-actions"
+            kind="ghost"
+            size="md"
+            align="bottom"
+          >
+            ${CloudFoundry16({ slot: 'icon' })}
+            <span slot="tooltip-content">action 3</span>
+          </cds-icon-button>
+        </c4p-page-header-breadcrumb>
+        <c4p-page-header-content
+          title="Virtual-Machine-DAL-really-long-title-example-that-goes-at-least-2-lines-long"
         >
-          ${AiGenerate16({ slot: 'icon' })}
-          <span slot="tooltip-content">action 2</span>
-        </cds-icon-button>
-        <cds-icon-button
-          slot="page-actions"
-          kind="ghost"
-          size="md"
-          align="bottom"
-        >
-          ${CloudFoundry16({ slot: 'icon' })}
-          <span slot="tooltip-content">action 3</span>
-        </cds-icon-button>
-      </c4p-page-header-breadcrumb>
-      <c4p-page-header-content
-        title="Virtual-Machine-DAL-really-long-title-example-that-goes-at-least-2-lines-long"
-      >
-        ${Bee32({ slot: 'icon' })}
-        <c4p-page-header-content-text subtitle="Subtitle">
-          Built for modern teams, our technology platform simplifies complexity
-          with powerful APIs, real-time collaboration tools, and seamless
-          integration. From deployment to monitoring, we help you ship faster,
-          scale efficiently, and stay in control every step of the way.
-        </c4p-page-header-content-text>
-      </c4p-page-header-content>
-    </c4p-page-header>`,
+          ${Bee32({ slot: 'icon' })}
+          <c4p-page-header-content-text subtitle="Subtitle">
+            Built for modern teams, our technology platform simplifies
+            complexity with powerful APIs, real-time collaboration tools, and
+            seamless integration. From deployment to monitoring, we help you
+            ship faster, scale efficiently, and stay in control every step of
+            the way.
+          </c4p-page-header-content-text>
+        </c4p-page-header-content>
+      </c4p-page-header>`,
 };
 
 export const TabBarWithTabsAndTags = {
   render: () =>
-    html`<c4p-page-header>
+    html` <style>
+        ${styles}
+      </style>
+      <cds-header aria-label="IBM Platform Name">
+        <cds-header-name href="javascript:void 0" prefix="IBM"
+          >[Platform]</cds-header-name
+        >
+      </cds-header>
+      <c4p-page-header>
         <c4p-page-header-breadcrumb>
           ${Bee16({ slot: 'icon' })}
           <cds-breadcrumb>
@@ -518,7 +574,9 @@ export const TabBarWithTabsAndTags = {
           <div slot="tags">
             ${tags.map(
               (e) =>
-                html` <cds-tag type="${e.type}" size="${e.size}"
+                html` <cds-tag
+                  type="${e.type as TAG_TYPE}"
+                  size="${e.size as TAG_SIZE}"
                   >${e.text}</cds-tag
                 >`
             )}

--- a/packages/ibm-products-web-components/src/components/page-header/page-header.stories.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header.stories.ts
@@ -115,115 +115,117 @@ export const Default = {
       <style>
         ${styles}
       </style>
-      <cds-header aria-label="IBM Platform Name">
+      <cds-header class="ui-shell--header" aria-label="IBM Platform Name">
         <cds-header-name href="javascript:void 0" prefix="IBM"
           >[Platform]</cds-header-name
         >
       </cds-header>
-      <c4p-page-header>
-        <c4p-page-header-breadcrumb
-          ?border="${border}"
-          ?page-actions-flush="${pageActionsFlush}"
-          ?content-actions-flush="${contentActionsFlush}"
-        >
-          ${renderBreadcrumbIcon ? Bee16({ slot: 'icon' }) : undefined}
-          <cds-breadcrumb>
-            <cds-breadcrumb-item>
-              <cds-breadcrumb-link href="#">Breadcrumb 1</cds-breadcrumb-link>
-            </cds-breadcrumb-item>
-            <cds-breadcrumb-item>
-              <cds-breadcrumb-link href="#">Breadcrumb 2</cds-breadcrumb-link>
-            </cds-breadcrumb-item>
-          </cds-breadcrumb>
-          <div slot="content-actions">
-            <cds-button size="md">Button</cds-button>
+      <main>
+        <c4p-page-header>
+          <c4p-page-header-breadcrumb
+            border=${border}
+            ?page-actions-flush="${pageActionsFlush}"
+            ?content-actions-flush="${contentActionsFlush}"
+          >
+            ${renderBreadcrumbIcon ? Bee16({ slot: 'icon' }) : undefined}
+            <cds-breadcrumb>
+              <cds-breadcrumb-item>
+                <cds-breadcrumb-link href="#">Breadcrumb 1</cds-breadcrumb-link>
+              </cds-breadcrumb-item>
+              <cds-breadcrumb-item>
+                <cds-breadcrumb-link href="#">Breadcrumb 2</cds-breadcrumb-link>
+              </cds-breadcrumb-item>
+            </cds-breadcrumb>
+            <div slot="content-actions">
+              <cds-button size="md">Button</cds-button>
+            </div>
+            <cds-icon-button
+              slot="page-actions"
+              kind="ghost"
+              size="md"
+              align="bottom"
+            >
+              ${Activity16({ slot: 'icon' })}
+              <span slot="tooltip-content">action 1</span>
+            </cds-icon-button>
+            <cds-icon-button
+              slot="page-actions"
+              kind="ghost"
+              size="md"
+              align="bottom"
+            >
+              ${AiGenerate16({ slot: 'icon' })}
+              <span slot="tooltip-content">action 2</span>
+            </cds-icon-button>
+            <cds-icon-button
+              slot="page-actions"
+              kind="ghost"
+              size="md"
+              align="bottom"
+            >
+              ${CloudFoundry16({ slot: 'icon' })}
+              <span slot="tooltip-content">action 3</span>
+            </cds-icon-button>
+          </c4p-page-header-breadcrumb>
+          <c4p-page-header-content title="${title}">
+            <c4p-page-header-content-text subtitle="Subtitle">
+              Built for modern teams, our technology platform simplifies
+              complexity with powerful APIs, real-time collaboration tools, and
+              seamless integration. From deployment to monitoring, we help you
+              ship faster, scale efficiently, and stay in control every step of
+              the way.
+            </c4p-page-header-content-text>
+          </c4p-page-header-content>
+          <c4p-page-header-tabs>
+            <cds-tabs value="tab-1">
+              <cds-tab id="tab-1" target="tab-panel-1" value="tab-1"
+                >Tab 1</cds-tab
+              >
+              <cds-tab id="tab-2" target="tab-panel-2" value="tab-2"
+                >Tab 2</cds-tab
+              >
+              <cds-tab id="tab-3" target="tab-panel-3" value="tab-3"
+                >Tab 3</cds-tab
+              >
+              <cds-tab id="tab-4" target="tab-panel-4" value="tab-4"
+                >Tab 4</cds-tab
+              >
+              <cds-tab id="tab-5" target="tab-panel-5" value="tab-5"
+                >Tab 5</cds-tab
+              >
+              <cds-tab id="tab-6" target="tab-panel-6" value="tab-6"
+                >Tab 6</cds-tab
+              >
+              <cds-tab id="tab-7" target="tab-panel-7" value="tab-7"
+                >Tab 7</cds-tab
+              >
+            </cds-tabs>
+          </c4p-page-header-tabs>
+        </c4p-page-header>
+        <div class="tabs-demo">
+          <div id="tab-panel-1" role="tabpanel" aria-labelledby="tab-1" hidden>
+            Tab Panel 1
           </div>
-          <cds-icon-button
-            slot="page-actions"
-            kind="ghost"
-            size="md"
-            align="bottom"
-          >
-            ${Activity16({ slot: 'icon' })}
-            <span slot="tooltip-content">action 1</span>
-          </cds-icon-button>
-          <cds-icon-button
-            slot="page-actions"
-            kind="ghost"
-            size="md"
-            align="bottom"
-          >
-            ${AiGenerate16({ slot: 'icon' })}
-            <span slot="tooltip-content">action 2</span>
-          </cds-icon-button>
-          <cds-icon-button
-            slot="page-actions"
-            kind="ghost"
-            size="md"
-            align="bottom"
-          >
-            ${CloudFoundry16({ slot: 'icon' })}
-            <span slot="tooltip-content">action 3</span>
-          </cds-icon-button>
-        </c4p-page-header-breadcrumb>
-        <c4p-page-header-content title="${title}">
-          <c4p-page-header-content-text subtitle="Subtitle">
-            Built for modern teams, our technology platform simplifies
-            complexity with powerful APIs, real-time collaboration tools, and
-            seamless integration. From deployment to monitoring, we help you
-            ship faster, scale efficiently, and stay in control every step of
-            the way.
-          </c4p-page-header-content-text>
-        </c4p-page-header-content>
-        <c4p-page-header-tabs>
-          <cds-tabs value="tab-1">
-            <cds-tab id="tab-1" target="tab-panel-1" value="tab-1"
-              >Tab 1</cds-tab
-            >
-            <cds-tab id="tab-2" target="tab-panel-2" value="tab-2"
-              >Tab 2</cds-tab
-            >
-            <cds-tab id="tab-3" target="tab-panel-3" value="tab-3"
-              >Tab 3</cds-tab
-            >
-            <cds-tab id="tab-4" target="tab-panel-4" value="tab-4"
-              >Tab 4</cds-tab
-            >
-            <cds-tab id="tab-5" target="tab-panel-5" value="tab-5"
-              >Tab 5</cds-tab
-            >
-            <cds-tab id="tab-6" target="tab-panel-6" value="tab-6"
-              >Tab 6</cds-tab
-            >
-            <cds-tab id="tab-7" target="tab-panel-7" value="tab-7"
-              >Tab 7</cds-tab
-            >
-          </cds-tabs>
-        </c4p-page-header-tabs>
-      </c4p-page-header>
-      <div class="tabs-demo">
-        <div id="tab-panel-1" role="tabpanel" aria-labelledby="tab-1" hidden>
-          Tab Panel 1
+          <div id="tab-panel-2" role="tabpanel" aria-labelledby="tab-2" hidden>
+            Tab Panel 2
+          </div>
+          <div id="tab-panel-3" role="tabpanel" aria-labelledby="tab-3" hidden>
+            Tab Panel 3
+          </div>
+          <div id="tab-panel-4" role="tabpanel" aria-labelledby="tab-4" hidden>
+            Tab Panel 4
+          </div>
+          <div id="tab-panel-5" role="tabpanel" aria-labelledby="tab-5" hidden>
+            Tab Panel 5
+          </div>
+          <div id="tab-panel-6" role="tabpanel" aria-labelledby="tab-6" hidden>
+            Tab Panel 6
+          </div>
+          <div id="tab-panel-7" role="tabpanel" aria-labelledby="tab-7" hidden>
+            Tab Panel 7
+          </div>
         </div>
-        <div id="tab-panel-2" role="tabpanel" aria-labelledby="tab-2" hidden>
-          Tab Panel 2
-        </div>
-        <div id="tab-panel-3" role="tabpanel" aria-labelledby="tab-3" hidden>
-          Tab Panel 3
-        </div>
-        <div id="tab-panel-4" role="tabpanel" aria-labelledby="tab-4" hidden>
-          Tab Panel 4
-        </div>
-        <div id="tab-panel-5" role="tabpanel" aria-labelledby="tab-5" hidden>
-          Tab Panel 5
-        </div>
-        <div id="tab-panel-6" role="tabpanel" aria-labelledby="tab-6" hidden>
-          Tab Panel 6
-        </div>
-        <div id="tab-panel-7" role="tabpanel" aria-labelledby="tab-7" hidden>
-          Tab Panel 7
-        </div>
-      </div>
+      </main>
     `;
   },
 };
@@ -233,77 +235,80 @@ export const ContentWithContextualActions = {
     html` <style>
         ${styles}
       </style>
-      <cds-header aria-label="IBM Platform Name">
+      <cds-header class="ui-shell--header" aria-label="IBM Platform Name">
         <cds-header-name href="javascript:void 0" prefix="IBM"
           >[Platform]</cds-header-name
         >
       </cds-header>
-      <c4p-page-header>
-        <c4p-page-header-breadcrumb>
-          ${Bee16({ slot: 'icon' })}
-          <cds-breadcrumb>
-            <cds-breadcrumb-item>
-              <cds-breadcrumb-link href="#">Breadcrumb 1</cds-breadcrumb-link>
-            </cds-breadcrumb-item>
-            <cds-breadcrumb-item>
-              <cds-breadcrumb-link href="#">Breadcrumb 2</cds-breadcrumb-link>
-            </cds-breadcrumb-item>
-          </cds-breadcrumb>
-          <cds-icon-button
-            slot="page-actions"
-            kind="ghost"
-            size="md"
-            align="bottom"
+      <main>
+        <c4p-page-header>
+          <c4p-page-header-breadcrumb>
+            ${Bee16({ slot: 'icon' })}
+            <cds-breadcrumb>
+              <cds-breadcrumb-item>
+                <cds-breadcrumb-link href="#">Breadcrumb 1</cds-breadcrumb-link>
+              </cds-breadcrumb-item>
+              <cds-breadcrumb-item>
+                <cds-breadcrumb-link href="#">Breadcrumb 2</cds-breadcrumb-link>
+              </cds-breadcrumb-item>
+            </cds-breadcrumb>
+            <cds-icon-button
+              slot="page-actions"
+              kind="ghost"
+              size="md"
+              align="bottom"
+            >
+              ${Activity16({ slot: 'icon' })}
+              <span slot="tooltip-content">action 1</span>
+            </cds-icon-button>
+            <cds-icon-button
+              slot="page-actions"
+              kind="ghost"
+              size="md"
+              align="bottom"
+            >
+              ${AiGenerate16({ slot: 'icon' })}
+              <span slot="tooltip-content">action 2</span>
+            </cds-icon-button>
+            <cds-icon-button
+              slot="page-actions"
+              kind="ghost"
+              size="md"
+              align="bottom"
+            >
+              ${CloudFoundry16({ slot: 'icon' })}
+              <span slot="tooltip-content">action 3</span>
+            </cds-icon-button>
+          </c4p-page-header-breadcrumb>
+          <c4p-page-header-content
+            title="Virtual-Machine-DAL-really-long-title-example-that-goes-at-least-2-lines-long"
           >
-            ${Activity16({ slot: 'icon' })}
-            <span slot="tooltip-content">action 1</span>
-          </cds-icon-button>
-          <cds-icon-button
-            slot="page-actions"
-            kind="ghost"
-            size="md"
-            align="bottom"
-          >
-            ${AiGenerate16({ slot: 'icon' })}
-            <span slot="tooltip-content">action 2</span>
-          </cds-icon-button>
-          <cds-icon-button
-            slot="page-actions"
-            kind="ghost"
-            size="md"
-            align="bottom"
-          >
-            ${CloudFoundry16({ slot: 'icon' })}
-            <span slot="tooltip-content">action 3</span>
-          </cds-icon-button>
-        </c4p-page-header-breadcrumb>
-        <c4p-page-header-content
-          title="Virtual-Machine-DAL-really-long-title-example-that-goes-at-least-2-lines-long"
-        >
-          <div slot="contextual-actions">
-            <cds-tag type="blue" size="lg">Tag</cds-tag>
-          </div>
-          <c4p-page-header-content-text subtitle="Subtitle">
-            Built for modern teams, our technology platform simplifies
-            complexity with powerful APIs, real-time collaboration tools, and
-            seamless integration. From deployment to monitoring, we help you
-            ship faster, scale efficiently, and stay in control every step of
-            the way.
-          </c4p-page-header-content-text>
-        </c4p-page-header-content>
-      </c4p-page-header>`,
+            <div slot="contextual-actions">
+              <cds-tag type="blue" size="lg">Tag</cds-tag>
+            </div>
+            <c4p-page-header-content-text subtitle="Subtitle">
+              Built for modern teams, our technology platform simplifies
+              complexity with powerful APIs, real-time collaboration tools, and
+              seamless integration. From deployment to monitoring, we help you
+              ship faster, scale efficiently, and stay in control every step of
+              the way.
+            </c4p-page-header-content-text>
+          </c4p-page-header-content> </c4p-page-header
+        >,
+      </main>`,
 };
 
 export const ContentWithContextualActionsAndPageActions = {
-  render: () =>
-    html` <style>
-        ${styles}
-      </style>
-      <cds-header aria-label="IBM Platform Name">
-        <cds-header-name href="javascript:void 0" prefix="IBM"
-          >[Platform]</cds-header-name
-        >
-      </cds-header>
+  render: () => html`
+    <style>
+      ${styles}
+    </style>
+    <cds-header class="ui-shell--header" aria-label="IBM Platform Name">
+      <cds-header-name href="javascript:void 0" prefix="IBM"
+        >[Platform]</cds-header-name
+      >
+    </cds-header>
+    <main>
       <c4p-page-header>
         <c4p-page-header-breadcrumb>
           ${Bee16({ slot: 'icon' })}
@@ -362,7 +367,9 @@ export const ContentWithContextualActionsAndPageActions = {
             the way.
           </c4p-page-header-content-text>
         </c4p-page-header-content>
-      </c4p-page-header>`,
+      </c4p-page-header>
+    </main>
+  `,
 };
 
 export const ContentWithHeroImage = {
@@ -371,15 +378,16 @@ export const ContentWithHeroImage = {
     <style>
         ${styles}
       </style>
-      <cds-header aria-label="IBM Platform Name">
+      <cds-header class="ui-shell--header" aria-label="IBM Platform Name">
         <cds-header-name href="javascript:void 0" prefix="IBM"
           >[Platform]</cds-header-name
         >
       </cds-header>
-    <c4p-page-header>
+      <main>
+<c4p-page-header>
       <div class="cds--css-grid">
         <div class="cds--sm:col-span-4 cds--md:col-span-4 cds--lg:col-span-8 cds--css-grid-column">
-          <c4p-page-header-breadcrumb ?border=${false} within-grid>
+          <c4p-page-header-breadcrumb border=${false} within-grid>
         ${Bee16({ slot: 'icon' })}
         <cds-breadcrumb>
           <cds-breadcrumb-item>
@@ -420,19 +428,22 @@ export const ContentWithHeroImage = {
         </div>
       </div>
       </div>
-    </c4p-page-header>`,
+    </c4p-page-header>
+      </main>
+    `,
 };
 
 export const ContentWithIcon = {
-  render: () =>
-    html` <style>
-        ${styles}
-      </style>
-      <cds-header aria-label="IBM Platform Name">
-        <cds-header-name href="javascript:void 0" prefix="IBM"
-          >[Platform]</cds-header-name
-        >
-      </cds-header>
+  render: () => html`
+    <style>
+      ${styles}
+    </style>
+    <cds-header class="ui-shell--header" aria-label="IBM Platform Name">
+      <cds-header-name href="javascript:void 0" prefix="IBM"
+        >[Platform]</cds-header-name
+      >
+    </cds-header>
+    <main>
       <c4p-page-header>
         <c4p-page-header-breadcrumb>
           ${Bee16({ slot: 'icon' })}
@@ -484,19 +495,22 @@ export const ContentWithIcon = {
             the way.
           </c4p-page-header-content-text>
         </c4p-page-header-content>
-      </c4p-page-header>`,
+      </c4p-page-header>
+    </main>
+  `,
 };
 
 export const TabBarWithTabsAndTags = {
-  render: () =>
-    html` <style>
-        ${styles}
-      </style>
-      <cds-header aria-label="IBM Platform Name">
-        <cds-header-name href="javascript:void 0" prefix="IBM"
-          >[Platform]</cds-header-name
-        >
-      </cds-header>
+  render: () => html`
+    <style>
+      ${styles}
+    </style>
+    <cds-header class="ui-shell--header" aria-label="IBM Platform Name">
+      <cds-header-name href="javascript:void 0" prefix="IBM"
+        >[Platform]</cds-header-name
+      >
+    </cds-header>
+    <main>
       <c4p-page-header>
         <c4p-page-header-breadcrumb>
           ${Bee16({ slot: 'icon' })}
@@ -605,7 +619,9 @@ export const TabBarWithTabsAndTags = {
         <div id="tab-panel-7" role="tabpanel" aria-labelledby="tab-7" hidden>
           Tab Panel 7
         </div>
-      </div>`,
+      </div>
+    </main>
+  `,
 };
 
 const meta = {

--- a/packages/ibm-products-web-components/src/components/page-header/page-header.test.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header.test.ts
@@ -15,7 +15,7 @@ import { prefix } from '../../globals/settings';
 import './index';
 
 describe('c4p-page-header', function () {
-    it.only('should find custom css properties to initialize sticky positioning', async () => {
+  it('should find custom css properties to initialize sticky positioning', async () => {
     const pageHeader: CDSPageHeader = await fixture(
       html`<c4p-page-header>
         <c4p-page-header-breadcrumb>
@@ -25,13 +25,20 @@ describe('c4p-page-header', function () {
           </cds-breadcrumb>
         </c4p-page-header-breadcrumb>
         <c4p-page-header-content title="Page header content title">
-          </c4p-page-header-content>
+        </c4p-page-header-content>
       </c4p-page-header>`
     );
-    await pageHeader.updated;
-    console.log(getComputedStyle(pageHeader), 'HEREEEEEEEE????????????', pageHeader);
-    console.log(getComputedStyle(pageHeader).getPropertyValue(`--${prefix}-page-header-header-top`));
+    await pageHeader.updateComplete;
+    const contentHeight = getComputedStyle(pageHeader).getPropertyValue(
+      `--${prefix}-page-header-header-top`
+    );
+    const breadcrumbPosition = getComputedStyle(pageHeader).getPropertyValue(
+      `--${prefix}-page-header-breadcrumb-top`
+    );
+    expect(contentHeight).toBeDefined();
+    expect(breadcrumbPosition).toBeDefined();
   });
+
   describe('c4p-page-header-breadcrumb', () => {
     it('should place className on the outermost element', async () => {
       const el: CDSPageHeaderBreadcrumb = await fixture(

--- a/packages/ibm-products-web-components/src/components/page-header/page-header.test.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header.test.ts
@@ -29,14 +29,16 @@ describe('c4p-page-header', function () {
       </c4p-page-header>`
     );
     await pageHeader.updateComplete;
+    await new Promise((resolve) => setTimeout(resolve, 0));
     const contentHeight = getComputedStyle(pageHeader).getPropertyValue(
       `--${prefix}-page-header-header-top`
     );
     const breadcrumbPosition = getComputedStyle(pageHeader).getPropertyValue(
       `--${prefix}-page-header-breadcrumb-top`
     );
-    expect(contentHeight).toBeDefined();
-    expect(breadcrumbPosition).toBeDefined();
+
+    expect(parseFloat(contentHeight)).toBeTypeOf('number');
+    expect(parseFloat(breadcrumbPosition)).toBeTypeOf('number');
   });
 
   describe('c4p-page-header-breadcrumb', () => {

--- a/packages/ibm-products-web-components/src/components/page-header/page-header.test.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header.test.ts
@@ -11,9 +11,27 @@ import CDSPageHeader from './page-header';
 import CDSPageHeaderBreadcrumb from './page-header-breadcrumb';
 import CDSPageHeaderTabs from './page-header-tabs';
 import CDSTabs from '@carbon/web-components/es/components/tabs/tabs';
+import { prefix } from '../../globals/settings';
 import './index';
 
 describe('c4p-page-header', function () {
+    it.only('should find custom css properties to initialize sticky positioning', async () => {
+    const pageHeader: CDSPageHeader = await fixture(
+      html`<c4p-page-header>
+        <c4p-page-header-breadcrumb>
+          <cds-breadcrumb>
+            <cds-breadcrumb-item href="/#">Breadcrumb 1</cds-breadcrumb-item>
+            <cds-breadcrumb-item href="#">Breadcrumb 2</cds-breadcrumb-item>
+          </cds-breadcrumb>
+        </c4p-page-header-breadcrumb>
+        <c4p-page-header-content title="Page header content title">
+          </c4p-page-header-content>
+      </c4p-page-header>`
+    );
+    await pageHeader.updated;
+    console.log(getComputedStyle(pageHeader), 'HEREEEEEEEE????????????', pageHeader);
+    console.log(getComputedStyle(pageHeader).getPropertyValue(`--${prefix}-page-header-header-top`));
+  });
   describe('c4p-page-header-breadcrumb', () => {
     it('should place className on the outermost element', async () => {
       const el: CDSPageHeaderBreadcrumb = await fixture(

--- a/packages/ibm-products-web-components/src/components/page-header/page-header.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019, 2023
+ * Copyright IBM Corp. 2025, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -13,11 +13,104 @@ import styles from './page-header.scss?lit';
 import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element.js';
 
 /**
+ * ----------
+ * Utilities
+ * ----------
+ */
+
+const getHeaderOffset = (el: HTMLElement): number => {
+  const scrollableContainer = scrollableAncestor(el);
+  const scrollableContainerTop = scrollableContainer
+    ? (scrollableContainer as HTMLElement).getBoundingClientRect().top
+    : 0;
+  console.log(scrollableContainer);
+  const offsetMeasuringTop = el ? el.getBoundingClientRect().top : 0;
+  console.log(el, offsetMeasuringTop);
+  const totalHeaderOffset =
+    offsetMeasuringTop !== 0 ? offsetMeasuringTop - scrollableContainerTop : 0;
+  return totalHeaderOffset;
+};
+
+const windowExists = typeof window !== `undefined`;
+
+/**
+ * Determines if the given target is scrollable
+ *
+ * @param {HTMLElement} target
+ * @returns {boolean}
+ */
+const scrollable = (target: HTMLElement): boolean => {
+  const style = window.getComputedStyle(target);
+  return /(auto|scroll|hidden)/.test(style.overflow);
+};
+
+/**
+ * Recursively looks for the scrollable ancestor
+ */
+const scrollableAncestorInner = (target: HTMLElement) => {
+  if (target.parentNode && target.parentNode !== document) {
+    if (scrollable(target.parentNode as HTMLElement)) {
+      return target.parentNode;
+    } else {
+      return scrollableAncestorInner(target.parentNode as HTMLElement);
+    }
+  } else {
+    return document.scrollingElement;
+  }
+};
+
+/**
+ * Walks up the parent nodes to identify the first scrollable ancestor
+ *
+ * @param {HTMLElement} target
+ * @returns {HTMLElement}
+ */
+const scrollableAncestor = (target: HTMLElement) => {
+  if (!windowExists || !target) {
+    return null;
+  }
+
+  // based on https://stackoverflow.com/questions/35939886/find-first-scrollable-parent
+  const style = window.getComputedStyle(target);
+
+  if (!target || !style || style.position === 'fixed') {
+    return document.scrollingElement;
+  }
+  return scrollableAncestorInner(target);
+};
+
+/**
  * Page header.
  * @element c4p-page-header
  */
 @customElement(`${prefix}-page-header`)
 class CDSPageHeader extends LitElement {
+  updated() {
+    const contentElement = this.querySelector('c4p-page-header-content');
+
+    if (contentElement) {
+      const resizeObserver = new ResizeObserver((entries) => {
+        const contentElEntry = entries[0];
+        const contentHeight = contentElEntry.contentRect.height;
+        const padding =
+          parseFloat(getComputedStyle(contentElement)?.paddingBlockStart) +
+          parseFloat(getComputedStyle(contentElement)?.paddingBlockEnd);
+        const totalContentHeight = contentHeight + padding;
+        const headerOffset = getHeaderOffset(this);
+
+        this.style.setProperty(
+          `--${prefix}-page-header-header-top`,
+          `${(Math.round(totalContentHeight) - headerOffset) * -1}px`
+        );
+        this.style.setProperty(
+          `--${prefix}-page-header-breadcrumb-top`,
+          `${headerOffset}px`
+        );
+      });
+
+      resizeObserver.observe(contentElement);
+    }
+  }
   render() {
     return html` <slot></slot>`;
   }

--- a/packages/ibm-products-web-components/src/components/page-header/page-header.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header.ts
@@ -84,7 +84,7 @@ const scrollableAncestor = (target: HTMLElement) => {
 @customElement(`${prefix}-page-header`)
 class CDSPageHeader extends LitElement {
   updated() {
-    const contentElement = this.querySelector('c4p-page-header-content');
+    const contentElement = this.querySelector(`${prefix}-page-header-content`);
 
     if (contentElement) {
       const resizeObserver = new ResizeObserver((entries) => {

--- a/packages/ibm-products-web-components/src/components/page-header/page-header.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header.ts
@@ -23,9 +23,7 @@ const getHeaderOffset = (el: HTMLElement): number => {
   const scrollableContainerTop = scrollableContainer
     ? (scrollableContainer as HTMLElement).getBoundingClientRect().top
     : 0;
-  console.log(scrollableContainer);
   const offsetMeasuringTop = el ? el.getBoundingClientRect().top : 0;
-  console.log(el, offsetMeasuringTop);
   const totalHeaderOffset =
     offsetMeasuringTop !== 0 ? offsetMeasuringTop - scrollableContainerTop : 0;
   return totalHeaderOffset;

--- a/packages/ibm-products-web-components/vite.config.ts
+++ b/packages/ibm-products-web-components/vite.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
       exclude: ['src/**/*.stories.{js,ts}'],
       reporter: ['text', 'html', 'json'],
     },
+    css: true
   },
   css: {
     preprocessorOptions: {

--- a/packages/ibm-products-web-components/vite.config.ts
+++ b/packages/ibm-products-web-components/vite.config.ts
@@ -39,7 +39,9 @@ export default defineConfig({
       exclude: ['src/**/*.stories.{js,ts}'],
       reporter: ['text', 'html', 'json'],
     },
-    css: true
+    css: {
+      include: /page-header/,
+    },
   },
   css: {
     preprocessorOptions: {


### PR DESCRIPTION
Closes #7740 

Adds sticky functionality to page header web component when there is scrolling content, similar to the current page header.

#### What did you change?
```
packages/ibm-products-web-components/src/components/page-header/_story-assets/_storybook-styles.scss
packages/ibm-products-web-components/src/components/page-header/page-header.scss
packages/ibm-products-web-components/src/components/page-header/page-header.stories.ts
packages/ibm-products-web-components/src/components/page-header/page-header.ts
```
#### How did you test and verify your work?
Verified in each of the page header stories
#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [X] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [X] Addressed any impact on accessibility (a11y)
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
