### PR TITLE
fix(SidePanel): unable to find a feature flag with the name: 'enableSidepanelResizer'

### DIFF
--- a/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
@@ -6,6 +6,7 @@
  */
 
 import { ArrowLeft, Close } from '@carbon/react/icons';
+import '../../feature-flags';
 // Carbon and package components we use.
 import {
   Button,


### PR DESCRIPTION
Closes #7969 

We had a [similar issue](https://github.com/carbon-design-system/ibm-products/pull/5516/files) in the past which put the same fix. 
Merging with carbon flag is happening in f`eature-flags.js`.



#### How did you test and verify your work?

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
