### PR TITLE
chore(release): remove avt script temporarily

### DIFF
--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -74,34 +74,34 @@ jobs:
           fi
 
       # For generating playwright json report for avt tests
-      - name: Install browsers
-        run: yarn playwright install --with-deps
+      # - name: Install browsers
+      #   run: yarn playwright install --with-deps
 
       - name: Continuous integration check (includes build)
         run: yarn ci-check
 
-      - name: Run storybook
-        id: storybook
-        run: |
-          npx serve -l 3000 packages/ibm-products/storybook-static &
-          pid=$!
-          echo "pid=$pid" >> $GITHUB_OUTPUT
-      - uses: ./actions/wait-for-it
-        with:
-          URL: 'http://localhost:3000'
-        timeout-minutes: 3
-      - name: Run AVT
-        if: github.repository == 'carbon-design-system/ibm-products'
-        run: |
-          yarn playwright test --project chromium --grep @avt --shard="${{ matrix.shardIndex }}/${{ matrix.shardTotal }}"
-      - name: Stop storybook
-        run: kill ${{ steps.storybook.outputs.pid }}
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: playwright-avt-report
-          path: .playwright
+      # - name: Run storybook
+      #   id: storybook
+      #   run: |
+      #     npx serve -l 3000 packages/ibm-products/storybook-static &
+      #     pid=$!
+      #     echo "pid=$pid" >> $GITHUB_OUTPUT
+      # - uses: ./actions/wait-for-it
+      #   with:
+      #     URL: 'http://localhost:3000'
+      #   timeout-minutes: 3
+      # - name: Run AVT
+      #   if: github.repository == 'carbon-design-system/ibm-products'
+      #   run: |
+      #     yarn playwright test --project chromium --grep @avt --shard="${{ matrix.shardIndex }}/${{ matrix.shardTotal }}"
+      # - name: Stop storybook
+      #   run: kill ${{ steps.storybook.outputs.pid }}
+      # - name: Upload test results
+      #   if: always()
+      #   uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      #   with:
+      #     name: playwright-avt-report
+      #     path: .playwright
 
       - name: Set NPM token
         run: |

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -92,7 +92,8 @@ jobs:
         timeout-minutes: 3
       - name: Run AVT
         if: github.repository == 'carbon-design-system/ibm-products'
-        run: yarn avt
+        run: |
+          yarn playwright test --project chromium --grep @avt --shard="${{ matrix.shardIndex }}/${{ matrix.shardTotal }}"
       - name: Stop storybook
         run: kill ${{ steps.storybook.outputs.pid }}
       - name: Upload test results


### PR DESCRIPTION
Removes the avt setup from within the release action for now. It is timing out since it's not run as a matrix like it is from within our `ci.yml` workflow.

#### What did you change?
```
.github/workflows/release-base.yml
```
#### How did you test and verify your work?

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
