### PR TITLE
fix(PageHeader): add workaround for tab focus state with scroll buttons

### DIFF
--- a/packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
+++ b/packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
@@ -917,6 +917,10 @@ $duration: 1000ms;
     }
   }
 
+  .#{$carbon-prefix}--tabs .#{$carbon-prefix}--tabs__nav-link {
+    margin-inline-end: $spacing-01;
+  }
+
   .#{$block-class}__tags {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Closes #7816

Adds a small style workaround until this is addressed in `@carbon/react` for the focus state border on the tab getting clipped.

#### What did you change?
```
packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
```
#### How did you test and verify your work?
Storybook
#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
