### PR TITLE
chore(Interstitial): reorganize story category

### DIFF
--- a/packages/ibm-products-web-components/src/components/interstitial-screen/interstitial-screen.stories.ts
+++ b/packages/ibm-products-web-components/src/components/interstitial-screen/interstitial-screen.stories.ts
@@ -497,7 +497,7 @@ export const FullScreenWithMultipleSteps = {
 };
 
 const meta = {
-  title: 'Experimental/InterstitialScreen',
+  title: 'Components/InterstitialScreen',
 };
 
 export default meta;


### PR DESCRIPTION
Puts the Interstitial web component into the `Components` category with the others
