### PR TITLE
fix: unintentional leakage of carbon webcomponents when page-header or interstial-screen is used in any app

### DIFF
--- a/packages/ibm-products-web-components/src/components/interstitial-screen/interstitial-screen-footer.ts
+++ b/packages/ibm-products-web-components/src/components/interstitial-screen/interstitial-screen-footer.ts
@@ -17,7 +17,7 @@ import styles from './interstitial-screen-footer.scss?lit';
 import { interstitialDetailsSignal } from './interstitial-screen-context';
 import { SignalWatcher } from '@lit-labs/signals';
 import '@carbon/web-components/es/components/inline-loading/inline-loading.js';
-import { CDSModalFooter } from '@carbon/web-components/es/index.js';
+import CDSModalFooter from '@carbon/web-components/es/components/modal/modal-footer';
 import ArrowRight from '@carbon/icons/es/arrow--right/16.js';
 import { iconLoader } from '@carbon/web-components/es/globals/internal/icon-loader.js';
 import { registerFocusableContainers } from '../../utilities/manageFocusTrap/manageFocusTrap';

--- a/packages/ibm-products-web-components/src/components/page-header/page-header-title-breadcrumb.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header-title-breadcrumb.ts
@@ -10,7 +10,7 @@
 import { html } from 'lit';
 import { consume, ContextConsumer } from '@lit/context';
 import { carbonElement as customElement } from '@carbon/web-components/es/globals/decorators/carbon-element.js';
-import { CDSBreadcrumbItem } from '@carbon/web-components/es/index';
+import CDSBreadcrumbItem from '@carbon/web-components/es/components/breadcrumb/breadcrumb-item';
 import { prefix } from '../../globals/settings';
 import styles from './page-header.scss?lit';
 import { pageHeaderContext } from './context';


### PR DESCRIPTION
Closes #8269

The Envizi team reported on Slack that when they use the cds-tabs Angular component in their application, the UI breaks if the page-header web component is imported from the C4P library.

After further analysis, I found that importing either the page-header or interstitial-screen web components in their application automatically brings in all Carbon web components. As a result, when they try to render cds-tabs from the Angular repo, the cds-tabs from the core webcomponent library is actually being rendered instead.

#### What did you change?
I changed the import of carbon webcompoents index in these components

#### How did you test and verify your work?
Envizi app by modifying the node modules

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
