### PR TITLE
fix: options-tile review updates

### DIFF
--- a/packages/ibm-products-web-components/src/components/options-tile/options-tile.scss
+++ b/packages/ibm-products-web-components/src/components/options-tile/options-tile.scss
@@ -90,7 +90,13 @@ $block-class: #{$prefix}--options-tile;
     }
   }
 
-  .#{$block-class}--open .#{$block-class}__chevron {
-    transform: rotate(-180deg);
+  .#{$block-class}--open {
+    .#{$block-class}__chevron {
+      transform: rotate(-180deg);
+    }
+
+    .#{$block-class}__summary {
+      display: none;
+    }
   }
 }

--- a/packages/ibm-products-web-components/src/components/options-tile/options-tile.stories.ts
+++ b/packages/ibm-products-web-components/src/components/options-tile/options-tile.stories.ts
@@ -10,13 +10,15 @@
 import { html } from 'lit';
 import './index';
 import '@carbon/web-components/es/components/toggle/index.js';
+import '@carbon/web-components/es/components/dropdown/index.js';
+import styles from './story-styles.scss?lit';
 
 const argTypes = {
   body: {
     control: 'text',
     description: 'Slot body content',
   },
-  open: {
+  defaultOpen: {
     control: 'boolean',
     description: 'If `true` the body of the component is shown',
   },
@@ -39,25 +41,29 @@ const argTypes = {
   },
 };
 
+const blockClass = 'options-tile';
+
 const handleOpen = (evt: Event) => {
-  const tile = document.querySelector('#my-tile');
-  tile?.setAttribute('open', 'true');
+  console.log('open');
 };
 
 const handleClose = (evt: Event) => {
-  const tile = document.querySelector('#my-tile');
-  tile?.removeAttribute('open');
+  console.log('close');
 };
 
 const renderTemplate = (args) => {
-  const { open, size, titleText, titleId } = args;
+  const { defaultOpen, size, titleText, titleId } = args;
   return html`
+    <style>
+      ${styles}
+    </style>
     <c4p-options-tile
+      class="${blockClass}"
+      ?defaultOpen="${defaultOpen}"
       id="my-tile"
-      ?open=${open}
-      size=${size}
-      titleId=${titleId}
-      titleText=${titleText}
+      size="${size}"
+      titleId="${titleId}"
+      titleText="${titleText}"
       @c4p-options-tile-open=${handleOpen}
       @c4p-options-tile-close=${handleClose}
     >
@@ -67,19 +73,33 @@ const renderTemplate = (args) => {
       <div slot="toggle">
         <cds-toggle id="my-toggle" size="sm" hideLabel></cds-toggle>
       </div>
-      <div slot="body">${args.body}</div>
+      <div slot="body">
+        <div class="${`${blockClass}__body`}">
+          <p>${args.body}</p>
+          <div class="${`${blockClass}__dropdown`}">
+            <cds-dropdown title-text="User interface" label="User interface">
+              <cds-dropdown-item value="option-0">English</cds-dropdown-item>
+            </cds-dropdown>
+          </div>
+          <div class="${`${blockClass}__dropdown`}">
+            <cds-dropdown title-text="Locale" label="Locale">
+              <cds-dropdown-item value="option-0">English</cds-dropdown-item>
+            </cds-dropdown>
+          </div>
+        </div>
+      </div>
     </c4p-options-tile>
   `;
 };
 
 export const Default = {
   args: {
-    body: 'Body content',
-    open: false,
+    body: 'User interface defines the language the application is displayed in. Locale sets the regional display formats for information like time, date, currency and decimal delimiters.',
+    defaultOpen: false,
     size: 'lg',
-    summary: 'Back up every 10min',
+    summary: 'English | Locale: English',
     titleId: 'title-01',
-    titleText: 'Auto recovery',
+    titleText: 'Language',
   },
   argTypes,
   render: renderTemplate,

--- a/packages/ibm-products-web-components/src/components/options-tile/options-tile.test.ts
+++ b/packages/ibm-products-web-components/src/components/options-tile/options-tile.test.ts
@@ -14,9 +14,9 @@ const defaultEvents = {
 };
 
 const defaultProps = {
-  open: false,
+  defaultOpen: false,
   size: 'lg',
-  title: 'Test title',
+  titleText: 'Test title',
   titleId: 'test-title',
 };
 
@@ -37,9 +37,9 @@ const template = (args = {}) => {
   return html`
     <c4p-options-tile
       id="my-tile"
-      ?open=${props.open}
+      ?defaultOpen=${props.defaultOpen}
       size=${props.size}
-      title=${props.title}
+      titleText=${props.titleText}
       titleId=${props.titleId}
       @c4p-options-tile-open=${events.handleOpen}
       @c4p-options-tile-close=${events.handleClose}
@@ -66,7 +66,7 @@ describe('c4p-options-tile', () => {
   it('renders a title', async () => {
     const el: CDSOptionsTile = await fixture(template());
     expect(el).toBeDefined();
-    expect(el.title).to.equal(defaultProps.title);
+    expect(el.titleText).to.equal(defaultProps.titleText);
     const titleEl = el.shadowRoot?.querySelector(`.${blockClass}__title`);
     expect(titleEl).toBeDefined();
     const id = titleEl?.getAttribute('id');
@@ -97,7 +97,7 @@ describe('c4p-options-tile', () => {
 
   it('renders a body', async () => {
     const el: CDSOptionsTile = await fixture(
-      template({ props: { open: true } })
+      template({ props: { defaultOpen: true } })
     );
     const slot = el.shadowRoot?.querySelector(
       `slot[name="body"]`
@@ -121,7 +121,7 @@ describe('c4p-options-tile', () => {
 
   it('fires close handler', async () => {
     const el: CDSOptionsTile = await fixture(
-      template({ props: { open: true } })
+      template({ props: { defaultOpen: true } })
     );
     const header = el.shadowRoot?.querySelector(
       `.${blockClass}__header`

--- a/packages/ibm-products-web-components/src/components/options-tile/story-styles.scss
+++ b/packages/ibm-products-web-components/src/components/options-tile/story-styles.scss
@@ -1,0 +1,21 @@
+/*
+* Copyright IBM Corp. 2025
+*
+* This source code is licensed under the Apache-2.0 license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+@use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/spacing' as *;
+
+.options-tile {
+  &__body p {
+    @include type.type-style('body-01');
+
+    margin-block-end: $spacing-05;
+  }
+
+  &__dropdown:first-of-type {
+    margin-block-end: $spacing-05;
+  }
+}


### PR DESCRIPTION
Closes #7999 

addresses design review items and also includes enhancements to the default `options-tile` story to more closely resemble the react version
