### PR TITLE
fix(SidePanel): remove shadow on slide-ins

### DIFF
--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -2779,8 +2779,11 @@ p.c4p--about-modal__copyright-text:first-child {
 .c4p--side-panel.c4p--side-panel--condensed-actions {
   --c4p--side-panel--actions-height: 3rem;
 }
-.c4p--side-panel.c4p--side-panel--slide-in, .c4p--side-panel:not(.c4p--side-panel--has-overlay) {
+.c4p--side-panel.c4p--side-panel--has-overlay {
   box-shadow: 0 0.125rem 0.25rem var(--cds-overlay, rgba(22, 22, 22, 0.5));
+}
+.c4p--side-panel.c4p--side-panel--slide-in:not(.c4p--side-panel--has-overlay) {
+  box-shadow: none;
 }
 .c4p--side-panel .c4p--side-panel__actions-container {
   inline-size: 100%;
@@ -9638,7 +9641,8 @@ button.c4p--add-select__global-filter-toggle--open {
   /* stylelint-disable-next-line carbon/layout-use */
   inset-block-start: var(--c4p-page-header-breadcrumb-top);
 }
-.c4p--page-header__next .c4p--page-header__breadcrumb-bar .cds--subgrid {
+.c4p--page-header__next .c4p--page-header__breadcrumb-bar .cds--subgrid,
+.c4p--page-header__next .c4p--page-header__breadcrumb-bar .cds--css-grid {
   block-size: 100%;
 }
 .c4p--page-header__next .c4p--page-header__breadcrumb-container {
@@ -9662,12 +9666,30 @@ button.c4p--add-select__global-filter-toggle--open {
 }
 .c4p--page-header__next .c4p--page-header__breadcrumb__actions {
   display: inline-flex;
+  justify-content: flex-end;
+  inline-size: 100%;
 }
 .c4p--page-header__next .c4p--page-header__breadcrumb__content-actions {
+  inline-size: 100%;
   margin-inline-end: 0.75rem;
 }
 .c4p--page-header__next .c4p--page-header__breadcrumb-wrapper {
   display: inline-flex;
+  inline-size: 100%;
+}
+.c4p--page-header__next .c4p--page-header__breadcrumb-wrapper .c4p--page-header-breadcrumb-overflow {
+  inline-size: 100%;
+}
+.c4p--page-header__next .c4p--page-header__breadcrumb-wrapper .c4p--page-header-breadcrumb-overflow .cds--breadcrumb {
+  display: flex;
+}
+.c4p--page-header__next .c4p--page-header__breadcrumb-wrapper .c4p--page-header-breadcrumb-overflow-item {
+  display: none;
+  opacity: 0;
+}
+.c4p--page-header__next .c4p--page-header__breadcrumb-wrapper .c4p--page-header-overflow-breadcrumb-item-with-items {
+  display: flex;
+  opacity: 1;
 }
 .c4p--page-header__next .c4p--page-header__content {
   padding: 1.5rem 0;

--- a/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
+++ b/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
@@ -193,6 +193,7 @@ $clabs-prefix: 'clabs';
   }
 
   // Slide-in panels should use border not shadows since they don’t layer
+  &.#{$block-class}--slide-in,
   &.#{$block-class}--slide-in:not(.#{$block-class}--has-overlay) {
     box-shadow: none;
   }

--- a/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
+++ b/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
@@ -188,7 +188,7 @@ $clabs-prefix: 'clabs';
     --#{$block-class}--actions-height: #{$spacing-09};
   }
 
-  &.#{$block-class}--has-overlay {
+  &:not(.#{$block-class}--has-overlay) {
     box-shadow: 0 $spacing-01 $spacing-02 $overlay;
   }
 

--- a/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
+++ b/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
@@ -188,9 +188,13 @@ $clabs-prefix: 'clabs';
     --#{$block-class}--actions-height: #{$spacing-09};
   }
 
-  &.#{$block-class}--slide-in,
-  &:not(.#{$block-class}--has-overlay) {
+  &.#{$block-class}--has-overlay {
     box-shadow: 0 $spacing-01 $spacing-02 $overlay;
+  }
+
+  // Slide-in panels should use border not shadows since they don’t layer
+  &.#{$block-class}--slide-in:not(.#{$block-class}--has-overlay) {
+    box-shadow: none;
   }
 
   .#{$block-class}__actions-container {

--- a/packages/ibm-products-web-components/src/components/side-panel/side-panel.scss
+++ b/packages/ibm-products-web-components/src/components/side-panel/side-panel.scss
@@ -134,6 +134,11 @@ $block-class-action-set: #{$prefix}--action-set;
     }
   }
 
+  // Slide-in panels should use border not shadows since they don’t layer
+  .#{$block-class}[slide-in]:not(.#{$block-class}__overlay) {
+    box-shadow: none;
+  }
+
   .#{$block-class}__header {
     &::before {
       z-index: 99; /* must be higher than action toolbar */


### PR DESCRIPTION
Closes #7923

Remove box-shadow on side panel slide-in variants.
These are not overlaid but inline with existing content.

Note: In the React version, we only remove the shadow when the `slide-in` panel does not include an overlay. You can still achieve slide-over with no overlay but a shadow (or a slide-in with an overlay).
This does not appear to be the same in the WC version. In WC, the overlay is only present in a slide-over but never in a slide-in. (Although you can have a slide-over with no overlay.)

#### What did you change?
Remove shadow on `slide-in` side panel variant.

#### How did you test and verify your work?
Storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
