### PR TITLE
fix(PageHeader): export as preview from ts exports, bump resizer

### DIFF
--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -108,7 +108,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.26.10",
-    "@carbon-labs/react-resizer": "^0.3.0",
+    "@carbon-labs/react-resizer": "^0.5.0",
     "@carbon/feature-flags": "^0.27.0",
     "@carbon/ibm-products-styles": "^2.67.0",
     "@carbon/telemetry": "^0.1.0",

--- a/packages/ibm-products/src/components/PageHeader/next/PageHeader.test.js
+++ b/packages/ibm-products/src/components/PageHeader/next/PageHeader.test.js
@@ -8,7 +8,7 @@
 import { render, screen, act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { unstable__PageHeader as PageHeader } from '../../..';
+import { preview__PageHeader as PageHeader } from '../../..';
 import {
   PageHeader as PageHeaderDirect,
   PageHeaderBreadcrumbBar as PageHeaderBreadcrumbBarDirect,

--- a/packages/ibm-products/src/components/index.ts
+++ b/packages/ibm-products/src/components/index.ts
@@ -76,7 +76,7 @@ export { ActionBar } from './ActionBar';
 export * from './FilterPanel';
 export * from './ConditionBuilder';
 export * from './GetStartedCard';
-export * as unstable__PageHeader from './PageHeader/next/PageHeader';
+export * as preview__PageHeader from './PageHeader/next/PageHeader';
 
 export {
   FeatureFlags as unstable_FeatureFlags,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1815,10 +1815,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon-labs/react-resizer@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@carbon-labs/react-resizer@npm:0.3.0"
-  checksum: 10/a32f01375bed13fad0ec46356132e93542d4d9e96b8f09849b12ef531042ae762adf7f7c4babb913fd9e9d98a56bafe1ab17f4020f7fb017201051614dcb771b
+"@carbon-labs/react-resizer@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@carbon-labs/react-resizer@npm:0.5.0"
+  checksum: 10/95f465c5ee04afeccd891db320255bf5f0f4899a302215e4e24173cd5be0003bbf183d30a80940b45c08693bbb11a7f15a00f97549d65eb97ad53f5806383b65
   languageName: node
   linkType: hard
 
@@ -1984,7 +1984,7 @@ __metadata:
     "@babel/preset-react": "npm:^7.26.3"
     "@babel/preset-typescript": "npm:^7.26.0"
     "@babel/runtime": "npm:^7.26.10"
-    "@carbon-labs/react-resizer": "npm:^0.3.0"
+    "@carbon-labs/react-resizer": "npm:^0.5.0"
     "@carbon/feature-flags": "npm:^0.27.0"
     "@carbon/ibm-products-styles": "npm:^2.67.0"
     "@carbon/telemetry": "npm:^0.1.0"


### PR DESCRIPTION
Chatting with a product team trying to use new page header, we discovered that it's being exported as `unstable__PageHeader` rather than `preview__PageHeader`. Export was updated in `packages/ibm-products/src/components/index.js` but not `packages/ibm-products/src/components/index.ts`. We may need to cleanup this structure later on.

I also bumped the resizer package from labs that has the esm/cjs fix.

#### What did you change?

#### How did you test and verify your work?

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
