### PR TITLE
feat(EmptyState): integration of open in Stackblitz

### DIFF
--- a/packages/ibm-products/src/components/EmptyStates/EmptyState.mdx
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyState.mdx
@@ -1,0 +1,129 @@
+import { Story, Controls, Source, Canvas } from '@storybook/addon-docs/blocks';
+import * as stories from './EmptyStates.stories';
+import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
+
+# Empty State
+
+[Carbon empty states pattern](https://carbondesignsystem.com/patterns/empty-states-pattern/)
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Default](#default)
+- [WithTooltipInSubtitle](#with-tooltip-in-subtitle)
+- [WithCustomIllustration](#with-custom-illustration)
+- [withAction](#with-action)
+- [withActionIconButton](#with-action-icon-button)
+- [withLink](#with-link)
+- [withActionAndLink](#with-action-and-link)
+
+## Overview
+
+Empty states are moments in an app where there is no data to display to the
+user. They are most commonly seen the first time a user interacts with a product
+or page, but can be used when data has been deleted or is unavailable.
+
+## Default
+
+<Canvas
+  of={stories.Default}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.Default,
+        }),
+    },
+  ]}
+/>
+
+## With Tooltip In Subtitle
+
+<Canvas
+  of={stories.WithTooltipInSubtitle}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.WithTooltipInSubtitle,
+        }),
+    },
+  ]}
+/>
+
+## With Custom Illustration
+
+<Canvas
+  of={stories.WithCustomIllustration}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.WithCustomIllustration,
+        }),
+    },
+  ]}
+/>
+
+## With Action
+
+<Canvas
+  of={stories.withAction}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withAction,
+        }),
+    },
+  ]}
+/>
+
+## with Action Icon Button
+
+<Canvas
+  of={stories.withActionIconButton}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withActionIconButton,
+        }),
+    },
+  ]}
+/>
+
+## With Link
+
+<Canvas
+  of={stories.withLink}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withLink,
+        }),
+    },
+  ]}
+/>
+
+## With Action And Link
+
+<Canvas
+  of={stories.withActionAndLink}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withActionAndLink,
+        }),
+    },
+  ]}
+/>

