### PR TITLE
fix(checklist): title and chart title do not show tooltip when truncated

### DIFF
--- a/packages/ibm-products-styles/src/components/Checklist/_checklist.scss
+++ b/packages/ibm-products-styles/src/components/Checklist/_checklist.scss
@@ -62,12 +62,10 @@ $block-class: #{c4p-settings.$pkg-prefix}--checklist;
 
 .#{$block-class}__title {
   @include type-style('productive-heading-02');
-  @include ellipsis-2-lines();
 }
 
 .#{$block-class}__chart-label {
   @include type-style('label-01');
-  @include ellipsis-2-lines();
 
   color: $text-secondary;
 }

--- a/packages/ibm-products/src/components/Checklist/Checklist.stories.jsx
+++ b/packages/ibm-products/src/components/Checklist/Checklist.stories.jsx
@@ -11,6 +11,8 @@ import { action } from 'storybook/actions';
 import { getSelectedCarbonTheme } from '../../global/js/utils/story-helper';
 
 import { Checklist } from '.';
+import { TruncatedText } from '../TruncatedText';
+
 import styles from './_storybook-styles.scss?inline';
 import DocsPage from './Checklist.docs-page';
 
@@ -114,9 +116,27 @@ checklist.args = {
     action(`toggle ${isOpen ? 'open' : 'closed'}`)();
   },
   chartValue: 0.15,
-  chartLabel: '15% complete',
+  chartLabel: (
+    <TruncatedText
+      autoAlign
+      align="bottom"
+      id="example-id-1"
+      lines={2}
+      type="tooltip"
+      value="15% complete"
+    />
+  ),
   taskLists: taskLists,
-  title: 'Checklist header',
+  title: (
+    <TruncatedText
+      autoAlign
+      align="bottom"
+      id="example-id-2"
+      lines={2}
+      type="tooltip"
+      value="A long title running over the lines to show truncation and tooltips"
+    />
+  ),
   viewAllLabel: `View all (10)`,
 };
 

--- a/packages/ibm-products/src/components/Checklist/Checklist.tsx
+++ b/packages/ibm-products/src/components/Checklist/Checklist.tsx
@@ -64,7 +64,7 @@ export interface ChecklistProps {
   /**
    * Define both `chartLabel` and `chartValue` to show the chart and its label together.
    */
-  chartLabel?: string;
+  chartLabel?: ReactNode;
   /**
    * A number between 0 and 1.
    *
@@ -354,7 +354,7 @@ Checklist.propTypes = {
   /**
    * Define both `chartLabel` and `chartValue` to show the chart and its label together.
    */
-  chartLabel: PropTypes.string,
+  chartLabel: PropTypes.node,
   /**
    * A number between 0 and 1.
    *


### PR DESCRIPTION
Closes #8521 

#### What did you change?

- Used the TruncatedText component in default Checklist story to demonstrate how to implement truncated behavior in Checklist header.
- Changed the type of `chartLabel` prop to `ReactNode` from `String`

#### How did you test and verify your work?

Storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
