### PR TITLE
fix: condition builder minor issue fixes

### DIFF
--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItem.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItem.tsx
@@ -118,6 +118,15 @@ export const ConditionBuilderItem = ({
     statementIdMap
   );
 
+  const getCustomOperatorLabel = (propertyLabel) => {
+    return (
+      propertyLabel &&
+      config?.operators?.find((operator) => {
+        return operator.id === propertyLabel;
+      })
+    );
+  };
+
   const getPropertyDetails = () => {
     const { property, operator } = condition || {};
     if (
@@ -128,6 +137,12 @@ export const ConditionBuilderItem = ({
       return {
         propertyLabel: invalidText,
         isInvalid: true,
+      };
+    }
+    if (rest['data-name'] == 'operatorField' && type == 'custom') {
+      return {
+        isInvalid: false,
+        propertyLabel: getCustomOperatorLabel(label)?.id,
       };
     }
     const propertyId =
@@ -215,15 +230,6 @@ export const ConditionBuilderItem = ({
     if (evt.key === 'Escape') {
       manageInvalidSelection();
     }
-  };
-
-  const getCustomOperatorLabel = (propertyLabel) => {
-    return (
-      propertyLabel &&
-      config?.operators?.find((operator) => {
-        return operator.id === propertyLabel;
-      })
-    );
   };
 
   const getLabel = () => {

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItemDate/ConditionBuilderItemDate.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItemDate/ConditionBuilderItemDate.tsx
@@ -42,7 +42,7 @@ export const ConditionBuilderItemDate = ({
 
   const [dateFromState, setDateFromState] = useState<Date[] | undefined>();
 
-  const dateFormat = config.dateFormat || 'm/d/Y';
+  const dateFormat = config?.dateFormat || 'm/d/Y';
 
   const { conditionBuilderRef } = useContext(ConditionBuilderContext);
   const datePickerType =

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItemNumber/ConditionBuilderItemNumber.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItemNumber/ConditionBuilderItemNumber.tsx
@@ -27,35 +27,37 @@ export const ConditionBuilderItemNumber = ({
   const [invalidNumberWarnText] = useTranslations(['invalidNumberWarnText']);
   const onChangeHandler = (e, { value }) => {
     if (value !== '' && !isNaN(value) && checkIfValid(value)) {
-      onChange(`${value} ${config.unit ?? ''}`);
+      onChange(config?.unit ? `${value} ${config.unit}` : String(value));
     } else {
       onChange('INVALID');
     }
   };
   const checkIfValid = (value) => {
+    if (!config) {
+      return true;
+    }
+
+    const { min, max } = config;
+
+    if (max !== undefined && min === undefined && value > max) {
+      return false;
+    }
+
+    if (min !== undefined && max === undefined && value < min) {
+      return false;
+    }
+
     if (
-      config.max !== undefined &&
-      config.min === undefined &&
-      value > config.max
+      min !== undefined &&
+      max !== undefined &&
+      (value < min || value > max)
     ) {
       return false;
     }
-    if (
-      config.min !== undefined &&
-      config.max === undefined &&
-      value < config.min
-    ) {
-      return false;
-    }
-    if (
-      config.max !== undefined &&
-      config.min !== undefined &&
-      (value > config.max || value < config.min)
-    ) {
-      return false;
-    }
+
     return true;
   };
+
   const getDefaultValue = () => {
     return (conditionState.value as string)?.split(' ')?.[0] ?? '';
   };

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItemOption/ItemOption.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItemOption/ItemOption.tsx
@@ -41,7 +41,7 @@ export const ItemOption = ({
     'clearSearchText',
   ]);
   const { conditionBuilderRef } = useContext(ConditionBuilderContext);
-  const allOptions = config.options;
+  const allOptions = config?.options;
   const [searchValue, setSearchValue] = useState('');
 
   const selection = conditionState.value;
@@ -129,7 +129,7 @@ export const ItemOption = ({
               <div className={`${blockClass}__item-option__option-content`}>
                 <span className={`${blockClass}__item-option__option-label`}>
                   {Icon && <Icon />}
-                  {config.isStatement
+                  {config?.isStatement
                     ? getStatementContent(option)
                     : option.label}
                 </span>

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItemOption/ItemOptionForValueField.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItemOption/ItemOptionForValueField.tsx
@@ -57,7 +57,7 @@ export const ItemOptionForValueField = ({
   const contentRef = useRef<HTMLDivElement>(null);
 
   const [allOptions, setAllOptions] = useState<Option[]>(
-    config.options as Option[]
+    config?.options as Option[]
   );
   const [searchValue, setSearchValue] = useState<string>('');
 

--- a/packages/ibm-products/src/components/ConditionBuilder/assets/sampleInput.js
+++ b/packages/ibm-products/src/components/ConditionBuilder/assets/sampleInput.js
@@ -604,7 +604,7 @@ export const inputData = {
         operators: customOperators,
         valueFormatter: (value) => {
           // add any customization to the value to be populated
-          return value.toLocaleUpperCase();
+          return value?.toLocaleUpperCase();
         },
       },
     },

--- a/packages/ibm-products/src/components/ConditionBuilder/utils/useTranslations.js
+++ b/packages/ibm-products/src/components/ConditionBuilder/utils/useTranslations.js
@@ -15,7 +15,10 @@ export const useTranslations = (translationKeys, alterTranslationKeyMap) => {
     if (alterTranslationKeyMap?.[translationKey]) {
       translationKey = alterTranslationKeyMap[translationKey];
     }
-    if (translateWithId?.(translationKey)) {
+    if (
+      translateWithId?.(translationKey) &&
+      translateWithId?.(translationKey) !== translationKey
+    ) {
       return translateWithId(translationKey);
     } else if (translationsObject[translationKey]) {
       return translationsObject[translationKey];


### PR DESCRIPTION
Closes #7803,#7856,#7868

Condition builder issue fixes

- Fix story crash issue when custom component is used, which is a storybook specific issue
- When a custom operator uses the same ID as a default operator, the label displays the generic "Add operator" text instead of the configured custom label.
- Remove extra space from inout type number, when unit is not passed
- Null check for config object



#### How did you test and verify your work?
local storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
