### PR TITLE
fix(PageHeader): use section and heading components for heading levels

### DIFF
--- a/packages/ibm-products/src/components/PageHeader/next/PageHeader.test.js
+++ b/packages/ibm-products/src/components/PageHeader/next/PageHeader.test.js
@@ -266,6 +266,7 @@ describe('PageHeader', () => {
           <PageHeader.Content className="custom-class" title="title" />
         </PageHeader.Root>
       );
+      expect(screen.getByRole('heading', { level: 2 })).toBeInTheDocument();
       expect(container.firstChild.firstChild).toHaveClass('custom-class');
     });
 

--- a/packages/ibm-products/src/components/PageHeader/next/PageHeader.tsx
+++ b/packages/ibm-products/src/components/PageHeader/next/PageHeader.tsx
@@ -35,6 +35,8 @@ import {
   BreadcrumbItem,
   BreadcrumbProps,
   Breadcrumb,
+  Section,
+  Heading,
 } from '@carbon/react';
 import { breakpoints } from '@carbon/layout';
 import { blockClass } from '../PageHeaderUtils';
@@ -382,7 +384,7 @@ const PageHeaderContent = React.forwardRef<
   }, [title]);
 
   return (
-    <div className={classNames} ref={componentRef} {...other}>
+    <Section as="div" className={classNames} ref={componentRef} {...other}>
       <Grid>
         <Column lg={16} md={8} sm={4}>
           <div className={`${blockClass}__content__title-wrapper`}>
@@ -398,7 +400,7 @@ const PageHeaderContent = React.forwardRef<
                   <DefinitionTooltip definition={title}>
                     <Text
                       ref={titleRef}
-                      as="h4"
+                      as={Heading}
                       className={`${blockClass}__content__title`}
                     >
                       {title}
@@ -407,7 +409,7 @@ const PageHeaderContent = React.forwardRef<
                 ) : (
                   <Text
                     ref={titleRef}
-                    as="h4"
+                    as={Heading}
                     className={`${blockClass}__content__title`}
                   >
                     {title}
@@ -425,7 +427,7 @@ const PageHeaderContent = React.forwardRef<
           {children}
         </Column>
       </Grid>
-    </div>
+    </Section>
   );
 });
 PageHeaderContent.displayName = 'PageHeaderContent';


### PR DESCRIPTION
Closes #8257

Uses the `Section` and `Heading` components so that the title in the page header receives a more appropriate heading level.

#### What did you change?
- `packages/ibm-products/src/components/PageHeader/next/PageHeader.tsx`
- `packages/ibm-products/src/components/PageHeader/next/PageHeader.test.js`
#### How did you test and verify your work?
Verified in browser that the heading level is using the correct semantic level
#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [X] Wrote passing tests that cover this change
- [X] Addressed any impact on accessibility (a11y)
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
