### PR TITLE
chore: remove redundant upgrade scripts

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -32,11 +32,13 @@ jobs:
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: ${{ steps.generate_token.outputs.token }}
-          commit-message: 'build(deps): update Carbon 11 compatible versions to latest'
+          commit-message:
+            'build(deps): update Carbon 11 compatible versions to latest'
           delete-branch: true
           branch: 'deps/update-carbon-packages'
           branch-suffix: random
-          title: 'build(deps): update to Carbon 11 compatible versions to latest'
+          title:
+            'build(deps): update to Carbon 11 compatible versions to latest'
           body: |
             This PR was automatically generated to update Carbon 11 compatible versions on a regular basis. This is not intended to create any breaking changes, and will be reflected as a minor version bump for affected packages. NB we'll run all tests and do visual verifications, but there is always the opportunity for unexpected regressions. If you're using one of the packages in a stable or production context you may want to check this before taking the next minor version, and do let us know ASAP if you see anything problematic.
 
@@ -54,54 +56,3 @@ jobs:
             - [ ] A reminder message has been posted onto the ibmproducts-pal-dev Slack channel that a version update PR is going through.
             - [ ] `yarn ci-check` runs cleanly and all tests pass (done automatically as part of the PR checks).
             - [ ] the Netlify deploy-preview has been used to ensure that storybook runs and the main published components render correctly.
-
-  dependencies:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Install
-        run: yarn
-
-      - name: Update packages
-        run: |
-          yarn set version latest
-          yarn upgrade:automatic
-          rm yarn.lock
-          yarn
-          yarn update-gallery-config
-        env:
-          YARN_ENABLE_IMMUTABLE_INSTALLS: false
-
-      - name: Generate token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a #v2.1.0
-        id: generate_token
-        with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: Create PR
-        id: create-pr
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
-        with:
-          token: ${{ steps.generate_token.outputs.token }}
-          commit-message: 'build(deps): update dev dependencies'
-          delete-branch: true
-          branch: 'deps/update-dev-packages'
-          branch-suffix: random
-          title: 'build(deps): update dev dependencies'
-          body: |
-            This PR was automatically generated to update versions of dev dependencies to their latest versions. This helps ensure we get fixes and improvements in a timely fashion and reduces the impact of updating the versions that can arise if versions are allowed to become stale for an extended period.
-
-            #### What did you change?
-
-            This action ran `yarn upgrade:automatic` to update `package.json` files to request the latest versions of each package. Certain critical packages are intentionally excluded.
-
-            This action also deleted the `yarn.lock` file in order to recreate it with the latest matching versions of secondary dependencies.
-
-            This PR includes the various `package.json` that pull our dependencies forward to the latest versions, the `yarn.lock` update that maps required versions to the actual versions to be used, and updates the offline mirror.
-
-            #### How did you test and verify your work?
-
-            This PR should not normally significantly affect the build outputs or runtime packages. Ensure that `yarn ci-check` runs cleanly and all tests pass (done automatically as part of the PR checks).

--- a/config/babel-preset-ibm-cloud-cognitive/package.json
+++ b/config/babel-preset-ibm-cloud-cognitive/package.json
@@ -17,13 +17,6 @@
     "carbon for cloud & cognitive",
     "carbon for ibm products"
   ],
-  "scripts": {
-    "//upgrade-dependencies": "# don't upgrade carbon (done globally)",
-    "upgrade-dependencies": "npm-check-updates -u --dep dev,peer,prod --color --reject '/(carbon)/'"
-  },
-  "devDependencies": {
-    "npm-check-updates": "^18.0.0"
-  },
   "dependencies": {
     "@babel/core": "^7.26.10",
     "@babel/plugin-proposal-class-properties": "^7.18.6",

--- a/config/jest-config-ibm-cloud-cognitive/package.json
+++ b/config/jest-config-ibm-cloud-cognitive/package.json
@@ -17,13 +17,6 @@
     "carbon for cloud & cognitive",
     "carbon for ibm products"
   ],
-  "scripts": {
-    "//upgrade-dependencies": "# don't upgrade carbon (done globally), chalk (issue #1596)",
-    "upgrade-dependencies": "npm-check-updates -u --dep dev,peer,prod --color --reject '/(carbon|^chalk$)/'"
-  },
-  "devDependencies": {
-    "npm-check-updates": "^18.0.0"
-  },
   "peerDependencies": {
     "jest": "^29.7.0"
   },

