### PR TITLE
fix(AddSelect): modal is getting closed while trying to click and select from sort overflowmenu

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
@@ -471,6 +471,7 @@ export const TearsheetShell = React.forwardRef(
               `.${carbonPrefix}--tooltip`,
               '.flatpickr-calendar',
               `.${bc}__container`,
+              `.${carbonPrefix}--menu`,
               ...selectorsFloatingMenus,
             ]}
             size="sm"


### PR DESCRIPTION
Closes #7761 

addSelect getting closed while selecting any item from sort popover

#### What did you change?
include .`cds--menu` to selectorsFloatingMenus in Tearsheet

#### How did you test and verify your work?
storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
