### PR TITLE
fix(Tearsheet): tearsheet heading level for title and label"

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/TearsheetShell.tsx
@@ -35,7 +35,6 @@ import {
   Section,
   usePrefix,
   unstable_FeatureFlags as FeatureFlags,
-  Heading,
 } from '@carbon/react';
 
 import { ActionSet } from '../ActionSet';
@@ -491,7 +490,7 @@ export const TearsheetShell = React.forwardRef(
                   effectiveHasCloseIcon ? closeIconDescription : undefined
                 }
               >
-                <Section
+                <Wrap
                   className={`${bc}__header-content`}
                   element={wide ? Layer : undefined}
                 >
@@ -499,14 +498,15 @@ export const TearsheetShell = React.forwardRef(
                     {/* we create the label and title here instead of passing them
                       as modal header props so we can wrap them in layout divs */}
                     <Wrap className={`${bcModalHeader}__label`}>{label}</Wrap>
-                    <Section
+                    <Wrap
+                      element="h3"
                       className={cx(
                         `${bcModalHeader}__heading`,
                         `${bc}__heading`
                       )}
                     >
-                      <Heading>{title}</Heading>
-                    </Section>
+                      {title}
+                    </Wrap>
                     <Wrap className={`${bc}__header-description`}>
                       {description}
                     </Wrap>
@@ -514,7 +514,7 @@ export const TearsheetShell = React.forwardRef(
                   <Wrap className={`${bc}__header-actions`}>
                     {headerActions}
                   </Wrap>
-                </Section>
+                </Wrap>
                 <Wrap className={`${bc}__header-navigation`}>{navigation}</Wrap>
               </ModalHeader>
             )}


### PR DESCRIPTION
Closes #8828, #8930.

PR #8675 caused multiple regressions, both visually and semantically.

In particular, it broke the Tearsheet header size settings by applying the classes to the wrong node.

And, IMO, modals should always be at the H2 level, regardless of where they appear in the VDOM.

It's still questionable for Tearsheet to use *both* H2 and H3, but I didn't change that in this PR.

#### What did you change?

This reverts commit d952a8f256c29d97261c06799e22f63c799c9780.

#### How did you test and verify your work?

Storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
