### PR TITLE
docs(AboutModal): update content and structure

### DIFF
--- a/cspell.packages.txt
+++ b/cspell.packages.txt
@@ -1,3 +1,4 @@
+argstable
 browserslist
 cdai
 codeql

--- a/e2e/components/AboutModal/AboutModal-test.avt.e2e.js
+++ b/e2e/components/AboutModal/AboutModal-test.avt.e2e.js
@@ -15,7 +15,7 @@ test.describe('AboutModal @avt', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'AboutModal',
-      id: 'components-aboutmodal--about-modal',
+      id: 'components-aboutmodal--default',
       globals: {
         carbonTheme: 'white',
       },
@@ -27,7 +27,7 @@ test.describe('AboutModal @avt', () => {
   test('@avt-initially-focus-close-button', async ({ page }) => {
     await visitStory(page, {
       component: 'AboutModal',
-      id: 'components-aboutmodal--about-modal',
+      id: 'components-aboutmodal--default',
       globals: {
         carbonTheme: 'white',
       },
@@ -40,7 +40,7 @@ test.describe('AboutModal @avt', () => {
   test('@avt-open-close-with-focus-trap', async ({ page }) => {
     await visitStory(page, {
       component: 'AboutModal',
-      id: 'components-aboutmodal--about-modal-with-all-props-set',
+      id: 'components-aboutmodal--with-additional-content',
       globals: {
         carbonTheme: 'white',
       },

--- a/packages/ibm-products/.storybook/index.scss
+++ b/packages/ibm-products/.storybook/index.scss
@@ -59,3 +59,9 @@ body {
 [data-carbon-theme='debug'] body {
   color: initial;
 }
+
+// Docs overrides
+.docblock-argstable-head ~ .docblock-argstable-body,
+.docblock-argstable-head ~ .docblock-argstable-body p {
+  @include styles.type-style('body-01');
+}

--- a/packages/ibm-products/.storybook/preview-head.html
+++ b/packages/ibm-products/.storybook/preview-head.html
@@ -1,0 +1,29 @@
+<style>
+  .sbdocs-li {
+    list-style: circle;
+  }
+
+  .sbdocs-wrapper .sbdocs-a {
+    color: #0f62fe;
+  }
+
+  .sbdocs-wrapper .sbdocs-a:hover {
+    color: #0353e9;
+  }
+
+  .sbdocs-wrapper .sbdocs-h2 {
+    padding-bottom: 12px;
+    margin-bottom: 0;
+  }
+
+  .sb-show-main.sb-main-padded {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 42px;
+  }
+
+  body #storybook-root {
+    width: 100%;
+  }
+</style>

--- a/packages/ibm-products/.storybook/preview.js
+++ b/packages/ibm-products/.storybook/preview.js
@@ -116,7 +116,11 @@ const parameters = {
       },
     ],
   },
-  controls: { expanded: true, hideNoControlsWarning: true },
+  controls: {
+    expanded: true,
+    hideNoControlsWarning: true,
+    sort: 'alpha',
+  },
   layout: 'centered',
   options: {
     showPanel: true,

--- a/packages/ibm-products/src/components/AboutModal/AboutModal.mdx
+++ b/packages/ibm-products/src/components/AboutModal/AboutModal.mdx
@@ -25,12 +25,12 @@ The about modal is triggered by a user’s action which appears on top of the ma
 The purpose of this modal should be immediately apparent to the user, with a clear and obvious path to completion.
 
 <Canvas
-  of={stories.aboutModal}
+  of={stories.Default}
   additionalActions={[
       {
         title: 'Open in Stackblitz',
         onClick: () => stackblitzPrefillConfig({
-          'story': stories.aboutModal,
+          'story': stories.Default,
           'styles': stories.default.parameters.styles
       }),
       },
@@ -41,12 +41,12 @@ The purpose of this modal should be immediately apparent to the user, with a cle
 ### With additional content
 
 <Canvas
-  of={stories.aboutModalWithAllPropsSet}
+  of={stories.withAdditionalContent}
   additionalActions={[
       {
         title: 'Open in Stackblitz',
         onClick: () => stackblitzPrefillConfig({
-          'story': stories.aboutModalWithAllPropsSet,
+          'story': stories.withAdditionalContent,
           'styles': stories.default.parameters.styles
       }),
       },

--- a/packages/ibm-products/src/components/AboutModal/AboutModal.mdx
+++ b/packages/ibm-products/src/components/AboutModal/AboutModal.mdx
@@ -40,6 +40,28 @@ The purpose of this modal should be immediately apparent to the user, with a cle
 
 ### With additional content
 
+Some products may be legally required to display logos of technologies used to build the product.
+These can be provided through the `additionalInfo` prop and will be displayed in the footer.
+
+While the about modal supports an array of Carbon `Link` components via the `links` prop, these
+should be used to display product information and not to direct users to find help content.
+
+```jsx
+<AboutModal
+  closeIconDescription="Close"
+  copyrightText="Copyright © IBM Corp. 2020, 2025"
+  logo={logo}
+  title="IBM Product name"
+  version="Version 0.0.0"
+  additionalInfo={
+    <p className={`${pkg.prefix}--about-modal__footer-label`}>Powered by</p>
+    <img src={img1} alt="First logo"/>
+    <img src={img2} alt="Second logo"/>
+    <img src={img3} alt="Third logo"/>
+  }
+/>
+```
+
 <Canvas
   of={stories.withAdditionalContent}
   additionalActions={[

--- a/packages/ibm-products/src/components/AboutModal/AboutModal.mdx
+++ b/packages/ibm-products/src/components/AboutModal/AboutModal.mdx
@@ -4,25 +4,25 @@ import { AboutModal } from '.';
 import * as stories from './AboutModal.stories';
 import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
 
-# About Modal
+# AboutModal
 
-[Usage guidelines](https://pages.github.ibm.com/carbon/ibm-products/components/about-modal/usage/) | [Carbon modal usage guidelines](https://www.carbondesignsystem.com/components/modal/usage) | [Carbon modal documentation](https://react.carbondesignsystem.com/?path=/docs/components-modal)
+[Source code](https://github.com/carbon-design-system/ibm-products/tree/main/packages/ibm-products/src/components/AboutModal)
+&nbsp;|&nbsp;
+[Usage guidelines](https://pages.github.ibm.com/carbon/ibm-products/components/about-modal/usage/)
 
 ## Table of Contents
 
 - [Overview](#overview)
-- [Example usage](#example-usage)
-  - [About Modal](#about-modal-1)
-  - [About Modal With All Props Set](#about-modal-with-all-props-set)
+  - [With additional content](#with-additional-content)
 - [Component API](#component-api)
+- [References](#references)
+- [Feedback](#feedback)
 
 ## Overview
 
-The About modal component conveys product information, including the version number, copyright information, and license details.
-The About modal is triggered by a user’s action which appears on top of the main page content and is persistent until dismissed. 
+The `AboutModal` component conveys product information, including the version number, copyright information, and license details.
+The about modal is triggered by a user’s action which appears on top of the main page content and is persistent until dismissed. 
 The purpose of this modal should be immediately apparent to the user, with a clear and obvious path to completion.
-
-### About Modal
 
 <Canvas
   of={stories.aboutModal}
@@ -38,7 +38,7 @@ The purpose of this modal should be immediately apparent to the user, with a cle
 </Canvas>
 
 
-### About Modal With All Props Set
+### With additional content
 
 <Canvas
   of={stories.aboutModalWithAllPropsSet}
@@ -56,3 +56,14 @@ The purpose of this modal should be immediately apparent to the user, with a cle
 ## Component API
 
 <Controls />
+
+## References
+
+The `AboutModal` is built using the `ComposedModal`. Any additional props will be passed to the `ComposedModal`.
+For a full list of props, please see the [ComposedModal](https://react.carbondesignsystem.com/?path=/docs/components-modal).
+
+## Feedback
+
+Help us improve this component by providing feedback, asking questions on Slack,
+or updating this file on
+[GitHub](https://github.com/carbon-design-system/ibm-products/edit/main/packages/ibm-products/src/components/AboutModal/AboutModal.mdx).

--- a/packages/ibm-products/src/components/AboutModal/AboutModal.stories.jsx
+++ b/packages/ibm-products/src/components/AboutModal/AboutModal.stories.jsx
@@ -27,6 +27,7 @@ export default {
       page: mdx,
     },
     controls: { sort: 'requiredFirst' },
+    layout: 'padded',
   },
   argTypes: {
     additionalInfo: {
@@ -220,8 +221,8 @@ const commonArgs = {
   copyrightText: 'Copyright © IBM Corp. 2020, 2023',
 };
 
-export const aboutModal = Template.bind({});
-aboutModal.args = {
+export const Default = Template.bind({});
+Default.args = {
   title: 1,
   links: 0,
   content: 0,
@@ -229,8 +230,8 @@ aboutModal.args = {
   ...commonArgs,
 };
 
-export const aboutModalWithAllPropsSet = Template.bind({});
-aboutModalWithAllPropsSet.args = {
+export const withAdditionalContent = Template.bind({});
+withAdditionalContent.args = {
   title: 2,
   links: 3,
   content: 2,

--- a/packages/ibm-products/src/components/AboutModal/AboutModal.stories.jsx
+++ b/packages/ibm-products/src/components/AboutModal/AboutModal.stories.jsx
@@ -26,7 +26,6 @@ export default {
     docs: {
       page: mdx,
     },
-    controls: { sort: 'requiredFirst' },
     layout: 'padded',
   },
   argTypes: {
@@ -216,25 +215,22 @@ const Template = (args, context) => {
 Template.propTypes = AboutModal.propTypes;
 
 const commonArgs = {
+  copyrightText: 'Copyright © IBM Corp. 2020, 2023',
   closeIconDescription: 'Close',
   version: 'Version 0.0.0',
-  copyrightText: 'Copyright © IBM Corp. 2020, 2023',
 };
 
 export const Default = Template.bind({});
 Default.args = {
   title: 1,
-  links: 0,
-  content: 0,
-  additionalInfo: 0,
   ...commonArgs,
 };
 
 export const withAdditionalContent = Template.bind({});
 withAdditionalContent.args = {
-  title: 2,
-  links: 3,
-  content: 2,
   additionalInfo: 1,
+  content: 2,
+  links: 3,
+  title: 2,
   ...commonArgs,
 };

--- a/packages/ibm-products/src/components/AboutModal/AboutModal.tsx
+++ b/packages/ibm-products/src/components/AboutModal/AboutModal.tsx
@@ -32,77 +32,71 @@ const componentName = 'AboutModal';
 
 export interface AboutModalProps {
   /**
-   * If you are legally required to display logos of technologies used
-   * to build your product you can provide this in the additionalInfo.
-   * Additional information will be displayed in the footer.
+   * Provide additional detail for the modal footer, such as logos of
+   * technologies used in the product, legally required for some products
    */
   additionalInfo?: ReactNode;
 
   /**
-   * Provide an optional class to be applied to the modal root node.
+   * Specify an optional className to be applied to the modal root node
    */
   className?: string;
 
   /**
-   * The accessibility title for the close icon.
+   * Provide an accessible name for the close icon
    */
   closeIconDescription: string;
 
   /**
-   * Subhead text providing any relevant product disclaimers including
-   * legal information (optional)
+   * Provide any relevant product disclaimers or legal information
    */
   content?: ReactNode;
 
   /**
-   * Trademark and copyright information. Displays first year of
-   * product release to current year.
+   * Specify the first year of product release to the current year
    */
   copyrightText: string;
 
   /**
-   * An array of Carbon `Link` component if there are additional information
-   * to call out within the card. The about modal should be used to display
-   * the product information and not where users go to find help (optional)
+   * Provide an array of Carbon `Link`s for additional detail about the
+   * product
    */
   links?: ReactNode[];
 
   /**
-   * A visual symbol used to represent the product.
+   * Provide a visual representation of the product
    */
   logo: ReactNode;
 
   /**
-   * Specifies aria label for AboutModal
+   * Specify an aria-label for the modal
    */
   modalAriaLabel?: string;
 
   /**
-   * Specifies an optional handler which is called when the AboutModal
-   * is closed. Returning `false` prevents the AboutModal from closing.
+   * Specify an optional handler for closing modal. Returning `false`
+   * prevents the modal from closing
    */
   onClose?: () => void | boolean;
 
   /**
-   * Specifies whether the AboutModal is open or not.
+   * Specify whether the modal is currently open
    */
   open?: boolean;
 
   /**
-   * The DOM node the tearsheet should be rendered within. Defaults to document.body.
+   * Provide the DOM node where the modal should be rendered.
+   * Defaults to `document.body`
    */
   portalTarget?: ReactNode;
 
   /**
-   * Header text that provides the product name. The IBM Services logo
-   * consists of two discrete, but required, elements: the iconic
-   * IBM 8-bar logo represented alongside the IBM Services logotype.
-   * Please follow these guidelines to ensure proper execution.
+   * Provide the product name for the modal header
    */
   title: ReactNode;
 
   /**
-   * Text that provides information on the version number of your product.
+   * Provide the product’s version number
    */
   version: string;
 }
@@ -225,77 +219,71 @@ AboutModal.displayName = componentName;
 // See https://www.npmjs.com/package/prop-types#usage.
 AboutModal.propTypes = {
   /**
-   * If you are legally required to display logos of technologies used
-   * to build your product you can provide this in the additionalInfo.
-   * Additional information will be displayed in the footer.
+   * Provide additional detail for the modal footer, such as logos of
+   * technologies used in the product, legally required for some products
    */
   additionalInfo: PropTypes.node,
 
   /**
-   * Provide an optional class to be applied to the modal root node.
+   * Specify an optional className to be applied to the modal root node
    */
   className: PropTypes.string,
 
   /**
-   * The accessibility title for the close icon.
+   * Provide an accessible name for the close icon
    */
   closeIconDescription: PropTypes.string.isRequired,
 
   /**
-   * Subhead text providing any relevant product disclaimers including
-   * legal information (optional)
+   * Provide any relevant product disclaimers or legal information
    */
   content: PropTypes.node,
 
   /**
-   * Trademark and copyright information. Displays first year of
-   * product release to current year.
+   * Specify the first year of product release to the current year
    */
   copyrightText: PropTypes.string.isRequired,
 
   /**
-   * An array of Carbon `Link` component if there are additional information
-   * to call out within the card. The about modal should be used to display
-   * the product information and not where users go to find help (optional)
+   * Provide an array of Carbon `Link`s for additional detail about the
+   * product
    */
   links: PropTypes.arrayOf(PropTypes.element),
 
   /**
-   * A visual symbol used to represent the product.
+   * Provide a visual representation of the product
    */
   logo: PropTypes.node.isRequired,
 
   /**
-   * Specifies aria label for AboutModal
+   * Specify an aria-label for the modal
    */
   modalAriaLabel: PropTypes.string,
 
   /**
-   * Specifies an optional handler which is called when the AboutModal
-   * is closed. Returning `false` prevents the AboutModal from closing.
+   * Specify an optional handler for closing modal. Returning `false`
+   * prevents the modal from closing
    */
   onClose: PropTypes.func,
 
   /**
-   * Specifies whether the AboutModal is open or not.
+   * Specify whether the modal is currently open
    */
   open: PropTypes.bool,
 
   /**
-   * The DOM node the tearsheet should be rendered within. Defaults to document.body.
+   * Provide the DOM node where the modal should be rendered.
+   * Defaults to `document.body`
    */
   portalTarget: PropTypes.node,
 
   /**
-   * Header text that provides the product name. The IBM Services logo
-   * consists of two discrete, but required, elements: the iconic
-   * IBM 8-bar logo represented alongside the IBM Services logotype.
-   * Please follow these guidelines to ensure proper execution.
+   * Provide the product name for the modal header
    */
   title: PropTypes.node.isRequired,
 
   /**
-   * Text that provides information on the version number of your product.
+   * Provide the product’s version number
    */
   version: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
Closes #7717

#### What did you change?

Update `AboutModal` docs:
- Rename “about modal” story to “default”
- Rename “with all props set” to “with additional content”
- Add detailed description on `additionalInfo` and `links` usage
- Move links to `ComposedModal` to a new “References” section
- Rewrite prop descriptions to imperative voice
- Align “open modal” button to top left (no longer obscured by modal)

Additional changes:
- Alphabetize props (previously `requiredFirst`)
  - Note that this works on the individual story pages
  - The MDX page sets any args passed in to the top and alphabetizes what remains
- Update styles
  - Use primary link color instead of generic Storybook blue
  - Fix mixed text sizes in prop table
- Update AVT links

#### How did you test and verify your work?
Storybook, `yarn avt`

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
