### PR TITLE
fix(Create tearsheets and modals): disable ability to submit form using the Enter key

### DIFF
--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.tsx
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.tsx
@@ -33,7 +33,6 @@ import {
   useCreateComponentFocus,
   useCreateComponentStepChange,
   usePreviousValue,
-  useResetCreateComponent,
   useValidCreateStepCount,
 } from '../../global/js/hooks';
 
@@ -388,7 +387,13 @@ export let CreateFullPage = React.forwardRef(
           <div className={`${blockClass}__body`}>
             <div className={`${blockClass}__main`}>
               <div className={`${blockClass}__content`}>
-                <Form className={`${blockClass}__form`} aria-label={title}>
+                <Form
+                  className={`${blockClass}__form`}
+                  aria-label={title}
+                  onSubmit={(e: React.FormEvent<HTMLFormElement>) =>
+                    e.preventDefault()
+                  }
+                >
                   <StepsContext.Provider
                     value={
                       {

--- a/packages/ibm-products/src/components/CreateModal/CreateModal.tsx
+++ b/packages/ibm-products/src/components/CreateModal/CreateModal.tsx
@@ -128,7 +128,13 @@ export let CreateModal = React.forwardRef<HTMLDivElement, CreateModalProps>(
           {description && (
             <p className={`${blockClass}__description`}>{description}</p>
           )}
-          <Form className={`${blockClass}__form`} aria-label={title}>
+          <Form
+            className={`${blockClass}__form`}
+            aria-label={title}
+            onSubmit={(e: React.FormEvent<HTMLFormElement>) =>
+              e.preventDefault()
+            }
+          >
             {children}
           </Form>
         </ModalBody>

--- a/packages/ibm-products/src/components/CreateSidePanel/CreateSidePanel.tsx
+++ b/packages/ibm-products/src/components/CreateSidePanel/CreateSidePanel.tsx
@@ -181,7 +181,13 @@ export let CreateSidePanel = React.forwardRef(
           >
             {formDescription}
           </p>
-          <Form className={`${blockClass}__form`} aria-labelledby={formTitleId}>
+          <Form
+            className={`${blockClass}__form`}
+            aria-labelledby={formTitleId}
+            onSubmit={(e: React.FormEvent<HTMLFormElement>) =>
+              e.preventDefault()
+            }
+          >
             {children}
           </Form>
         </SidePanel>

--- a/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.tsx
+++ b/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheet.tsx
@@ -337,7 +337,12 @@ export let CreateTearsheet = forwardRef(
         selectorPrimaryFocus={selectorPrimaryFocus}
       >
         <div className={`${blockClass}__content`} ref={contentRef}>
-          <Form aria-label={title}>
+          <Form
+            aria-label={title}
+            onSubmit={(e: React.FormEvent<HTMLFormElement>) =>
+              e.preventDefault()
+            }
+          >
             <StepsContext.Provider
               value={{
                 currentStep,

--- a/packages/ibm-products/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.tsx
+++ b/packages/ibm-products/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.tsx
@@ -185,7 +185,11 @@ export let CreateTearsheetNarrow = React.forwardRef(
         >
           {formDescription}
         </p>
-        <Form className={`${blockClass}__form`} aria-labelledby={formTitleId}>
+        <Form
+          className={`${blockClass}__form`}
+          aria-labelledby={formTitleId}
+          onSubmit={(e: React.FormEvent<HTMLFormElement>) => e.preventDefault()}
+        >
           {children}
         </Form>
       </TearsheetNarrow>


### PR DESCRIPTION
Closes #7866

This fix disables this default behavior [W3 Section 8.2](https://www.w3.org/MarkUp/html-spec/html-spec_8.html#SEC8.2) "When there is only one single-line text input field in a form, the user agent 'should' accept Enter in that field as a request to submit the form."

You can see Storybook example here:
1. [Create Full Page With Step In Error State](https://ibm-products.carbondesignsystem.com/?path=/story/patterns-prebuilt-patterns-create-flows-createfullpage--create-full-page-with-step-in-error-state). Single input field reloads the page. 
    - Set focus on the input field, 
    - hit the Enter key, 
    - the page reloads. 
3. [Create Full Page With Header](https://ibm-products.carbondesignsystem.com/?path=/story/patterns-prebuilt-patterns-create-flows-createfullpage--create-full-page-with-header). Single input field _and other form elements on the page_ (button for the toggle component, checkbox) prevent a page reload. More form elements on steps 3 and 4 in this example also exist on the page, but are hidden from the user.
    - Set focus on the input field, 
    - hit the Enter key, 
    - nothing happens. 

The "Create" components (listed below) wrap a `<Form>` around all developer content across multiple steps. All content for all steps are rendered to the DOM, but only the content on a specific step is made visible to the user.

**Issues**

1. If there is a single input text field in one of these forms, then hitting the Enter key while that field has focus will, following HTML standards, submit the form. This applies even if there is a single input field across multiple steps.
5. The `<Form>` used in the components are for internal use only. It is a recommended practice in wrapping multiple form elements, and is not meant to be reachable by the developer.
6. For the purposes of the Create components listed below, only clicking the component's Submit button should trigger a form submission. This action is accessible via the `onRequestSubmit` prop.

**Solution**

Added an _onSubmit = preventDefault()_ to the forms for each component below.

#### What did you change?

```
CreateFullPage
CreateModal
CreateSidePanel
CreateTearSheet
CreateTearSheetNarrow
```

#### How did you test and verify your work?

- Storybook.

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [x] Tested for cross-browser consistency (Chrome, Firefox)
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
