### PR TITLE
fix: workaround fix to prevent popover to close on date sel

### DIFF
--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.test.jsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.test.jsx
@@ -915,6 +915,46 @@ describe(componentName, () => {
     expect(selectedItem).toBeVisible();
   });
 
+  it('should keep the popover open when a date is selected from the flatpickr calendar', async () => {
+    render(<ConditionBuilder {...defaultProps} inputConfig={inputData} />);
+
+    await act(() => userEvent.click(screen.getByText('Add condition')));
+
+    await act(() =>
+      userEvent.click(
+        screen.getByRole('option', {
+          name: 'Date',
+        })
+      )
+    );
+
+    const isOperator = screen.getByRole('option', {
+      name: 'is',
+    });
+    await act(() => userEvent.click(isOperator));
+
+    // The value field popover should be open — the date input is rendered inside it
+    expect(document.querySelector('#datePicker')).toBeInTheDocument();
+
+    // Simulate a click inside a flatpickr calendar (as if the user is picking a date).
+    // The flatpickr calendar is appended outside the popover DOM, so Carbon's Popover
+    // fires onRequestClose when it detects an outside click. Our workaround should
+    // suppress this and keep the popover open.
+    const flatpickrCalendar = document.createElement('div');
+    flatpickrCalendar.className = 'flatpickr-calendar';
+    document.body.appendChild(flatpickrCalendar);
+
+    await act(() => {
+      fireEvent.click(flatpickrCalendar);
+    });
+
+    // The date input should still be in the document (popover should remain open)
+    expect(document.querySelector('#datePicker')).toBeInTheDocument();
+
+    // Cleanup
+    document.body.removeChild(flatpickrCalendar);
+  });
+
   it('render the component with input type date range', async () => {
     render(<ConditionBuilder {...defaultProps} inputConfig={inputData} />);
 

--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItem.tsx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilderItem/ConditionBuilderItem.tsx
@@ -284,7 +284,18 @@ export const ConditionBuilderItem = ({
       role="gridcell"
       className={`${popOverClassName} ${blockClass}__popover`}
       ref={popoverRef}
-      onRequestClose={closePopover}
+      onRequestClose={() => {
+        // Workaround: prevent closing the popover when a date is selected
+        // from the flatpickr calendar, which is rendered outside the popover DOM.
+        // The flatpickr calendar is appended outside the popover DOM, so clicks on it
+        // trigger onRequestClose. We use the global event object to check the click target.
+        // carbon issue: https://github.com/carbon-design-system/carbon/issues/21690
+        const target = (event as MouseEvent)?.target as Element | null;
+        if (target?.closest('.flatpickr-calendar')) {
+          return;
+        }
+        closePopover();
+      }}
     >
       <ConditionBuilderButton
         label={getLabel()}


### PR DESCRIPTION

When we try ti select a date in the condition builder, the popover ittself is getting closed. Looks like this issue is tied up to carbon recent fix on popover. I have opened this ticket on carbon , and we can revert the change once they fix it.

#### What did you change?
Add a check in the onRequestClose before closing.

#### How did you test and verify your work?

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
