### PR TITLE
fix: remove requiredIf props helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ package-lock.json
 
 # Playwright
 .playwright/
+blob-report/
 
 # Actions
 /actions/**/node_modules

--- a/packages/ibm-products/src/components/APIKeyModal/APIKeyModal.tsx
+++ b/packages/ibm-products/src/components/APIKeyModal/APIKeyModal.tsx
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2024
+// Copyright IBM Corp. 2021, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -35,9 +35,7 @@ import {
 import { APIKeyDownloader } from './APIKeyDownloader';
 import { pkg } from '../../settings';
 import { usePortalTarget } from '../../global/js/hooks/usePortalTarget';
-
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
-import { isRequiredIf } from '../../global/js/utils/props-helper';
 import uuidv4 from '../../global/js/utils/uuidv4';
 import { APIKeyModalProps } from './APIKeyModal.types';
 import { useFocus, usePreviousValue } from '../../global/js/hooks';
@@ -403,18 +401,6 @@ export let APIKeyModal: React.FC<APIKeyModalProps> = forwardRef(
   }
 );
 
-const customStepsRequiredProps = (type) =>
-  isRequiredIf(
-    type,
-    ({ customSteps }) => customSteps && customSteps.length > 1
-  );
-
-const editRequiredProps = (type) =>
-  isRequiredIf(type, ({ editing }) => editing);
-
-const downloadRequiredProps = (type) =>
-  isRequiredIf(type, ({ hasDownloadLink }) => hasDownloadLink);
-
 // Return a placeholder if not released and not enabled by feature flag
 APIKeyModal = pkg.checkComponentEnabled(APIKeyModal, componentName);
 
@@ -496,31 +482,31 @@ APIKeyModal.propTypes = {
   /**
    * designates the name of downloadable json file with the key. if not specified will default to 'apikey'
    */
-  downloadFileName: downloadRequiredProps(PropTypes.string),
+  downloadFileName: PropTypes.string,
   /**
    * designates the file type for the downloadable key
    */
-  downloadFileType: downloadRequiredProps(PropTypes.oneOf(['txt', 'json'])),
+  downloadFileType: PropTypes.oneOf(['txt', 'json']),
   /**
    * aria-label for the download link
    */
-  downloadLinkLabel: downloadRequiredProps(PropTypes.string),
+  downloadLinkLabel: PropTypes.string,
   /**
    * anchor text for the download link
    */
-  downloadLinkText: downloadRequiredProps(PropTypes.string),
+  downloadLinkText: PropTypes.string,
   /**
    * text for the edit button
    */
-  editButtonText: editRequiredProps(PropTypes.string),
+  editButtonText: PropTypes.string,
   /**
    * designates if the edit request was successful
    */
-  editSuccess: editRequiredProps(PropTypes.bool),
+  editSuccess: PropTypes.bool,
   /**
    * title for a successful edit
    */
-  editSuccessMessage: editRequiredProps(PropTypes.string),
+  editSuccessMessage: PropTypes.string,
   /**
    * designates if the modal is in the edit mode
    */
@@ -603,7 +589,7 @@ APIKeyModal.propTypes = {
   /**
    * text that displays in the primary button when using custom steps to indicate to the user that there is a next step
    */
-  nextStepButtonText: customStepsRequiredProps(PropTypes.string),
+  nextStepButtonText: PropTypes.string,
   /**
    * handler for on modal close
    */
@@ -632,7 +618,7 @@ APIKeyModal.propTypes = {
   /**
    * text that displays in the secondary button when using custom steps to indicate to the user that there is a previous step
    */
-  previousStepButtonText: customStepsRequiredProps(PropTypes.string),
+  previousStepButtonText: PropTypes.string,
   /**
    * label text that's displayed when hovering over visibility toggler to show key
    */

--- a/packages/ibm-products/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
+++ b/packages/ibm-products/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2023
+// Copyright IBM Corp. 2020, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -389,9 +389,7 @@ BreadcrumbWithOverflow.propTypes = {
       /**
        * A string based alternative to the children, required only if children is not of type string
        */
-      title: PropTypes.string.isRequired.if(
-        ({ label }) => typeof label !== 'string'
-      ),
+      title: PropTypes.string,
     })
   ),
   /**
@@ -413,9 +411,7 @@ BreadcrumbWithOverflow.propTypes = {
   /**
    * overflowAriaLabel label for open close button overflow used for breadcrumb items that do not fit.
    */
