### PR TITLE
fix: add resolutions for vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,8 @@
   "//resolutions:http-signature": "package 'request' deprecated but still used, asks for http-signature ~1.2.0 which indirectly has vulnerabilities",
   "//resolutions:minimist": "https://security.snyk.io/vuln/SNYK-JS-MINIMIST-2429795 (version <=1.2.5)",
   "//resolutions:@isaacs/brace-expansion": "DoS via unbounded brace range expansion (versions <=5.0.0).",
+  "//resolutions:flatted": "CVE-2026-33228 (prototype pollution) and CVE-2026-32141 (stack overflow) fixed in 3.4.2",
+  "//resolutions:minimatch": "CVE-2026-27904 (catastrophic backtracking) and CVE-2026-27903 (unbounded recursion) fixed in 3.1.4, 5.1.8, 9.0.7",
   "resolutions": {
     "body-parser": "2.2.2",
     "braces": "^3.0.3",
@@ -147,11 +149,15 @@
     "minimatch@^3.0.0": "^3.1.4",
     "minimatch@^5.0.0": "^5.1.8",
     "minimatch@^9.0.0": "^9.0.7",
+    "minimatch@3.1.3": "3.1.4",
+    "minimatch@5.1.7": "5.1.8",
+    "minimatch@9.0.6": "9.0.7",
     "immutable": "^5.1.5",
     "yauzl": "^3.2.1",
     "js-yaml": "^4.1.1",
     "js-yaml@^3.0.0": "^3.14.2",
-    "js-yaml@^4.0.0": "^4.1.1"
+    "js-yaml@^4.0.0": "^4.1.1",
+    "flatted": "^3.4.2"
   },
   "lint-staged": {
     "*": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -13759,10 +13759,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flatted@npm:^3.2.9, flatted@npm:^3.3.1, flatted@npm:^3.3.3":
-  version: 3.3.3
-  resolution: "flatted@npm:3.3.3"
-  checksum: 10/8c96c02fbeadcf4e8ffd0fa24983241e27698b0781295622591fc13585e2f226609d95e422bcf2ef044146ffacb6b68b1f20871454eddf75ab3caa6ee5f4a1fe
+"flatted@npm:^3.4.2":
+  version: 3.4.2
+  resolution: "flatted@npm:3.4.2"
+  checksum: 10/a9e78fe5c2c1fcd98209a015ccee3a6caa953e01729778e83c1fe92e68601a63e1e69cd4e573010ca99eaf585a581b80ccf1018b99283e6cbc2117bcba1e030f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #9133, #9115

add resolutions for vulnerabilities.

  "//resolutions:flatted": "CVE-2026-33228 (prototype pollution) and CVE-2026-32141fixed in 3.4.2",
  "//resolutions:minimatch": "CVE-2026-27904 (catastrophic backtracking) and CVE-2026-27903 fixed in 3.1.4, 5.1.8, 9.0.7",

#### What did you change?

#### How did you test and verify your work?

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