--- a/packages/ibm-products/src/components/EmptyStates/EmptyState.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyState.tsx
@@ -92,12 +92,12 @@ export interface EmptyStateProps {
   /**
    * Empty state subtitle
    */
-  subtitle?: string | ReactNode;
+  subtitle?: ReactNode;
 
   /**
    * Empty state title
    */
-  title: string | ReactNode;
+  title: ReactNode;
 
   /**
    * **Deprecated:** Designates which version of the EmptyState component is being used. Refer to V2 documentation separately.
@@ -217,12 +217,12 @@ EmptyState.propTypes = {
   /**
    * Empty state subtext
    */
-  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  subtitle: PropTypes.node,
 
   /**
    * Empty state heading
    */
-  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  title: PropTypes.node.isRequired,
   /**
    * **Deprecated:** Designates which version of the EmptyState component is being used. Refer to V2 documentation separately.
    * @deprecated

--- a/packages/ibm-products/src/components/EmptyStates/EmptyStateContent.tsx
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyStateContent.tsx
@@ -40,11 +40,11 @@ interface EmptyStateProps {
   /**
    * Empty state subtitle
    */
-  subtitle?: string | ReactNode;
+  subtitle?: ReactNode;
   /**
    * Empty state title
    */
-  title: string | ReactNode;
+  title: ReactNode;
 }
 
 export const EmptyStateContent = (props: EmptyStateProps) => {
@@ -126,9 +126,9 @@ EmptyStateContent.propTypes = {
   /**
    * Empty state subtitle
    */
-  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  subtitle: PropTypes.node,
   /**
    * Empty state title
    */
-  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  title: PropTypes.node.isRequired,
 };

--- a/packages/ibm-products/src/components/EmptyStates/EmptyStates.stories.jsx
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyStates.stories.jsx
@@ -6,11 +6,11 @@
  */
 
 import React from 'react';
-import { action } from 'storybook/actions';
+import { action as storybookAction } from 'storybook/actions';
 import { Add, Information } from '@carbon/react/icons';
 import CustomIllustration from './story_assets/empty-state-bright-magnifying-glass.svg';
 import { EmptyState } from '.';
-import { StoryDocsPage } from '../../global/js/utils/StoryDocsPage';
+import mdx from './EmptyState.mdx';
 import { Tooltip } from '@carbon/react';
 
 export default {
@@ -20,31 +20,72 @@ export default {
   parameters: {
     // styles,
     docs: {
-      page: () => (
-        <StoryDocsPage
-          altGuidelinesHref={[
-            {
-              href: 'https://www.carbondesignsystem.com/patterns/empty-states-pattern/',
-              label: 'Carbon empty states pattern',
-            },
-          ]}
-        />
-      ),
+      page: mdx,
     },
   },
 };
 
 const emptyStateCommonProps = {
   title: 'Start by adding data assets',
-  subtitle: (
-    <>
-      Click <span>Upload assets</span> to upload your data
-    </>
-  ),
+  subtitle: 0,
 };
 
-const Template = (args) => {
-  return <EmptyState {...args} />;
+const Template = ({ ...args }, context) => {
+  const sbDocs = context.viewMode !== 'docs';
+  const { subtitle, action } = args;
+
+  const getSubTitle = (value) => {
+    if (value === 0) {
+      return (
+        <>
+          Click <span>Upload assets</span> to upload your data
+        </>
+      );
+    }
+    if (value === 1) {
+      return (
+        <>
+          Click <span>here</span> to upload your data
+          <Tooltip label="Facts and statistics collected together for reference or analysis">
+            <Information size="16" />
+          </Tooltip>
+        </>
+      );
+    }
+  };
+
+  const getAction = (value) => {
+    if (value === 0) {
+      return {
+        text: 'Create new',
+        onClick: () => {
+          sbDocs
+            ? storybookAction('Clicked empty state action button')()
+            : console.log('Clicked empty state action button');
+        },
+      };
+    }
+    if (value === 1) {
+      return {
+        text: 'Create new',
+        onClick: () => {
+          sbDocs
+            ? storybookAction('Clicked empty state action button')()
+            : console.log('Clicked empty state action button');
+        },
+        renderIcon: (props) => <Add size={20} {...props} />,
+        iconDescription: 'Add icon',
+      };
+    }
+  };
+
+  return (
+    <EmptyState
+      {...args}
+      subtitle={getSubTitle(subtitle)}
+      action={getAction(action)}
+    />
+  );
 };
 
 export const Default = Template.bind({});
@@ -55,14 +96,7 @@ Default.args = {
 export const WithTooltipInSubtitle = Template.bind({});
 WithTooltipInSubtitle.args = {
   ...emptyStateCommonProps,
-  subtitle: (
-    <>
-      Click <span>here</span> to upload your data
-      <Tooltip label="Facts and statistics collected together for reference or analysis">
-        <Information size="16" />
-      </Tooltip>
-    </>
-  ),
+  subtitle: 1,
 };
 
 export const WithCustomIllustration = Template.bind({});
@@ -75,21 +109,13 @@ WithCustomIllustration.args = {
 export const withAction = Template.bind({});
 withAction.args = {
   ...emptyStateCommonProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-  },
+  action: 0,
 };
 
 export const withActionIconButton = Template.bind({});
 withActionIconButton.args = {
   ...emptyStateCommonProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: (props) => <Add size={20} {...props} />,
-    iconDescription: 'Add icon',
-  },
+  action: 1,
 };
 
 export const withLink = Template.bind({});
@@ -105,12 +131,7 @@ withLink.args = {
 export const withActionAndLink = Template.bind({});
 withActionAndLink.args = {
   ...emptyStateCommonProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: (props) => <Add size={20} {...props} />,
-    iconDescription: 'Add icon',
-  },
+  action: 1,
   link: {
     text: 'View documentation',
     href: 'https://www.carbondesignsystem.com',

--- a/packages/ibm-products/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.mdx
+++ b/packages/ibm-products/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.mdx
@@ -1,0 +1,112 @@
+import { Story, Controls, Source, Canvas } from '@storybook/addon-docs/blocks';
+import * as stories from './ErrorEmptyState.stories';
+import { stackblitzPrefillConfig } from '../../../../previewer/codePreviewer';
+
+# Error Empty State
+
+[Carbon empty states pattern](https://carbondesignsystem.com/patterns/empty-states-pattern/)
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Default](#default)
+- [WithDarkModeIllustration](#with-dark-mode-illustration)
+- [withAction](#with-action)
+- [withActionIconButton](#with-action-icon-button)
+- [withLink](#with-link)
+- [withActionAndLink](#with-action-and-link)
+
+## Overview
+
+Empty states are moments in an app where there is no data to display to the
+user.
+
+## Default
+
+<Canvas
+  of={stories.Default}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.Default,
+        }),
+    },
+  ]}
+/>
+
+## With Dark Mode Illustration
+
+<Canvas
+  of={stories.WithDarkModeIllustration}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.WithDarkModeIllustration,
+        }),
+    },
+  ]}
+/>
+
+## With Action
+
+<Canvas
+  of={stories.withAction}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withAction,
+        }),
+    },
+  ]}
+/>
+
+## with Action Icon Button
+
+<Canvas
+  of={stories.withActionIconButton}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withActionIconButton,
+        }),
+    },
+  ]}
+/>
+
+## With Link
+
+<Canvas
+  of={stories.withLink}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withLink,
+        }),
+    },
+  ]}
+/>
+
+## With Action And Link
+
+<Canvas
+  of={stories.withActionAndLink}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withActionAndLink,
+        }),
+    },
+  ]}
+/>

