### PR TITLE
chore(Tearsheet): replace h2 and h3 tags with Section and Heading

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
@@ -35,6 +35,7 @@ import {
   Section,
   usePrefix,
   unstable_FeatureFlags as FeatureFlags,
+  Heading,
 } from '@carbon/react';
 
 import { ActionSet } from '../ActionSet';
@@ -490,25 +491,22 @@ export const TearsheetShell = React.forwardRef(
                   effectiveHasCloseIcon ? closeIconDescription : undefined
                 }
               >
-                <Wrap
+                <Section
                   className={`${bc}__header-content`}
                   element={wide ? Layer : undefined}
                 >
                   <Wrap className={`${bc}__header-fields`}>
                     {/* we create the label and title here instead of passing them
                       as modal header props so we can wrap them in layout divs */}
-                    <Wrap element="h2" className={`${bcModalHeader}__label`}>
-                      {label}
-                    </Wrap>
-                    <Wrap
-                      element="h3"
+                    <Wrap className={`${bcModalHeader}__label`}>{label}</Wrap>
+                    <Section
                       className={cx(
                         `${bcModalHeader}__heading`,
                         `${bc}__heading`
                       )}
                     >
-                      {title}
-                    </Wrap>
+                      <Heading>{title}</Heading>
+                    </Section>
                     <Wrap className={`${bc}__header-description`}>
                       {description}
                     </Wrap>
@@ -516,7 +514,7 @@ export const TearsheetShell = React.forwardRef(
                   <Wrap className={`${bc}__header-actions`}>
                     {headerActions}
                   </Wrap>
-                </Wrap>
+                </Section>
                 <Wrap className={`${bc}__header-navigation`}>{navigation}</Wrap>
               </ModalHeader>
             )}


### PR DESCRIPTION
Closes #

Replace hard-coded heading levels with Section and Heading components from @carbon/react

#### What did you change?

Replaced h3 with `Heading` and h2 with `Wrap` div.

#### How did you test and verify your work?

Storybook
`yarn avt`

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
