### PR TITLE
fix(deps): add resolutions for `add-review-label` action

### DIFF
--- a/actions/add-review-labels/package.json
+++ b/actions/add-review-labels/package.json
@@ -18,6 +18,11 @@
     "components",
     "react"
   ],
+  "resolutions": {
+    "@octokit/plugin-paginate-rest": "^13.1.1",
+    "@octokit/request": "^9.2.1",
+    "undici": "^7.11.0"
+  },
   "dependencies": {
     "@actions/core": "^1.2.3",
     "@actions/github": "^6.0.0",


### PR DESCRIPTION
Closes #7848 
Closes #7847 

Added a `resolutions` key to the `actions/add-review-labels` packages, not sure if this will break anything related to the action itself. I went through the release notes for the packages I added and didn't notice any breaking changes that seem to apply to us. We're on the latest for the packages that are getting flagged with these security vulnerabilities so we can't upgrade them directly (`@actions/core` and `@actions/github`).

Typically we only have `resolutions` in our root `package.json` but this one is separate from our monorepo packages (`packages/*`) so it seems to still pin those packages.

#### What did you change?
```
actions/add-review-labels/package.json
```
#### How did you test and verify your work?
Mend check passes in this PR

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
