### PR TITLE
fix: replace yarn with npx for playwright scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
         run: yarn
       - name: Install browsers
         working-directory: packages/ibm-products-web-components
-        run: yarn playwright install --with-deps
+        run: npx playwright install --with-deps
       - name: Build web-components project
         run: yarn build:packages
       - name: CI tests for products web components
@@ -171,7 +171,7 @@ jobs:
         run: yarn
 
       - name: Install browsers
-        run: yarn playwright install --with-deps
+        run: npx playwright install --with-deps
 
       - name: Build project
         run: yarn build
@@ -190,7 +190,7 @@ jobs:
       - name: Run AVT
         if: github.repository == 'carbon-design-system/ibm-products'
         run: |
-          yarn playwright test --project chromium --grep @avt --shard="${{ matrix.shardIndex }}/${{ matrix.shardTotal }}"
+          npx playwright test --project chromium --grep @avt --shard="${{ matrix.shardIndex }}/${{ matrix.shardTotal }}"
       - name: Stop storybook
         run: kill ${{ steps.storybook.outputs.pid }}
 
@@ -262,7 +262,7 @@ jobs:
       - name: Install
         run: yarn
       - name: Install browsers
-        run: yarn playwright install --with-deps
+        run: npx playwright install --with-deps
       - name: Build project
         run: yarn build
       - name: Run VRT

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -80,7 +80,7 @@ jobs:
 
       # For generating playwright json report for avt tests
       # - name: Install browsers
-      #   run: yarn playwright install --with-deps
+      #   run: npx playwright install --with-deps
 
       - name: Continuous integration check (includes build)
         run: yarn ci-check
@@ -98,7 +98,7 @@ jobs:
       # - name: Run AVT
       #   if: github.repository == 'carbon-design-system/ibm-products'
       #   run: |
-      #     yarn playwright test --project chromium --grep @avt --shard="${{ matrix.shardIndex }}/${{ matrix.shardTotal }}"
+      #     npx playwright test --project chromium --grep @avt --shard="${{ matrix.shardIndex }}/${{ matrix.shardTotal }}"
       # - name: Stop storybook
       #   run: kill ${{ steps.storybook.outputs.pid }}
       # - name: Upload test results

--- a/docs/e2e_testing.md
+++ b/docs/e2e_testing.md
@@ -2,16 +2,16 @@
 
 ## Overview
 
-| Task                                                  | Command                                            |
-| :---------------------------------------------------- | :------------------------------------------------- |
-| Run playwright tests                                  | `yarn playwright test`                             |
-| Run a specific playwright test                        | `yarn playwright test path/to/test-e2e.js`         |
-| Run playwright tests in a specific browser            | `yarn playwright test --browser=chromium`          |
-| Run playwright tests in a specific project            | `yarn playwright test --project=chromium`          |
-| Debug playwright tests                                | `yarn playwright test --debug`                     |
-| Run playwright with browser visible                   | `yarn playwright test --project=chromium --headed` |
-| Run playwright tests that match a specific tag        | `yarn playwright test --grep @tag-name`            |
-| Run playwright tests that do not match a specific tag | `yarn playwright test --grep-invert @tag-name`     |
+| Task                                                  | Command                                           |
+| :---------------------------------------------------- | :------------------------------------------------ |
+| Run playwright tests                                  | `npx playwright test`                             |
+| Run a specific playwright test                        | `npx playwright test path/to/test-e2e.js`         |
+| Run playwright tests in a specific browser            | `npx playwright test --browser=chromium`          |
+| Run playwright tests in a specific project            | `npx playwright test --project=chromium`          |
+| Debug playwright tests                                | `npx playwright test --debug`                     |
+| Run playwright with browser visible                   | `npx playwright test --project=chromium --headed` |
+| Run playwright tests that match a specific tag        | `npx playwright test --grep @tag-name`            |
+| Run playwright tests that do not match a specific tag | `npx playwright test --grep-invert @tag-name`     |
 
 ### Playwright
 
@@ -54,7 +54,7 @@ will also need to run the follow installation command so that Playwright has the
 browsers specified in `playwright.config.js` to run the e2e tests:
 
 ```bash
-yarn playwright install
+npx playwright install
 ```
 
 Now you can run the playwright tests with one of the commands in the overview

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "audit": "node scripts/audit.js '--environment production' moderate",
-    "avt": "AVT=true yarn playwright test --project chromium --grep @avt",
+    "avt": "AVT=true npx playwright test --project chromium --grep @avt",
     "build": "run-s -s 'build:*' storybook:build",
     "build:packages": "yarn run-all --include-dependencies build",
     "ci-check": "run-s -s 'ci-check:*' storybook:build",
@@ -49,7 +49,7 @@
     "test:c4p": "lerna run --stream --scope @carbon/ibm-products test --",
     "test:c4p:snapshot": "yarn test:c4p-styles styles -u",
     "test:c4p-styles": "lerna run --stream --scope @carbon/ibm-products-styles test --",
-    "test:c4p-wc": "yarn playwright install && lerna run --stream --scope @carbon/ibm-products-web-components test --",
+    "test:c4p-wc": "npx playwright install && lerna run --stream --scope @carbon/ibm-products-web-components test --",
     "spellcheck": "cspell '**' -e './examples' --gitignore --quiet --no-must-find-files",
     "storybook": "cd packages/ibm-products && yarn storybook:start",
     "storybook:build": "cd packages/ibm-products && yarn storybook:build",


### PR DESCRIPTION
looks like `yarn playwright` is having issues as per https://github.com/microsoft/playwright/issues/17975#issuecomment-1917441952

to alleviate this we will switch all the playwright script commands to use `npx` instead of `yarn`