### PR TITLE
ci(release): configure oidc for npm publishes

### DIFF
--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -19,13 +19,14 @@ on:
         type: boolean
         default: true
 
+# Required for OIDC publishing https://docs.npmjs.com/trusted-publishers
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
-    # Recommended by npm for publishing with provenance https://docs.npmjs.com/generating-provenance-statements
-    permissions:
-      id-token: write
-      contents: write
     timeout-minutes: 60
     env:
       GH_TOKEN: ${{ secrets.MERGE_ACTION }}

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -12,12 +12,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Required for OIDC publishing https://docs.npmjs.com/trusted-publishers
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   release-canary:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/release-v1.yml
+++ b/.github/workflows/release-v1.yml
@@ -3,13 +3,14 @@ name: v1 release # Builds and releases @carbon/v10 supported version of @carbon/
 on:
   workflow_dispatch:
 
+# Required for OIDC publishing https://docs.npmjs.com/trusted-publishers
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   Release_v1:
     runs-on: ubuntu-latest
-    # Recommended by npm for publishing with provenance https://docs.npmjs.com/generating-provenance-statements
-    permissions:
-      id-token: write
-      contents: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,14 @@ on:
         default: ''
         type: string
 
+# Required for OIDC publishing https://docs.npmjs.com/trusted-publishers
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   Release:
     runs-on: ubuntu-latest
-    # Recommended by npm for publishing with provenance https://docs.npmjs.com/generating-provenance-statements
-    permissions:
-      id-token: write
-      contents: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-example-upgrade.yml
+++ b/.github/workflows/test-example-upgrade.yml
@@ -5,6 +5,11 @@ on:
   # schedule:
   # - cron: '30 4 * * TUE' # Release every Tuesday at 4:30am EST
 
+# Required for OIDC publishing https://docs.npmjs.com/trusted-publishers
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   Release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Configures our release workflows to work with the [upcoming changes](https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/) to classic tokens, we'll now be required to use granular access tokens instead. We will need to manually update our package within npm to specify which workflows are allowed to publish. That can be done before or after this is merged, see docs [here](https://docs.npmjs.com/trusted-publishers) for adding a trusted publisher.

#### What did you change?
- Publishing workflows
#### How did you test and verify your work?
- We won't be able to test until this is merged and trusted publisher workflows are added manually to our project in npm.
#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
