### PR TITLE
chore(deps): updated lower vite versions to 5.4.20 in all examples to address security vulnerabilities

### DIFF
--- a/examples/carbon-for-ibm-products/APIKeyModal/package.json
+++ b/examples/carbon-for-ibm-products/APIKeyModal/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/AboutModal/package.json
+++ b/examples/carbon-for-ibm-products/AboutModal/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/BigNumbers/package.json
+++ b/examples/carbon-for-ibm-products/BigNumbers/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/Cascade/package.json
+++ b/examples/carbon-for-ibm-products/Cascade/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/Coachmark/package.json
+++ b/examples/carbon-for-ibm-products/Coachmark/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/CoachmarkBeacon/package.json
+++ b/examples/carbon-for-ibm-products/CoachmarkBeacon/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/CoachmarkButton/package.json
+++ b/examples/carbon-for-ibm-products/CoachmarkButton/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/CoachmarkFixed/package.json
+++ b/examples/carbon-for-ibm-products/CoachmarkFixed/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/CoachmarkOverlayElement/package.json
+++ b/examples/carbon-for-ibm-products/CoachmarkOverlayElement/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/CoachmarkOverlayElements/package.json
+++ b/examples/carbon-for-ibm-products/CoachmarkOverlayElements/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/CoachmarkStack/package.json
+++ b/examples/carbon-for-ibm-products/CoachmarkStack/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/CoachmarkWithAnimatedMedia/package.json
+++ b/examples/carbon-for-ibm-products/CoachmarkWithAnimatedMedia/package.json
@@ -39,7 +39,7 @@
     "globals": "^15.9.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/ConditionBuilder/package.json
+++ b/examples/carbon-for-ibm-products/ConditionBuilder/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/CreateFullPage/package.json
+++ b/examples/carbon-for-ibm-products/CreateFullPage/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/CreateModal/package.json
+++ b/examples/carbon-for-ibm-products/CreateModal/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/CreateSidePanel/package.json
+++ b/examples/carbon-for-ibm-products/CreateSidePanel/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/CreateTearsheet/package.json
+++ b/examples/carbon-for-ibm-products/CreateTearsheet/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/CreateTearsheetNarrow/package.json
+++ b/examples/carbon-for-ibm-products/CreateTearsheetNarrow/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/DataSpreadsheet/package.json
+++ b/examples/carbon-for-ibm-products/DataSpreadsheet/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/Datagrid/package.json
+++ b/examples/carbon-for-ibm-products/Datagrid/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/Decorator/package.json
+++ b/examples/carbon-for-ibm-products/Decorator/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/DelimitedList/package.json
+++ b/examples/carbon-for-ibm-products/DelimitedList/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/DescriptionList/package.json
+++ b/examples/carbon-for-ibm-products/DescriptionList/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/EditInPlace/package.json
+++ b/examples/carbon-for-ibm-products/EditInPlace/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/EmptyStates/package.json
+++ b/examples/carbon-for-ibm-products/EmptyStates/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/ExportModal/package.json
+++ b/examples/carbon-for-ibm-products/ExportModal/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/ExpressiveCard/package.json
+++ b/examples/carbon-for-ibm-products/ExpressiveCard/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/FilterPanel/package.json
+++ b/examples/carbon-for-ibm-products/FilterPanel/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/FullPageError/package.json
+++ b/examples/carbon-for-ibm-products/FullPageError/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/GetStartedCard/package.json
+++ b/examples/carbon-for-ibm-products/GetStartedCard/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/HTTPErrors/package.json
+++ b/examples/carbon-for-ibm-products/HTTPErrors/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/ImportModal/package.json
+++ b/examples/carbon-for-ibm-products/ImportModal/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/InlineTipWithAnimatedMedia/package.json
+++ b/examples/carbon-for-ibm-products/InlineTipWithAnimatedMedia/package.json
@@ -37,7 +37,7 @@
     "globals": "^15.9.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/InterstitialScreen/package.json