--- a/packages/ibm-products/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.stories.jsx
+++ b/packages/ibm-products/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.stories.jsx
@@ -6,12 +6,11 @@
  */
 
 import React from 'react';
-import { action } from 'storybook/actions';
+import { action as storybookAction } from 'storybook/actions';
 import { Add } from '@carbon/react/icons';
-// import mdx from './ErrorEmptyState.mdx';
+import mdx from './ErrorEmptyState.mdx';
 
 import { ErrorEmptyState } from '.';
-import { StoryDocsPage } from '../../../global/js/utils/StoryDocsPage';
 
 // import styles from '../_index.scss';
 
@@ -22,16 +21,7 @@ export default {
   parameters: {
     // styles,
     docs: {
-      page: () => (
-        <StoryDocsPage
-          altGuidelinesHref={[
-            {
-              href: 'https://www.carbondesignsystem.com/patterns/empty-states-pattern/',
-              label: 'Carbon empty states pattern',
-            },
-          ]}
-        />
-      ),
+      page: mdx,
     },
   },
 };
@@ -43,8 +33,34 @@ const defaultStoryProps = {
   illustrationDescription: 'Test alt text',
 };
 
-const Template = (args) => {
-  return <ErrorEmptyState {...args} />;
+const Template = ({ ...args }, context) => {
+  const sbDocs = context.viewMode !== 'docs';
+  const { action } = args;
+  const getAction = (value) => {
+    if (value === 0) {
+      return {
+        text: 'Create new',
+        onClick: () => {
+          sbDocs
+            ? storybookAction('Clicked empty state action button')()
+            : console.log('Clicked empty state action button');
+        },
+      };
+    }
+    if (value === 1) {
+      return {
+        text: 'Create new',
+        onClick: () => {
+          sbDocs
+            ? storybookAction('Clicked empty state action button')()
+            : console.log('Clicked empty state action button');
+        },
+        renderIcon: (props) => <Add size={20} {...props} />,
+        iconDescription: 'Add icon',
+      };
+    }
+  };
+  return <ErrorEmptyState {...args} action={getAction(action)} />;
 };
 
 export const Default = Template.bind({});
@@ -61,21 +77,13 @@ WithDarkModeIllustration.args = {
 export const withAction = Template.bind({});
 withAction.args = {
   ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-  },
+  action: 0,
 };
 
 export const withActionIconButton = Template.bind({});
 withActionIconButton.args = {
   ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: (props) => <Add size={20} {...props} />,
-    iconDescription: 'Add icon',
-  },
+  action: 1,
 };
 
 export const withLink = Template.bind({});
@@ -90,12 +98,7 @@ withLink.args = {
 export const withActionAndLink = Template.bind({});
 withActionAndLink.args = {
   ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: (props) => <Add size={20} {...props} />,
-    iconDescription: 'Add icon',
-  },
+  action: 1,
   link: {
     text: 'View documentation',
     href: 'https://www.carbondesignsystem.com',

--- a/packages/ibm-products/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.mdx
+++ b/packages/ibm-products/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.mdx
@@ -1,0 +1,112 @@
+import { Story, Controls, Source, Canvas } from '@storybook/addon-docs/blocks';
+import * as stories from './NoDataEmptyState.stories';
+import { stackblitzPrefillConfig } from '../../../../previewer/codePreviewer';
+
+# NoData Empty State
+
+[Carbon empty states pattern](https://carbondesignsystem.com/patterns/empty-states-pattern/)
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Default](#default)
+- [WithDarkModeIllustration](#with-dark-mode-illustration)
+- [withAction](#with-action)
+- [withActionIconButton](#with-action-icon-button)
+- [withLink](#with-link)
+- [withActionAndLink](#with-action-and-link)
+
+## Overview
+
+Empty states are moments in an app where there is no data to display to the
+user.
+
+## Default
+
+<Canvas
+  of={stories.Default}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.Default,
+        }),
+    },
+  ]}
+/>
+
+## With Dark Mode Illustration
+
+<Canvas
+  of={stories.WithDarkModeIllustration}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.WithDarkModeIllustration,
+        }),
+    },
+  ]}
+/>
+
+## With Action
+
+<Canvas
+  of={stories.withAction}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withAction,
+        }),
+    },
+  ]}
+/>
+
+## with Action Icon Button
+
+<Canvas
+  of={stories.withActionIconButton}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withActionIconButton,
+        }),
+    },
+  ]}
+/>
+
+## With Link
+
+<Canvas
+  of={stories.withLink}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withLink,
+        }),
+    },
+  ]}
+/>
+
+## With Action And Link
+
+<Canvas
+  of={stories.withActionAndLink}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withActionAndLink,
+        }),
+    },
+  ]}
+/>

