### PR TITLE
fix(PageHeader): use TruncatedText in PageHeader subtitle

### DIFF
--- a/packages/ibm-products/src/components/PageHeader/PageHeader.stories.jsx
+++ b/packages/ibm-products/src/components/PageHeader/PageHeader.stories.jsx
@@ -43,6 +43,7 @@ import {
 import cx from 'classnames';
 
 import { PageHeader } from './PageHeader';
+import { TruncatedText } from '../TruncatedText';
 import { demoTableHeaders, demoTableData } from './PageHeaderDemo.data';
 
 import styles from './_storybook-styles.scss?inline';
@@ -480,6 +481,16 @@ const longSubtitle =
   'Optional subtitle if necessary, which is very long in this case, but will need to be handled somehow. It just keeps going on and on and on and on and on and on and on and on and on and on and on.';
 const demoSubtitle = 'This report details the monthly authentication failures';
 
+const longSubtitleReactNode = (
+  <TruncatedText
+    id="page-header-long-subtitle"
+    value={longSubtitle}
+    type="tooltip"
+    align="bottom"
+    autoAlign
+  />
+);
+
 const dummyPageContent = (
   <Grid className={`${storyClass}__dummy-content`} narrow={true}>
     <Column
@@ -805,7 +816,7 @@ export const fullyLoadedAndSome = Template.bind({});
 fullyLoadedAndSome.storyName = 'Page header with long values and many items';
 fullyLoadedAndSome.args = {
   title: 3,
-  subtitle: longSubtitle,
+  subtitle: longSubtitleReactNode,
   breadcrumbs: 3,
   pageActions: 3,
   children: 2,

--- a/packages/ibm-products/src/components/PageHeader/PageHeader.test.jsx
+++ b/packages/ibm-products/src/components/PageHeader/PageHeader.test.jsx
@@ -17,6 +17,7 @@ import { Tab, Tabs, TabList } from '@carbon/react';
 import { Lightning, Bee } from '@carbon/react/icons';
 
 import { PageHeader } from '.';
+import { TruncatedText } from '../TruncatedText';
 import { mockHTMLElement } from '../../global/js/utils/test-helper';
 
 import { TYPES as tagTypes } from '../TagSet/constants';
@@ -701,7 +702,7 @@ describe('PageHeader', () => {
     }
   });
 
-  it('renders subtitle with TruncatedText when subtitle is a string', async () => {
+  it('renders subtitle as string', async () => {
     const { title, subtitle } = testProps;
     render(<PageHeader {...{ title, subtitle }} />);
 
@@ -711,7 +712,7 @@ describe('PageHeader', () => {
     expect(screen.getByText(subtitle)).toBeInTheDocument();
   });
 
-  it('renders subtitle without TruncatedText when subtitle is not a string', async () => {
+  it('renders subtitle as ReactNode with custom component', async () => {
     const { title } = testProps;
     const subtitleNode = (
       <div data-testid="custom-subtitle">Custom subtitle</div>
@@ -725,22 +726,33 @@ describe('PageHeader', () => {
     expect(screen.getByText('Custom subtitle')).toBeInTheDocument();
   });
 
-  it('renders long subtitle with ellipses when text exceeds 2 lines', async () => {
+  it('renders subtitle with TruncatedText component for tooltip functionality', async () => {
     const { title } = testProps;
-    const longSubtitle =
+    const longSubtitleText =
       'This is a very long subtitle that should definitely exceed two lines when rendered in the page header component. It contains enough text to trigger the truncation behavior and show ellipses at the end of the second line. This ensures that the TruncatedText component is working correctly with the tooltip functionality.';
+    const subtitleWithTruncation = (
+      <TruncatedText
+        id="test-subtitle"
+        value={longSubtitleText}
+        lines={2}
+        type="tooltip"
+        align="bottom"
+      />
+    );
 
-    render(<PageHeader {...{ title, subtitle: longSubtitle }} />);
+    render(<PageHeader {...{ title, subtitle: subtitleWithTruncation }} />);
 
     expect(document.querySelectorAll(`.${blockClass}__subtitle`)).toHaveLength(
       1
     );
 
-    // Check that TruncatedText component is rendered with correct props
+    // Check that TruncatedText component is rendered
     const truncatedTextElement = document.querySelector(
       `.${prefix}--truncated-text`
     );
     expect(truncatedTextElement).toBeInTheDocument();
-    expect(screen.getByText(longSubtitle)).toBeInTheDocument();
+
+    // Verify the text content is present
+    expect(screen.getByText(longSubtitleText)).toBeInTheDocument();
   });
 });

--- a/packages/ibm-products/src/components/PageHeader/PageHeader.tsx
+++ b/packages/ibm-products/src/components/PageHeader/PageHeader.tsx
@@ -51,7 +51,6 @@ import { BreadcrumbWithOverflow } from '../BreadcrumbWithOverflow';
 import { ButtonSetWithOverflow } from '../ButtonSetWithOverflow';
 import { ChevronUp } from '@carbon/react/icons';
 import { PageHeaderTitle } from './PageHeaderTitle';
-import { TruncatedText } from '../TruncatedText';
 import PropTypes from 'prop-types';
 import { breakpoints } from '@carbon/layout';
 import cx from 'classnames';
@@ -1066,21 +1065,9 @@ export const PageHeader = React.forwardRef(
               {subtitle && (
                 <Row className={`${blockClass}__subtitle-row`}>
                   <Column className={`${blockClass}__subtitle`}>
-                    {typeof subtitle === 'string' ? (
-                      <TruncatedText
-                        id={`${blockClass}__subtitle`}
-                        className={`${blockClass}__subtitle-text`}
-                        value={subtitle}
-                        lines={2}
-                        type="tooltip"
-                        align="bottom"
-                        autoAlign={true}
-                      />
-                    ) : (
-                      <span className={`${blockClass}__subtitle-text`}>
-                        {subtitle}
-                      </span>
-                    )}
+                    <span className={`${blockClass}__subtitle-text`}>
+                      {subtitle}
+                    </span>
                   </Column>
                 </Row>
               )}


### PR DESCRIPTION
Closes #8615 

Use TruncatedText in storybook file of the PageHeader to truncate the subtitle 2 lines.

#### What did you change?

- Use TruncatedText in storybook file of the PageHeader to truncate the subtitle 2 lines
- Add tests for code coverage
- remove the existing overflow logic and reference to DefinitionTooltip component

#### How did you test and verify your work?
Local storybook and ran all PageHeader tests.

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
