### PR TITLE
fix: batch all storybook dependency upgrades using renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,5 +52,19 @@
       enabled: false,
       groupName: 'prevent major upgrades',
     },
+    {
+      groupName: 'storybook dependencies',
+      matchPackagePatterns: [
+        '^@storybook/',
+        '^storybook$', // exactly "storybook"
+        '^storybook-',
+      ],
+    },
+    {
+      matchPackageNames: ['storybook'],
+      matchUpdateTypes: ['major'],
+      enabled: false,
+      groupName: 'prevent major upgrade for storybook',
+    },
   ],
 }


### PR DESCRIPTION
Closes #7306 

upgrade any package that matches the pattern
Exclude major upgrade for storybook package

#### What did you change?
add config in rennovate.json
#### How did you test and verify your work?
We we closely watch the PR that opens for upgrading.

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
