### PR TITLE
feat(PageHeader): add new breadcrumb overflow utility sub-component

### DIFF
--- a/packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
+++ b/packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
@@ -727,7 +727,8 @@ $duration: 1000ms;
     inset-block-start: var(--#{$pkg-prefix}-page-header-breadcrumb-top);
   }
 
-  .#{$block-class}__breadcrumb-bar .#{$carbon-prefix}--subgrid {
+  .#{$block-class}__breadcrumb-bar .#{$carbon-prefix}--subgrid,
+  .#{$block-class}__breadcrumb-bar .#{$carbon-prefix}--css-grid {
     block-size: 100%;
   }
 
@@ -759,14 +760,36 @@ $duration: 1000ms;
 
   .#{$block-class}__breadcrumb__actions {
     display: inline-flex;
+    justify-content: flex-end;
+    inline-size: 100%;
   }
 
   .#{$block-class}__breadcrumb__content-actions {
+    inline-size: 100%;
     margin-inline-end: $spacing-04;
   }
 
   .#{$block-class}__breadcrumb-wrapper {
     display: inline-flex;
+    inline-size: 100%;
+  }
+
+  .#{$block-class}__breadcrumb-wrapper .#{$block-class}-breadcrumb-overflow {
+    inline-size: 100%;
+    .#{$carbon-prefix}--breadcrumb {
+      display: flex;
+    }
+  }
+
+  .#{$block-class}__breadcrumb-wrapper
+    .#{$block-class}-breadcrumb-overflow-item {
+    display: none;
+    opacity: 0;
+  }
+  .#{$block-class}__breadcrumb-wrapper
+    .#{$block-class}-overflow-breadcrumb-item-with-items {
+    display: flex;
+    opacity: 1;
   }
 
   .#{$block-class}__content {

--- a/packages/ibm-products/src/components/PageHeader/next/PageHeader.stories.js
+++ b/packages/ibm-products/src/components/PageHeader/next/PageHeader.stories.js
@@ -28,6 +28,8 @@ import {
   Tabs,
   TabPanels,
   TabPanel,
+  OverflowMenu,
+  OverflowMenuItem,
 } from '@carbon/react';
 import { breakpoints } from '@carbon/layout';
 import image1 from './_story-assets/2x1.jpg';
