### PR TITLE
fix: condition builder popover getting closed on scrollbar click

### DIFF
--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBlock/ConditionBlock.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBlock/ConditionBlock.tsx
@@ -237,6 +237,7 @@ const ConditionBlock = (props: ConditionBlockProps) => {
     );
   };
   return (
+    // eslint-disable-next-line jsx-a11y/interactive-supports-focus
     <div
       className={cx(
         `${blockClass}__condition-block`,
@@ -257,7 +258,6 @@ const ConditionBlock = (props: ConditionBlockProps) => {
       role="row"
       aria-label={conditionRowText}
       {...getAriaAttributes()}
-      tabIndex={-1}
       onMouseEnter={showAllActionsHandler}
       onMouseLeave={hideAllActionsHandler}
       onBlur={hideAllActionsHandler}

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItem.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItem.tsx
@@ -214,7 +214,8 @@ export const ConditionBuilderItem = ({
       return;
     }
 
-    const focusLeftPopover = !popoverEl.contains(relatedTarget);
+    const focusLeftPopover =
+      relatedTarget && !popoverEl.contains(relatedTarget);
     const targetInsidePopover = popoverEl.contains(focusEvent.target as Node);
 
     const targetEl = focusEvent.target as Element | null;


### PR DESCRIPTION
Closes #8564

When try to scroll the popover by clicking and dragging the scrollbar, popover getting closed and row is focussed.
Even though the row is not expected to focussed, we were setting tabindex -1. The browser (or your grid’s focus management) automatically restores focus to the last active focusable element in the grid context — which is your role="row" (because it has tabIndex=-1).

This will set the [relativeTarget](https://github.com/carbon-design-system/carbon/blob/main/packages/react/src/components/Popover/index.tsx#L202) as the row which is an element outside the popover recognising it as an outside click and closes.

#### What did you change?
Removed explicitly setting tab index -1
#### How did you test and verify your work?

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
