### PR TITLE
fix(release): build storybook first before running avt report

### DIFF
--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Install browsers
         run: yarn playwright install --with-deps
 
+      - name: Continuous integration check (includes build)
+        run: yarn ci-check
+
       - name: Run storybook
         id: storybook
         run: |
@@ -98,9 +101,6 @@ jobs:
         with:
           name: playwright-avt-report
           path: .playwright
-
-      - name: Continuous integration check (includes build)
-        run: yarn ci-check
 
       - name: Set NPM token
         run: |


### PR DESCRIPTION
This should fix the issue we're seeing during today's release action. Our storybook needs to build/create the `storybook-static` directory before we're able to startup the server to produce the avt report.

#### What did you change?
```
.github/workflows/release-base.yml
```
#### How did you test and verify your work?

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
