### PR TITLE
feat: update Storybook Docs page to Overview

### DIFF
--- a/packages/ibm-products-web-components/.storybook/main.ts
+++ b/packages/ibm-products-web-components/.storybook/main.ts
@@ -59,6 +59,9 @@ const config = {
       },
     });
   },
+  docs: {
+    defaultName: 'Overview',
+  },
 };
 
 export default config;

--- a/packages/ibm-products/.storybook/main.js
+++ b/packages/ibm-products/.storybook/main.js
@@ -107,6 +107,7 @@ export default {
 
   docs: {
     autodocs: 'tag',
+    defaultName: 'Overview',
   },
 };
 


### PR DESCRIPTION
Closes #7716

Update Storybook Docs page to Overview

#### What did you change?

- Set docs `defaultName` to Overview in React `.storybook/main.js`
- Set docs `defaultName` to Overview in Web Components `.storybook/main.ts`
- Verify website URLs are up-to-date : no update needed, existing url will continue to work

`https://ibm-products.carbondesignsystem.com/?path=/docs/components-aboutmodal`

#### How did you test and verify your work?

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
