### PR TITLE
fix(notification-panel): use truncated-text in notification-panel story

### DIFF
--- a/packages/ibm-products-web-components/src/components/notification-panel/notification-panel.stories.ts
+++ b/packages/ibm-products-web-components/src/components/notification-panel/notification-panel.stories.ts
@@ -16,6 +16,7 @@ import { prefix, carbonPrefix } from '../../globals/settings';
 import '@carbon/web-components/es/components/button/index.js';
 import '@carbon/web-components/es/components/ui-shell/index.js';
 import '@carbon/web-components/es/components/heading/index.js';
+import './../truncated-text/index.js';
 import { UnreadNotificationBell } from './_story-assets/unread-notification-bell';
 import User20 from '@carbon/icons/es/user/20.js';
 import Notification20 from '@carbon/icons/es/notification/20.js';
@@ -279,15 +280,14 @@ const defaultTemplate = {
                     >
                       ${item.title}
                     </h4>
-                    <span slot="description">
-                      <c4p-truncated-text
-                        value=${item.description}
-                        lines="2"
-                        type="expand"
-                        expand-label="Read more"
-                        collapse-label="Read less"
-                      />
-                    </span>
+                    <c4p-truncated-text
+                      slot="description"
+                      value=${item.description}
+                      lines="2"
+                      type="expand"
+                      expand-label="Read more"
+                      collapse-label="Read less"
+                    />
                   </c4p-notification>
                 `;
               })}
@@ -316,15 +316,14 @@ const defaultTemplate = {
                     >
                       ${item.title}
                     </h4>
-                    <span slot="description">
-                      <c4p-truncated-text
-                        value=${item.description}
-                        lines="2"
-                        type="expand"
-                        expand-label="Read more"
-                        collapse-label="Read less"
-                      />
-                    </span>
+                    <c4p-truncated-text
+                      slot="description"
+                      value=${item.description}
+                      lines="2"
+                      type="expand"
+                      expand-label="Read more"
+                      collapse-label="Read less"
+                    />
                   </c4p-notification>
                 `;
               })}


### PR DESCRIPTION
Closes #8662 

Use truncatedText component from the story level to truncate the text to 2 lines.

#### What did you change?

- Use truncatedText component to description slot in story
- Add type 'expand' and expand/collapse labels as 'Read more' / 'Read less'

#### How did you test and verify your work?
Local storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
