### PR TITLE
fix: update configs to create stackblitz examples with ts support

### DIFF
--- a/packages/ibm-products/previewer/codePreviewer.tsx
+++ b/packages/ibm-products/previewer/codePreviewer.tsx
@@ -7,7 +7,14 @@
 
 import StackBlitzSDK from '@stackblitz/sdk';
 import { Project } from '@stackblitz/sdk';
-import { index, main, packageJson, style, viteConfig } from './configFiles';
+import {
+  index,
+  main,
+  packageJson,
+  style,
+  tsconfig,
+  viteConfig,
+} from './configFiles';
 import * as carbonComponentsReact from '@carbon/react';
 import * as carbonIconsReact from '@carbon/icons-react';
 const iconsNames = Object.keys(carbonIconsReact);
@@ -49,23 +56,24 @@ export const stackblitzPrefillConfig = async ({
     styleImport += styles.replace(licenseCommentRegex, '');
   }
   const stackblitzFileConfig: Project = {
-    title: 'Carbon demo',
+    title: 'Carbon demo (TypeScript)',
     description:
-      'Run official live example code for a Carbon component, created by Carbon Design System on StackBlitz',
+      'Run official live example code for a Carbon component, created by Carbon Design System on StackBlitz using TypeScript',
     template: 'node',
     files: {
       'package.json': packageJson,
       'index.html': index,
-      'vite.config.js': viteConfig,
-      'src/main.jsx': main,
-      'src/App.jsx': app,
+      'vite.config.ts': viteConfig,
+      'tsconfig.json': tsconfig,
+      'src/main.tsx': main,
+      'src/App.tsx': app,
       'src/index.scss': styleImport,
     },
   };
 
   StackBlitzSDK.openProject(stackblitzFileConfig, {
     newWindow: true,
-    openFile: 'src/App.jsx',
+    openFile: 'src/App.tsx',
   });
 };
 

--- a/packages/ibm-products/previewer/configFiles.tsx
+++ b/packages/ibm-products/previewer/configFiles.tsx
@@ -22,10 +22,25 @@ export const packageJson: string = `{
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+   "typescript": "^5.0.0",
     "@vitejs/plugin-react": "4.0.0",
     "sass": "^1.77.7",
     "vite": "^4.3.8"
   }
+}`;
+
+export const tsconfig: string = `{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
 }`;
 
 export const index: string = `
@@ -39,7 +54,7 @@ export const index: string = `
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>
 


### PR DESCRIPTION
Closes #7693 , #7555

Now, Open in StackBlitz will launch the examples as a TypeScript application.
I think we are good to close the [original issue](https://github.com/carbon-design-system/ibm-products/issues/7555) as well

#### What did you change?
Added tsconfig
Updated filesnames to .ts extensions

#### How did you test and verify your work?
opened in StackBlitz few examples

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
