### PR TITLE
refactor(scripts): remove chalk dep

### DIFF
--- a/config/jest-config-ibm-cloud-cognitive/package.json
+++ b/config/jest-config-ibm-cloud-cognitive/package.json
@@ -33,7 +33,6 @@
     "axe-core": "^4.10.3",
     "babel-jest": "^29.7.0",
     "babel-preset-ibm-cloud-cognitive": "^0.33.0",
-    "chalk": "4.1.2",
     "identity-obj-proxy": "^3.0.0",
     "jest-circus": "^29.7.0",
     "jest-watch-typeahead": "^3.0.0",

--- a/config/jest-config-ibm-cloud-cognitive/setup/setupFilesAfterEnv.js
+++ b/config/jest-config-ibm-cloud-cognitive/setup/setupFilesAfterEnv.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2024
+ * Copyright IBM Corp. 2020, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -8,12 +8,12 @@
 // `setupFilesAfterEnv` enables running the code immediately after the test framework has been installed in the environment - https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array
 
 import '@testing-library/jest-dom';
-
-import chalk from 'chalk';
 import util from 'util';
-
 import * as matchers from './matchers';
 import '../../../packages/ibm-products/src/feature-flags';
+
+const reset = '\x1b[0m';
+const gray = (str) => `\x1b[48;5;244m${str + reset}`;
 
 // `expect` can be extended using custom matchers as per https://jest-bot.github.io/jest/docs/expect.html#expectextendmatchers
 expect.extend(matchers);
@@ -61,10 +61,11 @@ const oldConsole = {};
           `${message}\n` +
           `${stack
             .split('\n')
-            .map((line) => chalk.gray(line))
+            .map((line) => gray(line))
             .join('\n')}`
       );
