### PR TITLE
fix: remove patterns from build output

### DIFF
--- a/packages/ibm-products/scripts/build.js
+++ b/packages/ibm-products/scripts/build.js
@@ -140,6 +140,7 @@ function getRollupConfig(input, rootDir, outDir) {
           rootDir,
           outDir,
         },
+        exclude: ['**/patterns/**'], // pattern code doesn't need to be included in build
       }),
       babel(babelConfig),
       preserveDirectives(),


### PR DESCRIPTION
Closes #8385

excludes `/patterns/` from build output since pattern code isn't actually a build artifact. the only part of the rollup config that seemed to be contributing to the `pattern` output was the `typescript` plugin, so `exclude` was added to the config.

verified locally with `yarn build`