--- a/packages/ibm-products/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.stories.jsx
+++ b/packages/ibm-products/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.stories.jsx
@@ -6,13 +6,10 @@
  */
 
 import React from 'react';
-import { action } from 'storybook/actions';
+import { action as storybookAction } from 'storybook/actions';
 import { Add } from '@carbon/react/icons';
-// import mdx from './NoDataEmptyState.mdx';
-
+import mdx from './NoDataEmptyState.mdx';
 import { NoDataEmptyState } from '.';
-import { StoryDocsPage } from '../../../global/js/utils/StoryDocsPage';
-
 // import styles from '../_index.scss';
 
 export default {
@@ -22,16 +19,7 @@ export default {
   parameters: {
     // styles,
     docs: {
-      page: () => (
-        <StoryDocsPage
-          altGuidelinesHref={[
-            {
-              href: 'https://www.carbondesignsystem.com/patterns/empty-states-pattern/',
-              label: 'Carbon empty states pattern',
-            },
-          ]}
-        />
-      ),
+      page: mdx,
     },
   },
 };
@@ -43,8 +31,34 @@ const defaultStoryProps = {
   illustrationDescription: 'Test alt text',
 };
 
-const Template = (args) => {
-  return <NoDataEmptyState {...args} />;
+const Template = ({ ...args }, context) => {
+  const sbDocs = context.viewMode !== 'docs';
+  const { action } = args;
+  const getAction = (value) => {
+    if (value === 0) {
+      return {
+        text: 'Create new',
+        onClick: () => {
+          sbDocs
+            ? storybookAction('Clicked empty state action button')()
+            : console.log('Clicked empty state action button');
+        },
+      };
+    }
+    if (value === 1) {
+      return {
+        text: 'Create new',
+        onClick: () => {
+          sbDocs
+            ? storybookAction('Clicked empty state action button')()
+            : console.log('Clicked empty state action button');
+        },
+        renderIcon: (props) => <Add size={20} {...props} />,
+        iconDescription: 'Add icon',
+      };
+    }
+  };
+  return <NoDataEmptyState {...args} action={getAction(action)} />;
 };
 
 export const Default = Template.bind({});
@@ -61,21 +75,13 @@ WithDarkModeIllustration.args = {
 export const withAction = Template.bind({});
 withAction.args = {
   ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-  },
+  action: 0,
 };
 
 export const withActionIconButton = Template.bind({});
 withActionIconButton.args = {
   ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: (props) => <Add size={20} {...props} />,
-    iconDescription: 'Add icon',
-  },
+  action: 1,
 };
 
 export const withLink = Template.bind({});
@@ -90,12 +96,7 @@ withLink.args = {
 export const withActionAndLink = Template.bind({});
 withActionAndLink.args = {
   ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: (props) => <Add size={20} {...props} />,
-    iconDescription: 'Add icon',
-  },
+  action: 1,
   link: {
     text: 'View documentation',
     href: 'https://www.carbondesignsystem.com',

--- a/packages/ibm-products/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.mdx
+++ b/packages/ibm-products/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.mdx
@@ -1,0 +1,112 @@
+import { Story, Controls, Source, Canvas } from '@storybook/addon-docs/blocks';
+import * as stories from './NoTagsEmptyState.stories';
+import { stackblitzPrefillConfig } from '../../../../previewer/codePreviewer';
+
+# NoTags Empty State
+
+[Carbon empty states pattern](https://carbondesignsystem.com/patterns/empty-states-pattern/)
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Default](#default)
+- [WithDarkModeIllustration](#with-dark-mode-illustration)
+- [withAction](#with-action)
+- [withActionIconButton](#with-action-icon-button)
+- [withLink](#with-link)
+- [withActionAndLink](#with-action-and-link)
+
+## Overview
+
+Empty states are moments in an app where there is no data to display to the
+user.
+
+## Default
+
+<Canvas
+  of={stories.Default}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.Default,
+        }),
+    },
+  ]}
+/>
+
+## With Dark Mode Illustration
+
+<Canvas
+  of={stories.WithDarkModeIllustration}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.WithDarkModeIllustration,
+        }),
+    },
+  ]}
+/>
+
+## With Action
+
+<Canvas
+  of={stories.withAction}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withAction,
+        }),
+    },
+  ]}
+/>
+
+## with Action Icon Button
+
+<Canvas
+  of={stories.withActionIconButton}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withActionIconButton,
+        }),
+    },
+  ]}
+/>
+
+## With Link
+
+<Canvas
+  of={stories.withLink}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withLink,
+        }),
+    },
+  ]}
+/>
+
+## With Action And Link
+
+<Canvas
+  of={stories.withActionAndLink}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withActionAndLink,
+        }),
+    },
+  ]}
+/>