+++ b/examples/carbon-for-ibm-products/InterstitialScreen/package.json
@@ -35,7 +35,7 @@
     "globals": "^15.9.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/InterstitialScreenView/package.json
+++ b/examples/carbon-for-ibm-products/InterstitialScreenView/package.json
@@ -35,7 +35,7 @@
     "globals": "^15.9.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/InterstitialScreenWithAnimatedMedia/package.json
+++ b/examples/carbon-for-ibm-products/InterstitialScreenWithAnimatedMedia/package.json
@@ -36,7 +36,7 @@
     "globals": "^15.9.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/Nav/package.json
+++ b/examples/carbon-for-ibm-products/Nav/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/NotificationsPanel/package.json
+++ b/examples/carbon-for-ibm-products/NotificationsPanel/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/OptionsTile/package.json
+++ b/examples/carbon-for-ibm-products/OptionsTile/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/PageHeader/package.json
+++ b/examples/carbon-for-ibm-products/PageHeader/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/ProductiveCard/package.json
+++ b/examples/carbon-for-ibm-products/ProductiveCard/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/RemoveModal/package.json
+++ b/examples/carbon-for-ibm-products/RemoveModal/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/Saving/package.json
+++ b/examples/carbon-for-ibm-products/Saving/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/ScrollGradient/package.json
+++ b/examples/carbon-for-ibm-products/ScrollGradient/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/SearchBar/package.json
+++ b/examples/carbon-for-ibm-products/SearchBar/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/SidePanel/package.json
+++ b/examples/carbon-for-ibm-products/SidePanel/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/StatusIcon/package.json
+++ b/examples/carbon-for-ibm-products/StatusIcon/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/StatusIndicator/package.json
+++ b/examples/carbon-for-ibm-products/StatusIndicator/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/StringFormatter/package.json
+++ b/examples/carbon-for-ibm-products/StringFormatter/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/TagOverflow/package.json
+++ b/examples/carbon-for-ibm-products/TagOverflow/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/TagSet/package.json
+++ b/examples/carbon-for-ibm-products/TagSet/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/Tearsheet/package.json
+++ b/examples/carbon-for-ibm-products/Tearsheet/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/TruncatedList/package.json
+++ b/examples/carbon-for-ibm-products/TruncatedList/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/UserAvatar/package.json
+++ b/examples/carbon-for-ibm-products/UserAvatar/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/UserProfileImage/package.json
+++ b/examples/carbon-for-ibm-products/UserProfileImage/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/WebTerminal/package.json
+++ b/examples/carbon-for-ibm-products/WebTerminal/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/example-gallery/package.json
+++ b/examples/carbon-for-ibm-products/example-gallery/package.json
@@ -30,7 +30,7 @@
     "eslint-plugin-react": "^7.33.1",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.3",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/prefix-example/package.json
+++ b/examples/carbon-for-ibm-products/prefix-example/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/react-16-example/package.json
+++ b/examples/carbon-for-ibm-products/react-16-example/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/examples/carbon-for-ibm-products/react-17-example/package.json
+++ b/examples/carbon-for-ibm-products/react-17-example/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "vite": "^4.5.3"
+    "vite": "^5.4.20"
   },
   "resolutions": {
     "react-is": "^19.0.0"

--- a/packages/ibm-products-web-components/examples/about-modal/package.json
+++ b/packages/ibm-products-web-components/examples/about-modal/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "vite": "5.4.19"
+    "vite": "^5.4.20"
   }
 }

--- a/packages/ibm-products-web-components/examples/export-modal/package.json
+++ b/packages/ibm-products-web-components/examples/export-modal/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "vite": "5.4.19",
+    "vite": "^5.4.20",
     "vite-plugin-lit-css": "^2.1.0",
     "typescript": "^5.5.3"
   }

--- a/packages/ibm-products-web-components/examples/full-page-error/package.json
+++ b/packages/ibm-products-web-components/examples/full-page-error/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "vite": "5.4.19"
+    "vite": "^5.4.20"
   }
 }

