### PR TITLE
fix: conditionBuilder need to close on outside click while used inside composeModal/ Tearsheet

### DIFF
--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItem.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItem.tsx
@@ -41,6 +41,7 @@ import {
   getValue,
 } from '../utils/util';
 import { translationsObject } from '../ConditionBuilderContext/translationObject';
+import { useEvent } from '../useEvent';
 
 interface ConditionBuilderItemProps extends PropsWithChildren {
   className?: string;
@@ -201,6 +202,28 @@ export const ConditionBuilderItem = ({
       }
     }
   }, [popoverRef, open]);
+
+  //This code is added to address the issue in ComposeModal, where popovers are not getting closed on outside click(#18872)
+  //This is added as a work around to unblock users to use conditionBuilder in Tearsheets or Compose modal
+  useEvent(popoverRef, 'focusout', (event) => {
+    const focusEvent = event as FocusEvent;
+    const relatedTarget = focusEvent.relatedTarget as Node | null;
+
+    const popoverEl = popoverRef.current;
+    if (!popoverEl) {
+      return;
+    }
+
+    const focusLeftPopover = !popoverEl.contains(relatedTarget);
+    const targetInsidePopover = popoverEl.contains(focusEvent.target as Node);
+
+    const targetEl = focusEvent.target as Element | null;
+    const focusMovedToDatePicker = targetEl?.closest('.flatpickr-calendar');
+
+    if ((focusLeftPopover || !targetInsidePopover) && !focusMovedToDatePicker) {
+      closePopover();
+    }
+  });
 
   const manageInvalidSelection = () => {
     //when the user didn't select any value , we need to show as incomplete

--- a/packages/ibm-products/src/components/ConditionBuilder/useEvent.ts
+++ b/packages/ibm-products/src/components/ConditionBuilder/useEvent.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright IBM Corp. 2016, 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useEffect, useRef, RefObject } from 'react';
+
+export const useEvent = <E extends keyof GlobalEventHandlersEventMap>(
+  elementOrRef: HTMLElement | RefObject<Element | null>,
+  eventName: E,
+  callback: (event: GlobalEventHandlersEventMap[E]) => void
+) => {
+  const savedCallback = useRef<
+    ((event: GlobalEventHandlersEventMap[E]) => void) | null
+  >(null);
+
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    const element =
+      'current' in elementOrRef ? elementOrRef.current : elementOrRef;
+    if (!element) {
+      return;
+    }
+
+    const handler = (event: GlobalEventHandlersEventMap[E]) => {
+      if (savedCallback.current) {
+        savedCallback.current(event);
+      }
+    };
+
+    element.addEventListener(eventName, handler as EventListener);
+
+    return () => {
+      element.removeEventListener(eventName, handler as EventListener);
+    };
+  }, [elementOrRef, eventName]);
+};


### PR DESCRIPTION
Closes #7885, #7972

This PR serves as a workaround for the [original issue](https://github.com/carbon-design-system/carbon/issues/18872) in core  where popovers are not getting closed on outside click when used inside ComposeModal.
This caused sev1 issue in condition Builder and this fix can unblock them for now


#### What did you change?
Added useEvent hook from core
Listened to `focusout` event as implemented in popover in core

#### How did you test and verify your work?
Storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
