### PR TITLE
fix(InterstitalScreen): avoid reset to step 1 on window resize

### DIFF
--- a/packages/ibm-products/src/components/Carousel/Carousel.tsx
+++ b/packages/ibm-products/src/components/Carousel/Carousel.tsx
@@ -73,6 +73,10 @@ export interface CarouselProps {
    * and other items will be hidden and inactive.
    */
   isScrollMode?: boolean;
+  /**
+   *This overrides the default behavior of resetting scrollLeft to 0 on resize.
+   */
+  disableResetOnResize?: boolean;
 }
 
 // The block part of our conventional BEM class names (blockClass__E--M).
@@ -112,6 +116,7 @@ const Carousel = React.forwardRef<HTMLDivElement, CarouselProps>(
       onChangeIsScrollable = defaults.onChangeIsScrollable,
       onScroll = defaults.onScroll,
       isScrollMode = false,
+      disableResetOnResize = false,
       ...rest
     } = props;
     const carouselRef = useRef<HTMLDivElement>(null);
@@ -303,12 +308,15 @@ const Carousel = React.forwardRef<HTMLDivElement, CarouselProps>(
         if (!scrollRef.current) {
           return;
         }
-        scrollRef.current.scrollLeft = 0;
-        handleOnScroll();
+        if (!disableResetOnResize) {
+          scrollRef.current.scrollLeft = 0;
+          handleOnScroll();
+        }
       };
 
       window.addEventListener('resize', handleWindowResize);
       return () => window.removeEventListener('resize', handleWindowResize);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [handleOnScroll]);
 
     // On scrollRef.scrollend, trigger a callback.

--- a/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreenBody.tsx
+++ b/packages/ibm-products/src/components/InterstitialScreen/InterstitialScreenBody.tsx
@@ -146,6 +146,7 @@ const InterstitialScreenBody = React.forwardRef<
           <div className={`${blockClass}__carousel`}>
             <Carousel
               disableArrowScroll
+              disableResetOnResize
               ref={scrollRef}
               onScroll={onScrollHandler}
             >


### PR DESCRIPTION
Closes #8805

Add a new prop `disableResetOnResize` to the Carousel internal component to override this behavior




#### How did you test and verify your work?
local storybook
#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
