### PR TITLE
fix(CoachmarkBeacon): removed role from wrapper div

### DIFF
--- a/packages/ibm-products/src/components/Coachmark/next/Coachmark/Coachmark.stories.jsx
+++ b/packages/ibm-products/src/components/Coachmark/next/Coachmark/Coachmark.stories.jsx
@@ -116,25 +116,27 @@ const TooltipTemplate = ({ ...args }, context) => {
 
   return (
     <Theme theme={carbonTheme}>
-      <Coachmark
-        position={{ x: 151, y: 155 }}
-        open={isOpen}
-        onClose={handleClose}
-        {...args}
-      >
-        <CoachmarkBeacon
-          label="Show information"
-          buttonProps={{ onClick: handleBeaconClick, id: 'CoachmarkBtn' }}
-        ></CoachmarkBeacon>
-        <Coachmark.Content highContrast={true}>
-          <Coachmark.Content.Header closeIconDescription="Close"></Coachmark.Content.Header>
-          <Coachmark.Content.Body>
-            <h2>Hello World</h2>
-            <p>this is a description test</p>
-            <Button size="sm">Done</Button>
-          </Coachmark.Content.Body>
-        </Coachmark.Content>
-      </Coachmark>
+      <main>
+        <Coachmark
+          position={{ x: 151, y: 155 }}
+          open={isOpen}
+          onClose={handleClose}
+          {...args}
+        >
+          <CoachmarkBeacon
+            label="Show information"
+            buttonProps={{ onClick: handleBeaconClick, id: 'CoachmarkBtn' }}
+          ></CoachmarkBeacon>
+          <Coachmark.Content highContrast={true}>
+            <Coachmark.Content.Header closeIconDescription="Close"></Coachmark.Content.Header>
+            <Coachmark.Content.Body>
+              <h2>Hello World</h2>
+              <p>this is a description test</p>
+              <Button size="sm">Done</Button>
+            </Coachmark.Content.Body>
+          </Coachmark.Content>
+        </Coachmark>
+      </main>
     </Theme>
   );
 };
@@ -154,29 +156,36 @@ const FloatingTemplate = ({ ...args }, context) => {
   };
   return (
     <Theme theme={carbonTheme}>
-      <Coachmark open={isOpen} onClose={handleClose} floating={true} {...args}>
-        <Button
-          id="CoachmarkBtn"
-          kind="tertiary"
-          size="md"
-          label="Show information"
-          renderIcon={Crossroads}
-          onClick={handleButtonClick}
+      <main>
+        <Coachmark
+          open={isOpen}
+          onClose={handleClose}
+          floating={true}
+          {...args}
         >
-          Show information
-        </Button>
-        <Coachmark.Content highContrast={true}>
-          <Coachmark.Content.Header
-            closeIconDescription="Close"
-            dragIconDescription="Drag"
-          ></Coachmark.Content.Header>
-          <Coachmark.Content.Body>
-            <h2>Hello World</h2>
-            <p>this is a description test</p>
-            <Button size="sm">Done</Button>
-          </Coachmark.Content.Body>
-        </Coachmark.Content>
-      </Coachmark>
+          <Button
+            id="CoachmarkBtn"
+            kind="tertiary"
+            size="md"
+            label="Show information"
+            renderIcon={Crossroads}
+            onClick={handleButtonClick}
+          >
+            Show information
+          </Button>
+          <Coachmark.Content highContrast={true}>
+            <Coachmark.Content.Header
+              closeIconDescription="Close"
+              dragIconDescription="Drag"
+            ></Coachmark.Content.Header>
+            <Coachmark.Content.Body>
+              <h2>Hello World</h2>
+              <p>this is a description test</p>
+              <Button size="sm">Done</Button>
+            </Coachmark.Content.Body>
+          </Coachmark.Content>
+        </Coachmark>
+      </main>
     </Theme>
   );
 };

--- a/packages/ibm-products/src/components/Coachmark/next/Coachmark/CoachmarkBeacon/CoachmarkBeacon.tsx
+++ b/packages/ibm-products/src/components/Coachmark/next/Coachmark/CoachmarkBeacon/CoachmarkBeacon.tsx
@@ -66,7 +66,6 @@ export const CoachmarkBeacon = forwardRef<
     <div
       className={cx(blockClass, `${blockClass}-${kind}`, className)}
       {...getDevtoolsProps(componentName)}
-      role="tooltip"
       {...rest}
       ref={ref}
     >
@@ -74,9 +73,13 @@ export const CoachmarkBeacon = forwardRef<
         type="button"
         {...buttonProps}
         className={`${blockClass}__target`}
+        aria-label={label}
       >
-        <svg className={`${blockClass}__center`} aria-label={label}>
-          <title>{label}</title>
+        <svg
+          className={`${blockClass}__center`}
+          aria-hidden="true"
+          focusable="false"
+        >
           <circle r={1} cx={38} cy={38} />
         </svg>
       </button>


### PR DESCRIPTION
Closes #7935 

Removed tooltip role from the CoachmarkBeacon wrapper and added <main> in stories.tsx to fix the required page-level landmark role.

#### What did you change? packages/ibm-products/src/components/Coachmark/next/Coachmark/CoachmarkBeacon/CoachmarkBeacon.tsx
packages/ibm-products/src/components/Coachmark/next/Coachmark/Coachmark.stories.jsx

#### How did you test and verify your work? IBM accessibility checker

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