--- a/packages/ibm-products/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.stories.jsx
+++ b/packages/ibm-products/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.stories.jsx
@@ -6,12 +6,11 @@
  */
 
 import React from 'react';
-import { action } from 'storybook/actions';
+import { action as storybookAction } from 'storybook/actions';
 import { Add } from '@carbon/react/icons';
-// import mdx from './NoTagsEmptyState.mdx';
+import mdx from './NoTagsEmptyState.mdx';
 
 import { NoTagsEmptyState } from '.';
-import { StoryDocsPage } from '../../../global/js/utils/StoryDocsPage';
 
 // import styles from '../_index.scss';
 
@@ -22,16 +21,7 @@ export default {
   parameters: {
     // styles,
     docs: {
-      page: () => (
-        <StoryDocsPage
-          altGuidelinesHref={[
-            {
-              href: 'https://www.carbondesignsystem.com/patterns/empty-states-pattern/',
-              label: 'Carbon empty states pattern',
-            },
-          ]}
-        />
-      ),
+      page: mdx,
     },
   },
 };
@@ -43,8 +33,34 @@ const defaultStoryProps = {
   illustrationDescription: 'Test alt text',
 };
 
-const Template = (args) => {
-  return <NoTagsEmptyState {...args} />;
+const Template = ({ ...args }, context) => {
+  const sbDocs = context.viewMode !== 'docs';
+  const { action } = args;
+  const getAction = (value) => {
+    if (value === 0) {
+      return {
+        text: 'Create new',
+        onClick: () => {
+          sbDocs
+            ? storybookAction('Clicked empty state action button')()
+            : console.log('Clicked empty state action button');
+        },
+      };
+    }
+    if (value === 1) {
+      return {
+        text: 'Create new',
+        onClick: () => {
+          sbDocs
+            ? storybookAction('Clicked empty state action button')()
+            : console.log('Clicked empty state action button');
+        },
+        renderIcon: (props) => <Add size={20} {...props} />,
+        iconDescription: 'Add icon',
+      };
+    }
+  };
+  return <NoTagsEmptyState {...args} action={getAction(action)} />;
 };
 
 export const Default = Template.bind({});
@@ -61,21 +77,13 @@ WithDarkModeIllustration.args = {
 export const withAction = Template.bind({});
 withAction.args = {
   ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-  },
+  action: 0,
 };
 
 export const withActionIconButton = Template.bind({});
 withActionIconButton.args = {
   ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: (props) => <Add size={20} {...props} />,
-    iconDescription: 'Add icon',
-  },
+  action: 1,
 };
 
 export const withLink = Template.bind({});
@@ -90,12 +98,7 @@ withLink.args = {
 export const withActionAndLink = Template.bind({});
 withActionAndLink.args = {
   ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: (props) => <Add size={20} {...props} />,
-    iconDescription: 'Add icon',
-  },
+  action: 1,
   link: {
     text: 'View documentation',
     href: 'https://www.carbondesignsystem.com',

--- a/packages/ibm-products/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.mdx
+++ b/packages/ibm-products/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.mdx
@@ -1,0 +1,112 @@
+import { Story, Controls, Source, Canvas } from '@storybook/addon-docs/blocks';
+import * as stories from './NotFoundEmptyState.stories';
+import { stackblitzPrefillConfig } from '../../../../previewer/codePreviewer';
+
+# NotFound Empty State
+
+[Carbon empty states pattern](https://carbondesignsystem.com/patterns/empty-states-pattern/)
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Default](#default)
+- [WithDarkModeIllustration](#with-dark-mode-illustration)
+- [withAction](#with-action)
+- [withActionIconButton](#with-action-icon-button)
+- [withLink](#with-link)
+- [withActionAndLink](#with-action-and-link)
+
+## Overview
+
+Empty states are moments in an app where there is no data to display to the
+user.
+
+## Default
+
+<Canvas
+  of={stories.Default}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.Default,
+        }),
+    },
+  ]}
+/>
+
+## With Dark Mode Illustration
+
+<Canvas
+  of={stories.WithDarkModeIllustration}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.WithDarkModeIllustration,
+        }),
+    },
+  ]}
+/>
+
+## With Action
+
+<Canvas
+  of={stories.withAction}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withAction,
+        }),
+    },
+  ]}
+/>
+
+## with Action Icon Button
+
+<Canvas
+  of={stories.withActionIconButton}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withActionIconButton,
+        }),
+    },
+  ]}
+/>
+
+## With Link
+
+<Canvas
+  of={stories.withLink}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withLink,
+        }),
+    },
+  ]}
+/>
+
+## With Action And Link
+
+<Canvas
+  of={stories.withActionAndLink}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withActionAndLink,
+        }),
+    },
+  ]}
+/>

