### PR TITLE
fix: prevent disable buttons hook from running on column resize

### DIFF
--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
@@ -103,6 +103,7 @@ const FilterFlyout = ({
       initialValue: true,
       filtersState,
       prevFiltersRef,
+      open,
     });
 
   // Skip resize testing

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
@@ -117,6 +117,7 @@ const FilterPanel = ({
       initialValue: true,
       filtersState,
       prevFiltersRef,
+      open: panelOpen,
     });
 
   const shouldReduceMotion = usePrefersReducedMotion();

--- a/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useShouldDisableButtons.js
+++ b/packages/ibm-products/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useShouldDisableButtons.js
@@ -21,12 +21,17 @@ const useShouldDisableButtons = ({
   initialValue, // initially the buttons should be disabled
   filtersState,
   prevFiltersRef,
+  open,
 }) => {
   const [shouldDisableButtons, setShouldDisableButtons] =
     useState(initialValue);
 
   useEffect(
     function updateDisabledButtonsState() {
+      // prevent this effect from running when columns are being resized
+      if (!open) {
+        return;
+      }
       setShouldDisableButtons(
         deepCompareObject(filtersState, JSON.parse(prevFiltersRef.current))
       );


### PR DESCRIPTION
Closes #8094 

addresses the second scenario where the `useFiltering` hook, which calls the `useShouldDisableButtons`, shouldn't run when closed.
