### PR TITLE
fix(datagrid): pagination row not displaying when filters are used

### DIFF
--- a/packages/ibm-products-styles/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/ibm-products-styles/src/components/Datagrid/styles/_datagrid.scss
@@ -330,8 +330,8 @@
 
   .#{$block-class}-filter-panel
     + .#{$block-class}__table-container-inner
-    .#{c4p-settings.$carbon-prefix}--data-table-content {
-    block-size: fit-content;
+    .#{c4p-settings.$carbon-prefix}--pagination {
+    background-color: $layer-02;
   }
 
   table.#{$block-class}__table-simple {
@@ -660,6 +660,10 @@
 
   .#{c4p-settings.$pkg-prefix}--datagrid__table-simple {
     block-size: 100%;
+  }
+
+  .#{c4p-settings.$carbon-prefix}--data-table-content {
+    block-size: fit-content;
   }
 }
 


### PR DESCRIPTION
Closes #8237 

#### What did you change?
packages/ibm-products-styles/src/components/Datagrid/styles/_datagrid.scss

#### How did you test and verify your work?

local Storybook by modifying the FilterPanel story to include pagination functionality.

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
