### PR TITLE
chore(PageHeader): use condensed grid for tab bar text alignment

### DIFF
--- a/packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
+++ b/packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
@@ -905,7 +905,6 @@ $duration: 1000ms;
 
   .#{$block-class}__tab-bar {
     background-color: $layer;
-    margin-inline-start: -$spacing-05;
   }
 
   .#{$block-class}__tab-bar--tablist {

--- a/packages/ibm-products-web-components/src/components/page-header/page-header-tabs.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header-tabs.ts
@@ -19,7 +19,7 @@ import { carbonElement as customElement } from '@carbon/web-components/es/global
 @customElement(`${prefix}-page-header-tabs`)
 class CDSPageHeaderTabs extends LitElement {
   render() {
-    return html` <div class="${carbonPrefix}--css-grid">
+    return html` <div class="${carbonPrefix}--css-grid" condensed="">
       <div
         class="${carbonPrefix}--sm:col-span-4 ${carbonPrefix}--md:col-span-8 ${carbonPrefix}--lg:col-span-16 ${carbonPrefix}--css-grid-column"
       >

--- a/packages/ibm-products-web-components/src/components/page-header/page-header.scss
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header.scss
@@ -259,10 +259,12 @@ $carbon-prefix: 'cds';
 }
 
 :host(#{$prefix}-page-header-tabs) {
-  margin-inline-start: -$spacing-05;
   // TODO: remove above styles when styles from React have been migrated
   // and use the extend below
   // @extend .#{$prefix}--page-header__tab-bar;
+  .#{$carbon-prefix}--css-grid .#{$carbon-prefix}--css-grid-column {
+    margin: 0;
+  }
 }
 
 :host(#{$prefix}-page-header-tabs) .#{$prefix}--page-header__tab-bar--tablist {

--- a/packages/ibm-products-web-components/src/components/page-header/page-header.stories.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header.stories.ts
@@ -615,7 +615,7 @@ export const TabBarWithTabsAndTags = {
 };
 
 const meta = {
-  title: 'Patterns/PageHeader',
+  title: 'Components/PageHeader',
   decorators: [
     (story) =>
       html` <style>

--- a/packages/ibm-products/src/components/PageHeader/next/PageHeader.tsx
+++ b/packages/ibm-products/src/components/PageHeader/next/PageHeader.tsx
@@ -771,7 +771,7 @@ const PageHeaderTabBar = React.forwardRef<
   if (!tags) {
     return (
       <div className={classNames} ref={ref} {...other}>
-        <Grid>
+        <Grid condensed>
           <Column lg={16} md={8} sm={4}>
             {children}
             {renderScroller()}
@@ -783,7 +783,7 @@ const PageHeaderTabBar = React.forwardRef<
 
   return (
     <div className={classNames} ref={ref} {...other}>
-      <Grid>
+      <Grid condensed>
         <Column lg={16} md={8} sm={4}>
           <div
             className={classnames(`${blockClass}__tab-bar--tablist`, {


### PR DESCRIPTION
Closes #8489

This PR updates the page header tab bar so that the text alignment is correct. Updates have been made for both react and web components. I also re-categorized the page header in the web component storybook to it's correct place, within the "components" section.

#### What did you change?
- Used condensed prop for grid usage in tab bar
#### How did you test and verify your work?
Storybook, react and web component
#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [X] Addressed any impact on accessibility (a11y)
- [X] Tested for cross-browser consistency
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
