### PR TITLE
chore: remove unneeded tabIndex={0} settings

### DIFF
--- a/packages/ibm-products/src/components/CoachmarkBeacon/CoachmarkBeacon.tsx
+++ b/packages/ibm-products/src/components/CoachmarkBeacon/CoachmarkBeacon.tsx
@@ -77,7 +77,6 @@ export let CoachmarkBeacon = React.forwardRef<
       role="tooltip"
     >
       <button
-        tabIndex={0}
         type="button"
         {...buttonProps}
         className={`${blockClass}__target`}

--- a/packages/ibm-products/src/components/EditInPlace/EditInPlace.tsx
+++ b/packages/ibm-products/src/components/EditInPlace/EditInPlace.tsx
@@ -319,7 +319,6 @@ export let EditInPlace = forwardRef<HTMLDivElement, EditInplaceProps>(
                   label={cancelLabel}
                   onClick={onCancelHandler}
                   kind="ghost"
-                  tabIndex={0}
                   key="cancel"
                   className={`${blockClass}__btn ${blockClass}__btn-cancel`}
                 >
@@ -332,7 +331,6 @@ export let EditInPlace = forwardRef<HTMLDivElement, EditInplaceProps>(
                   label={saveLabel}
                   onClick={onSaveHandler}
                   kind="ghost"
-                  tabIndex={0}
                   key="save"
                   className={`${blockClass}__btn ${blockClass}__btn-save`}
                   disabled={!canSave}
@@ -351,7 +349,6 @@ export let EditInPlace = forwardRef<HTMLDivElement, EditInplaceProps>(
                 label={editLabel}
                 onClick={onFocusHandler}
                 kind="ghost"
-                tabIndex={0}
                 key="edit"
               >
                 <Edit size={16} />

--- a/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.tsx
+++ b/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.tsx
@@ -748,7 +748,6 @@ export let NotificationsPanel = React.forwardRef(
         role="dialog"
         aria-labelledby={headingId}
         onKeyDown={handleKeydown}
-        tabIndex={0}
         {
           // Pass through any other property values as HTML attributes.
           ...rest

--- a/packages/ibm-products/src/components/PageHeader/PageHeader.stories.jsx
+++ b/packages/ibm-products/src/components/PageHeader/PageHeader.stories.jsx
@@ -649,7 +649,6 @@ const Template = ({
       <style>{`.${carbonPrefix}--modal { opacity: 0; }`};</style>
       <ContainerDivOrTabs
         className={`${storyClass}__content-container`}
-        tabIndex={0}
         navigation={navigation}
       >
         <main>
@@ -864,7 +863,6 @@ const TemplateDemo = ({
       >
         <ContainerDivOrTabs
           className={`${storyClass}__content-container`}
-          tabIndex={0}
           navigation={navigation}
         >
           <main>

--- a/packages/ibm-products/src/components/ScrollGradient/ScrollGradient.js
+++ b/packages/ibm-products/src/components/ScrollGradient/ScrollGradient.js
@@ -168,12 +168,10 @@ export let ScrollGradient = React.forwardRef(
         role="presentation"
         {...getDevtoolsProps(componentName)}
       >
-        {/* eslint-disable jsx-a11y/no-noninteractive-tabindex */}
         <div
           onScroll={onScroll}
           ref={setRefs}
           className={cx(`${blockClass}__content`, scrollElementClassName)}
-          tabIndex={0}
         >
           <span ref={intersectionStartRef} data-start-vertical />
           <span ref={intersectionLeftRef} data-start-horizontal />


### PR DESCRIPTION
Refs #7043 and https://github.com/IBMa/equal-access/issues/2281.

It's no longer necessary to set `tabIndex={0}` for scrollable `<div>` or `<section>` elements.  See #7043.

You also don't need it for `<IconButton>` or `<button>`, as it's the default.

#### What did you change?

Removed various unneeded `tabIndex={0}`.

#### How did you test and verify your work?

Storybook.

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
