### PR TITLE
feat(PageHeader): add compact story, fix preview styles in storybook docs page

### DIFF
--- a/packages/ibm-products/src/components/PageHeader/next/PageHeader.stories.js
+++ b/packages/ibm-products/src/components/PageHeader/next/PageHeader.stories.js
@@ -74,7 +74,7 @@ const tags = [
 ];
 
 export default {
-  title: 'Experimental/Patterns/PageHeader',
+  title: 'Experimental/PageHeader',
   component: PageHeader,
   subcomponents: {
     PageHeaderBreadcrumbBar,
@@ -585,6 +585,86 @@ export const TabBarWithTabsAndTags = (args) => (
         </PageHeader.ContentText>
       </PageHeader.Content>
       <PageHeader.TabBar tags={tags} scroller={<PageHeader.ScrollButton />}>
+        <TabList>
+          <Tab>Tab 1</Tab>
+          <Tab>Tab 2</Tab>
+          <Tab>Tab 3</Tab>
+          <Tab>Tab 4</Tab>
+          <Tab>Tab 5</Tab>
+          <Tab>Tab 6</Tab>
+          <Tab>Tab 7</Tab>
+        </TabList>
+      </PageHeader.TabBar>
+    </PageHeader.Root>
+    <TabPanels>
+      <TabPanel className="page-header-story--tall-tab-panel">
+        Tab Panel 1
+      </TabPanel>
+      <TabPanel className="page-header-story--tall-tab-panel">
+        Tab Panel 2
+      </TabPanel>
+      <TabPanel className="page-header-story--tall-tab-panel">
+        Tab Panel 3
+      </TabPanel>
+      <TabPanel className="page-header-story--tall-tab-panel">
+        Tab Panel 4
+      </TabPanel>
+      <TabPanel className="page-header-story--tall-tab-panel">
+        Tab Panel 5
+      </TabPanel>
+      <TabPanel className="page-header-story--tall-tab-panel">
+        Tab Panel 6
+      </TabPanel>
+      <TabPanel className="page-header-story--tall-tab-panel">
+        Tab Panel 7
+      </TabPanel>
+    </TabPanels>
+  </Tabs>
+);
+
+export const Compact = (args) => (
+  <Tabs>
+    <PageHeader.Root>
+      <PageHeader.BreadcrumbBar
+        border={args.border}
+        pageActionsFlush={args.pageActionsFlush}
+        contentActionsFlush={args.contentActionsFlush}
+        renderIcon={args.renderBreadcrumbIcon ? BreadcrumbBeeIcon : null}
+        pageActions={breadcrumbPageActions}
+        contentActions={
+          <PageHeader.ContentPageActions
+            menuButtonLabel="Actions"
+            actions={pageActionButtonItems}
+          />
+        }
+      >
+        <PageHeader.BreadcrumbOverflow
+          renderOverflowBreadcrumb={(hiddenItems) => (
+            <BreadcrumbItem data-floating-menu-container>
+              <OverflowMenu
+                align="bottom"
+                aria-label="Overflow menu in a breadcrumb"
+              >
+                {hiddenItems.map((el) => (
+                  <OverflowMenuItem itemText={el.innerText} />
+                ))}
+              </OverflowMenu>
+            </BreadcrumbItem>
+          )}
+        >
+          <BreadcrumbItem href="/#">Breadcrumb 1</BreadcrumbItem>
+          <BreadcrumbItem href="/#">Breadcrumb 2</BreadcrumbItem>
+          <BreadcrumbItem href="/#">Breadcrumb 3</BreadcrumbItem>
+          <PageHeader.TitleBreadcrumb data-fixed>
+            <TruncatedText
+              value="Virtual-Machine-DAL-really-long-title-example"
+              align="bottom"
+              lines={1}
+            />
+          </PageHeader.TitleBreadcrumb>
+        </PageHeader.BreadcrumbOverflow>
+      </PageHeader.BreadcrumbBar>
+      <PageHeader.TabBar tags={tags}>
         <TabList>
           <Tab>Tab 1</Tab>
           <Tab>Tab 2</Tab>

--- a/packages/ibm-products/src/components/PageHeader/next/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/PageHeader/next/_storybook-styles.scss
@@ -18,8 +18,12 @@
   height: 200vh;
 }
 
-.page-header--docs-demo .docs-story div:first-child {
+.page-header--docs-demo .docs-story > div:first-child {
   padding: 0;
+}
+
+.page-header--docs-demo .docs-story > div > div:first-child {
+  inline-size: 100%;
 }
 
 .page-header--docs-demo .innerZoomElementWrapper > * {

--- a/packages/ibm-products/src/components/PageHeader/next/_storybook-styles.scss
+++ b/packages/ibm-products/src/components/PageHeader/next/_storybook-styles.scss
@@ -7,6 +7,9 @@
 
 @use '@carbon/react/scss/spacing';
 @use '@carbon/styles/scss/theme';
+@use 'ALIAS_STORY_STYLE_CONFIG' as c4p-settings;
+
+$block-class: #{c4p-settings.$pkg-prefix}--page-header;
 
 .page-header-story-wrapper {
   margin-block-start: spacing.$spacing-09;
@@ -51,5 +54,16 @@
 
 .breadcrumb-bar-action-button {
   align-items: center;
+  block-size: 40px;
+}
+
+// Fixes style issues in storybook docs page
+.page-header--docs-demo
+  .#{$block-class}__breadcrumb-bar
+  .#{c4p-settings.$carbon-prefix}--css-grid
+  .#{c4p-settings.$carbon-prefix}--css-grid-column,
+.page-header--docs-demo
+  .#{$block-class}__breadcrumb-bar
+  .#{$block-class}__breadcrumb__actions {
   block-size: 40px;
 }


### PR DESCRIPTION
Closes #8119 

Adds a `compact` story for new page header, no new changes needed to implement this, you just exclude the `PageHeader.Content` component and only use `PageHeader.BreadcrumbBar` and `PageHeader.TabBar`.

I also addressed an issue with how the preview was displaying from the doc page and moved the component from `Experimental/Patterns/PageHeader` to `Experimental/PageHeader` since we're classifying compound components as components, rather than patterns.

#### What did you change?
```
packages/ibm-products/src/components/PageHeader/next/PageHeader.stories.js
packages/ibm-products/src/components/PageHeader/next/_storybook-styles.scss
```
#### How did you test and verify your work?
Storybook
#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
