### PR TITLE
chore: resolve accessibility-checker mend cve

### DIFF
--- a/config/jest-config-ibm-cloud-cognitive/package.json
+++ b/config/jest-config-ibm-cloud-cognitive/package.json
@@ -29,7 +29,7 @@
     "@babel/preset-env": "^7.26.9",
     "@babel/preset-react": "^7.26.3",
     "@testing-library/jest-dom": "^6.6.3",
-    "accessibility-checker": "^4.0.2",
+    "accessibility-checker": "^4.0.6",
     "axe-core": "^4.10.3",
     "babel-jest": "^29.7.0",
     "babel-preset-ibm-cloud-cognitive": "^0.29.0-rc.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/carbon__layout": "^0.0.3",
     "@typescript-eslint/eslint-plugin": "^8.26.1",
-    "accessibility-checker": "^4.0.2",
+    "accessibility-checker": "^4.0.6",
     "commander": "^14.0.0",
     "copyfiles": "^2.4.1",
     "cspell": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7680,9 +7680,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"accessibility-checker@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "accessibility-checker@npm:4.0.2"
+"accessibility-checker@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "accessibility-checker@npm:4.0.6"
   dependencies:
     chromedriver: "npm:*"
     deep-diff: "npm:^1.0.2"
@@ -7692,7 +7692,7 @@ __metadata:
     string-hash: "npm:^1.1.3"
   bin:
     achecker: bin/achecker.js
-  checksum: 10/47abf83f96eb40a58bb36e08933a8f3110ca59e1b3680abc742150b9bd17a1f36b4e5427d73cc1dce9a3b42738634365559db10294667e85d81bc376b8fb7500
+  checksum: 10/cb303d8ccfa417e80531fa0ca563b1cc45d1877a6fdbe6f6a344088704143249276a2cf33f83f0db44bf7320d46ad979f0f6c0cf8f205cda854ec51886d1b4d8
   languageName: node
   linkType: hard
 
@@ -13243,7 +13243,7 @@ __metadata:
     "@testing-library/user-event": "npm:^14.4.3"
     "@types/carbon__layout": "npm:^0.0.3"
     "@typescript-eslint/eslint-plugin": "npm:^8.26.1"
-    accessibility-checker: "npm:^4.0.2"
+    accessibility-checker: "npm:^4.0.6"
     commander: "npm:^14.0.0"
     copyfiles: "npm:^2.4.1"
     cspell: "npm:^9.0.0"
@@ -14298,7 +14298,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.26.9"
     "@babel/preset-react": "npm:^7.26.3"
     "@testing-library/jest-dom": "npm:^6.6.3"
-    accessibility-checker: "npm:^4.0.2"
+    accessibility-checker: "npm:^4.0.6"
     axe-core: "npm:^4.10.3"
     babel-jest: "npm:^29.7.0"
     babel-preset-ibm-cloud-cognitive: "npm:^0.29.0-rc.0"


### PR DESCRIPTION
Closes #7865 

updates `accessibility-checker` from `4.0.2` to `4.0.6`
