### PR TITLE
feat(page-header): add breadcrumb overflow example

### DIFF
--- a/packages/ibm-products-web-components/examples/set-of-breadcrumbs/index.html
+++ b/packages/ibm-products-web-components/examples/set-of-breadcrumbs/index.html
@@ -24,9 +24,9 @@ LICENSE file in the root directory of this source tree.
       </div>
     </section>
     <script type="module">
-      import { breadcrumbData } from './src/example-data.ts';
+      import { breadcrumbsData } from './src/example-data.ts';
       const setOfBreadcrumbs = document.getElementById('setOfBreadcrumbs');
-      setOfBreadcrumbs.breadcrumbData = breadcrumbData;
+      setOfBreadcrumbs.breadcrumbsData = breadcrumbsData;
     </script>
   </body>
 </html>

--- a/packages/ibm-products-web-components/examples/set-of-breadcrumbs/package.json
+++ b/packages/ibm-products-web-components/examples/set-of-breadcrumbs/package.json
@@ -20,8 +20,8 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
+    "typescript": "^5.5.3",
     "vite": "5.4.19",
-    "vite-plugin-lit-css": "^2.1.0",
-    "typescript": "^5.5.3"
+    "vite-plugin-lit-css": "^2.1.0"
   }
 }

--- a/packages/ibm-products-web-components/src/components/page-header/_story-assets/overflowHandler.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/_story-assets/overflowHandler.ts
@@ -1,0 +1,262 @@
+/**
+ * Copyright IBM Corp. 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// TODO: delete this file after overflowHandler from carbon/utils gets updated
+
+/**
+ * Calculates the size (width or height) of a given HTML element.
+ *
+ * This function performs an expensive calculation by temporarily changing the
+ * display style of the element if it is not currently visible. It then uses
+ * `getBoundingClientRect` to retrieve the size of the element.
+ *
+ * @param el - The HTML element whose size is to be calculated.
+ * @param dimension - The dimension to measure ('width' or 'height').
+ * @returns The size of the element in pixels. Returns 0 if the element is not provided.
+ */
+export function getSize(
+  el: HTMLElement,
+  dimension: 'width' | 'height'
+): number {
+  if (!el) {
+    return 0;
+  }
+  const originalDisplay = el.style.display;
+  if (!el.offsetParent && getComputedStyle(el).display === 'none') {
+    el.style.display = 'inline-block';
+  }
+  let size = el.getBoundingClientRect()[dimension];
+  el.style.display = originalDisplay;
+  const computedStyles = getComputedStyle(el);
+  size =
+    dimension === 'width'
+      ? size +
+        parseInt(computedStyles.paddingLeft) +
+        parseInt(computedStyles.paddingRight) +
+        parseInt(computedStyles.marginLeft) +
+        parseInt(computedStyles.marginRight)
+      : size +
+        parseInt(computedStyles.paddingTop) +
+        parseInt(computedStyles.paddingBottom) +
+        parseInt(computedStyles.marginTop) +
+        parseInt(computedStyles.marginBottom);
+  return size;
+}
+
+/**
+ * Options for updating the overflow handler.
+ * Determines which items should be visible and which should be hidden
+ * based on the container size, item sizes, and other constraints.
+ */
+export interface UpdateOverflowHandlerOptions {
+  /** The container element that holds the items. */
+  container: HTMLElement;
+  /** An array of item elements to be managed for overflow. */
+  items: HTMLElement[];
+  /** An element that represents the offset, which can be shown or hidden based on overflow. Identified by `data-offset` attribute. */
+  offset: HTMLElement;
+  /** An array of sizes corresponding to each item in the `items` array. */
+  sizes: number[];
+  /** An array of sizes corresponding to each item in the fixed items array. */
+  fixedSizes: number[];
+  /** The size of the offset element. */
+  offsetSize: number;
+  /** The maximum number of items that can be visible at once. If undefined, all items can be visible. */
+  maxVisibleItems?: number;
+  /** The dimension to consider for overflow, either 'width' or 'height'. */
+  dimension: 'width' | 'height';
+  /** A callback function that is called when the visible or hidden items change. */
+  onChange: (visibleItems: HTMLElement[], hiddenItems: HTMLElement[]) => void;
+  /** An array of previously hidden items to compare against the new hidden items. */
+  previousHiddenItems?: HTMLElement[];
+  offsetValue?: number;
+}
+
+/**
+ * Updates the overflow handler by determining which items should be visible and which should be hidden.
+ *
+ * @param options - Configuration options for updating the overflow handler.
+ * @param options.container - Container for overflowing
+ * @param options.items - Child elements within container
+ * @param options.offset - Children with data-offset attribute
+ * @param options.sizes - Sizes of child elements
+ * @param options.fixedSizes - Fixed sizes of child elements with data-fixed attribute
+ * @param options.offsetSize - Total offset size
+ * @param options.offsetValue - Additional offset
+ * @param options.maxVisibleItems - Max visible items
+ * @param options.dimension - width | height used to measure overflow
+ * @param options.onChange - onChange callback
+ * @param options.previousHiddenItems - Array of previously hidden items
+ * @returns An array of hidden items after the update.
+ */
+export function updateOverflowHandler({
+  container,
+  items,
+  offset,
+  sizes,
+  fixedSizes,
+  offsetSize,
+  maxVisibleItems,
+  dimension,
+  onChange,
+  previousHiddenItems = [],
+  offsetValue = 0,
+}: UpdateOverflowHandlerOptions): HTMLElement[] {
+  const containerSize =
+    dimension === 'width' ? container.clientWidth : container.clientHeight;
+
+  let visibleItems: HTMLElement[] = [];
+  let hiddenItems: HTMLElement[] = [];
+
+  const totalSize = sizes.reduce((sum, size) => sum + size, 0);
+  const totalFixedSize = fixedSizes.reduce((sum, size) => sum + size, 0);
+
+  if (totalSize + totalFixedSize <= containerSize) {
+    visibleItems = maxVisibleItems
+      ? items.slice(0, maxVisibleItems)
+      : [...items];
+    hiddenItems = maxVisibleItems ? items.slice(maxVisibleItems) : [];
+  } else {
+    const available = containerSize - offsetSize - totalFixedSize - offsetValue;
+    let accumulated = 0;
+    let breakIndex = items.length;
+
+    for (let i = 0; i < items.length; i++) {
+      const size = sizes[i];
+      if (
+        accumulated + size <= available &&
+        (!maxVisibleItems || visibleItems.length < maxVisibleItems)
+      ) {
+        visibleItems.push(items[i]);
+        accumulated += size;
+      } else {
+        breakIndex = i;
+        break;
+      }
+    }
+    hiddenItems = items.slice(breakIndex);
+  }
+
+  if (
+    previousHiddenItems.length === hiddenItems.length &&
+    previousHiddenItems.every((item, index) => item === hiddenItems[index])
+  ) {
+    return previousHiddenItems;
+  }
+
+  visibleItems.forEach((item) => item.removeAttribute('data-hidden'));
+  hiddenItems.forEach((item) => item.setAttribute('data-hidden', ''));
+
+  if (offset) {
+    offset.toggleAttribute('data-hidden', hiddenItems.length === 0);
+  }
+  onChange(visibleItems, hiddenItems);
+  return hiddenItems;
+}
+
+/**
+ * Options for initializing an overflow handler.
+ */
+export interface OverflowHandlerOptions {
+  /**
+   * The container element that holds the items. along with offset item
+   */
+  container: HTMLElement;
+  /**
+   * Maximum number of visible items. If provided, only this number of items will be shown.
+   */
+  maxVisibleItems?: number;
+  /**
+   * Callback function invoked when the visible and hidden items change.
+   * @param visibleItems - The array of items that are currently visible.
+   * @param hiddenItems - The array of items that are currently hidden.
+   */
+  onChange: (visibleItems: HTMLElement[], hiddenItems: HTMLElement[]) => void;
+  /**
+   * The dimension to consider for overflow calculations. Defaults to 'width'.
+   */
+  dimension?: 'width' | 'height';
+  offsetValue?: number;
+}
+
+/**
+ * Represents an instance of an overflow handler.
+ */
+export interface OverflowHandler {
+  /**
+   * Disconnects the overflow handler, cleaning up any event listeners or resources.
+   */
+  disconnect: () => void;
+}
+
+export function createOverflowHandler({
+  container,
+  maxVisibleItems,
+  onChange,
+  dimension = 'width',
+  offsetValue = 0,
+}: OverflowHandlerOptions): OverflowHandler {
+  // Error handling
+  if (!(container instanceof HTMLElement)) {
+    throw new Error('container must be an HTMLElement');
+  }
+  if (typeof onChange !== 'function') {
+    throw new Error('onChange must be a function');
+  }
+  if (
+    maxVisibleItems !== undefined &&
+    (!Number.isInteger(maxVisibleItems) || maxVisibleItems <= 0)
+  ) {
+    throw new Error('maxVisibleItems must be a positive integer');
+  }
+
+  const children = Array.from(container.children) as HTMLElement[];
+  const offset = children.find((item) =>
+    item.hasAttribute('data-offset')
+  ) as HTMLElement;
+  const fixedItems = children.filter((item) =>
+    item.hasAttribute('data-fixed')
+  ) as HTMLElement[];
+  const items = children.filter(
+    (item) => item !== offset && !fixedItems.includes(item)
+  );
+
+  const fixedSizes = fixedItems.map((item) => getSize(item, dimension));
+  const sizes = items.map((item) => getSize(item, dimension));
+  const offsetSize = getSize(offset, dimension);
+
+  let previousHiddenItems: HTMLElement[] = [];
+
+  function update() {
+    previousHiddenItems = updateOverflowHandler({
+      container,
+      items,
+      offset,
+      sizes,
+      fixedSizes,
+      offsetSize,
+      maxVisibleItems,
+      dimension,
+      onChange,
+      previousHiddenItems,
+      offsetValue,
+    });
+  }
+
+  const resizeObserver = new ResizeObserver(() =>
+    requestAnimationFrame(update)
+  );
+  resizeObserver.observe(container);
+
+  requestAnimationFrame(update); // Initial update
+
+  return {
+    disconnect() {
+      resizeObserver.disconnect();
+    },
+  };
+}

