### PR TITLE
feat(sidepanel): add prop for close button tooltip alignment

### DIFF
--- a/packages/ibm-products-web-components/src/components/side-panel/side-panel.stories.ts
+++ b/packages/ibm-products-web-components/src/components/side-panel/side-panel.stories.ts
@@ -17,6 +17,7 @@ import { prefix } from '../../globals/settings';
 import '@carbon/web-components/es/components/button/index.js';
 import '@carbon/web-components/es/components/text-input/index.js';
 import '@carbon/web-components/es/components/textarea/index.js';
+import { ICON_BUTTON_TOOLTIP_ALIGNMENT } from '@carbon/web-components/es/components/icon-button/defs.js';
 
 import {
   getContent,
@@ -110,6 +111,10 @@ const slugs = {
   'With Slug': 1,
 };
 
+const closeIconTooltipAlignmentOptions: string[] = Object.values(
+  ICON_BUTTON_TOOLTIP_ALIGNMENT
+);
+
 const defaultTemplate = {
   args: {
     actionItems: 1,
@@ -117,6 +122,7 @@ const defaultTemplate = {
     animateTitle: true,
     class: 'a-user-class',
     closeIconDescription: 'Close panel',
+    closeIconTooltipAlignment: 'left',
     condensedActions: false,
     content: 2,
     includeOverlay: true,
@@ -156,6 +162,11 @@ const defaultTemplate = {
     closeIconDescription: {
       control: 'text',
       description: 'Close icon description',
+    },
+    closeIconTooltipAlignment: {
+      control: 'select',
+      description: 'Close icon tooltip alignment',
+      options: closeIconTooltipAlignmentOptions,
     },
     condensedActions: {
       control: 'boolean',
@@ -246,6 +257,8 @@ const defaultTemplate = {
         size=${args.size}
         ?slide-in=${args.slideIn}
         ?hide-close-button=${args.hideCloseButton}
+        close-icon-description=${args.closeIconDescription}
+        close-icon-tooltip-alignment=${args.closeIconTooltipAlignment}
         .title=${args.title}
         @c4p-side-panel-navigate-back=${prevStep}
       >

--- a/packages/ibm-products-web-components/src/components/side-panel/side-panel.ts
+++ b/packages/ibm-products-web-components/src/components/side-panel/side-panel.ts
@@ -22,7 +22,7 @@ import styles from './side-panel.scss?lit';
 import { selectorTabbable } from '@carbon/web-components/es/globals/settings.js';
 import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element.js';
 import ArrowLeft16 from '@carbon/web-components/es/icons/arrow--left/16';
-import Close20 from '@carbon/web-components/es/icons/close/20';
+import Close16 from '@carbon/web-components/es/icons/close/16';
 import { moderate02 } from '@carbon/motion';
 import Handle from '../../globals/internal/handle';
 import '@carbon/web-components/es/components/button/index.js';
@@ -548,8 +548,22 @@ class CDSSidePanel extends HostListenerMixin(LitElement) {
   /**
    * Sets the close button icon description
    */
-  @property({ reflect: true, attribute: 'close-icon-description' })
+  @property({
+    reflect: true,
+    attribute: 'close-icon-description',
+    type: String,
+  })
   closeIconDescription = 'Close';
+
+  /**
+   * Sets the close button tooltip alignment
+   */
+  @property({
+    reflect: true,
+    attribute: 'close-icon-tooltip-alignment',
+    type: String,
+  })
+  closeIconTooltipAlignment = 'left';
 
   /**
    * Determines whether the side panel should render the condensed version (affects action buttons primarily)
@@ -664,6 +678,7 @@ class CDSSidePanel extends HostListenerMixin(LitElement) {
   render() {
     const {
       closeIconDescription,
+      closeIconTooltipAlignment,
       condensedActions,
       currentStep,
       includeOverlay,
@@ -744,14 +759,14 @@ class CDSSidePanel extends HostListenerMixin(LitElement) {
           <!-- {normalizedSlug} -->
           ${!hideCloseButton
             ? html`<cds-icon-button
-                align="bottom-right"
+                align=${closeIconTooltipAlignment}
                 aria-label=${closeIconDescription}
                 kind="ghost"
                 size="sm"
                 class=${`${blockClass}__close-button`}
                 @click=${this._handleCloseClick}
               >
-                ${Close20({ slot: 'icon' })}
+                ${Close16({ slot: 'icon' })}
                 <span slot="tooltip-content"> ${closeIconDescription} </span>
               </cds-icon-button>`
             : ''}


### PR DESCRIPTION
Closes #7831 

This PR also fixes the below issues,

- The close icon is not centrally aligned within the button
- closeIconDescription prop change in the story is not reflecting correctly

#### What did you change?

Introduced new prop for configuring the alignment of close button tooltip

#### How did you test and verify your work?

Storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
