### PR TITLE
test(coachmark): add avt tests

### DIFF
--- a/e2e/components/Coachmark/next/Coachmark-test.avt.e2e.js
+++ b/e2e/components/Coachmark/next/Coachmark-test.avt.e2e.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright IBM Corp. 2024, 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { expect, test } from '@playwright/test';
+import { visitStory } from '../../../test-utils/storybook';
+import { pkg } from '../../../../packages/ibm-products/src/settings';
+
+const blockClass = `${pkg.prefix}--coachmark__next`;
+
+test.describe('Coachmark @avt', () => {
+  test('@avt-default-state', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Coachmark',
+      id: 'experimental-onboarding-coachmark-next--tooltip',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    await expect(page).toHaveNoACViolations('Coachmark @avt-default-state');
+  });
+
+  test('@avt-initially-focus-done-button', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Coachmark',
+      id: 'experimental-onboarding-coachmark-next--tooltip',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+    const primaryButton = page.getByRole('button', { name: 'Done' });
+    await expect(primaryButton).toBeFocused();
+  });
+
+  test('@avt-dragging-happening-on-header', async ({ page }) => {
+    await visitStory(page, {
+      component: 'Coachmark',
+      id: 'experimental-onboarding-coachmark-next--floating',
+      globals: {
+        carbonTheme: 'white',
+      },
+    });
+
+    const dragButton = page.getByRole('button', { name: 'Drag' });
+    await expect(dragButton).toBeInViewport();
+
+    await dragButton.click();
+
+    const container = page.locator(`.${blockClass}--coachmark-content`);
+    await expect(container).toBeVisible();
+
+    const getPos = async () => {
+      const draggableContainer = await container.boundingBox();
+      if (draggableContainer)
+        return { x: draggableContainer.x, y: draggableContainer.y };
+    };
+
+    const position = await getPos();
+
+    await page.keyboard.press('ArrowLeft');
+    const afterLeft = await getPos();
+    expect(afterLeft.x).toBeLessThan(position.x);
+
+    await page.keyboard.press('ArrowRight');
+    const afterRight = await getPos();
+    expect(afterRight.x).toBeGreaterThan(afterLeft.x);
+
+    await page.keyboard.press('ArrowUp');
+    const afterUp = await getPos();
+    expect(afterUp.y).toBeLessThan(afterRight.y);
+
+    await page.keyboard.press('ArrowDown');
+    const afterDown = await getPos();
+    expect(afterDown.y).toBeGreaterThan(afterUp.y);
+
+    await page.keyboard.press('Escape');
+    await expect(container).not.toBeVisible();
+
+    const TriggerButton = page.getByRole('button', {
+      name: 'Show information',
+    });
+    await TriggerButton.click();
+
+    await expect(container).toBeVisible();
+    const newPosition = await getPos();
+    expect(position.x).toEqual(newPosition.x);
+    expect(position.y).toEqual(newPosition.y);
+  });
+});

--- a/packages/ibm-products/src/components/Coachmark/next/Coachmark/Coachmark.tsx
+++ b/packages/ibm-products/src/components/Coachmark/next/Coachmark/Coachmark.tsx
@@ -53,10 +53,6 @@ export interface CoachmarkProps {
    */
   className?: string;
   /**
-   * The aria label applied to the Coachmark component
-   */
-  ariaLabel?: string;
-  /**
    * Specifies whether the component is currently open.
    */
   open?: boolean;
@@ -116,7 +112,6 @@ export const Coachmark = forwardRef<HTMLDivElement, CoachmarkProps>(
     const {
       children,
       className,
-      ariaLabel,
       onClose,
       align = 'bottom',
       open,
@@ -198,7 +193,6 @@ export const Coachmark = forwardRef<HTMLDivElement, CoachmarkProps>(
             className, // Apply any supplied class names to the main HTML element.
             { [`${blockClass}--floating`]: floating }
           )}
-          aria-label={ariaLabel}
           ref={setRef}
           {...getDevtoolsProps(componentName)}
         >
@@ -222,10 +216,6 @@ Coachmark.propTypes = {
    * Where to render the Coachmark relative to its target.
    */
   align: PropTypes.string,
-  /**
-   * The aria label applied to the Coachmark component
-   */
-  ariaLabel: PropTypes.string,
   /**
    * Provide the contents of the CoachmarkV2.
    */


### PR DESCRIPTION
Closes #

Add AVT tests for Composable Coachmark

#### What did you change? Add e2e/components/Coachmark/next/Coachmark-test.avt.e2e.js and fix accessibility violation thrown by removing `aria-label` from `div`

#### How did you test and verify your work? yarn avt e2e/components/Coachmark/next/Coachmark-test.avt.e2e.js

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
