### PR TITLE
fix(coachmark): resolved circular dependency

### DIFF
--- a/packages/ibm-products/src/components/Coachmark/next/Coachmark/Coachmark.tsx
+++ b/packages/ibm-products/src/components/Coachmark/next/Coachmark/Coachmark.tsx
@@ -22,13 +22,13 @@ import React, {
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { getDevtoolsProps } from '../../../../global/js/utils/devtools';
-import { pkg } from '../../../../settings';
+import { CoachmarkContext, blockClass } from './context';
 import CoachmarkContent, { CoachmarkContentProps } from './CoachmarkContent';
 import { NewPopoverAlignment } from '@carbon/react';
 import { useIsomorphicEffect } from '../../../../global/js/hooks';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
-export const blockClass = `${pkg.prefix}--coachmark__next`;
+
 const componentName = 'Coachmark';
 
 // NOTE: the component SCSS is not imported here: it is rolled up separately.
@@ -80,28 +80,7 @@ export type CoachmarkComponent = ForwardRefExoticComponent<
 > & {
   Content: FC<CoachmarkContentProps>;
 };
-interface CoachmarkContextType {
-  onClose?: () => void;
-  open?: boolean;
-  setOpen: (value: boolean) => void;
-  align?: NewPopoverAlignment;
-  triggerRef: RefObject<HTMLElement | null>;
-  position: { x: number; y: number };
-  contentRef: HTMLElement | null;
-  setContentRef: (value: any) => void;
-  floating?: boolean;
-}
 
-export const CoachmarkContext = createContext<CoachmarkContextType>({
-  open: false,
-  setOpen: () => {},
-  align: 'bottom',
-  triggerRef: { current: null },
-  position: { x: 0, y: 0 },
-  contentRef: null,
-  setContentRef: (value: boolean) => {},
-  floating: false,
-});
 /**
  * Coachmarks are used to call out specific functionality or concepts
  * within the UI that may not be intuitive but are important for the

--- a/packages/ibm-products/src/components/Coachmark/next/Coachmark/CoachmarkContent.tsx
+++ b/packages/ibm-products/src/components/Coachmark/next/Coachmark/CoachmarkContent.tsx
@@ -17,7 +17,7 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import { pkg } from '../../../../settings';
-import { blockClass, CoachmarkContext } from './Coachmark';
+import { blockClass, CoachmarkContext } from './context';
 import { CoachmarkBubble } from './CoachmarkBubble';
 import ContentHeader, { ContentHeaderProps } from './ContentHeader';
 import ContentBody, { ContentBodyProps } from './ContentBody';

--- a/packages/ibm-products/src/components/Coachmark/next/Coachmark/ContentBody.tsx
+++ b/packages/ibm-products/src/components/Coachmark/next/Coachmark/ContentBody.tsx
@@ -8,7 +8,7 @@
 import React, { forwardRef, ReactNode } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { blockClass } from './Coachmark';
+import { blockClass } from './context';
 
 export interface ContentBodyProps {
   /**

--- a/packages/ibm-products/src/components/Coachmark/next/Coachmark/ContentHeader.tsx
+++ b/packages/ibm-products/src/components/Coachmark/next/Coachmark/ContentHeader.tsx
@@ -13,7 +13,7 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { blockClass, CoachmarkContext } from './Coachmark';
+import { blockClass, CoachmarkContext } from './context';
 import { CoachmarkBubbleHeader } from './CoachmarkBubble';
 import { Close, Draggable } from '@carbon/react/icons';
 import { makeDraggable } from '../../../../global/js/utils/makeDraggable';

--- a/packages/ibm-products/src/components/Coachmark/next/Coachmark/context.ts
+++ b/packages/ibm-products/src/components/Coachmark/next/Coachmark/context.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright IBM Corp. 2025
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { createContext, RefObject } from 'react';
+import { pkg } from '../../../../settings';
+import { NewPopoverAlignment } from '@carbon/react';
+
+interface CoachmarkContextType {
+  onClose?: () => void;
+  open?: boolean;
+  setOpen: (value: boolean) => void;
+  align?: NewPopoverAlignment;
+  triggerRef: RefObject<HTMLElement | null>;
+  position: { x: number; y: number };
+  contentRef: HTMLElement | null;
+  setContentRef: (value: any) => void;
+  floating?: boolean;
+}
+
+export const CoachmarkContext = createContext<CoachmarkContextType>({
+  open: false,
+  setOpen: () => {},
+  align: 'bottom',
+  triggerRef: { current: null },
+  position: { x: 0, y: 0 },
+  contentRef: null,
+  setContentRef: (value: boolean) => {},
+  floating: false,
+});
+
+export const blockClass = `${pkg.prefix}--coachmark__next`;


### PR DESCRIPTION
Closes #7982 

Fixed circular dependency caused by packages/ibm-products/src/components/Coachmark/next/Coachmark

#### What did you change? 

Context is separated from components by creating a Context.ts file
packages/ibm-products/src/components/Coachmark/next/Coachmark/context.ts

Modified
packages/ibm-products/src/components/Coachmark/next/Coachmark/Coachmark.tsx
packages/ibm-products/src/components/Coachmark/next/Coachmark/CoachmarkContent.tsx
packages/ibm-products/src/components/Coachmark/next/Coachmark/ContentBody.tsx
packages/ibm-products/src/components/Coachmark/next/Coachmark/ContentHeader.tsx

#### How did you test and verify your work? yarn build

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
