### PR TITLE
fix: include webcomponent storybook build for deployment

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -30,7 +30,9 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Build storybook
-        run: yarn storybook:build
+        run: |
+          yarn storybook:build
+          yarn storybook-wc:build
 
       # Deploy to staging Github Pages using `gh-pages` package
       - name: Prepare latest directory

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -29,7 +29,9 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Build packages and storybook
-        run: yarn build
+        run: |
+          yarn build
+          yarn storybook-wc:build
 
       # Deploy to staging Github Pages using `gh-pages` package
       - name: Prepare combined staging directory with clean URL paths


### PR DESCRIPTION
Closes #6985 

As part of https://github.com/carbon-design-system/ibm-products/pull/7638, we expect to have wc storybook deployment for staging and latest. Its failing now since wc storybook build was missed out in the CI.

#### What did you change?
Added `yarn storybook-wc:build` in deploy-staging.yml and deploy-latest.yml

#### How did you test and verify your work?

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
