### PR TITLE
test(playwright): use `with-deps` flag for web component test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test:c4p": "lerna run --stream --scope @carbon/ibm-products test --",
     "test:c4p:snapshot": "yarn test:c4p-styles styles -u",
     "test:c4p-styles": "lerna run --stream --scope @carbon/ibm-products-styles test --",
-    "test:c4p-wc": "yarn playwright install && lerna run --stream --scope @carbon/ibm-products-web-components test --",
+    "test:c4p-wc": "yarn playwright install --with-deps && lerna run --stream --scope @carbon/ibm-products-web-components test --",
     "spellcheck": "cspell '**' -e './examples' --gitignore --quiet --no-must-find-files",
     "storybook": "cd packages/ibm-products && yarn storybook:start",
     "storybook:build": "cd packages/ibm-products && yarn storybook:build",


### PR DESCRIPTION
Some of the [system level dependencies](https://playwright.dev/docs/browsers#install-system-dependencies) required for playwright don't seem to be installed in the [latest release workflow](https://github.com/carbon-design-system/ibm-products/actions/runs/18842316547/job/53757392070#step:8:807). We should include the `--with-deps` flag within the test script for web components so ensure everything is there that needs to be.

#### What did you change?
- `package.json`
#### How did you test and verify your work?

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
