### PR TITLE
docs(ProductiveCard): add docs about overflow menu items

### DIFF
--- a/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.docs-page.js
+++ b/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.docs-page.js
@@ -44,7 +44,7 @@ const DocsPage = () => (
       {
         story: stories.WithOverflow,
         description:
-          'To include an overflow menu within the productive card, you should provide an array of objects. These will map to the overflow items, all supported props from `OverflowItem` will be passed through to the overflow menu items created via the `overflowActions` prop.',
+          'To include an overflow menu within the productive card, you should provide an array of objects. These will map to the overflow items. All supported props from `OverflowItem` will be passed through to the overflow menu items created via the `overflowActions` prop.',
       },
       {
         title: 'With AI label',

--- a/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.docs-page.js
+++ b/packages/ibm-products/src/components/ProductiveCard/ProductiveCard.docs-page.js
@@ -43,6 +43,8 @@ const DocsPage = () => (
       },
       {
         story: stories.WithOverflow,
+        description:
+          'To include an overflow menu within the productive card, you should provide an array of objects. These will map to the overflow items, all supported props from `OverflowItem` will be passed through to the overflow menu items created via the `overflowActions` prop.',
       },
       {
         title: 'With AI label',


### PR DESCRIPTION
Closes #6728 

Adds some docs around overflow menu usage in `ProductiveCard`.

#### What did you change?
```
packages/ibm-products/src/components/ProductiveCard/ProductiveCard.docs-page.js
```
#### How did you test and verify your work?
Doc update only
#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [X] Updated documentation and storybook examples
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
