### PR TITLE
fix: add scroller word to spellcheck exclude

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -208,6 +208,7 @@
     "useravatar",
     "rendericon",
     "csvg",
-    "autoalign"
+    "autoalign",
+    "scroller"
   ]
 }


### PR DESCRIPTION


add `scroller` word to spellcheck exclude.
This word was added in [this commit](https://github.com/carbon-design-system/ibm-products/commit/3a98acf5915b574276d94105453e8b0d4057cc0b) caused [error](https://github.com/carbon-design-system/ibm-products/actions/runs/16724649335/job/47336995205)



#### How did you test and verify your work?

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