--- a/packages/ibm-products/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.stories.jsx
+++ b/packages/ibm-products/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.stories.jsx
@@ -6,11 +6,10 @@
  */
 
 import React from 'react';
-import { action } from 'storybook/actions';
+import { action as storybookAction } from 'storybook/actions';
 import { Add } from '@carbon/react/icons';
-// import mdx from './NotFoundEmptyState.mdx';
+import mdx from './NotFoundEmptyState.mdx';
 import { NotFoundEmptyState } from '.';
-import { StoryDocsPage } from '../../../global/js/utils/StoryDocsPage';
 
 // import styles from '../_index.scss';
 
@@ -21,16 +20,7 @@ export default {
   parameters: {
     // styles,
     docs: {
-      page: () => (
-        <StoryDocsPage
-          altGuidelinesHref={[
-            {
-              href: 'https://www.carbondesignsystem.com/patterns/empty-states-pattern/',
-              label: 'Carbon empty states pattern',
-            },
-          ]}
-        />
-      ),
+      page: mdx,
     },
   },
 };
@@ -42,8 +32,34 @@ const defaultStoryProps = {
   illustrationDescription: 'Test alt text',
 };
 
-const Template = (args) => {
-  return <NotFoundEmptyState {...args} />;
+const Template = ({ ...args }, context) => {
+  const sbDocs = context.viewMode !== 'docs';
+  const { action } = args;
+  const getAction = (value) => {
+    if (value === 0) {
+      return {
+        text: 'Create new',
+        onClick: () => {
+          sbDocs
+            ? storybookAction('Clicked empty state action button')()
+            : console.log('Clicked empty state action button');
+        },
+      };
+    }
+    if (value === 1) {
+      return {
+        text: 'Create new',
+        onClick: () => {
+          sbDocs
+            ? storybookAction('Clicked empty state action button')()
+            : console.log('Clicked empty state action button');
+        },
+        renderIcon: (props) => <Add size={20} {...props} />,
+        iconDescription: 'Add icon',
+      };
+    }
+  };
+  return <NotFoundEmptyState {...args} action={getAction(action)} />;
 };
 
 export const Default = Template.bind({});
@@ -60,21 +76,13 @@ WithDarkModeIllustration.args = {
 export const withAction = Template.bind({});
 withAction.args = {
   ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-  },
+  action: 0,
 };
 
 export const withActionIconButton = Template.bind({});
 withActionIconButton.args = {
   ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: (props) => <Add iconDescription="test" size={20} {...props} />,
-    iconDescription: 'Add icon',
-  },
+  action: 1,
 };
 
 export const withLink = Template.bind({});
@@ -89,12 +97,7 @@ withLink.args = {
 export const withActionAndLink = Template.bind({});
 withActionAndLink.args = {
   ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: (props) => <Add size={20} {...props} />,
-    iconDescription: 'Add icon',
-  },
+  action: 1,
   link: {
     text: 'View documentation',
     href: 'https://www.carbondesignsystem.com',

--- a/packages/ibm-products/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.mdx
+++ b/packages/ibm-products/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.mdx
@@ -1,0 +1,112 @@
+import { Story, Controls, Source, Canvas } from '@storybook/addon-docs/blocks';
+import * as stories from './NotificationsEmptyState.stories';
+import { stackblitzPrefillConfig } from '../../../../previewer/codePreviewer';
+
+# Notifications Empty State
+
+[Carbon empty states pattern](https://carbondesignsystem.com/patterns/empty-states-pattern/)
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Default](#default)
+- [WithDarkModeIllustration](#with-dark-mode-illustration)
+- [withAction](#with-action)
+- [withActionIconButton](#with-action-icon-button)
+- [withLink](#with-link)
+- [withActionAndLink](#with-action-and-link)
+
+## Overview
+
+Empty states are moments in an app where there is no data to display to the
+user.
+
+## Default
+
+<Canvas
+  of={stories.Default}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.Default,
+        }),
+    },
+  ]}
+/>
+
+## With Dark Mode Illustration
+
+<Canvas
+  of={stories.WithDarkModeIllustration}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.WithDarkModeIllustration,
+        }),
+    },
+  ]}
+/>
+
+## With Action
+
+<Canvas
+  of={stories.withAction}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withAction,
+        }),
+    },
+  ]}
+/>
+
+## with Action Icon Button
+
+<Canvas
+  of={stories.withActionIconButton}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withActionIconButton,
+        }),
+    },
+  ]}
+/>
+
+## With Link
+
+<Canvas
+  of={stories.withLink}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withLink,
+        }),
+    },
+  ]}
+/>
+
+## With Action And Link
+
+<Canvas
+  of={stories.withActionAndLink}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withActionAndLink,
+        }),
+    },
+  ]}
+/>

