### PR TITLE
fix: make style specific to sidepanel in tearsheet

### DIFF
--- a/packages/ibm-products-styles/src/components/Tearsheet/_tearsheet_next.scss
+++ b/packages/ibm-products-styles/src/components/Tearsheet/_tearsheet_next.scss
@@ -580,7 +580,7 @@ $transform-start: translate3d(0, calc(min(95vh, 500px)), 0);
 .#{$block-class__next}__main-content {
   position: relative;
 }
-.#{$pkg-prefix}--side-panel {
+.#{$block-class__next}__side-panel {
   position: absolute;
   z-index: 9999;
   block-size: 100%;

--- a/packages/ibm-products-web-components/src/components/tearsheet-preview/tearsheet.scss
+++ b/packages/ibm-products-web-components/src/components/tearsheet-preview/tearsheet.scss
@@ -239,7 +239,7 @@ $motion-duration: $duration-moderate-02;
 
 :host {
   #{$c4p-prefix}-side-panel::part(dialog) {
-    @extend .#{$c4p-prefix}--side-panel; // Extend the side panel styles}
+    @extend .#{$block-class__next}__side-panel; // Extend the side panel styles}
   }
 }
 

--- a/packages/ibm-products/src/components/Tearsheet/next/TearsheetBody.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/next/TearsheetBody.tsx
@@ -160,7 +160,7 @@ export const SummaryContent = forwardRef<HTMLDivElement, SummaryContentProps>(
         size="sm"
         open={summaryPanelOpen}
         onRequestClose={onSummaryPanelClose}
-        className={className}
+        className={cx(`${blockClass}__side-panel`, className)}
       >
         {children}
       </SidePanel>
@@ -211,7 +211,7 @@ export const Influencer = forwardRef<HTMLDivElement, InfluencerProps>(
         open={influencerPanelOpen}
         onRequestClose={onInfluencerPanelClose}
         placement="left"
-        className={className}
+        className={cx(`${blockClass}__side-panel`, className)}
       >
         {children}
       </SidePanel>


### PR DESCRIPTION


side panel style added for tearsheet impact actual side panel

#### What did you change?

#### How did you test and verify your work?

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
