### PR TITLE
fix(EmptyState): Modified subtitle container to be a div

### DIFF
--- a/packages/ibm-products/src/components/EmptyStates/EmptyStateV2.stories.jsx
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyStateV2.stories.jsx
@@ -7,11 +7,12 @@
 
 import React from 'react';
 import { action } from 'storybook/actions';
-import { Add } from '@carbon/react/icons';
+import { Add, Information } from '@carbon/react/icons';
 import CustomIllustration from './story_assets/empty-state-bright-magnifying-glass.svg';
 import { EmptyStateV2 } from '.';
 import { StoryDocsPage } from '../../global/js/utils/StoryDocsPage';
 import { Annotation } from '../../../.storybook/Annotation';
+import { Tooltip } from '@carbon/react';
 
 export default {
   title: 'Deprecated/Empty state/EmptyStateV2',
@@ -86,6 +87,19 @@ const Template = (args) => <EmptyStateV2 {...args} />;
 export const Default = Template.bind({});
 Default.args = {
   ...defaultProps,
+};
+
+export const WithTooltipInSubtitle = Template.bind({});
+WithTooltipInSubtitle.args = {
+  ...defaultProps,
+  subtitle: (
+    <>
+      Click <span>here</span> to upload your data
+      <Tooltip label="Facts and statistics collected together for reference or analysis">
+        <Information size="16" />
+      </Tooltip>
+    </>
+  ),
 };
 
 export const WithCustomIllustration = Template.bind({});

--- a/packages/ibm-products/src/components/EmptyStates/EmptyStateV2.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyStateV2.tsx
@@ -153,13 +153,13 @@ export let EmptyStateV2 = React.forwardRef<HTMLDivElement, EmptyStateV2Props>(
             {title}
           </h3>
           {subtitle && (
-            <p
+            <div
               className={cx(`${blockClass}__subtitle`, {
                 [`${blockClass}__subtitle--small`]: size === 'sm',
               })}
             >
               {subtitle}
-            </p>
+            </div>
           )}
           {action && (
             <Button


### PR DESCRIPTION
Closes #7490 
A team is implementing a design that adds a ToggleTip in the subtitle. The subtitle was a hardcoded paragraph tag, throwing a warning when elements that are div based are added as children of the <p> tag...


#### What did you change?
Modified the tag to be a div

#### How did you test and verify your work?
- Visual A/B testing initially using the dev tools
- Wrote a story including a Carbon tooltip

After cleaning up the isolated preview from the deprecated wrapper, the a11y violations were outside of the component:
<img width="1822" height="831" alt="image" src="https://github.com/user-attachments/assets/b6c54679-5111-45a3-8f0a-778ef067ae33" />


#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
