### PR TITLE
feat: add support for  children prop for InterstitialScreen.Body

### DIFF
--- a/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreenBody.tsx
+++ b/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreenBody.tsx
@@ -32,6 +32,10 @@ type contentRendererArgs = {
 };
 export interface InterstitialScreenBodyProps {
   /**
+   * Pass you static content as children
+   */
+  children?: ReactNode;
+  /**
    * Provide an optional class to be applied to the containing node.
    */
   className?: string;
@@ -39,7 +43,7 @@ export interface InterstitialScreenBodyProps {
    * This is a required callback that has to return the content to render in the body section.
    * It can be a single child or an array of children depending on your need
    */
-  contentRenderer: (
+  contentRenderer?: (
     config: contentRendererArgs
   ) => ReactElement<EnrichedChildren> | ReactNode;
 }
@@ -73,11 +77,12 @@ const InterstitialScreenBody = React.forwardRef<
   const [scrollPercent, setScrollPercent] = useState(-1);
 
   useEffect(() => {
-    const _bodyContent = contentRenderer({
-      handleGotoStep,
-      progStep,
-      disableActionButton,
-    });
+    const _bodyContent =
+      contentRenderer?.({
+        handleGotoStep,
+        progStep,
+        disableActionButton,
+      }) ?? props.children;
 
     const isElement = isValidElement(_bodyContent);
     const children = isElement


### PR DESCRIPTION
Closes #7790 

Currently InterstitialScreen.Body accepts contentRenderer callback prop that will return the content to render in body.
This enhancement will add support to children prop for InterstitialScreen.Body ,if user want to go with some simple static content that doesn't need to access internal state and also offers more performance by reducing re-renders

#### What did you change?
add support for children

#### How did you test and verify your work?

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
