### PR TITLE
fix: preserve namespace in storycode

### DIFF
--- a/packages/ibm-products/.storybook/main.js
+++ b/packages/ibm-products/.storybook/main.js
@@ -86,6 +86,7 @@ export default {
         include: /\.[jt]sx?$/,
         exclude: [],
         loader: 'tsx',
+        keepNames: true,
       },
       optimizeDeps: {
         esbuildOptions: {


### PR DESCRIPTION
Closes #8894 

In Storybook, the Docs page and Code tab are displaying local wrapper component names as single-letter identifiers (e.g., ), instead of their original component names.

#### What did you change?
 `keepNames: true, ` in storybook config file

#### How did you test and verify your work?
PR deploy preview

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
