### PR TITLE
fix: update examples with open prop instead of isOpen

### DIFF
--- a/examples/carbon-for-ibm-products/InterstitialScreen/src/Example/Example.tsx
+++ b/examples/carbon-for-ibm-products/InterstitialScreen/src/Example/Example.tsx
@@ -115,8 +115,12 @@ export const Example = () => {
                   </p>
                 </div>
                 <Layer>
-                  <TileGroup name="radio tile group" className="tileWrapper" defaultSelected='medium'>
-                    <RadioTile id="radio-tile-1" value="starter"  >
+                  <TileGroup
+                    name="radio tile group"
+                    className="tileWrapper"
+                    defaultSelected="medium"
+                  >
+                    <RadioTile id="radio-tile-1" value="starter">
                       <p>Starter size</p>
                       <p>
                         Trial size in extra small. Includes 1 general purpose
@@ -172,11 +176,10 @@ export const Example = () => {
         Show Interstitial modal
       </Button>
       <InterstitialScreen
-        isOpen={showInterstitialModal}
+        open={showInterstitialModal}
         onClose={() => {
           setShowInterstitialModal(false);
         }}
-        interstitialAriaLabel={defaultProps.interstitialAriaLabel}
         isFullScreen={false}
       >
         <InterstitialScreen.Header
@@ -189,7 +192,6 @@ export const Example = () => {
         />
         <InterstitialScreen.Footer />
       </InterstitialScreen>
-     
     </>
   );
 };

--- a/examples/carbon-for-ibm-products/InterstitialScreenView/src/Example/Example.tsx
+++ b/examples/carbon-for-ibm-products/InterstitialScreenView/src/Example/Example.tsx
@@ -63,11 +63,10 @@ export const Example = () => {
         Show Interstitial modal
       </Button>
       <InterstitialScreen
-        isOpen={showInterstitialModal}
+        open={showInterstitialModal}
         onClose={() => {
           setShowInterstitialModal(false);
         }}
-        interstitialAriaLabel={defaultProps.interstitialAriaLabel}
         isFullScreen={false}
       >
         <InterstitialScreen.Header

--- a/examples/carbon-for-ibm-products/InterstitialScreenWithAnimatedMedia/src/Example/Example.tsx
+++ b/examples/carbon-for-ibm-products/InterstitialScreenWithAnimatedMedia/src/Example/Example.tsx
@@ -192,11 +192,10 @@ export const Example = () => {
         Show Interstitial modal
       </Button>
       <InterstitialScreen
-        isOpen={showInterstitialModal}
+        open={showInterstitialModal}
         onClose={() => {
           setShowInterstitialModal(false);
         }}
-        interstitialAriaLabel={defaultProps.interstitialAriaLabel}
         isFullScreen={false}
       >
         <InterstitialScreen.Header


### PR DESCRIPTION
Closes #7893 

The examples were using the isOpen prop, but since we had already changed the component to use the open prop instead, the examples were throwing errors. Also removed interstitialAriaLabel is no longer accepted
These changes were done to component during release review



#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
