### PR TITLE
fix(styles): use correct syntax for custom CSS props

### DIFF
--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -2652,7 +2652,7 @@ p.c4p--about-modal__copyright-text:first-child {
 @property --panel-transform {
   inherits: true;
   initial-value: 320px;
-  syntax: "<integer>";
+  syntax: "<length>";
 }
 .c4p--side-panel--scrolls {
   overflow: auto;
@@ -4985,7 +4985,7 @@ p.c4p--about-modal__copyright-text:first-child {
 @property --panel-transform {
   inherits: true;
   initial-value: 320px;
-  syntax: "<integer>";
+  syntax: "<length>";
 }
 .c4p--datagrid-filter-panel {
   --panel-transform: 320px;

--- a/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_FilterPanel.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/addons/_FilterPanel.scss
@@ -17,7 +17,7 @@
 @property --panel-transform {
   inherits: true;
   initial-value: 320px;
-  syntax: '<integer>';
+  syntax: '<length>';
 }
 $block-class-component: #{$block-class}-filter-panel;
 

--- a/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
+++ b/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
@@ -36,7 +36,7 @@ $clabs-prefix: 'clabs';
 @property --panel-transform {
   inherits: true;
   initial-value: 320px;
-  syntax: '<integer>';
+  syntax: '<length>';
 }
 
 @mixin setPanelSize($size: map.get($side-panel-sizes, md)) {


### PR DESCRIPTION
Use correct syntax for custom CSS property.

#### What did you change?

A couple of custom CSS properties with value "320px" were incorrectly set as `<integer>` instead of `<length>`. The former should only be numbers and not contain any units, therefore should be using the latter.

I noticed this when building a separate project using [lightningcss](https://lightningcss.dev/), which is more strict than other CSS parsers. Lightningcss throws an error for these 2 references.

#### How did you test and verify your work?

Compared local storybook to deployed version. Tested `SidePanel` and `Datagrid/Filtering/Panel` to ensure that nothing regressed.

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
