### PR TITLE
build(web-components): do not include story styles in build output

### DIFF
--- a/packages/ibm-products-web-components/tasks/build.js
+++ b/packages/ibm-products-web-components/tasks/build.js
@@ -125,7 +125,13 @@ function getRollupConfig(input, rootDir, outDir, iconInput) {
         entries: [{ find: /^(.*)\.scss\?lit$/, replacement: '$1.scss' }],
       }),
       copy({
-        targets: [{ src: 'src/components/**/*.scss', dest: 'scss' }],
+        targets: [
+          {
+            src: 'src/components/**/*.scss',
+            dest: 'scss',
+            ignore: 'src/components/**/story-styles.scss',
+          },
+        ],
         flatten: false,
       }),
       [json()],


### PR DESCRIPTION
Closes #8064 

This change no longer includes the story styles in the build output for the web components package.

#### What did you change?
```
packages/ibm-products-web-components/tasks/build.js
```
#### How did you test and verify your work?
Manually ran build script for web components package
#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