--- a/packages/ibm-products-web-components/examples/import-modal/package.json
+++ b/packages/ibm-products-web-components/examples/import-modal/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "vite": "5.4.19",
+    "vite": "^5.4.20",
     "vite-plugin-lit-css": "^2.1.0",
     "typescript": "^5.5.3"
   }

--- a/packages/ibm-products-web-components/examples/interstitial-screen/package.json
+++ b/packages/ibm-products-web-components/examples/interstitial-screen/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "vite": "5.4.19"
+    "vite": "^5.4.20"
   }
 }

--- a/packages/ibm-products-web-components/examples/notification-panel/package.json
+++ b/packages/ibm-products-web-components/examples/notification-panel/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "vite": "5.4.19"
+    "vite": "^5.4.20"
   }
 }

--- a/packages/ibm-products-web-components/examples/options-tile/package.json
+++ b/packages/ibm-products-web-components/examples/options-tile/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "vite": "5.4.19"
+    "vite": "^5.4.20"
   }
 }

--- a/packages/ibm-products-web-components/examples/page-header/package.json
+++ b/packages/ibm-products-web-components/examples/page-header/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "vite": "5.4.19"
+    "vite": "^5.4.20"
   }
 }

--- a/packages/ibm-products-web-components/examples/saving/package.json
+++ b/packages/ibm-products-web-components/examples/saving/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "vite": "5.4.19",
+    "vite": "^5.4.20",
     "vite-plugin-lit-css": "^2.1.0",
     "typescript": "^5.5.3"
   }

--- a/packages/ibm-products-web-components/examples/set-of-actions/package.json
+++ b/packages/ibm-products-web-components/examples/set-of-actions/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "vite": "5.4.20",
+    "vite": "^5.4.20",
     "vite-plugin-lit-css": "^2.1.0",
     "typescript": "^5.5.3"
   }

--- a/packages/ibm-products-web-components/examples/set-of-breadcrumbs/package.json
+++ b/packages/ibm-products-web-components/examples/set-of-breadcrumbs/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
-    "vite": "5.4.20",
+    "vite": "^5.4.20",
     "vite-plugin-lit-css": "^2.1.0"
   }
 }

--- a/packages/ibm-products-web-components/examples/set-of-tags/package.json
+++ b/packages/ibm-products-web-components/examples/set-of-tags/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
-    "vite": "5.4.19",
+    "vite": "^5.4.20",
     "vite-plugin-lit-css": "^2.1.0"
   }
 }

--- a/packages/ibm-products-web-components/examples/set-of-users/package.json
+++ b/packages/ibm-products-web-components/examples/set-of-users/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "vite": "5.4.20",
+    "vite": "^5.4.20",
     "vite-plugin-lit-css": "^2.1.0",
     "typescript": "^5.5.3"
   }

--- a/packages/ibm-products-web-components/examples/side-panel/package.json
+++ b/packages/ibm-products-web-components/examples/side-panel/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "vite": "5.4.19"
+    "vite": "^5.4.20"
   }
 }

--- a/packages/ibm-products-web-components/examples/tearsheet/package.json
+++ b/packages/ibm-products-web-components/examples/tearsheet/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "vite": "5.4.20"
+    "vite": "^5.4.20"
   }
 }

--- a/packages/ibm-products-web-components/examples/truncated-text/package.json
+++ b/packages/ibm-products-web-components/examples/truncated-text/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "vite": "5.4.20"
+    "vite": "^5.4.20"
   }
 }

--- a/packages/ibm-products-web-components/examples/user-avatar/package.json
+++ b/packages/ibm-products-web-components/examples/user-avatar/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "vite": "5.4.19"
+    "vite": "^5.4.20"
   }
 }


### PR DESCRIPTION


This should address most of the [security vulnerabilities](https://github.com/carbon-design-system/ibm-products/security/dependabot?page=1&q=is%3Aopen) that has been throwing from examples projects. 
I have updated all the lower versions of vite to ^5.4.20 as suggested [here](https://github.com/carbon-design-system/ibm-products/security/dependabot/2002)



#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
