### PR TITLE
chore(Tearsheet): replace `h2` and `h3` tags with `Section` and `Heading`

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
@@ -505,7 +505,7 @@ export const TearsheetShell = React.forwardRef(
                         </Heading>
                       </Section>
                     )}
-                    <Section level={2}>
+                    <Section level={3}>
                       <Heading
                         className={cx(
                           `${bcModalHeader}__heading`,


### PR DESCRIPTION
Closes #8376 

Replace hard-coded tags with `Section` and `Heading` components from `@carbon/react`

#### What did you change?
Replaced `h2` and `h3` tags with `Section` and `Heading`

#### How did you test and verify your work?
Storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