@@ -477,15 +479,33 @@ export const TabBarWithTabsAndTags = (args) => (
         contentActionsFlush={args.contentActionsFlush}
         renderIcon={args.renderBreadcrumbIcon ? BreadcrumbBeeIcon : null}
         pageActions={breadcrumbPageActions}
+        contentActions={
+          <PageHeader.ContentPageActions
+            menuButtonLabel="Actions"
+            actions={pageActionButtonItems}
+          />
+        }
       >
-        <PageHeader.BreadcrumbOverflow>
-          {/* <Breadcrumb> */}
+        <PageHeader.BreadcrumbOverflow
+          renderOverflowBreadcrumb={(hiddenItems) => (
+            <BreadcrumbItem data-floating-menu-container>
+              <OverflowMenu
+                align="bottom"
+                aria-label="Overflow menu in a breadcrumb"
+              >
+                {hiddenItems.map((el) => (
+                  <OverflowMenuItem itemText={el.innerText} />
+                ))}
+              </OverflowMenu>
+            </BreadcrumbItem>
+          )}
+        >
           <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
-          <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
-          <PageHeader.TitleBreadcrumb>
+          <BreadcrumbItem href="/#">Breadcrumb 2</BreadcrumbItem>
+          <BreadcrumbItem href="/#">Breadcrumb 3</BreadcrumbItem>
+          <PageHeader.TitleBreadcrumb data-fixed>
             Virtual Machine DAL
           </PageHeader.TitleBreadcrumb>
-          {/* </Breadcrumb> */}
         </PageHeader.BreadcrumbOverflow>
       </PageHeader.BreadcrumbBar>
       <PageHeader.Content

--- a/packages/ibm-products/src/components/PageHeader/next/PageHeader.stories.js
+++ b/packages/ibm-products/src/components/PageHeader/next/PageHeader.stories.js
@@ -478,13 +478,15 @@ export const TabBarWithTabsAndTags = (args) => (
         renderIcon={args.renderBreadcrumbIcon ? BreadcrumbBeeIcon : null}
         pageActions={breadcrumbPageActions}
       >
-        <Breadcrumb>
+        <PageHeader.BreadcrumbOverflow>
+          {/* <Breadcrumb> */}
           <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
           <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
           <PageHeader.TitleBreadcrumb>
             Virtual Machine DAL
           </PageHeader.TitleBreadcrumb>
-        </Breadcrumb>
+          {/* </Breadcrumb> */}
+        </PageHeader.BreadcrumbOverflow>
       </PageHeader.BreadcrumbBar>
       <PageHeader.Content
         title="Virtual-Machine-DAL-really-long-title-example-that-goes-at-least-2-lines-long"

--- a/packages/ibm-products/src/components/PageHeader/next/PageHeader.test.js
+++ b/packages/ibm-products/src/components/PageHeader/next/PageHeader.test.js
@@ -8,7 +8,7 @@
 import { render, screen, act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { unstable__PageHeader as PageHeader } from '../../..';
+import { unstable__PageHeader as PageHeader, pkg } from '../../..';
 import {
   PageHeader as PageHeaderDirect,
   PageHeaderBreadcrumbBar as PageHeaderBreadcrumbBarDirect,
@@ -24,6 +24,8 @@ import {
   Tab,
   TabPanels,
   TabPanel,
+  OverflowMenu,
+  OverflowMenuItem,
 } from '@carbon/react';
 import { Bee } from '@carbon/icons-react';
 
@@ -963,6 +965,92 @@ describe('PageHeader', () => {
         userEvent.click(scrollerButton);
       });
       expect(scrollerOnClick).toHaveBeenCalledTimes(1);
+    });
+  });
+  describe('PageHeader.BreadcrumbOverflow', () => {
+    it('should render default breadcrumbs', () => {
+      render(
+        <PageHeader.Root>
+          <PageHeader.BreadcrumbBar>
+            <PageHeader.BreadcrumbOverflow>
+              <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
+              <BreadcrumbItem href="/#">Breadcrumb 2</BreadcrumbItem>
+              <BreadcrumbItem href="/#">Breadcrumb 3</BreadcrumbItem>
+              <PageHeader.TitleBreadcrumb data-fixed>
+                Virtual Machine DAL
+              </PageHeader.TitleBreadcrumb>
+            </PageHeader.BreadcrumbOverflow>
+          </PageHeader.BreadcrumbBar>
+        </PageHeader.Root>
+      );
+      expect(screen.getByText('Breadcrumb 1')).toBeInTheDocument();
+      expect(screen.getByText('Breadcrumb 2')).toBeInTheDocument();
+      expect(screen.getByText('Breadcrumb 3')).toBeInTheDocument();
+      expect(screen.getByText('Virtual Machine DAL')).toBeInTheDocument();
+    });
+    it('should accept a ref', () => {
+      const ref = React.createRef();
+      render(
+        <PageHeader.Root>
+          <PageHeader.BreadcrumbBar>
+            <PageHeader.BreadcrumbOverflow ref={ref}>
+              <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
+            </PageHeader.BreadcrumbOverflow>
+          </PageHeader.BreadcrumbBar>
+        </PageHeader.Root>
+      );
+      expect(ref.current).toHaveClass(
+        `${pkg.prefix}--page-header-breadcrumb-overflow`
+      );
+    });
+    it('should render children without overflow breadcrumb', () => {
+      const ref = React.createRef();
+      render(
+        <PageHeader.Root>
+          <PageHeader.BreadcrumbBar>
+            <PageHeader.BreadcrumbOverflow ref={ref}>
+              <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
+              <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
+              <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
+            </PageHeader.BreadcrumbOverflow>
+          </PageHeader.BreadcrumbBar>
+        </PageHeader.Root>
+      );
+      const breadcrumbParent = ref.current.firstChild;
+      expect(breadcrumbParent.childElementCount).toEqual(3);
+    });
+    it('should render children with overflow breadcrumb', () => {
+      const renderPropFn = jest.fn();
+      const ref = React.createRef();
+      render(
+        <PageHeader.Root>
+          <PageHeader.BreadcrumbBar>
+            <PageHeader.BreadcrumbOverflow
+              ref={ref}
+              renderOverflowBreadcrumb={() => {
+                renderPropFn();
+                return (
+                  <BreadcrumbItem>
+                    <OverflowMenu
+                      align="bottom"
+                      aria-label="Overflow menu in a breadcrumb"
+                    >
+                      <OverflowMenuItem itemText={'Hidden item'} />
+                    </OverflowMenu>
+                  </BreadcrumbItem>
+                );
+              }}
+            >
+              <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
+              <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
+              <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
+            </PageHeader.BreadcrumbOverflow>
+          </PageHeader.BreadcrumbBar>
+        </PageHeader.Root>
+      );
+      const breadcrumbParent = ref.current.firstChild;
+      expect(breadcrumbParent.childElementCount).toEqual(4);
+      expect(renderPropFn).toHaveBeenCalled();
     });
   });
 });

