### PR TITLE
fix: prevent customize column hook from running on column resize

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
@@ -102,6 +102,10 @@ const CustomizeColumnsTearsheet = ({
   const string = searchText.trim().toLowerCase();
 
   useEffect(() => {
+    // prevent this effect from running when columns are being resized
+    if (!isOpen) {
+      return;
+    }
     if (prevColumnDefinitions.current !== columnDefinitions) {
       setColumnObjects(columnDefinitions);
     }


### PR DESCRIPTION
Closes #8094 

prevents the `useEffect` inside of `CustomizeColumnsTearsheet` from running when datagrid columns are being resized, which causes the app to crash from re-renders.

`CustomizeColumnsTearsheet` isn't visible when the user is able to drag the column widths and shouldn't be affected by that interaction anyways.