--- a/packages/ibm-products-web-components/src/components/page-header/_story-assets/set-of-breadcrumbs.scss
+++ b/packages/ibm-products-web-components/src/components/page-header/_story-assets/set-of-breadcrumbs.scss
@@ -1,0 +1,41 @@
+/*
+* Copyright IBM Corp. 2025, 2025
+*
+* This source code is licensed under the Apache-2.0 license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+$css--plex: true !default;
+
+/* Other Carbon settings. */
+@use 'sass:map';
+@use '@carbon/styles';
+@use '@carbon/styles/scss/themes';
+@use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/breakpoint' as *;
+@use '@carbon/styles/scss/spacing' as *;
+
+$prefix: 'c4p';
+$carbon-prefix: 'cds';
+
+$block-class: #{$prefix}--set-of-breadcrumbs;
+
+:host {
+  display: block;
+  inline-size: 100%;
+
+  // Suppress custom elements until styles are loaded
+  #{$carbon-prefix}-breadcrumb:not(:defined),
+  #{$carbon-prefix}-overflow-menu:not(:defined) {
+    display: none;
+  }
+
+  /* stylelint-disable-next-line selector-type-no-unknown */
+  cds-breadcrumb-item {
+    flex: none;
+  }
+
+  [data-hidden]:not([data-fixed]) {
+    display: none;
+  }
+}