-  overflowAriaLabel: PropTypes.string.isRequired.if(
-    ({ breadcrumbs }) => breadcrumbs.length > 1
-  ),
+  overflowAriaLabel: PropTypes.string,
   /**
    * overflowTooltipAlign: align tooltip position
    */

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.tsx
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.tsx
@@ -25,10 +25,7 @@ import React, {
   ReactElement,
   isValidElement,
 } from 'react';
-import {
-  SimpleHeader,
-  overflowAriaLabel_required_if_breadcrumbs_exist,
-} from '../SimpleHeader/SimpleHeader';
+import { SimpleHeader } from '../SimpleHeader/SimpleHeader';
 import {
   useCreateComponentFocus,
   useCreateComponentStepChange,
@@ -504,7 +501,7 @@ CreateFullPage.propTypes = {
   /**
    * Label for open/close overflow button used for breadcrumb items that do not fit
    */
-  breadcrumbsOverflowAriaLabel: overflowAriaLabel_required_if_breadcrumbs_exist,
+  breadcrumbsOverflowAriaLabel: PropTypes.string,
 
   /**
    * The cancel button text

--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPageStep.tsx
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPageStep.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2023
+ * Copyright IBM Corp. 2021, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -295,9 +295,7 @@ CreateFullPageStep.propTypes = {
    * This is the legend text that appears above a fieldset html element for accessibility purposes. It is required when the optional `hasFieldset` prop is provided to a FullPageStep.
    */
   /**@ts-ignore */
-  fieldsetLegendText: PropTypes.string.isRequired.if(
-    ({ hasFieldset }) => hasFieldset === true
-  ),
+  fieldsetLegendText: PropTypes.string,
 
   /**
    * This optional prop will render your form content inside of a fieldset html element

--- a/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheetStep.tsx
+++ b/packages/ibm-products/src/components/CreateTearsheet/CreateTearsheetStep.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2023
+ * Copyright IBM Corp. 2021, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -398,9 +398,7 @@ CreateTearsheetStep.propTypes = {
    * This is the required legend id that appears as the aria-labelledby of fieldset for accessibility purposes.
    */
   /**@ts-ignore*/
-  fieldsetLegendId: PropTypes.node.isRequired.if(
-    ({ hasFieldset }) => !!hasFieldset
-  ),
+  fieldsetLegendId: PropTypes.node,
 
   /**
    * This is the required legend text that appears above a fieldset html element for accessibility purposes.
@@ -408,9 +406,7 @@ CreateTearsheetStep.propTypes = {
    * Otherwise, use CSS to hide/remove this label text.
    */
   /**@ts-ignore*/
-  fieldsetLegendText: PropTypes.string.isRequired.if(
-    ({ hasFieldset }) => !!hasFieldset
-  ),
+  fieldsetLegendText: PropTypes.string,
 
   /**
    * This optional prop will render your form content inside of a fieldset html element

--- a/packages/ibm-products/src/components/EditSidePanel/EditSidePanel.tsx
+++ b/packages/ibm-products/src/components/EditSidePanel/EditSidePanel.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -315,7 +315,7 @@ EditSidePanel.propTypes = {
    * This prop is required when using the `slideIn` variant of the side panel.
    */
   /**@ts-ignore*/
-  selectorPageContent: PropTypes.string.isRequired.if(({ slideIn }) => slideIn),
+  selectorPageContent: PropTypes.string,
 
   /**
    * Specifies which DOM element in the form should be focused.

--- a/packages/ibm-products/src/components/EditTearsheet/EditTearsheetForm.tsx
+++ b/packages/ibm-products/src/components/EditTearsheet/EditTearsheetForm.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -168,9 +168,7 @@ EditTearsheetForm.propTypes = {
    * This is the required legend id that appears as the aria-labelledby of fieldset for accessibility purposes.
    */
   /**@ts-ignore */
-  fieldsetLegendId: PropTypes.node.isRequired.if(
-    ({ hasFieldset }) => !!hasFieldset
-  ),
+  fieldsetLegendId: PropTypes.node,
 
   /**
    * This is the required legend text that appears above a fieldset html element for accessibility purposes.
@@ -178,9 +176,7 @@ EditTearsheetForm.propTypes = {
    * Otherwise, use CSS to hide/remove this label text.
    */
   /**@ts-ignore */
-  fieldsetLegendText: PropTypes.string.isRequired.if(
-    ({ hasFieldset }) => !!hasFieldset
-  ),
+  fieldsetLegendText: PropTypes.string,
 
   /**
    * This optional prop will render your form content inside of a fieldset html element

--- a/packages/ibm-products/src/components/EmptyStates/EmptyState.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyState.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -199,9 +199,7 @@ EmptyState.propTypes = {
    * The alt text for custom provided illustrations
    */
   /**@ts-ignore*/
-  illustrationDescription: PropTypes.string.isRequired.if(
-    ({ illustration }) => illustration
-  ),
+  illustrationDescription: PropTypes.string,
 
   /**
    * Designates the position of the illustration relative to the content

--- a/packages/ibm-products/src/components/PageHeader/PageHeader.tsx
+++ b/packages/ibm-products/src/components/PageHeader/PageHeader.tsx
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -29,7 +29,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { TagSet, string_required_if_more_than_10_tags } from '../TagSet/TagSet';
+import { TagSet } from '../TagSet/TagSet';
 import { baseFontSize, spacing } from '@carbon/layout';
 import {
   blockClass,
@@ -242,14 +242,14 @@ interface TitleIcon {
   loading?: boolean;
 
   // inline edit version properties
-  editableLabel?: string; // .isRequired.if(editInPlaceRequired),
-  id?: string; // .isRequired.if(editInPlaceRequired),
+  editableLabel?: string;
+  id?: string;
   onCancel?: () => void;
   onChange?: () => void;
   onSave?: () => void;
-  cancelDescription?: string; //.isRequired.if(editInPlaceRequired),
-  editDescription?: string; // .isRequired.if(editInPlaceRequired),
-  saveDescription?: string; //.isRequired.if(editInPlaceRequired),
+  cancelDescription?: string;
+  editDescription?: string;
+  saveDescription?: string;
   tooltipAlignment?:
     | 'top'
     | 'top-left'
@@ -850,8 +850,6 @@ export let PageHeader = React.forwardRef(
 
     useEffect(() => {
       // only has toggle if requested and withoutBackground is unset/falsy
-      // NOTE: prop-types isRequired.if for the expand and collapse
-      // icon descriptions depends on the this.
       setHasCollapseButton(
         (hasCollapseHeaderToggle && !withoutBackground) || false
       );
@@ -1332,9 +1330,7 @@ PageHeader.propTypes = {
    * NOTE: This prop is required if actionBarItems are supplied
    */
   /**@ts-ignore */
-  actionBarOverflowAriaLabel: PropTypes.string.isRequired.if(
-    ({ actionBarItems }) => actionBarItems && actionBarItems.length > 0
-  ),
+  actionBarOverflowAriaLabel: PropTypes.string,
   /**
    * When tags are supplied there may not be sufficient space to display all of the tags. This results in an overflow
    * menu being shown. If in the overflow menu there is still insufficient space this label is used in a dialog showing
@@ -1342,7 +1338,7 @@ PageHeader.propTypes = {
    *
    * **Note: Required if more than 10 tags**
    */
-  allTagsModalSearchLabel: string_required_if_more_than_10_tags,
+  allTagsModalSearchLabel: PropTypes.string,
   /**
    * When tags are supplied there may not be sufficient space to display all of the tags. This results in an overflow
    * menu being shown. If in the overflow menu there is still insufficient space this placeholder is used in a dialog
@@ -1350,7 +1346,7 @@ PageHeader.propTypes = {
    *
    * **Note: Required if more than 10 tags**
    */
-  allTagsModalSearchPlaceholderText: string_required_if_more_than_10_tags,
+  allTagsModalSearchPlaceholderText: PropTypes.string,
   /**
    * When tags are supplied there may not be sufficient space to display all of the tags. This results in an overflow
    * menu being shown. If in the overflow menu there is still insufficient space this title is used in a dialog showing
@@ -1358,15 +1354,13 @@ PageHeader.propTypes = {
    *
    * **Note: Required if more than 10 tags**
    */
-  allTagsModalTitle: string_required_if_more_than_10_tags,
+  allTagsModalTitle: PropTypes.string,
   /**
    * If the user supplies breadcrumbs then this property is required.
    * It is used in an overflow menu when there is insufficient space to display all breadcrumbs inline.
    */
   /**@ts-ignore */
-  breadcrumbOverflowAriaLabel: PropTypes.string.isRequired.if(
-    ({ breadcrumbs }) => breadcrumbs && breadcrumbs.length > 0
-  ),
+  breadcrumbOverflowAriaLabel: PropTypes.string,
   /**
    * align breadcrumb overflow tooltip
    */
@@ -1409,9 +1403,7 @@ PageHeader.propTypes = {
        * A text version of the `label` for display, required if `label` is not a string.
        */
       /**@ts-ignore */
-      title: PropTypes.string.isRequired.if(
-        ({ label }) => typeof label !== 'string'
-      ),
+      title: PropTypes.string,
     })
   ),
   /**
@@ -1437,10 +1429,7 @@ PageHeader.propTypes = {
    * required for both the expend and collapse states of the button component used.
    */
   /**@ts-ignore */
