### PR TITLE
fix(telemetry): bump version

### DIFF
--- a/packages/ibm-products-web-components/package.json
+++ b/packages/ibm-products-web-components/package.json
@@ -59,7 +59,7 @@
     "@carbon/ibm-products-styles": "^2.70.0",
     "@carbon/styles": "1.89.0",
     "@carbon/web-components": "2.37.0",
-    "@ibm/telemetry-js": "^1.10.1",
+    "@ibm/telemetry-js": "^1.10.2",
     "@lit-labs/signals": "^0.1.2",
     "@lit/context": "^1.1.5",
     "lit": "^3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1944,7 +1944,7 @@ __metadata:
     "@carbon/motion": "npm:^11.34.0"
     "@carbon/styles": "npm:1.89.0"
     "@carbon/web-components": "npm:2.37.0"
-    "@ibm/telemetry-js": "npm:^1.10.1"
+    "@ibm/telemetry-js": "npm:^1.10.2"
     "@ibm/telemetry-js-config-generator": "npm:^2.1.0"
     "@lit-labs/signals": "npm:^0.1.2"
     "@lit/context": "npm:^1.1.5"
@@ -3837,6 +3837,15 @@ __metadata:
   bin:
     ibmtelemetry: dist/collect.js
   checksum: 10/86357c2bcc41c8b4bd4ea5e748406480a70205db65adefd1f353e97497f80767c0a9ec4dd600a3d2ab8a9fc642fc6a2b50c5b2a962b51dc46dc80dde5afe6f65
+  languageName: node
+  linkType: hard
+
+"@ibm/telemetry-js@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@ibm/telemetry-js@npm:1.10.2"
+  bin:
+    ibmtelemetry: dist/collect.js
+  checksum: 10/bc1802cf691b0bb9df8cc19c8f4ab03b8022b5a53df778a9e99c817f708c51a02f440ea395ceb3656f057c8aa6356d5271f54eb3af3bcbb5c0b536fea9af2e36
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes N/A

For a bit of context, I'll give a brief rundown of how `@ibm/telemetry-js` works. 

When any repo using carbon packages is doing its `npm install`, all carbon packages are being installed at once. To avoid them running our `postinstall` collection script at the same time and affecting CI performance, we make it so the first package that runs the script will become an IPC server. All others will become IPC clients, and send over their "work to do" over to the server. The server then processes all the package's sequentially, in order to avoid using up too many resources. 

However, if the package that becomes a server is using any version of telemetry that is not `v1.10.0` or higher, then it won't have the code required to run the Web Components scope for data collection. In other words, unless our Carbon Web Components package becomes the server, the chances of collecting WC data would be very rare, especially because we've found that CWC is one of the last packages to install, probably due to being one of the last carbon packages in a `package.json` if ordered alphabetically.

To circumvent this, this new `1.10.2` version will always have Web Components data collection work to be sent to its own WC IPC server, instead of the default server. This ensures that, if any repo is using any WC package, we will always be collecting WC data no matter what the default IPC server's version of telemetry is.

TL;DR: we are spinning up a WC-only IPC server to ensure WC data collection

### Changelog

**Changed**

- update `@ibm/telemetry-js` package to `v1.10.2`
- web components data will be collected under a different IPC server

#### Testing / Reviewing
N/A

## PR Checklist

<!-- 
  Do not remove checklist items.
  If some are incomplete, create a draft pull request using the create button dropdown.
  If some do not apply, ~strike through the item text with tildes~.
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] ~~Updated documentation and storybook examples~~
- [ ] ~~Wrote passing tests that cover this change~~
- [ ] ~~Addressed any impact on accessibility (a11y)~~
- [ ] ~~Tested for cross-browser consistency~~
- [X] Validated that this code is ready for review and status checks should pass


More details can be found in the [pull request guide](https://github.com/carbon-design-system/carbon/blob/main/docs/guides/reviewing-pull-requests.md)
