### PR TITLE
fix: remove use client directive warnings from build

### DIFF
--- a/packages/ibm-products/.storybook/main.js
+++ b/packages/ibm-products/.storybook/main.js
@@ -70,6 +70,18 @@ export default {
     const { mergeConfig } = await import('vite');
 
     return mergeConfig(config, {
+      build: {
+        sourcemap: true,
+        rollupOptions: {
+          onLog(level, log, handler) {
+            // https://github.com/vitejs/vite/issues/15012#issuecomment-1815854072
+            if (log.code === 'MODULE_LEVEL_DIRECTIVE') {
+              return;
+            }
+            handler(level, log);
+          },
+        },
+      },
       esbuild: {
         include: /\.[jt]sx?$/,
         exclude: [],


### PR DESCRIPTION
Closes #8532 

suppresses logs that are showing up during build regarding `use client`

confirmed with `yarn build`