-  collapseHeaderIconDescription: PropTypes.string.isRequired.if(
-    ({ withoutBackground, hasCollapseHeaderToggle }) =>
-      !withoutBackground && hasCollapseHeaderToggle
-  ),
+  collapseHeaderIconDescription: PropTypes.string,
   /**
    * The title row typically starts below the breadcrumb row. This option
    * preCollapses it into the breadcrumb row.
@@ -1456,10 +1445,7 @@ PageHeader.propTypes = {
    * required for both the expend and collapse states of the button component used.
    */
   /**@ts-ignore */
-  expandHeaderIconDescription: PropTypes.string.isRequired.if(
-    ({ withoutBackground, hasCollapseHeaderToggle }) =>
-      !withoutBackground && hasCollapseHeaderToggle
-  ),
+  expandHeaderIconDescription: PropTypes.string,
   /**
    * The PageHeader is hosted in a Carbon grid, this value is passed through to the Carbon grid fullWidth prop.
    * 'xl' is used to override the grid width setting. Can be used with narrowGrid: true to get the largest size.
@@ -1533,10 +1519,7 @@ PageHeader.propTypes = {
    * NOTE: This prop is required if pageActions are supplied
    */
   /**@ts-ignore */
-  pageActionsOverflowLabel: PropTypes.node.isRequired.if(
-    ({ pageActions }) =>
-      pageActions && pageActions.length > 0 && !pageActions.content
-  ),
+  pageActionsOverflowLabel: PropTypes.node,
   /**
    * When tags are supplied there may not be sufficient space to display all of the tags. This results in an overflow
    * menu being shown. If in the overflow menu there is still insufficient space this label is used to offer a
@@ -1544,7 +1527,7 @@ PageHeader.propTypes = {
    *
    * **Note: Required if more than 10 tags**
    */
