### PR TITLE
chore(storybook): use theme tokens for sb doc previews

### DIFF
--- a/packages/ibm-products-web-components/.storybook/_container.scss
+++ b/packages/ibm-products-web-components/.storybook/_container.scss
@@ -79,3 +79,11 @@ body {
   block-size: 100vh;
   inline-size: 100%;
 }
+
+.docs-story {
+  background-color: theme.$background;
+}
+
+.docs-story > *:has(> .docblock-code-toggle) {
+  background-color: theme.$background;
+}

--- a/packages/ibm-products/.storybook/index.scss
+++ b/packages/ibm-products/.storybook/index.scss
@@ -65,3 +65,11 @@ body {
 .docblock-argstable-head ~ .docblock-argstable-body p {
   @include styles.type-style('body-01');
 }
+
+.docs-story {
+  background: styles.$background;
+}
+
+.docs-story > *:has(> .docblock-code-toggle) {
+  background-color: styles.$background;
+}


### PR DESCRIPTION
Closes #7998

Uses background theme token for the storybook doc previews so that we don't end up in mixed theme states.

#### What did you change?
```
packages/ibm-products-web-components/.storybook/_container.scss
packages/ibm-products/.storybook/index.scss
```
#### How did you test and verify your work?
Verified locally across both storybooks
#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