--- a/packages/ibm-products/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.stories.jsx
+++ b/packages/ibm-products/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.stories.jsx
@@ -6,11 +6,10 @@
  */
 
 import React from 'react';
-import { action } from 'storybook/actions';
+import { action as storybookAction } from 'storybook/actions';
 import { Add } from '@carbon/react/icons';
-// import mdx from './NotificationsEmptyState.mdx';
+import mdx from './NotificationsEmptyState.mdx';
 import { NotificationsEmptyState } from '.';
-import { StoryDocsPage } from '../../../global/js/utils/StoryDocsPage';
 
 // import styles from '../_index.scss';
 
@@ -21,16 +20,7 @@ export default {
   parameters: {
     // styles,
     docs: {
-      page: () => (
-        <StoryDocsPage
-          altGuidelinesHref={[
-            {
-              href: 'https://www.carbondesignsystem.com/patterns/empty-states-pattern/',
-              label: 'Carbon empty states pattern',
-            },
-          ]}
-        />
-      ),
+      page: mdx,
     },
   },
 };
@@ -42,8 +32,34 @@ const defaultStoryProps = {
   illustrationDescription: 'Test alt text',
 };
 
-const Template = (args) => {
-  return <NotificationsEmptyState {...args} />;
+const Template = ({ ...args }, context) => {
+  const sbDocs = context.viewMode !== 'docs';
+  const { action } = args;
+  const getAction = (value) => {
+    if (value === 0) {
+      return {
+        text: 'Create new',
+        onClick: () => {
+          sbDocs
+            ? storybookAction('Clicked empty state action button')()
+            : console.log('Clicked empty state action button');
+        },
+      };
+    }
+    if (value === 1) {
+      return {
+        text: 'Create new',
+        onClick: () => {
+          sbDocs
+            ? storybookAction('Clicked empty state action button')()
+            : console.log('Clicked empty state action button');
+        },
+        renderIcon: (props) => <Add size={20} {...props} />,
+        iconDescription: 'Add icon',
+      };
+    }
+  };
+  return <NotificationsEmptyState {...args} action={getAction(action)} />;
 };
 
 export const Default = Template.bind({});
@@ -60,21 +76,13 @@ WithDarkModeIllustration.args = {
 export const withAction = Template.bind({});
 withAction.args = {
   ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-  },
+  action: 0,
 };
 
 export const withActionIconButton = Template.bind({});
 withActionIconButton.args = {
   ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: (props) => <Add size={20} {...props} />,
-    iconDescription: 'Add icon',
-  },
+  action: 1,
 };
 
 export const withLink = Template.bind({});