-  showAllTagsLabel: string_required_if_more_than_10_tags,
+  showAllTagsLabel: PropTypes.string,
   /**
    * Sitting just below the title is this optional subtitle that provides additional context to
    * identify the current page.
@@ -1603,14 +1586,14 @@ PageHeader.propTypes = {
       loading: PropTypes.bool,
 
       // inline edit version properties
-      editableLabel: PropTypes.string, // .isRequired.if(editInPlaceRequired),
-      id: PropTypes.string, // .isRequired.if(editInPlaceRequired),
+      editableLabel: PropTypes.string,
+      id: PropTypes.string,
       onCancel: PropTypes.func,
       onChange: PropTypes.func,
       onSave: PropTypes.func,
-      cancelDescription: PropTypes.string, //.isRequired.if(editInPlaceRequired),
-      editDescription: PropTypes.string, // .isRequired.if(editInPlaceRequired),
-      saveDescription: PropTypes.string, //.isRequired.if(editInPlaceRequired),
+      cancelDescription: PropTypes.string,
+      editDescription: PropTypes.string,
+      saveDescription: PropTypes.string,
       tooltipAlignment: PropTypes.oneOf([
         'top',
         'top-left',

--- a/packages/ibm-products/src/components/PageHeader/PageHeaderTitle.js
+++ b/packages/ibm-products/src/components/PageHeader/PageHeaderTitle.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -151,13 +151,13 @@ PageHeaderTitle.propTypes = {
       loading: PropTypes.bool,
 
       // inline edit version properties
-      editDescription: PropTypes.string.isRequired.if(editInPlaceRequired),
-      editableLabel: PropTypes.string.isRequired.if(editInPlaceRequired),
-      id: PropTypes.string.isRequired.if(editInPlaceRequired),
+      editDescription: PropTypes.string,
+      editableLabel: PropTypes.string,
+      id: PropTypes.string,
       onChange: PropTypes.func,
       onSave: PropTypes.func,
-      cancelDescription: PropTypes.string.isRequired.if(editInPlaceRequired),
-      saveDescription: PropTypes.string.isRequired.if(editInPlaceRequired),
+      cancelDescription: PropTypes.string,
+      saveDescription: PropTypes.string,
       tooltipAlignment: PropTypes.oneOf([
         'top',
         'top-left',

--- a/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
@@ -1260,7 +1260,7 @@ SidePanel.propTypes = {
    * This prop is required when using the `slideIn` variant of the side panel.
    */
   /**@ts-ignore*/
