### PR TITLE
feat: show close icon when panels are open

### DIFF
--- a/packages/ibm-products-web-components/src/components/notification-panel/notification-panel.stories.ts
+++ b/packages/ibm-products-web-components/src/components/notification-panel/notification-panel.stories.ts
@@ -20,6 +20,7 @@ import './../truncated-text/index.js';
 import { UnreadNotificationBell } from './_story-assets/unread-notification-bell';
 import User20 from '@carbon/icons/es/user/20.js';
 import Notification20 from '@carbon/icons/es/notification/20.js';
+import Close20 from '@carbon/icons/es/close/20.js';
 import SwitcherIcon20 from '@carbon/icons/es/switcher/20.js';
 import {
   dataToday as initialDataToday,
@@ -196,7 +197,9 @@ const defaultTemplate = {
               setExpandUserPanel((prev) => !prev);
             }}
           >
-            ${iconLoader(User20, { slot: 'icon' })}
+            ${expandUserPanel
+              ? iconLoader(Close20, { slot: 'icon' })
+              : iconLoader(User20, { slot: 'icon' })}
           </cds-header-global-action>
           <cds-header-panel
             id="user-panel"
@@ -216,9 +219,11 @@ const defaultTemplate = {
             id="trigger-button"
             @click="${toggleButton}"
           >
-            ${isNewNotification
-              ? UnreadNotificationBell({ slot: 'icon' })
-              : iconLoader(Notification20, { slot: 'icon' })}
+            ${openPanel
+              ? iconLoader(Close20, { slot: 'icon' })
+              : isNewNotification
+                ? UnreadNotificationBell({ slot: 'icon' })
+                : iconLoader(Notification20, { slot: 'icon' })}
           </cds-header-global-action>
           <cds-header-global-action
             aria-label="App Switcher"
@@ -228,7 +233,9 @@ const defaultTemplate = {
               setExpandPanel((prev) => !prev);
             }}
           >
-            ${iconLoader(SwitcherIcon20, { slot: 'icon' })}
+            ${expandPanel
+              ? iconLoader(Close20, { slot: 'icon' })
+              : iconLoader(SwitcherIcon20, { slot: 'icon' })}
           </cds-header-global-action>
           <cds-header-panel
             id="switcher-panel"


### PR DESCRIPTION
Closes #8858

Following Carbon guidelines and the conversation of the PR #8933, the Close Icon should appear when appropriate panel is expanded, so I added this feature.
<img width="1608" height="364" alt="image" src="https://github.com/user-attachments/assets/987764c4-f6de-4e17-9cbe-70cee7b824a7" />


#### What did you change?

- Updated each icon of the Header Global Actions to show the Close icon when its panel is expanded in the storybook.

#### How did you test and verify your work?

- Tested stacking in storybook
- Tested feature flag in storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
