### PR TITLE
fix(tagset): restore operational tag styles

### DIFF
--- a/packages/ibm-products-styles/src/components/TagSet/_tag-set.scss
+++ b/packages/ibm-products-styles/src/components/TagSet/_tag-set.scss
@@ -102,12 +102,6 @@ $block-class-modal: #{$_block-class}-modal;
     text-align: start;
   }
 
-  .#{$block-class-overflow}__popover-trigger {
-    /* stylelint-disable-next-line declaration-no-important */
-    border: none !important;
-    font-family: inherit;
-  }
-
   .#{$block-class-overflow}__show-all-tags-link.#{$carbon-prefix}--link:visited {
     display: inline-block;
     margin: $spacing-03 0 $spacing-02; // to match the tags


### PR DESCRIPTION
Closes #8102 

Removes style overrides

#### What did you change?

packages/ibm-products-styles/src/components/TagSet/_tag-set.scss

#### How did you test and verify your work?

Storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