-  selectorPageContent: PropTypes.string.isRequired.if(({ slideIn }) => slideIn),
+  selectorPageContent: PropTypes.string,
 
   /**
    * Specify a CSS selector that matches the DOM element that should
@@ -1290,7 +1290,7 @@ SidePanel.propTypes = {
    * Sets the title text
    */
   /**@ts-ignore*/
-  title: PropTypes.string.isRequired.if(({ labelText }) => labelText),
+  title: PropTypes.string,
 
   ...deprecatedProps,
 };

--- a/packages/ibm-products/src/components/SimpleHeader/SimpleHeader.js
+++ b/packages/ibm-products/src/components/SimpleHeader/SimpleHeader.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2023, 2023
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,7 +12,6 @@ import cx from 'classnames';
 import { pkg } from '../../settings';
 import pconsole from '../../global/js/utils/pconsole';
 import { BreadcrumbWithOverflow } from '../BreadcrumbWithOverflow';
-import { isRequiredIf } from '../../global/js/utils/props-helper';
 import { Tooltip, Heading } from '@carbon/react';
 
 const blockClass = `${pkg.prefix}--simple-header`;
@@ -70,11 +69,6 @@ const SimpleHeader = ({
   );
 };
 
-export const overflowAriaLabel_required_if_breadcrumbs_exist = isRequiredIf(
-  PropTypes.string,
-  (props) => props.breadcrumbs?.length > 0
-);
-
 SimpleHeader.propTypes = {
   /** Header breadcrumbs */
   breadcrumbs: PropTypes.arrayOf(
@@ -102,7 +96,7 @@ SimpleHeader.propTypes = {
   noTrailingSlash: PropTypes.bool,
 
   /** Label for open/close overflow button used for breadcrumb items that do not fit */
-  overflowAriaLabel: overflowAriaLabel_required_if_breadcrumbs_exist,
+  overflowAriaLabel: PropTypes.string,
 
   /**
    * overflowTooltipAlign: align tooltip position

--- a/packages/ibm-products/src/components/TagOverflow/TagOverflow.tsx
+++ b/packages/ibm-products/src/components/TagOverflow/TagOverflow.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -22,7 +22,6 @@ import { TagOverflowModal } from './TagOverflowModal';
 import { TagOverflowPopover } from './TagOverflowPopover';
 import cx from 'classnames';
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
-import { isRequiredIf } from '../../global/js/utils/props-helper';
 import { pkg } from '../../settings';
 import { useOverflowItems } from '../../global/js/hooks/useOverflowItems';
 export interface TagOverflowItem {
@@ -258,15 +257,6 @@ TagOverflow.displayName = componentName;
 
 const tagTypes = Object.keys(TYPES);
 
-/**
- * The strings shown in the showAllModal are only shown if we have more than allTagsModalSearchLThreshold
- * @returns null if no problems
- */
-export const string_required_if_more_than_10_tags = isRequiredIf(
-  PropTypes.string,
-  ({ items }) => items?.length > allTagsModalSearchThreshold
-);
-
 // The types and DocGen commentary for the component props,
 // in alphabetical order (for consistency).
 // See https://www.npmjs.com/package/prop-types#usage.
@@ -282,11 +272,11 @@ TagOverflow.propTypes = {
   /**
    * label text for the show all search. **Note: Required if more than 10 tags**
    */
-  allTagsModalSearchLabel: string_required_if_more_than_10_tags,
+  allTagsModalSearchLabel: PropTypes.string,
   /**
    * placeholder text for the show all search. **Note: Required if more than 10 tags**
    */
-  allTagsModalSearchPlaceholderText: string_required_if_more_than_10_tags,
+  allTagsModalSearchPlaceholderText: PropTypes.string,
   /**
    * portal target for the all tags modal
    */
@@ -294,7 +284,7 @@ TagOverflow.propTypes = {
   /**
    * title for the show all modal. **Note: Required if more than 10 tags**
    */
-  allTagsModalTitle: string_required_if_more_than_10_tags,
+  allTagsModalTitle: PropTypes.string,
   /**
    * Will auto-align the popover on first render if it is not visible. This prop is currently experimental and is subject to future changes.
    */
@@ -368,7 +358,7 @@ TagOverflow.propTypes = {
    *
    * **Note:** Required if more than 10 tags
    */
-  showAllTagsLabel: string_required_if_more_than_10_tags,
+  showAllTagsLabel: PropTypes.string,
   /** Component definition of the items to be rendered inside TagOverflow.
    * If this is not passed, items will be rendered as Tag component
    */

--- a/packages/ibm-products/src/components/TagSet/TagSet.tsx
+++ b/packages/ibm-products/src/components/TagSet/TagSet.tsx
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2024
+// Copyright IBM Corp. 2020, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -23,7 +23,6 @@ import { TagSetModal } from './TagSetModal';
 import { TagSetOverflow } from './TagSetOverflow';
 import cx from 'classnames';
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
-import { isRequiredIf } from '../../global/js/utils/props-helper';
 import { pkg } from '../../settings';
 import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 import { DismissibleTag } from '@carbon/react';
@@ -472,15 +471,6 @@ export let TagSet = React.forwardRef<HTMLDivElement, TagSetProps>(
 
 // Return a placeholder if not released and not enabled by feature flag
 TagSet = pkg.checkComponentEnabled(TagSet, componentName);
-
-/**
- * The strings shown in the showAllModal are only shown if we have more than allTagsModalSearchLThreshold
- * @returns null if no problems
- */
-export const string_required_if_more_than_10_tags = isRequiredIf(
-  PropTypes.string,
-  ({ tags }) => tags && tags.length > allTagsModalSearchThreshold
-);
 
 // copied from carbon-components-react/src/components/Tag/Tag.js for DocGen
 const TYPES = {

--- a/packages/ibm-products/src/components/UserAvatar/UserAvatar.tsx
+++ b/packages/ibm-products/src/components/UserAvatar/UserAvatar.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -245,7 +245,7 @@ UserAvatar.propTypes = {
    * When passing the image prop use the imageDescription prop to describe the image for screen reader.
    */
   /**@ts-ignore */
-  imageDescription: PropTypes.string.isRequired.if(({ image }) => !!image),
+  imageDescription: PropTypes.string,
   /**
    * When passing the name prop, either send the initials to be used or the user's full name. The first two capital letters of the user's name will be used as the name.
    */

--- a/packages/ibm-products/src/components/UserProfileImage/UserProfileImage.tsx
+++ b/packages/ibm-products/src/components/UserProfileImage/UserProfileImage.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -274,7 +274,7 @@ UserProfileImage.propTypes = {
    * When passing the image prop use the imageDescription prop to describe the image for screen reader.
    */
   /**@ts-ignore */
-  imageDescription: PropTypes.string.isRequired.if(({ image }) => !!image),
+  imageDescription: PropTypes.string,
 
   /**
    * When passing the initials prop, either send the initials to be used or the user's display name. The first two capital letters of the display name will be used as the initials.

--- a/packages/ibm-products/src/global/js/utils/props-helper.test.js
+++ b/packages/ibm-products/src/global/js/utils/props-helper.test.js
@@ -1,21 +1,10 @@
 //
-// Copyright IBM Corp. 2021, 2021
+// Copyright IBM Corp. 2021, 2025
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-
-import React from 'react';
-import PropTypes from 'prop-types';
-import { render } from '@testing-library/react';
-
-import {
-  prepareProps,
-  allPropTypes,
-  deprecateProp,
-  deprecatePropUsage,
-  isRequiredIf,
-} from './props-helper';
+import { prepareProps, allPropTypes, deprecateProp } from './props-helper';
 
 describe('prepareProps', () => {
   const defaults = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8 };
@@ -61,30 +50,6 @@ describe('prepareProps', () => {
   });
 });
 
-describe('deprecateProp and deprecatePropUsage', () => {
-  const Component = () => null;
-  Component.displayName = 'x';
-  Component.propTypes = {
-    a: deprecateProp(PropTypes.string, 'Explanation 1.'),
-    b: PropTypes.string,
-    c: deprecatePropUsage(
-      PropTypes.shape({
-        d: PropTypes.string,
-      }),
-      PropTypes.number,
-      'Explanation 2.'
-    ),
-  };
-
-  it('does not report prop deprecated when non-deprecated prop is used', () => {
-    render(<Component b="fish" />);
-  });
-
-  it('does not report prop usage deprecated when non-deprecated usage is used', async () => {
-    render(<Component c={{ d: 'fish' }} />);
-  });
-});
-
 describe('allPropTypes', () => {
   const e1 = new Error();
   const e2 = new Error(
@@ -121,19 +86,5 @@ describe('allPropTypes', () => {
     expect(allPropTypes([p, p, p, p]).isRequired(...args1)).toBeNull();
     expect(allPropTypes([p, p, p, p]).isRequired(...args2)).toEqual(e2);
     expect(allPropTypes([f, f, f, f]).isRequired(...args3)).toEqual(e3);
-  });
-});
-
-describe('isRequiredIf', () => {
-  const Component = () => null;
-  Component.propTypes = {
-    a: isRequiredIf(PropTypes.string, ({ ctl }) => ctl === 'a'),
-    b: PropTypes.string.isRequired.if(({ ctl }) => ctl === 'b'),
-    ctl: PropTypes.string,
-  };
-
-  it('does not report required when condition false', async () => {
-    // any console error will cause the test to fail through global check
-    render(<Component ctl="x" />);
   });
 });


### PR DESCRIPTION
Closes #7793 

removes various props validation helper functions that specified if certain props are required based on the condition of other props. this will also aid in our overall effort to improve composability by removing some of the more restrictive safety nets that have been implemented over the years.

#### How did you test and verify your work?

`yarn test:c4p`
`yarn avt`
`yarn build`

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~~Updated documentation and storybook examples~~
- [ ] ~~Wrote passing tests that cover this change~~
- [ ] ~~Addressed any impact on accessibility (a11y)~~
- [ ] ~~Tested for cross-browser consistency~~
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