--- a/packages/ibm-products-web-components/src/components/page-header/_story-assets/set-of-breadcrumbs.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/_story-assets/set-of-breadcrumbs.ts
@@ -94,19 +94,6 @@ export default class SetOfBreadcrumbs extends LitElement {
       this.style.visibility = 'visible';
     });
   }
-  updated(changedProperties: Map<string, unknown>) {
-    if (changedProperties.has('breadcrumbsData')) {
-      this.hiddenItems = [];
-      this.overflowHandler?.disconnect();
-      this.overflowHandler = createOverflowHandler({
-        offsetValue: 14,
-        container: this.container,
-        onChange: (visibleItems: HTMLElement[], _) => {
-          this.hiddenItems = this.breadcrumbsData?.slice(visibleItems.length);
-        },
-      });
-    }
-  }
 
   disconnectedCallback() {
     super.disconnectedCallback();

--- a/packages/ibm-products-web-components/src/components/page-header/_story-assets/set-of-breadcrumbs.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/_story-assets/set-of-breadcrumbs.ts
@@ -16,6 +16,7 @@ import '@carbon/web-components/es/components/breadcrumb/index.js';
 import '@carbon/web-components/es/components/overflow-menu/index.js';
 import { createOverflowHandler } from './overflowHandler';
 import OverflowMenuHorizontal16 from '@carbon/web-components/es/icons/overflow-menu--horizontal/16.js';
+import '../../truncated-text';
 import styles from './set-of-breadcrumbs.scss?lit';
 import '../page-header-title-breadcrumb';
 
@@ -126,7 +127,7 @@ export default class SetOfBreadcrumbs extends LitElement {
           data-fixed
           style="display: ${this.hiddenItems?.length >= 2 ? 'flex' : 'none'}"
         >
-          <cds-overflow-menu breadcrumb="" align="top">
+          <cds-overflow-menu breadcrumb="" align="bottom">
             ${OverflowMenuHorizontal16({
               slot: 'icon',
             })}
@@ -146,7 +147,11 @@ export default class SetOfBreadcrumbs extends LitElement {
         </cds-breadcrumb-item>
         <c4p-page-header-title-breadcrumb data-fixed>
           <cds-breadcrumb-link is-currentpage="">
-            ${this.breadcrumbsData!.at(-1)!.text}
+            <c4p-truncated-text
+              value="${this.breadcrumbsData!.at(-1)!.text}"
+              lines="1"
+              autoalign
+            ></c4p-truncated-text>
           </cds-breadcrumb-link>
         </c4p-page-header-title-breadcrumb>
       </cds-breadcrumb>

--- a/packages/ibm-products-web-components/src/components/page-header/_story-assets/set-of-breadcrumbs.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/_story-assets/set-of-breadcrumbs.ts
@@ -1,0 +1,175 @@
+// cspell:words currentpage
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2025, 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { LitElement, html } from 'lit';
+import { customElement, property, query } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { repeat } from 'lit/directives/repeat.js';
+import '@carbon/web-components/es/components/breadcrumb/index.js';
+import '@carbon/web-components/es/components/overflow-menu/index.js';
+import { createOverflowHandler } from './overflowHandler';
+import OverflowMenuHorizontal16 from '@carbon/web-components/es/icons/overflow-menu--horizontal/16.js';
+import styles from './set-of-breadcrumbs.scss?lit';
+import '../page-header-title-breadcrumb';
+
+const blockClass = `c4p--set-of-breadcrumbs`;
+
+interface Breadcrumb {
+  text: string;
+  href: string;
+}
+
+@customElement('set-of-breadcrumbs')
+export default class SetOfBreadcrumbs extends LitElement {
+  /**
+   * Hidden items that will be rendered in the overflow menu.
+   */
+  @property({ type: Array })
+  hiddenItems: Breadcrumb[] = [];
+
+  /**
+   * The list of breadcrumbs.
+   */
+  @property({ type: Array, attribute: 'breadcrumbs-data', reflect: true })
+  breadcrumbsData: Breadcrumb[] = [];
+
+  /**
+   * Container holding all breadcrumbs and the overflow menu.
+   */
+  @query(`.${blockClass}`)
+  private container!: HTMLElement;
+
+  private overflowHandler: { disconnect: () => void } | undefined;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.style.visibility = 'hidden';
+  }
+
+  firstUpdated() {
+    if (!this.container) {
+      return;
+    }
+    const sr = this.shadowRoot;
+    const breadcrumb = sr?.querySelector(
+      'cds-breadcrumb'
+    ) as HTMLElement | null;
+
+    if (breadcrumb) {
+      breadcrumb.style.display = 'block';
+
+      requestAnimationFrame(() => {
+        const ol = breadcrumb.shadowRoot?.querySelector(
+          'ol'
+        ) as HTMLElement | null;
+        if (ol) {
+          ol.style.display = 'flex';
+          ol.style.flexWrap = 'unset';
+        }
+      });
+    }
+
+    this.updateComplete.then(() => {
+      requestAnimationFrame(() => {
+        this.overflowHandler = createOverflowHandler({
+          offsetValue: 14,
+          container: this.container,
+          onChange: (visibleItems: HTMLElement[], _) => {
+            this.hiddenItems = this.breadcrumbsData?.slice(visibleItems.length);
+          },
+        });
+      });
+    });
+    // On first render, all elements are initially visible. so hiding `this` visibility in connectedCallback
+    // The handler runs on the second render to hide specific elements as needed.
+    // The following line restores visibility after layout settles, allowing for smoother transitions.
+    setTimeout(() => {
+      this.style.visibility = 'visible';
+    });
+  }
+  updated(changedProperties: Map<string, unknown>) {
+    if (changedProperties.has('breadcrumbsData')) {
+      this.hiddenItems = [];
+      this.overflowHandler?.disconnect();
+      this.overflowHandler = createOverflowHandler({
+        offsetValue: 14,
+        container: this.container,
+        onChange: (visibleItems: HTMLElement[], _) => {
+          this.hiddenItems = this.breadcrumbsData?.slice(visibleItems.length);
+        },
+      });
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this.overflowHandler) {
+      this.overflowHandler.disconnect();
+    }
+  }
+
+  render() {
+    return html`
+      <cds-breadcrumb
+        aria-label="breadcrumbs"
+        class=${classMap({
+          [`${blockClass}`]: true,
+        })}
+      >
+        ${repeat(
+          this.breadcrumbsData?.slice(0, -1) ?? [],
+          (item) => item.href ?? item.text,
+          (item) => html`
+            <cds-breadcrumb-item>
+              <cds-breadcrumb-link href="${item.href}">
+                ${item.text}
+              </cds-breadcrumb-link>
+            </cds-breadcrumb-item>
+          `
+        )}
+
+        <cds-breadcrumb-item
+          data-fixed
+          style="display: ${this.hiddenItems?.length >= 2 ? 'flex' : 'none'}"
+        >
+          <cds-overflow-menu breadcrumb="" align="top">
+            ${OverflowMenuHorizontal16({
+              slot: 'icon',
+            })}
+            <span slot="tooltip-content"> Breadcrumbs </span>
+            <cds-overflow-menu-body size="sm">
+              ${repeat(
+                this.hiddenItems?.slice(0, -1) ?? [],
+                (item) => item.href ?? item.text,
+                (item) => html`
+                  <cds-overflow-menu-item href=${item.href}>
+                    ${item.text}
+                  </cds-overflow-menu-item>
+                `
+              )}
+            </cds-overflow-menu-body>
+          </cds-overflow-menu>
+        </cds-breadcrumb-item>
+        <c4p-page-header-title-breadcrumb data-fixed>
+          <cds-breadcrumb-link is-currentpage="">
+            ${this.breadcrumbsData!.at(-1)!.text}
+          </cds-breadcrumb-link>
+        </c4p-page-header-title-breadcrumb>
+      </cds-breadcrumb>
+    `;
+  }
+  static styles = styles;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'set-of-breadcrumbs': SetOfBreadcrumbs;
+  }
+}

--- a/packages/ibm-products-web-components/src/components/page-header/page-header.scss
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header.scss
@@ -78,6 +78,7 @@ $carbon-prefix: 'cds';
 
   .#{$prefix}--page-header__breadcrumb-wrapper {
     display: inline-flex;
+    inline-size: 100%;
   }
 
   .#{$prefix}--page-header__breadcrumb__actions {

