### PR TITLE
chore: bump @carbon/feature-flags version

### DIFF
--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -112,7 +112,7 @@
   "dependencies": {
     "@babel/runtime": "^7.26.10",
     "@carbon-labs/react-resizer": "^0.10.0",
-    "@carbon/feature-flags": "^0.32.0",
+    "@carbon/feature-flags": "^1.0.0",
     "@carbon/ibm-products-styles": "^2.79.0",
     "@carbon/telemetry": "^0.1.0",
     "@carbon/utilities": "^0.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2050,12 +2050,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/feature-flags@npm:>=0.32.0, @carbon/feature-flags@npm:^0.32.0":
-  version: 0.32.0
-  resolution: "@carbon/feature-flags@npm:0.32.0"
+"@carbon/feature-flags@npm:>=0.32.0, @carbon/feature-flags@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@carbon/feature-flags@npm:1.0.0"
   dependencies:
     "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10/4dd3f8c4c127b3ecdd45bdd51dd28c901e26c9aab508b0aec2aca894293c407b60087811ce5da4b8b8f5363bcbb005bbdd7bfed31abecc310edf5643aff4e1f4
+  checksum: 10/0c40e6674f2a2d49355ec3dcce68faa2d81ccfad9c2324e92a4d4ca88b5e4071d19c888ff7dfbe5b733ffe454eea2cd1779722ba6b5bfb204adaf450848aa090
   languageName: node
   linkType: hard
 
@@ -2179,7 +2179,7 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.26.0"
     "@babel/runtime": "npm:^7.26.10"
     "@carbon-labs/react-resizer": "npm:^0.10.0"
-    "@carbon/feature-flags": "npm:^0.32.0"
+    "@carbon/feature-flags": "npm:^1.0.0"
     "@carbon/ibm-products-styles": "npm:^2.79.0"
     "@carbon/styles": "npm:^1.99.0"
     "@carbon/telemetry": "npm:^0.1.0"


### PR DESCRIPTION
Refs carbon-design-system/carbon#21019.

The problem with the old @carbon/feature-flags version (^0.32.0) is that the caret doesn't mean the normal thing. This is a weird thing about 0.x.x versions in package.json files.  It will allow an update to 0.33 but not to 0.4.0 (and not to 1.0.0 either).

Note that yarn.lock still has a reference to @carbon/feature-flags@npm:>=0.32.0. That will be fixed after https://github.com/carbon-design-system/carbon/pull/21515 is merged/released and then @carbon/ibm-products updates its @carbon/react and @carbon/styles dependencies.

If you prefer, we could also bump to @carbon/react@1.101.0 in this PR.

#### What did you change?

Bumped @carbon/feature-flags version to ^1.0.0.

#### How did you test and verify your work?

Unit tests

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [x] Updated documentation and storybook examples
- [x] Wrote passing tests that cover this change
- [x] Addressed any impact on accessibility (a11y)
- [x] Tested for cross-browser consistency
- [] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
