### PR TITLE
fix: perform full  build before wc story build

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -31,7 +31,7 @@ jobs:
         run: yarn install
       - name: Build storybook
         run: |
-          yarn storybook:build
+          yarn build
           yarn storybook-wc:build
 
       # Deploy to staging Github Pages using `gh-pages` package

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -30,7 +30,7 @@ jobs:
         run: yarn install
       - name: Build packages and storybook
         run: |
-          yarn storybook:build
+          yarn build
           yarn storybook-wc:build
 
       # Deploy to staging Github Pages using `gh-pages` package


### PR DESCRIPTION
Closes #6985 

 `yarn storybook-wc:build` will fail with below error if run with out a full build 

```
Error: Can't find stylesheet to import.
   ╷
18 │ @use '@carbon/ibm-products-styles/scss/components/FullPageError' as *;
   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
  src/components/full-page-error/full-page-error.scss 18:1  root stylesheet
```

#### How did you test and verify your work?

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
