### PR TITLE
fix(build): include wc storybook build in build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "audit": "node scripts/audit.js '--environment production' moderate",
     "avt": "AVT=true yarn playwright test --project chromium --grep @avt",
-    "build": "run-s -s 'build:*' storybook:build",
+    "build": "run-s -s 'build:*' storybook:build storybook-wc:build",
     "build:packages": "yarn run-all --include-dependencies build",
     "ci-check": "run-s -s 'ci-check:*' storybook:build",
     "ci-check:build": "run-s -s 'build:*' 'run-all --no-sort ci-check'",


### PR DESCRIPTION
The last two times the `deploy prod storybook` and `deploy staging storybook` actions have run they have failed. This is because it's looking for the built storybook-static directory but we haven't built the web components storybook yet so it doesn't exist.

https://github.com/carbon-design-system/ibm-products/actions/workflows/deploy-staging.yml
https://github.com/carbon-design-system/ibm-products/actions/workflows/deploy-latest.yml

#### What did you change?
Added `storybook-wc:build` to `build` script
#### How did you test and verify your work?
Verify within this PR that the build script passes
#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