--- a/packages/ibm-products-web-components/src/components/page-header/page-header.stories.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header.stories.ts
@@ -516,6 +516,14 @@ const sampleBreadcrumbs = [
     text: 'Breadcrumb 3',
     href: 'https://www.carbondesignsystem.com',
   },
+  {
+    text: 'Breadcrumb 4',
+    href: 'https://www.carbondesignsystem.com',
+  },
+  {
+    text: 'Virtual-Machine-DAL-really-long-title-example',
+    href: 'https://www.carbondesignsystem.com',
+  },
 ];
 
 export const TabBarWithTabsAndTags = {

--- a/packages/ibm-products-web-components/src/components/page-header/page-header.stories.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header.stories.ts
@@ -29,6 +29,7 @@ import {
   TAG_SIZE,
   TAG_TYPE,
 } from '@carbon/web-components/es/components/tag/defs.js';
+import './_story-assets/set-of-breadcrumbs';
 
 const tags = [
   {
@@ -502,6 +503,21 @@ export const ContentWithIcon = {
   `,
 };
 
+const sampleBreadcrumbs = [
+  {
+    text: 'Breadcrumb 1',
+    href: 'https://www.carbondesignsystem.com',
+  },
+  {
+    text: 'Breadcrumb 2',
+    href: 'https://www.carbondesignsystem.com',
+  },
+  {
+    text: 'Breadcrumb 3',
+    href: 'https://www.carbondesignsystem.com',
+  },
+];
+
 export const TabBarWithTabsAndTags = {
   render: () => html`
     <style>
@@ -516,17 +532,9 @@ export const TabBarWithTabsAndTags = {
       <c4p-page-header>
         <c4p-page-header-breadcrumb>
           ${Bee16({ slot: 'icon' })}
-          <cds-breadcrumb>
-            <cds-breadcrumb-item>
-              <cds-breadcrumb-link href="#">Breadcrumb 1</cds-breadcrumb-link>
-            </cds-breadcrumb-item>
-            <cds-breadcrumb-item>
-              <cds-breadcrumb-link href="#">Breadcrumb 2</cds-breadcrumb-link>
-            </cds-breadcrumb-item>
-            <c4p-page-header-title-breadcrumb>
-              Virtual Machine DAL
-            </c4p-page-header-title-breadcrumb>
-          </cds-breadcrumb>
+          <set-of-breadcrumbs
+            .breadcrumbsData="${sampleBreadcrumbs}"
+          ></set-of-breadcrumbs>
           <cds-icon-button
             slot="page-actions"
             kind="ghost"


### PR DESCRIPTION
Closes #7799 

Adds an example to demonstrate how to include overflowing behavior for the breadcrumbs within the breadcrumb bar of the page header. These changes are implementation only as I've included the example that @devadula-nandan built to show this behavior, not directly included within the page header component itself.

A local `overflowHandler.ts` util was added because the one from `@carbon/utilities` does not include padding/margin spacing in the over element size calculation. Until I submit a PR to update it within core, I've included a local version that includes those values.

The changes can be viewed from [this story](https://deploy-preview-7913--ibm-products-web-components.netlify.app/?path=/story/patterns-pageheader--tab-bar-with-tabs-and-tags).

#### What did you change?
```
packages/ibm-products-web-components/examples/set-of-breadcrumbs/index.html
packages/ibm-products-web-components/examples/set-of-breadcrumbs/package.json
packages/ibm-products-web-components/src/components/page-header/_story-assets/overflowHandler.ts
packages/ibm-products-web-components/src/components/page-header/_story-assets/set-of-breadcrumbs.scss
packages/ibm-products-web-components/src/components/page-header/_story-assets/set-of-breadcrumbs.ts
packages/ibm-products-web-components/src/components/page-header/page-header.scss
packages/ibm-products-web-components/src/components/page-header/page-header.stories.ts
```
#### How did you test and verify your work?
Storybook
#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [X] Addressed any impact on accessibility (a11y)
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
