### PR TITLE
docs(storybook): restructure top level categories

### DIFF
--- a/packages/ibm-products-web-components/src/components/about-modal/about-modal.stories.ts
+++ b/packages/ibm-products-web-components/src/components/about-modal/about-modal.stories.ts
@@ -275,7 +275,7 @@ export const AboutModalWithAllPropsSet = {
 };
 
 const meta = {
-  title: 'Experimental/AboutModal',
+  title: 'Components/AboutModal',
 };
 
 export default meta;

--- a/packages/ibm-products-web-components/src/components/full-page-error/full-page-error.stories.ts
+++ b/packages/ibm-products-web-components/src/components/full-page-error/full-page-error.stories.ts
@@ -87,7 +87,7 @@ export const Error404 = {
 };
 
 const meta = {
-  title: 'Experimental/FullPageError',
+  title: 'Components/FullPageError',
   component: 'c4p-full-page-error',
 };
 

--- a/packages/ibm-products-web-components/src/components/notification-panel/notification-panel.stories.ts
+++ b/packages/ibm-products-web-components/src/components/notification-panel/notification-panel.stories.ts
@@ -324,7 +324,7 @@ export const defaultTemplate = {
   },
 };
 const meta = {
-  title: 'Experimental/NotificationPanel',
+  title: 'Components/NotificationPanel',
 };
 
 export default meta;

--- a/packages/ibm-products-web-components/src/components/options-tile/options-tile.stories.ts
+++ b/packages/ibm-products-web-components/src/components/options-tile/options-tile.stories.ts
@@ -86,7 +86,7 @@ export const Default = {
 };
 
 const meta = {
-  title: 'Experimental/OptionsTile',
+  title: 'Components/OptionsTile',
 };
 
 export default meta;

--- a/packages/ibm-products-web-components/src/components/side-panel/side-panel.stories.ts
+++ b/packages/ibm-products-web-components/src/components/side-panel/side-panel.stories.ts
@@ -334,7 +334,7 @@ export const WithoutTitle = {
 };
 
 const meta = {
-  title: 'Experimental/SidePanel',
+  title: 'Components/SidePanel',
 };
 
 export default meta;

--- a/packages/ibm-products-web-components/src/components/tearsheet/tearsheet.stories.ts
+++ b/packages/ibm-products-web-components/src/components/tearsheet/tearsheet.stories.ts
@@ -453,7 +453,7 @@ export const StackingTemplate = {
 };
 
 const meta = {
-  title: 'Experimental/Tearsheet',
+  title: 'Components/Tearsheet',
 };
 
 export default meta;

--- a/packages/ibm-products-web-components/src/components/truncated-text/truncated-text.stories.ts
+++ b/packages/ibm-products-web-components/src/components/truncated-text/truncated-text.stories.ts
@@ -312,7 +312,7 @@ export const WithExpand = {
 };
 
 const meta = {
-  title: 'Experimental/Utilities/TruncatedText',
+  title: 'Utilities/TruncatedText',
   component: 'c4p-truncated-text',
   parameters: {
     layout: 'fullscreen',

--- a/packages/ibm-products-web-components/src/components/user-avatar/user-avatar.stories.ts
+++ b/packages/ibm-products-web-components/src/components/user-avatar/user-avatar.stories.ts
@@ -144,6 +144,6 @@ export const WithImage = {
   },
 };
 
-const meta = { title: 'Components/Useravatar' };
+const meta = { title: 'Components/UserAvatar' };
 
 export default meta;

--- a/packages/ibm-products-web-components/src/components/user-avatar/user-avatar.stories.ts
+++ b/packages/ibm-products-web-components/src/components/user-avatar/user-avatar.stories.ts
@@ -144,6 +144,6 @@ export const WithImage = {
   },
 };
 
-const meta = { title: 'Experimental/Useravatar' };
+const meta = { title: 'Components/Useravatar' };
 
 export default meta;

--- a/packages/ibm-products-web-components/src/utilities/overflow-handler/overflow-handler.stories.ts
+++ b/packages/ibm-products-web-components/src/utilities/overflow-handler/overflow-handler.stories.ts
@@ -203,7 +203,7 @@ export const WithButtons = {
 };
 
 const meta = {
-  title: 'Experimental/Utilities/overflowHandler',
+  title: 'Utilities/overflowHandler',
 };
 
 export default meta;


### PR DESCRIPTION
Closes #7821 

Restructures the top level categories in our web component storybook, renaming `Experimental` to `Components` and moving `Utilities` to the top level.

#### What did you change?
```
packages/ibm-products-web-components/src/components/about-modal/about-modal.stories.ts
packages/ibm-products-web-components/src/components/full-page-error/full-page-error.stories.ts
packages/ibm-products-web-components/src/components/notification-panel/notification-panel.stories.ts
packages/ibm-products-web-components/src/components/options-tile/options-tile.stories.ts
packages/ibm-products-web-components/src/components/side-panel/side-panel.stories.ts
packages/ibm-products-web-components/src/components/tearsheet/tearsheet.stories.ts
packages/ibm-products-web-components/src/components/truncated-text/truncated-text.stories.ts
packages/ibm-products-web-components/src/components/user-avatar/user-avatar.stories.ts
packages/ibm-products-web-components/src/utilities/overflow-handler/overflow-handler.stories.ts
```
#### How did you test and verify your work?
Storybook
#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [X] Updated documentation and storybook examples
- [X] Wrote passing tests that cover this change
- [X] Addressed any impact on accessibility (a11y)
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