--- a/config/storybook-addon-carbon-theme/package.json
+++ b/config/storybook-addon-carbon-theme/package.json
@@ -36,9 +36,7 @@
     "build": "run-s clean build:js",
     "build:js": "babel src --out-dir dist -s",
     "postinstall": "ibmtelemetry --config=telemetry.yml",
-    "prepare": "npm run build",
-    "//upgrade-dependencies": "# don't upgrade carbon (done globally)",
-    "upgrade-dependencies": "npm-check-updates -u --dep dev,peer,prod --color --reject '/(carbon)/'"
+    "prepare": "npm run build"
   },
   "peerDependencies": {
     "react": "*",
@@ -60,7 +58,6 @@
     "@babel/cli": "^7.26.4",
     "@babel/core": "^7.26.10",
     "@babel/preset-react": "^7.26.3",
-    "npm-check-updates": "^18.0.0",
     "npm-run-all": "^4.1.5",
     "rimraf": "^6.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -59,11 +59,7 @@
     "storybook-wc:build": "cd packages/ibm-products-web-components && run-s build build:storybook",
     "sync": "carbon-cli sync",
     "update-gallery-config": "node scripts/example-gallery-builder/index.js; prettier examples/carbon-for-ibm-products/**/src/**/*.{js,jsx,md,mdx,scss,json} --write --loglevel=silent",
-    "//upgrade:dependencies:top": "# don't upgrade carbon (done globally), react/react-dom (not tested)",
-    "upgrade:dependencies:top": "npm-check-updates -u --dep dev,peer,prod --reject '/(carbon|^react$|^react-dom$|^@testing-library|^commander)/'",
-    "upgrade:dependencies:packages": "yarn run-all --no-sort --concurrency 1 upgrade-dependencies",
     "upgrade:dependencies:examples": "npm-check-updates -u --dep dev,peer,prod --color --target minor --packageFile 'scripts/example-gallery-builder/update-example/**/package.json'",
-    "upgrade:automatic": "run-s -s 'upgrade:dependencies:*'",
     "upgrade:carbon": "npm-check-updates -u --dep dev,peer,prod --packageFile '{package.json,{config/**,packages/**}/package.json}' --filter '/carbon/' --target minor",
     "visual-snapshot": "cd packages/ibm-products && yarn percy storybook storybook-static",
     "wc-coverage": "cd packages/ibm-products-web-components && yarn coverage"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,9 +18,7 @@
     "carbon for ibm products"
   ],
   "scripts": {
-    "clean": "yarn dlx rimraf storybook-static css",
-    "//upgrade-dependencies": "# don't upgrade carbon (done globally), react/react-dom (issue #1595)",
-    "upgrade-dependencies": "npm-check-updates -u --dep dev,peer,prod --color --reject '/(carbon|^react$|^react-dom$)/'"
+    "clean": "yarn dlx rimraf storybook-static css"
   },
   "devDependencies": {
     "@carbon/grid": "^11.37.0",
@@ -31,7 +29,6 @@
     "@carbon/themes": "^11.54.0",
     "@carbon/type": "^11.41.0",
     "fast-glob": "^3.3.3",
-    "npm-check-updates": "^18.0.0",
     "npm-run-all": "^4.1.5",
     "prop-types": "^15.8.1",
     "react": "^19.1.0",

--- a/packages/ibm-products-styles/package.json
+++ b/packages/ibm-products-styles/package.json
@@ -42,9 +42,7 @@
     "build-css-update-maps": "node ../../scripts/updateSourceMaps.js",
     "clean": "rimraf css scss",
     "postinstall": "ibmtelemetry --config=telemetry.yml",
-    "test": "jest --colors",
-    "//upgrade-dependencies": "# don't upgrade carbon (done globally), react/react-dom (explicit range peer dependency), chalk (issue #1596)",
-    "upgrade-dependencies": "npm-check-updates -u --dep dev,peer,prod --color --reject '/(carbon|^react$|^react-dom$|^chalk$|^namor)/'"
+    "test": "jest --colors"
   },
   "devDependencies": {
     "chalk": "^4.1.2",
@@ -54,7 +52,6 @@
     "jest": "^29.7.0",
     "jest-config-ibm-cloud-cognitive": "^1.29.0-rc.0",
     "jest-environment-jsdom": "^29.7.0",
-    "npm-check-updates": "^18.0.0",
     "npm-run-all": "^4.1.5",
     "rimraf": "^6.0.1",
     "sass": "^1.85.1",

--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -56,9 +56,7 @@
     "storybook:build": "run-s build:carbon build:storybook",
     "storybook:start": "storybook dev ./public -p 3000",
     "telemetry-config": "ibmtelemetry-config generate --id 495342db-5046-4ecf-85ea-9ffceb6f8cdf --endpoint https://www-api.ibm.com/ibm-telemetry/v1/metrics --files ./src/components/**/*.(tsx|js|jsx)",
-    "test": "jest --colors",
-    "//upgrade-dependencies": "# don't upgrade carbon (done globally), react/react-dom (explicit range peer dependency), chalk (issue #1596)",
-    "upgrade-dependencies": "npm-check-updates -u --dep dev,peer,prod --color --reject '/(carbon|^react$|^react-dom$|^chalk$|^namor)/'"
+    "test": "jest --colors"
   },
   "devDependencies": {
     "@babel/cli": "^7.26.4",
@@ -105,7 +103,6 @@
     "jest-config-ibm-cloud-cognitive": "^1.29.0-rc.0",
     "jest-environment-jsdom": "^29.7.0",
     "namor": "^1.1.2",
-    "npm-check-updates": "^18.0.0",
     "npm-run-all": "^4.1.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1922,7 +1922,6 @@ __metadata:
     "@carbon/type": "npm:^11.41.0"
     fast-glob: "npm:^3.3.3"
     lottie-web: "npm:^5.12.2"
-    npm-check-updates: "npm:^18.0.0"
     npm-run-all: "npm:^4.1.5"
     prop-types: "npm:^15.8.1"
     react: "npm:^19.1.0"
@@ -1948,7 +1947,6 @@ __metadata:
     jest: "npm:^29.7.0"
     jest-config-ibm-cloud-cognitive: "npm:^1.29.0-rc.0"
     jest-environment-jsdom: "npm:^29.7.0"
-    npm-check-updates: "npm:^18.0.0"
     npm-run-all: "npm:^4.1.5"
     rimraf: "npm:^6.0.1"
     sass: "npm:^1.85.1"
@@ -2078,7 +2076,6 @@ __metadata:
     jest-config-ibm-cloud-cognitive: "npm:^1.29.0-rc.0"
     jest-environment-jsdom: "npm:^29.7.0"
     namor: "npm:^1.1.2"
-    npm-check-updates: "npm:^18.0.0"
     npm-run-all: "npm:^4.1.5"
     react: "npm:^19.1.0"
     react-dom: "npm:^19.1.0"
@@ -2245,7 +2242,6 @@ __metadata:
     "@storybook/theming": "npm:^8.6.6"
     core-js: "npm:^3.41.0"
     global: "npm:^4.4.0"
-    npm-check-updates: "npm:^18.0.0"
     npm-run-all: "npm:^4.1.5"
     rimraf: "npm:^6.0.1"
   peerDependencies:
@@ -9869,7 +9865,6 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.26.0"
     babel-plugin-dev-expression: "npm:^0.2.3"
     browserslist-config-carbon: "npm:^11.2.0"
-    npm-check-updates: "npm:^18.0.0"
   languageName: unknown
   linkType: soft
 
@@ -15800,7 +15795,6 @@ __metadata:
     identity-obj-proxy: "npm:^3.0.0"
     jest-circus: "npm:^29.7.0"
     jest-watch-typeahead: "npm:^3.0.0"
-    npm-check-updates: "npm:^18.0.0"
     sass: "npm:^1.85.1"
   peerDependencies:
     jest: ^29.7.0


### PR DESCRIPTION
Closes #7549 

Remove redundant upgrade scrips from various packages and rely on renovate

#### What did you change?

- Removed the upgrade:dependencies and npm-check-updates dev dependencies from the following package.jsons

  -   config/babel-preset-ibm-cloud-cognitive
  -   config/jest-config-ibm-cloud-cognitive
  -   config/storybook-addon-carbon-theme
  -   packages/core
  -   packages/ibm-products
  -   packages/ibm-products/styles

- Removed the `upgrade:*` scripts from root package.json except `upgrade:dependencies:examples` and `upgrade:carbon`
- Removed the dependencies step (~ L58) from the update.yml file.

#### How did you test and verify your work?

Run `upgrade:carbon` and `upgrade:dependencies:examples` to verify it still works as expect

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