-      const message = `Expected test not to call ${chalk.bold(
+      const message = `Expected test not to call ${util.styleText(
+        'bold',
         `console.${method}()`
       )}`;
 

--- a/packages/ibm-products-styles/package.json
+++ b/packages/ibm-products-styles/package.json
@@ -45,7 +45,6 @@
     "test": "jest --colors"
   },
   "devDependencies": {
-    "chalk": "4.1.2",
     "copyfiles": "^2.4.1",
     "cross-env": "^10.0.0",
     "glob": "^11.0.1",

--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -83,7 +83,6 @@
     "@types/react-table": "^7.7.20",
     "babel-plugin-dev-expression": "^0.2.3",
     "babel-preset-ibm-cloud-cognitive": "^0.33.0",
-    "chalk": "4.1.2",
     "change-case": "5.4.4",
     "classnames": "^2.5.1",
     "copyfiles": "^2.4.1",

--- a/packages/ibm-products/scripts/generate/index.mjs
+++ b/packages/ibm-products/scripts/generate/index.mjs
@@ -18,8 +18,9 @@ const __dirname = dirname(__filename);
 import fsExtra from 'fs-extra';
 const { outputFileSync, readFileSync } = fsExtra;
 
-import chalk from 'chalk';
-const { green, red } = chalk;
+const reset = "\x1b[0m";
+const green = str => `\x1b[42m${str + reset}`;
+const red = str => `\x1b[41m${str + reset}`;
 
 // https://www.npmjs.com/package/yargs#usage
 import yargs from 'yargs';

--- a/packages/ibm-products/scripts/import.js
+++ b/packages/ibm-products/scripts/import.js
@@ -5,8 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const { bgGreen, bgRed, red } = require('chalk');
 const path = require('node:path');
+
+const reset = "\x1b[0m";
+const green = str => `\x1b[42m${str + reset}`;
+const red = str => `\x1b[41m${str + reset}`;
 
 /**
  * used in `yarn ci-check` to check if lib is generate in the build command
@@ -20,7 +23,7 @@ const importCheck = () => {
   } catch (error) {
     status = error;
   } finally {
-    console.log(`${status ? bgRed('FAIL') : bgGreen('PASS')} Import '${lib}'`);
+    console.log(`${status ? red('FAIL') : green('PASS')} Import '${lib}'`);
 
     if (status) {
       console.error(`\n${red(status)}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1928,7 +1928,6 @@ __metadata:
   resolution: "@carbon/ibm-products-styles@workspace:packages/ibm-products-styles"
   dependencies:
     "@ibm/telemetry-js": "npm:^1.9.1"
-    chalk: "npm:4.1.2"
     copyfiles: "npm:^2.4.1"
     cross-env: "npm:^10.0.0"
     glob: "npm:^11.0.1"
@@ -2042,7 +2041,6 @@ __metadata:
     "@types/react-table": "npm:^7.7.20"
     babel-plugin-dev-expression: "npm:^0.2.3"
     babel-preset-ibm-cloud-cognitive: "npm:^0.33.0"
-    chalk: "npm:4.1.2"
     change-case: "npm:5.4.4"
     classnames: "npm:^2.5.1"
     copyfiles: "npm:^2.4.1"
@@ -9235,16 +9233,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:4.1.2, chalk@npm:^4.0.0, chalk@npm:^4.0.2, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "chalk@npm:4.1.2"
-  dependencies:
-    ansi-styles: "npm:^4.1.0"
-    supports-color: "npm:^7.1.0"
-  checksum: 10/cb3f3e594913d63b1814d7ca7c9bafbf895f75fbf93b92991980610dfd7b48500af4e3a5d4e3a8f337990a96b168d7eb84ee55efdce965e2ee8efc20f8c8f139
-  languageName: node
-  linkType: hard
-
 "chalk@npm:^3.0.0":
   version: 3.0.0
   resolution: "chalk@npm:3.0.0"
@@ -9252,6 +9240,16 @@ __metadata:
     ansi-styles: "npm:^4.1.0"
     supports-color: "npm:^7.1.0"
   checksum: 10/37f90b31fd655fb49c2bd8e2a68aebefddd64522655d001ef417e6f955def0ed9110a867ffc878a533f2dafea5f2032433a37c8a7614969baa7f8a1cd424ddfc
+  languageName: node
+  linkType: hard
+
+"chalk@npm:^4.0.0, chalk@npm:^4.0.2, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "chalk@npm:4.1.2"
+  dependencies:
+    ansi-styles: "npm:^4.1.0"
+    supports-color: "npm:^7.1.0"
+  checksum: 10/cb3f3e594913d63b1814d7ca7c9bafbf895f75fbf93b92991980610dfd7b48500af4e3a5d4e3a8f337990a96b168d7eb84ee55efdce965e2ee8efc20f8c8f139
   languageName: node
   linkType: hard
 
@@ -14644,7 +14642,6 @@ __metadata:
     axe-core: "npm:^4.10.3"
     babel-jest: "npm:^29.7.0"
     babel-preset-ibm-cloud-cognitive: "npm:^0.33.0"
-    chalk: "npm:4.1.2"
     identity-obj-proxy: "npm:^3.0.0"
     jest-circus: "npm:^29.7.0"
     jest-watch-typeahead: "npm:^3.0.0"


### PR DESCRIPTION
Closes #8290 

Removes the `chalk` package from our repo, was used across a handful of places for various component generation scripts and jest setup. Everything was replaced with a more native approach so that we don't have to rely on that dependency anymore.

#### What did you change?
```
config/jest-config-ibm-cloud-cognitive/package.json
config/jest-config-ibm-cloud-cognitive/setup/setupFilesAfterEnv.js
packages/ibm-products-styles/package.json
packages/ibm-products/package.json
packages/ibm-products/scripts/generate/index.mjs
packages/ibm-products/scripts/import.js
yarn.lock
```
#### How did you test and verify your work?
Ran scripts locally, will also verify in PR checks
#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
