### PR TITLE
fix: exception focusing launcherButton

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
@@ -332,7 +332,7 @@ export const TearsheetShell = React.forwardRef(
     useEffect(() => {
       if (prevOpen && !open && launcherButtonRef?.current) {
         setTimeout(() => {
-          launcherButtonRef?.current.focus();
+          launcherButtonRef?.current?.focus();
         }, 10);
       }
     }, [open, prevOpen, launcherButtonRef]);


### PR DESCRIPTION
Refs #7057.

Just because `launcherButtonRef.current` is defined before calling `setTimeout()` doesn't mean that it's defined when the `setTimeout()` callback executes.

One *example* of when this fails is during a Jest test that finishes before the `setTimeout()` callback runs, but the test suite itself is still running.  Something like:

```js
it("close tearsheet", async () => {
   ...
   await userEvent.click(closeButton);
}

it("long running test", async () => {
   ...
}
```

Somehow this bug causes the second Jest test to fail, even though the callback runs in a separate thread.

#### What did you change?

Don't try to focus if `launcherButtonRef` is undefined.

#### How did you test and verify your work?

Tested locally.

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
