### PR TITLE
feat: show Close icon at global header actions when expanded

### DIFF
--- a/examples/carbon-for-ibm-products/NotificationsPanel/src/Example/Example.jsx
+++ b/examples/carbon-for-ibm-products/NotificationsPanel/src/Example/Example.jsx
@@ -8,7 +8,7 @@ import {
   HeaderGlobalAction,
   Button,
 } from '@carbon/react';
-import { Notification } from '@carbon/icons-react';
+import { Close, Notification } from '@carbon/icons-react';
 
 import './_example.scss';
 
@@ -46,7 +46,11 @@ export const Example = () => {
                 aria-label="Notifications"
                 onClick={() => setOpen(!open)}
               >
-                <Notification size={20} />
+                {open ? (
+                  <Close size={20} />
+                ) : (
+                  <Notification size={20} />
+                )}
               </HeaderGlobalAction>
             </HeaderGlobalBar>
           </Header>

--- a/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.stories.jsx
+++ b/packages/ibm-products/src/components/NotificationsPanel/NotificationsPanel.stories.jsx
@@ -15,7 +15,7 @@ import {
   HeaderGlobalBar,
   HeaderGlobalAction,
 } from '@carbon/react';
-import { User, Notification, Switcher } from '@carbon/react/icons';
+import { User, Notification, Switcher, Close } from '@carbon/react/icons';
 import { StoryDocsPage } from '../../global/js/utils/StoryDocsPage';
 import styles from './_storybook-styles.scss?inline';
 import uuidv4 from '../../global/js/utils/uuidv4';
@@ -213,7 +213,7 @@ const Template = (args) => {
               }, 0);
             }}
           >
-            <User size={20} />
+            {userOpen ? <Close size={20} /> : <User size={20} />}
           </HeaderGlobalAction>
           <HeaderPanel expanded={userOpen}>
             <div className={`${storyBlockClass}__header-panel`}>
@@ -242,7 +242,9 @@ const Template = (args) => {
               setSwitcherOpen(false);
             }}
           >
-            {!notificationsOpen && hasUnreadNotifications ? (
+            {notificationsOpen ? (
+              <Close size={20} />
+            ) : hasUnreadNotifications ? (
               <UnreadNotificationBell />
             ) : (
               <Notification size={20} />
@@ -289,7 +291,7 @@ const Template = (args) => {
               }, 0);
             }}
           >
-            <Switcher size={20} />
+            {switcherOpen ? <Close size={20} /> : <Switcher size={20} />}
           </HeaderGlobalAction>
           <HeaderPanel expanded={switcherOpen}>
             <div className={`${storyBlockClass}__header-panel`}>


### PR DESCRIPTION
Closes #8858

Following Carbon guidelines, the Close Icon should appear when appropriate panel is expanded, so I added this feature.
<img width="409" height="292" alt="image" src="https://github.com/user-attachments/assets/51686fc5-faab-4b94-b177-5da92df19df7" />

#### What did you change?

- Updated each icon of the Header Global Actions to show the Close icon when its panel is expanded in the storybook.
- Updated the example that is associated with the component.

#### How did you test and verify your work?

- Tested stacking in storybook
- Tested feature flag in storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
