### PR TITLE
feat(Tearsheet_preview): refactor portalTarget implementation in preview_Tearsheet

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/next/Tearsheet.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/next/Tearsheet.tsx
@@ -409,38 +409,6 @@ export const Tearsheet = forwardRef<HTMLDivElement, TearsheetProps>(
       />
     );
   }
-);
-
-/**
- * Wrapper component that handles presence logic and conditionally renders TearsheetInternal.
- * This ensures that all component state and effects are only initialized when the tearsheet is present.
- */
-export const Tearsheet = forwardRef<HTMLDivElement, TearsheetProps>(
-  (props, ref: ForwardedRef<HTMLDivElement>) => {
-    const { open = false, keepMounted = false } = props;
-    const presenceRef = useRef<HTMLDivElement>(null);
-
-    // Use presence hook for enter/exit animations (unless keepMounted is true)
-    const { isPresent, isExiting } = usePresence(
-      presenceRef,
-      keepMounted ? true : open
-    );
-
-    // Don't render if not present (after exit animation completes) - unless keepMounted is true
-    if (!keepMounted && !isPresent) {
-      return null;
-    }
-
-    // When present, render the internal component with all props
-    return (
-      <TearsheetInternal
-        {...props}
-        ref={ref}
-        presenceRef={presenceRef}
-        isExiting={isExiting}
-      />
-    );
-  }
 ) as TearsheetComponentType;
 
 export interface FooterProps {


### PR DESCRIPTION
Closes #9040 

In the legacy Tearsheet, we expose a portalTarget prop that accepts a DOM node and renders the component via a React portal. By default, when the feature flag is enabled, the portal target falls back to document.body. However, the current implementation uses the usePortalTarget hook, which is causing unnecessary re-renders.

The legacy Tearsheet's usePortalTarget hook was causing unnecessary re-renders due to its implementation pattern using useState + useEffect, which creates an initial null state before setting the actual portal target.
The new Tearsheet now uses an optimized portal implementation that eliminates the re-render issue while maintaining all existing functionality.

#### What did you change?

- Removed usePortalTarget Hook Dependency
- Replaced the hook with a direct, more efficient implementation
- Default used body as portal instead of being through a feature flag as in old tearsheet.
- Added disablePortal Prop to render in existing dom sequence.

#### How did you test and verify your work?

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
