### PR TITLE
fix(PageHeader): add role prop to pageheader's breadcrumb overflow menu

### DIFF
--- a/packages/ibm-products/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
+++ b/packages/ibm-products/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
@@ -71,6 +71,7 @@ export let BreadcrumbWithOverflow = ({
       <BreadcrumbItem key={`breadcrumb-overflow-${internalId.current}`}>
         <FeatureFlags enableV12Overflowmenu>
           <OverflowMenu
+            role="navigation"
             aria-label={overflowAriaLabel}
             label={overflowAriaLabel} // also needs setting to avoid a11y "Accessible name does not match or contain the visible label text"
             renderIcon={(props) => (
@@ -107,6 +108,7 @@ export let BreadcrumbWithOverflow = ({
         <Breadcrumb aria-label={`${label}-hidden`}>
           <BreadcrumbItem key={`${blockClass}-hidden-overflow-${internalId}`}>
             <OverflowMenu
+              role="navigation"
               aria-label={overflowAriaLabel}
               renderIcon={(props) => (
                 <OverflowMenuHorizontal size={32} {...props} />


### PR DESCRIPTION
Closes #7779 

The `Breadcrumb's` `OverflowMenu` has an `aria-label`, but because the `aria-label` is applied to a `div` it also needs a specified `role` for accessibility.

#### What did you change?

Added `role="navigation"` to the `div`. 
- This specific `Breadcrumbs` components is internal to `PageHeader` only. 
- The breadcrumbs are limited to navigating the site. 
- "Navigation" was more appropriate over the more generic "menu".

#### How did you test and verify your work?

- Storybook 

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency (Chrome, Firefox)
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