--- a/packages/ibm-products/src/components/PageHeader/next/PageHeader.tsx
+++ b/packages/ibm-products/src/components/PageHeader/next/PageHeader.tsx
@@ -37,6 +37,8 @@ import {
   IconButton,
   BreadcrumbItemProps,
   BreadcrumbItem,
+  BreadcrumbProps,
+  Breadcrumb,
 } from '@carbon/react';
 import { breakpoints } from '@carbon/layout';
 import { blockClass } from '../PageHeaderUtils';
@@ -913,6 +915,7 @@ const PageHeaderTitleBreadcrumb = forwardRef<
   const { titleClipped, refs } = usePageHeader();
   return (
     <BreadcrumbItem
+      ref={ref}
       isCurrentPage
       {...other}
       className={classnames(
@@ -928,6 +931,32 @@ const PageHeaderTitleBreadcrumb = forwardRef<
     </BreadcrumbItem>
   );
 });
+
+const PageHeaderBreadcrumbOverflow = forwardRef<HTMLElement, BreadcrumbProps>(
+  ({ className, children, ...other }, ref) => {
+    const fallbackRef = useRef<Breadcrumb | null>(null);
+    const componentRef = ref ?? fallbackRef;
+    // Initialize overflow resize handler
+    useEffect(() => {
+      if (!componentRef) {
+        return;
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return (
+      <Breadcrumb
+        className={classnames(
+          className,
+          `${pkg.prefix}--page-header-breadcrumb-overflow`
+        )}
+        ref={componentRef}
+        {...other}
+      >
+        {children}
+      </Breadcrumb>
+    );
+  }
+);
 
 /**
  * -------
@@ -961,6 +990,9 @@ ScrollButton.displayName = 'PageHeaderScrollButton';
 const TitleBreadcrumb = PageHeaderTitleBreadcrumb;
 TitleBreadcrumb.displayName = 'PageHeaderTitleBreadcrumb';
 
+const BreadcrumbOverflow = PageHeaderBreadcrumbOverflow;
+BreadcrumbOverflow.displayName = 'PageHeaderBreadcrumbOverflow';
+
 export {
   // direct exports
   PageHeader,
@@ -972,6 +1004,7 @@ export {
   PageHeaderTabBar,
   PageHeaderScrollButton,
   PageHeaderTitleBreadcrumb,
+  PageHeaderBreadcrumbOverflow,
   // namespaced
   Root,
   BreadcrumbBar,
@@ -982,6 +1015,7 @@ export {
   TabBar,
   ScrollButton,
   TitleBreadcrumb,
+  BreadcrumbOverflow,
 };
 export type {
   PageHeaderProps,

--- a/packages/ibm-products/src/components/PageHeader/next/index.ts
+++ b/packages/ibm-products/src/components/PageHeader/next/index.ts
@@ -14,6 +14,7 @@ export {
   PageHeaderHeroImage,
   PageHeaderScrollButton,
   PageHeaderTitleBreadcrumb,
+  PageHeaderBreadcrumbOverflow,
   //
   Root,
   BreadcrumbBar,
@@ -24,6 +25,7 @@ export {
   HeroImage,
   ScrollButton,
   TitleBreadcrumb,
+  BreadcrumbOverflow,
 } from './PageHeader';
 export type {
   PageHeaderProps,

--- a/packages/ibm-products/src/components/PageHeader/next/overflowHandler.ts
+++ b/packages/ibm-products/src/components/PageHeader/next/overflowHandler.ts
@@ -1,0 +1,251 @@
+/**
+ * Copyright IBM Corp. 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Calculates the size (width or height) of a given HTML element.
+ *
+ * This function performs an expensive calculation by temporarily changing the
+ * display style of the element if it is not currently visible. It then uses
+ * `getBoundingClientRect` to retrieve the size of the element.
+ *
+ * @param el - The HTML element whose size is to be calculated.
+ * @param dimension - The dimension to measure ('width' or 'height').
+ * @returns The size of the element in pixels. Returns 0 if the element is not provided.
+ */
+export function getSize(
+  el: HTMLElement,
+  dimension: 'width' | 'height'
+): number {
+  if (!el) {
+    return 0;
+  }
+  const originalDisplay = el.style.display;
+  if (!el.offsetParent && getComputedStyle(el).display === 'none') {
+    el.style.display = 'inline-block';
+  }
+  let size = el.getBoundingClientRect()[dimension];
+  el.style.display = originalDisplay;
+  const computedStyles = getComputedStyle(el);
+  size =
+    dimension === 'width'
+      ? size +
+        parseInt(computedStyles.paddingLeft) +
+        parseInt(computedStyles.paddingRight) +
+        parseInt(computedStyles.marginLeft) +
+        parseInt(computedStyles.marginRight)
+      : size +
+        parseInt(computedStyles.paddingTop) +
+        parseInt(computedStyles.paddingBottom) +
+        parseInt(computedStyles.marginTop) +
+        parseInt(computedStyles.marginBottom);
+  return size;
+}
+
+/**
+ * Options for updating the overflow handler.
+ * Determines which items should be visible and which should be hidden
+ * based on the container size, item sizes, and other constraints.
+ */
+export interface UpdateOverflowHandlerOptions {
+  /** The container element that holds the items. */
+  container: HTMLElement;
+  /** An array of item elements to be managed for overflow. */
+  items: HTMLElement[];
+  /** An element that represents the offset, which can be shown or hidden based on overflow. Identified by `data-offset` attribute. */
+  offset: HTMLElement;
+  /** An array of sizes corresponding to each item in the `items` array. */
+  sizes: number[];
+  /** An array of sizes corresponding to each item in the fixed items array. */
+  fixedSizes: number[];
+  /** The size of the offset element. */
+  offsetSize: number;
+  /** The maximum number of items that can be visible at once. If undefined, all items can be visible. */
+  maxVisibleItems?: number;
+  /** The dimension to consider for overflow, either 'width' or 'height'. */
+  dimension: 'width' | 'height';
+  /** A callback function that is called when the visible or hidden items change. */
+  onChange: (visibleItems: HTMLElement[], hiddenItems: HTMLElement[]) => void;
+  /** An array of previously hidden items to compare against the new hidden items. */
+  previousHiddenItems?: HTMLElement[];
+}
+
+/**
+ * Updates the overflow handler by determining which items should be visible and which should be hidden.
+ *
+ * @param options - Configuration options for updating the overflow handler.
+ * @param options.container - Container for overflowing
+ * @param options.items - Child elements within container
+ * @param options.offset - Children with data-offset attribute
+ * @param options.sizes - Sizes of child elements
+ * @param options.fixedSizes - Fixed sizes of child elements with data-fixed attribute
+ * @param options.offsetSize - Total offset size
+ * @param options.maxVisibleItems - Max visible items
+ * @param options.dimension - width | height used to measure overflow
+ * @param options.onChange - onChange callback
+ * @param options.previousHiddenItems - Array of previously hidden items
+ * @returns An array of hidden items after the update.
+ */
+export function updateOverflowHandler({
+  container,
+  items,
+  offset,
+  sizes,
+  fixedSizes,
+  offsetSize,
+  maxVisibleItems,
+  dimension,
+  onChange,
+  previousHiddenItems = [],
+}: UpdateOverflowHandlerOptions): HTMLElement[] {
+  const containerSize =
+    dimension === 'width' ? container.clientWidth : container.clientHeight;
+
+  let visibleItems: HTMLElement[] = [];
+  let hiddenItems: HTMLElement[] = [];
+
+  const totalSize = sizes.reduce((sum, size) => sum + size, 0);
+  const totalFixedSize = fixedSizes.reduce((sum, size) => sum + size, 0);
+
+  if (totalSize + totalFixedSize <= containerSize) {
+    visibleItems = maxVisibleItems
+      ? items.slice(0, maxVisibleItems)
+      : [...items];
+    hiddenItems = maxVisibleItems ? items.slice(maxVisibleItems) : [];
+  } else {
+    const available = containerSize - offsetSize;
+    let accumulated = 0;
+
+    for (let i = 0; i < items.length; i++) {
+      const size = sizes[i];
+      if (
+        accumulated + size + totalFixedSize <= available &&
+        (!maxVisibleItems || visibleItems.length < maxVisibleItems)
+      ) {
+        visibleItems.push(items[i]);
+        accumulated += size;
+      } else {
+        hiddenItems.push(items[i]);
+      }
+    }
+  }
+
+  if (
+    previousHiddenItems.length === hiddenItems.length &&
+    previousHiddenItems.every((item, index) => item === hiddenItems[index])
+  ) {
+    return previousHiddenItems;
+  }
+
+  visibleItems.forEach((item) => item.removeAttribute('data-hidden'));
+  hiddenItems.forEach((item) => item.setAttribute('data-hidden', ''));
+
+  if (offset) {
+    offset.toggleAttribute('data-hidden', hiddenItems.length === 0);
+  }
+  onChange(visibleItems, hiddenItems);
+  return hiddenItems;
+}
+
+/**
+ * Options for initializing an overflow handler.
+ */
+export interface OverflowHandlerOptions {
+  /**
+   * The container element that holds the items. along with offset item
+   */
+  container: HTMLElement;
+  /**
+   * Maximum number of visible items. If provided, only this number of items will be shown.
+   */
+  maxVisibleItems?: number;
+  /**
+   * Callback function invoked when the visible and hidden items change.
+   * @param visibleItems - The array of items that are currently visible.
+   * @param hiddenItems - The array of items that are currently hidden.
+   */
+  onChange: (visibleItems: HTMLElement[], hiddenItems: HTMLElement[]) => void;
+  /**
+   * The dimension to consider for overflow calculations. Defaults to 'width'.
+   */
+  dimension?: 'width' | 'height';
+}
+
+/**
+ * Represents an instance of an overflow handler.
+ */
+export interface OverflowHandler {
+  /**
+   * Disconnects the overflow handler, cleaning up any event listeners or resources.
+   */
+  disconnect: () => void;
+}
+
+export function createOverflowHandler({
+  container,
+  maxVisibleItems,
+  onChange,
+  dimension = 'width',
+}: OverflowHandlerOptions): OverflowHandler {
+  // Error handling
+  if (!(container instanceof HTMLElement)) {
+    throw new Error('container must be an HTMLElement');
+  }
+  if (typeof onChange !== 'function') {
+    throw new Error('onChange must be a function');
+  }
+  if (
+    maxVisibleItems !== undefined &&
+    (!Number.isInteger(maxVisibleItems) || maxVisibleItems <= 0)
+  ) {
+    throw new Error('maxVisibleItems must be a positive integer');
+  }
+
+  const children = Array.from(container.children) as HTMLElement[];
+  const offset = children.find((item) =>
+    item.hasAttribute('data-offset')
+  ) as HTMLElement;
+  const fixedItems = children.filter((item) =>
+    item.hasAttribute('data-fixed')
+  ) as HTMLElement[];
+  const items = children.filter(
+    (item) => item !== offset && !fixedItems.includes(item)
+  );
+
+  const fixedSizes = fixedItems.map((item) => getSize(item, dimension));
+  const sizes = items.map((item) => getSize(item, dimension));
+  const offsetSize = getSize(offset, dimension);
+
+  let previousHiddenItems: HTMLElement[] = [];
+
+  function update() {
+    previousHiddenItems = updateOverflowHandler({
+      container,
+      items,
+      offset,
+      sizes,
+      fixedSizes,
+      offsetSize,
+      maxVisibleItems,
+      dimension,
+      onChange,
+      previousHiddenItems,
+    });
+  }
+
+  const resizeObserver = new ResizeObserver(() => {
+    requestAnimationFrame(update);
+  });
+  resizeObserver.observe(container);
+
+  requestAnimationFrame(update); // Initial update
+
+  return {
+    disconnect() {
+      resizeObserver.disconnect();
+    },
+  };
+}


### PR DESCRIPTION
Closes (part of) #7799 

This PR updates the React `PageHeader` and adds a new sub-component to render breadcrumbs with overflowing support, similar to the existing `PageHeader.ContentPageActions`. The usage looks like the following:
```jsx
<PageHeader.BreadcrumbOverflow
          renderOverflowBreadcrumb={(hiddenItems) => (
            <BreadcrumbItem data-floating-menu-container>
              <OverflowMenu
                align="bottom"
                aria-label="Overflow menu in a breadcrumb"
              >
                {hiddenItems.map((el) => (
                  <OverflowMenuItem itemText={el.innerText} />
                ))}
              </OverflowMenu>
            </BreadcrumbItem>
          )}
        >
          <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
          <BreadcrumbItem href="/#">Breadcrumb 2</BreadcrumbItem>
          <BreadcrumbItem href="/#">Breadcrumb 3</BreadcrumbItem>
          <PageHeader.TitleBreadcrumb data-fixed>
            Virtual Machine DAL
          </PageHeader.TitleBreadcrumb>
        </PageHeader.BreadcrumbOverflow>
```
The new component utilizes `renderOverflowBreadcrumb` and provides the hidden items via callback. They can then be rendered as overflow menu items, or anything but we expect them to be overflow menu items based on the page header guidance.

I created a local version of `createOverflowUtility` because the version from `@carbon/utilities` does not include padding/margins in the calculation of child element sizes. I'll work on submitting a PR to core to update the utility, but until then will use the local version.

#### What did you change?
```
packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
packages/ibm-products/src/components/PageHeader/next/PageHeader.stories.js
packages/ibm-products/src/components/PageHeader/next/PageHeader.test.js
packages/ibm-products/src/components/PageHeader/next/PageHeader.tsx
packages/ibm-products/src/components/PageHeader/next/index.ts
packages/ibm-products/src/components/PageHeader/next/overflowHandler.ts
```
#### How did you test and verify your work?
Storybook, tests
#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [X] Wrote passing tests that cover this change
- [X] Addressed any impact on accessibility (a11y)
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
