### PR TITLE
fix(pr-labeler): use write permissions for prs

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
   contents: read
 
 jobs:


### PR DESCRIPTION
Noticed the PR labeler action [failed again](https://github.com/carbon-design-system/ibm-products/actions/runs/18752821307/job/53496844171), based on the `issue-labeler` action docs you also have to include write permissions to pull requests.

#### What did you change?
- `.github/workflows/pr-labeler.yml`
#### How did you test and verify your work?
N/A
#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [X] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~
- [ ] ~Wrote passing tests that cover this change~
- [ ] ~Addressed any impact on accessibility (a11y)~
- [ ] ~Tested for cross-browser consistency~
- [X] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