@@ -89,12 +97,7 @@ withLink.args = {
 export const withActionAndLink = Template.bind({});
 withActionAndLink.args = {
   ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: (props) => <Add size={20} {...props} />,
-    iconDescription: 'Add icon',
-  },
+  action: 1,
   link: {
     text: 'View documentation',
     href: 'https://www.carbondesignsystem.com',

--- a/packages/ibm-products/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.mdx
+++ b/packages/ibm-products/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.mdx
@@ -1,0 +1,112 @@
+import { Story, Controls, Source, Canvas } from '@storybook/addon-docs/blocks';
+import * as stories from './UnauthorizedEmptyState.stories';
+import { stackblitzPrefillConfig } from '../../../../previewer/codePreviewer';
+
+# Unauthorized Empty State
+
+[Carbon empty states pattern](https://carbondesignsystem.com/patterns/empty-states-pattern/)
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Default](#default)
+- [WithDarkModeIllustration](#with-dark-mode-illustration)
+- [withAction](#with-action)
+- [withActionIconButton](#with-action-icon-button)
+- [withLink](#with-link)
+- [withActionAndLink](#with-action-and-link)
+
+## Overview
+
+Empty states are moments in an app where there is no data to display to the
+user.
+
+## Default
+
+<Canvas
+  of={stories.Default}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.Default,
+        }),
+    },
+  ]}
+/>
+
+## With Dark Mode Illustration
+
+<Canvas
+  of={stories.WithDarkModeIllustration}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.WithDarkModeIllustration,
+        }),
+    },
+  ]}
+/>
+
+## With Action
+
+<Canvas
+  of={stories.withAction}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withAction,
+        }),
+    },
+  ]}
+/>
+
+## with Action Icon Button
+
+<Canvas
+  of={stories.withActionIconButton}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withActionIconButton,
+        }),
+    },
+  ]}
+/>
+
+## With Link
+
+<Canvas
+  of={stories.withLink}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withLink,
+        }),
+    },
+  ]}
+/>
+
+## With Action And Link
+
+<Canvas
+  of={stories.withActionAndLink}
+  additionalActions={[
+    {
+      title: 'Open in Stackblitz',
+      onClick: () =>
+        stackblitzPrefillConfig({
+          story: stories.withActionAndLink,
+        }),
+    },
+  ]}
+/>

--- a/packages/ibm-products/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.stories.jsx
+++ b/packages/ibm-products/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.stories.jsx
@@ -6,11 +6,10 @@
  */
 
 import React from 'react';
-import { action } from 'storybook/actions';
+import { action as storybookAction } from 'storybook/actions';
 import { Add } from '@carbon/react/icons';
-// import mdx from './UnauthorizedEmptyState.mdx';
+import mdx from './UnauthorizedEmptyState.mdx';
 import { UnauthorizedEmptyState } from '.';
-import { StoryDocsPage } from '../../../global/js/utils/StoryDocsPage';
 
 // import styles from '../_index.scss';
 
@@ -21,16 +20,7 @@ export default {
   parameters: {
     // styles,
     docs: {
-      page: () => (
-        <StoryDocsPage
-          altGuidelinesHref={[
-            {
-              href: 'https://www.carbondesignsystem.com/patterns/empty-states-pattern/',
-              label: 'Carbon empty states pattern',
-            },
-          ]}
-        />
-      ),
+      page: mdx,
     },
   },
 };
@@ -42,8 +32,34 @@ const defaultStoryProps = {
   illustrationDescription: 'Test alt text',
 };
 
-const Template = (args) => {
-  return <UnauthorizedEmptyState {...args} />;
+const Template = ({ ...args }, context) => {
+  const sbDocs = context.viewMode !== 'docs';
+  const { action } = args;
+  const getAction = (value) => {
+    if (value === 0) {
+      return {
+        text: 'Create new',
+        onClick: () => {
+          sbDocs
+            ? storybookAction('Clicked empty state action button')()
+            : console.log('Clicked empty state action button');
+        },
+      };
+    }
+    if (value === 1) {
+      return {
+        text: 'Create new',
+        onClick: () => {
+          sbDocs
+            ? storybookAction('Clicked empty state action button')()
+            : console.log('Clicked empty state action button');
+        },
+        renderIcon: (props) => <Add size={20} {...props} />,
+        iconDescription: 'Add icon',
+      };
+    }
+  };
+  return <UnauthorizedEmptyState {...args} action={getAction(action)} />;
 };
 
 export const Default = Template.bind({});
@@ -60,21 +76,13 @@ WithDarkModeIllustration.args = {
 export const withAction = Template.bind({});
 withAction.args = {
   ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-  },
+  action: 0,
 };
 
 export const withActionIconButton = Template.bind({});
 withActionIconButton.args = {
   ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: (props) => <Add size={20} {...props} />,
-    iconDescription: 'Add icon',
-  },
+  action: 1,
 };
 
 export const withLink = Template.bind({});
@@ -89,12 +97,7 @@ withLink.args = {
 export const withActionAndLink = Template.bind({});
 withActionAndLink.args = {
   ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: (props) => <Add size={20} {...props} />,
-    iconDescription: 'Add icon',
-  },
+  action: 1,
   link: {
     text: 'View documentation',
     href: 'https://www.carbondesignsystem.com',


### PR DESCRIPTION
Closes #8267 

Integration of `Open in Stackblitz ` in Overview page of below components:

- EmptyState
- ErrorEmptyState
- NoDataEmptyState
- NoTagsEmptyState
- NotFoundEmptyState
- NotificationsEmptyState
- UnauthorizedEmptyState

#### What did you change?
Added `mdx` file for each component and made the required updates in their story files.

#### How did you test and verify your work? yarn storybook and Open in stackblitz

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
