### PR TITLE
fix: build warnings from CoachmarkOverlayElements and CoachmarkStacked

### DIFF
--- a/packages/ibm-products/src/patterns/CoachmarkOverlayElements/CoachmarkOverlayElements.mdx
+++ b/packages/ibm-products/src/patterns/CoachmarkOverlayElements/CoachmarkOverlayElements.mdx
@@ -58,6 +58,6 @@ explain, educate, and cultivate novice users into high-functioning power users.
 
 <Canvas className="coachmarkExample" withSource="none">
   <div className="CoachmarkBaseExampleUsage">
-    <Story of={CoachmarkOverlayElementsStories.coachmarkOverlayElements} />
+    <Story of={CoachmarkOverlayElementsStories.CoachmarkOverlay} />
   </div>
 </Canvas>

--- a/packages/ibm-products/src/patterns/CoachmarkStacked/CoachmarkStacked.mdx
+++ b/packages/ibm-products/src/patterns/CoachmarkStacked/CoachmarkStacked.mdx
@@ -56,6 +56,6 @@ explain, educate, and cultivate novice users into high-functioning power users.
 
 <Canvas className="coachmarkExample" withSource="none">
   <div className="CoachmarkBaseExampleUsage">
-    <Story of={CoachmarkStackedStories.CoachmarkStacked} />
+    <Story of={CoachmarkStackedStories.CoachmarkStack} />
   </div>
 </Canvas>


### PR DESCRIPTION
Closes #8525 

Resolve warnings coming from `CoachmarkOevrlayElements.mdx` and  `CoachmarkStacked.mdx`

#### What did you change?
packages/ibm-products/src/patterns/CoachmarkOverlayElements/CoachmarkOverlayElements.mdx
packages/ibm-products/src/patterns/CoachmarkStacked/CoachmarkStacked.mdx

#### How did you test and verify your work? yarn build

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
