### PR TITLE
fix(Pageheader_preview): header calulation issue when compose modal is open

### DIFF
--- a/packages/ibm-products-web-components/src/components/page-header/utils.ts
+++ b/packages/ibm-products-web-components/src/components/page-header/utils.ts
@@ -48,6 +48,14 @@ const windowExists = typeof window !== `undefined`;
  */
 export const scrollable = (target: HTMLElement): boolean => {
   const style = window.getComputedStyle(target);
+  const tagName = target.tagName.toLowerCase();
+
+  // Exclude body/html from hidden check (modals set overflow:hidden on body)
+  if (tagName === 'body' || tagName === 'html') {
+    return /(auto|scroll)/.test(style.overflow);
+  }
+
+  // For other elements, include hidden as it may be intentional scroll container
   return /(auto|scroll|hidden)/.test(style.overflow);
 };
 

--- a/packages/ibm-products/src/components/PageHeader/next/utils.ts
+++ b/packages/ibm-products/src/components/PageHeader/next/utils.ts
@@ -46,6 +46,14 @@ const windowExists = typeof window !== `undefined`;
  */
 const scrollable = (target: HTMLElement): boolean => {
   const style = window.getComputedStyle(target);
+  const tagName = target.tagName.toLowerCase();
+
+  // Exclude body/html from hidden check (modals set overflow:hidden on body)
+  if (tagName === 'body' || tagName === 'html') {
+    return /(auto|scroll)/.test(style.overflow);
+  }
+
+  // For other elements, include hidden as it may be intentional scroll container
   return /(auto|scroll|hidden)/.test(style.overflow);
 };
 


### PR DESCRIPTION
Closes #8939 

The specific scenario is keeping the compose modal open and then resizing the window, this will mess up the header position calculations and broke the header.
While the modal is open, it applies overflow: hidden to the body, which causes the PageHeader calculations to break(ComposeModal behaviour).




#### How did you test and verify your work?
local

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
