### PR TITLE
fix(SidePanel): fix action buttons stacking issue in size 2xl

### DIFF
--- a/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
+++ b/packages/ibm-products-styles/src/components/SidePanel/_side-panel.scss
@@ -559,8 +559,6 @@ $clabs-prefix: resizer.$prefix;
           inline-size: 25%;
         }
       }
-
-      flex-direction: column;
     }
 
     .#{$action-set-block-class}__action-button.#{$action-set-block-class}__action-button {


### PR DESCRIPTION
Closes #8689 

Fix issue of action buttons stacking vertically when size is 2xl

#### What did you change?

- Remove styling `flex-direction: column;` for the 2xl css class 

#### How did you test and verify your work?
Local storybook and re-ran component tests and AVT

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
