### PR TITLE
chore(ci): do not update playwright reports for drafts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,9 @@ jobs:
 
   merge-reports:
     # Merge reports after playwright-tests, even if some shards have failed
-    if: ${{ !cancelled() }}
+    if:
+      ${{ github.repository == 'carbon-design-system/ibm-products' && !cancelled() &&
+      github.event.pull_request.draft == false }}
     needs: avt-runner
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
I noticed a PR over in core that fixes this so thought I'd bring the change over here for our ci workflow. This will opt-out of updating the playwright coverage reports for draft PRs.
#### What did you change?
- `.github/workflows/ci.yml`
#### How did you test and verify your work?
Will verify in this PR, I'll open initially as a draft
#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
