### PR TITLE
fix: update popover link in tagset and overflow

### DIFF
--- a/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products-styles/src/__tests__/__snapshots__/styles.test.js.snap
@@ -8992,11 +8992,6 @@ button.c4p--add-select__global-filter-toggle--open {
   min-inline-size: initial;
   text-align: start;
 }
-.c4p--tag-set-overflow__tagset-popover .c4p--tag-set-overflow__show-all-tags-link.cds--link:visited {
-  display: inline-block;
-  margin: 0.5rem 0 0.25rem;
-  color: var(--cds-link-inverse, #78a9ff);
-}
 .c4p--tag-set-overflow__tagset-popover .cds--link:active,
 .c4p--tag-set-overflow__tagset-popover .cds--link:active:visited,
 .c4p--tag-set-overflow__tagset-popover .cds--link:active:visited:hover {
@@ -9009,6 +9004,15 @@ button.c4p--add-select__global-filter-toggle--open {
 .c4p--tag-set-overflow__tagset-popover .c4p--tag-set-overflow__show-all-tags-link {
   color: var(--cds-link-inverse, #78a9ff);
   margin-block-start: 0.5rem;
+}
+.c4p--tag-set-overflow__tagset-popover .c4p--tag-set-overflow__show-all-tags-link:hover {
+  color: var(--cds-link-inverse-hover, #a6c8ff);
+}
+.c4p--tag-set-overflow__tagset-popover .c4p--tag-set-overflow__show-all-tags-link:focus {
+  color: var(--cds-focus-inverse, #ffffff);
+}
+.c4p--tag-set-overflow__tagset-popover .c4p--tag-set-overflow__show-all-tags-link:visited {
+  color: var(--cds-link-inverse, #78a9ff);
 }
 .c4p--tag-set-overflow__tagset-popover .c4p--tag-set-overflow__tag-item.c4p--tag-set-overflow__tag-item--tag .cds--tag {
   background-color: var(--cds-background-inverse-hover, #474747);

--- a/packages/ibm-products-styles/src/components/TagOverflow/_tag-overflow.scss
+++ b/packages/ibm-products-styles/src/components/TagOverflow/_tag-overflow.scss
@@ -100,12 +100,6 @@ $block-class-modal: #{$block-class}-modal;
     font-family: inherit;
   }
 
-  .#{$block-class-overflow}__show-all-tags-link.#{c4p-settings.$carbon-prefix}--link:visited {
-    display: inline-block;
-    margin: $spacing-03 0 $spacing-02; // to match the tags
-    color: $link-inverse;
-  }
-
   .#{c4p-settings.$carbon-prefix}--link:active,
   .#{c4p-settings.$carbon-prefix}--link:active:visited,
   .#{c4p-settings.$carbon-prefix}--link:active:visited:hover {
@@ -120,6 +114,18 @@ $block-class-modal: #{$block-class}-modal;
   .#{$block-class-overflow}__show-all-tags-link {
     color: $link-inverse;
     margin-block-start: $spacing-03;
+
+    &:hover {
+      color: $link-inverse-hover;
+    }
+
+    &:focus {
+      color: $focus-inverse;
+    }
+
+    &:visited {
+      color: $link-inverse;
+    }
   }
 
   .#{$block-class-overflow}__tag-item.#{$block-class-overflow}__tag-item--tag

--- a/packages/ibm-products-styles/src/components/TagSet/_tag-set.scss
+++ b/packages/ibm-products-styles/src/components/TagSet/_tag-set.scss
@@ -102,12 +102,6 @@ $block-class-modal: #{$_block-class}-modal;
     text-align: start;
   }
 
-  .#{$block-class-overflow}__show-all-tags-link.#{$carbon-prefix}--link:visited {
-    display: inline-block;
-    margin: $spacing-03 0 $spacing-02; // to match the tags
-    color: $link-inverse;
-  }
-
   .#{$carbon-prefix}--link:active,
   .#{$carbon-prefix}--link:active:visited,
   .#{$carbon-prefix}--link:active:visited:hover {
@@ -122,6 +116,18 @@ $block-class-modal: #{$_block-class}-modal;
   .#{$block-class-overflow}__show-all-tags-link {
     color: $link-inverse;
     margin-block-start: $spacing-03;
+
+    &:hover {
+      color: $link-inverse-hover;
+    }
+
+    &:focus {
+      color: $focus-inverse;
+    }
+
+    &:visited {
+      color: $link-inverse;
+    }
   }
 
   .#{$block-class-overflow}__tag-item.#{$block-class-overflow}__tag-item--tag


### PR DESCRIPTION
Closes #8189 

just some small styling issues for the show more link in `TagSet` and `TagOverflow`

also removes some styles for the `:visited` state because they weren't being used. today i learned `:visitied` has certain css restrictions for privacy reasons

<img width="529" height="218" alt="Screenshot 2025-09-15 at 1 28 48 PM" src="https://github.com/user-attachments/assets/85b49d4c-ed47-4ca1-97a6-96bea0e61f41" />

