### PR TITLE
fix: add wordbreak to sidepanel title

### DIFF
--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -2777,10 +2777,10 @@ p.c4p--about-modal__copyright-text:first-child {
 .c4p--side-panel.c4p--side-panel--condensed-actions {
   --c4p--side-panel--actions-height: 3rem;
 }
-.c4p--side-panel.c4p--side-panel--has-overlay {
+.c4p--side-panel:not(.c4p--side-panel--has-overlay) {
   box-shadow: 0 0.125rem 0.25rem var(--cds-overlay, rgba(22, 22, 22, 0.5));
 }
-.c4p--side-panel.c4p--side-panel--slide-in:not(.c4p--side-panel--has-overlay) {
+.c4p--side-panel.c4p--side-panel--slide-in, .c4p--side-panel.c4p--side-panel--slide-in:not(.c4p--side-panel--has-overlay) {
   box-shadow: none;
 }
 .c4p--side-panel .c4p--side-panel__actions-container {
@@ -2937,6 +2937,7 @@ p.c4p--about-modal__copyright-text:first-child {
   -webkit-line-clamp: 2;
   /* stylelint-disable-next-line carbon/layout-use -- custom css property set below */
   padding-inline-end: var(--c4p--side-panel--title-padding-right);
+  word-break: break-all;
   opacity: calc(1 - var(--c4p--side-panel--scroll-animation-progress));
 }
 .c4p--side-panel .c4p--side-panel__title--no-label .c4p--side-panel__title-text {
@@ -2968,6 +2969,7 @@ p.c4p--about-modal__copyright-text:first-child {
   -webkit-line-clamp: 2;
   /* stylelint-disable-next-line carbon/layout-use -- custom css property set below */
   padding-inline-end: var(--c4p--side-panel--title-padding-right);
+  word-break: break-all;
   position: absolute;
   inset-block-start: 0;
   opacity: var(--c4p--side-panel--scroll-animation-progress);
@@ -3095,18 +3097,6 @@ p.c4p--about-modal__copyright-text:first-child {
 }
 .c4p--side-panel .c4p--side-panel__actions-container .c4p--action-set__action-button.c4p--action-set__action-button {
   block-size: var(--c4p--side-panel--actions-height);
-}
-
-.c4p--side-panel .cds--text-input,
-.c4p--side-panel .cds--text-area,
-.c4p--side-panel .cds--search-input,
-.c4p--side-panel .cds--select-input,
-.c4p--side-panel .cds--multi-select,
-.c4p--side-panel .cds--dropdown,
-.c4p--side-panel .cds--dropdown-list,
-.c4p--side-panel .cds--number input[type=number],
-.c4p--side-panel .cds--date-picker__input {
-  background-color: var(--cds-field-02, #ffffff);
 }
 
 @keyframes side-panel-overlay-entrance {
@@ -9001,11 +8991,6 @@ button.c4p--add-select__global-filter-toggle--open {
 .c4p--tag-set-overflow__tagset-popover.c4p--tag-set-overflow__tagset-popover {
   min-inline-size: initial;
   text-align: start;
-}
-.c4p--tag-set-overflow__tagset-popover .c4p--tag-set-overflow__popover-trigger {
-  /* stylelint-disable-next-line declaration-no-important */
-  border: none !important;
-  font-family: inherit;
 }
 .c4p--tag-set-overflow__tagset-popover .c4p--tag-set-overflow__show-all-tags-link.cds--link:visited {
   display: inline-block;

--- a/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
+++ b/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
@@ -61,6 +61,7 @@ $clabs-prefix: 'clabs';
   -webkit-line-clamp: 2;
   /* stylelint-disable-next-line carbon/layout-use -- custom css property set below */
   padding-inline-end: var(--#{$block-class}--title-padding-right);
+  word-break: break-all;
 }
 
 .#{$block-class}--scrolls {


### PR DESCRIPTION
Closes #8201 

just adds `word-break` to the sidepanel title to prevent issues with long non-breaking strings in the title

<img width="836" height="668" alt="Screenshot 2025-09-10 at 3 56 51 PM" src="https://github.com/user-attachments/assets/85906802-edf3-4bcb-9096-2d3f9f10bd37" />

you can verify the change by viewing the [story with a long title in mobile view](https://carbon-for-ibm-products.netlify.app/?path=/story/components-sidepanel--slide-over&args=title:112-34123-412-341-23412-34123-412-34123-4123-41234-1234-12341-2341-2341-2341-2341&globals=viewport.value:mobile1) and then using the same parameters in the deploy preview
