### PR TITLE
feat(page-header): position updates when content element not provided

### DIFF
--- a/packages/ibm-products-web-components/src/components/page-header/page-header-title-breadcrumb.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header-title-breadcrumb.ts
@@ -14,7 +14,7 @@ import { CDSBreadcrumbItem } from '@carbon/web-components/es/index';
 import { prefix } from '../../globals/settings';
 import styles from './page-header.scss?lit';
 import { pageHeaderContext } from './context';
-import { offsetValues } from './page-header';
+import { pageHeaderContextType } from './page-header';
 
 /**
  * Page header Title Breadcrumb
@@ -31,7 +31,7 @@ class CDSPageHeaderTitleBreadcrumb extends CDSBreadcrumbItem {
       context: pageHeaderContext,
       subscribe: true,
       callback: (state) => {
-        if ((state as offsetValues).withContent) {
+        if ((state as pageHeaderContextType).withContent) {
           this.classList.add(
             `${prefix}--page-header-title-breadcrumb-show__with-content`
           );

--- a/packages/ibm-products-web-components/src/components/page-header/page-header-title-breadcrumb.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header-title-breadcrumb.ts
@@ -8,10 +8,13 @@
  */
 
 import { html } from 'lit';
+import { consume, ContextConsumer } from '@lit/context';
 import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element.js';
 import { CDSBreadcrumbItem } from '@carbon/web-components/es/index';
 import { prefix } from '../../globals/settings';
 import styles from './page-header.scss?lit';
+import { pageHeaderContext } from './context';
+import { offsetValues } from './page-header';
 
 /**
  * Page header Title Breadcrumb
@@ -19,6 +22,33 @@ import styles from './page-header.scss?lit';
  */
 @customElement(`${prefix}-page-header-title-breadcrumb`)
 class CDSPageHeaderTitleBreadcrumb extends CDSBreadcrumbItem {
+  @consume({ context: pageHeaderContext, subscribe: true })
+  context;
+
+  constructor() {
+    super();
+    new ContextConsumer(this, {
+      context: pageHeaderContext,
+      subscribe: true,
+      callback: (state) => {
+        if ((state as offsetValues).withContent) {
+          this.classList.add(
+            `${prefix}--page-header-title-breadcrumb-show__with-content`
+          );
+          this.classList.remove(
+            `${prefix}--page-header-title-breadcrumb-show__by-default`
+          );
+        } else {
+          this.classList.remove(
+            `${prefix}--page-header-title-breadcrumb-show__with-content`
+          );
+          this.classList.add(
+            `${prefix}--page-header-title-breadcrumb-show__by-default`
+          );
+        }
+      },
+    });
+  }
   render() {
     return html`
       <cds-breadcrumb-item class="${prefix}--page-header-title-breadcrumb">

--- a/packages/ibm-products-web-components/src/components/page-header/page-header.scss
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header.scss
@@ -354,8 +354,15 @@ $carbon-prefix: 'cds';
       transition: opacity motion(standard, productive) $duration-moderate-01;
     }
   }
+}
+
+:host(
+  #{$prefix}-page-header-title-breadcrumb.#{$prefix}--page-header-title-breadcrumb-show__with-content
+) {
   // `animation-timeline: scroll()` only currently supported in Chromium based browsers
   @supports (animation-timeline: scroll()) {
+    // Show by default should not have any animation, this means
+    // there was not a page header content element provided
     animation-direction: alternate;
     animation-duration: 1ms; /* Firefox requires this to apply the animation */
     animation-name: page-header-title-breadcrumb-animation;
@@ -366,4 +373,11 @@ $carbon-prefix: 'cds';
       transform: translateY(0);
     }
   }
+}
+
+:host(
+  #{$prefix}-page-header-title-breadcrumb.#{$prefix}--page-header-title-breadcrumb-show__by-default
+) {
+  opacity: 1;
+  transform: translateY(0);
 }

--- a/packages/ibm-products-web-components/src/components/page-header/page-header.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header.ts
@@ -17,7 +17,7 @@ import { pageHeaderContext } from './context';
 import { getHeaderOffset } from './utils';
 import CDSPageHeaderContent from './page-header-content';
 
-export interface offsetValues {
+export interface pageHeaderContextType {
   breadcrumbOffset?: number;
   headerOffset?: number;
   fullyCollapsed?: boolean;
@@ -33,7 +33,7 @@ export interface offsetValues {
 class CDSPageHeader extends LitElement {
   @state()
   @provide({ context: pageHeaderContext })
-  context: offsetValues = {};
+  context: pageHeaderContextType = {};
 
   private resizeObserver: ResizeObserver | undefined;
 


### PR DESCRIPTION
Closes #7932 

Correctly sets the sticky positioning values even when the page header content element isn't provided. This allows for the "condensed" version that some teams have inquired about. This change also allows for no scroll animation for the title breadcrumb if there is not a page header content element, in this case the title breadcrumb should be fully visible initially.

#### What did you change?
```
packages/ibm-products-web-components/src/components/page-header/page-header-title-breadcrumb.ts
packages/ibm-products-web-components/src/components/page-header/page-header.scss
packages/ibm-products-web-components/src/components/page-header/page-header.ts
```
#### How did you test and verify your work?
Storybook
#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [X] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [X] Addressed any impact on accessibility (a11y)
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
