### PR TITLE
fix: add authenticated remote

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -33,7 +33,9 @@ jobs:
         run: |
           yarn build
           yarn storybook-wc:build
-
+      # Set authenticated Git remote
+      - name: Set authenticated Git remote
+        run: git remote set-url origin https://git:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
       # Deploy to staging Github Pages using `gh-pages` package
       - name: Prepare latest directory
         run: |

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -26,8 +26,10 @@ jobs:
           node-version: '20.x'
           registry-url: https://registry.npmjs.org
           cache: 'yarn'
+
       - name: Install dependencies
         run: yarn install
+
       - name: Build packages and storybook
         run: |
           yarn build
@@ -41,6 +43,12 @@ jobs:
 
           mkdir -p staging-dist/web-components
           cp -r packages/ibm-products-web-components/storybook-static/* staging-dist/web-components
+
+      # Set authenticated Git remote
+      - name: Set authenticated Git remote
+        run:
+          git remote set-url origin https://git:${{ secrets.GITHUB_TOKEN
+          }}@github.com/${{ github.repository }}.git
 
       - name: Deploy both Storybooks to GitHub Pages (gh-pages/staging)
         run: |


### PR DESCRIPTION
Closes #6985 

Deployement failed with authentication [error](https://github.com/carbon-design-system/ibm-products/actions/runs/16020384802/job/45195685524)

```
npm warn exec The following package was not found and will be installed: gh-pages@6.3.0
ProcessError: fatal: could not read Username for 'https://github.com/': No such device or address
```

#### What did you change?

#### How did you test and verify your work?

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
