### PR TITLE
fix(SidePanel): Allow closing SidePanel via ESC key

### DIFF
--- a/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
+++ b/packages/ibm-products/src/components/SidePanel/SidePanel.tsx
@@ -320,11 +320,23 @@ export const SidePanel = React.forwardRef<HTMLDivElement, SidePanelProps>(
     // Title animation on scroll related state
     const [labelTextHeight, setLabelTextHeight] = useState<any>(0);
 
-    const handleEscapeKey = (event) => {
-      if (event.key === 'Escape' && open) {
-        onRequestClose?.();
+    const handleEscapeKey = useCallback(
+      (event) => {
+        if (event.key === 'Escape' && open) {
+          onRequestClose?.();
+        }
+      },
+      [onRequestClose, open]
+    );
+
+    useEffect(() => {
+      if (open && !slideIn) {
+        window.addEventListener('keydown', handleEscapeKey);
+        return () => {
+          window.removeEventListener('keydown', handleEscapeKey);
+        };
       }
-    };
+    }, [handleEscapeKey, open, slideIn]);
 
     useEffect(() => {
       if (!enableResizer) {


### PR DESCRIPTION
Closes #8614 

#### What did you change?

Attached an event listener for `window` and handled the `Esc` key event.

`window.addEventListener('keydown', handleEscapeKey);`

#### How did you test and verify your work?
Storybook 

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
