### PR TITLE
fix: include `OptionsTile` style in `_index-released-only.scss` file

### DIFF
--- a/packages/ibm-products-styles/src/components/_index-released-only.scss
+++ b/packages/ibm-products-styles/src/components/_index-released-only.scss
@@ -28,6 +28,7 @@
 @use './ImportModal';
 @use './MultiAddSelect';
 @use './NotificationsPanel';
+@use './OptionsTile';
 @use './PageHeader';
 @use './ProductiveCard';
 @use './RemoveModal';


### PR DESCRIPTION
Closes #8400

Imported the `OptionsTile` styles in `packages/ibm-products-styles/src/components/_index-released-only.scss`

#### What did you change?
`@use './OptionsTile';` in the file `packages/ibm-products-styles/src/components/_index-released-only.scss`

#### How did you test and verify your work?
Storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
