### PR TITLE
fix: Coachmark design parity

### DIFF
--- a/packages/ibm-products-web-components/src/components/coachmark/coachmark-header.ts
+++ b/packages/ibm-products-web-components/src/components/coachmark/coachmark-header.ts
@@ -62,8 +62,7 @@ class CDSCoachmarkHeader extends SignalWatcher(HostListenerMixin(LitElement)) {
               kind="ghost"
               size="sm"
               class="${prefix}--coachmark-header-drag-handle"
-              iconDescription="${this.dragIconDescription}"
-              hasIconOnly
+              tooltip-text="${this.dragIconDescription}"
             >
               ${iconLoader(Draggable, {
                 slot: 'icon',
@@ -76,8 +75,7 @@ class CDSCoachmarkHeader extends SignalWatcher(HostListenerMixin(LitElement)) {
       <cds-button
         kind="ghost"
         size="sm"
-        iconDescription="${this.closeIconDescription}"
-        hasIconOnly
+        tooltip-text="${this.closeIconDescription}"
         @click=${this._handleClick}
       >
         ${iconLoader(Close, {

--- a/packages/ibm-products-web-components/src/components/coachmark/coachmark-helpers.ts
+++ b/packages/ibm-products-web-components/src/components/coachmark/coachmark-helpers.ts
@@ -18,10 +18,27 @@ export const handleDone = () => {
   document.querySelector(`${prefix}-coachmark`)?.removeAttribute('open');
 };
 
-// Listen for coachmark-opened event to focus the Done button
+// Listen for coachmark-opened event to focus the appropriate element
 export const handleCoachmarkOpened = () => {
   setTimeout(() => {
-    const doneButton = document.querySelector('.coachmark-body cds-button');
-    (doneButton as HTMLElement)?.focus();
+    const coachmark = document.querySelector(`${prefix}-coachmark`);
+    const isFloating = coachmark?.hasAttribute('floating');
+
+    if (isFloating) {
+      // Focus drag icon for floating coachmark
+      const header = coachmark?.querySelector(
+        `${prefix}-coachmark-header`
+      ) as HTMLElement;
+      if (header && header.shadowRoot) {
+        const dragHandle = header.shadowRoot.querySelector(
+          `.${prefix}--coachmark-header-drag-handle`
+        ) as HTMLElement;
+        dragHandle?.focus();
+      }
+    } else {
+      // Focus done button for non-floating coachmark
+      const doneButton = document.querySelector('.coachmark-body cds-button');
+      (doneButton as HTMLElement)?.focus();
+    }
   }, 100);
 };

--- a/packages/ibm-products-web-components/src/components/coachmark/coachmark.stories.ts
+++ b/packages/ibm-products-web-components/src/components/coachmark/coachmark.stories.ts
@@ -37,9 +37,31 @@ const args = { align: POPOVER_ALIGNMENT.TOP };
 const argTypes = {
   align: {
     control: 'select',
-    description:
-      'Specify the alignment of the Coachmark relative to its target',
+    description: 'Where to render the Coachmark relative to its target',
     options: tooltipAlignments,
+  },
+  open: {
+    control: 'boolean',
+    description: 'Specifies whether the component is currently open',
+  },
+  highContrast: {
+    control: 'boolean',
+    description:
+      'Specify whether the component should be rendered on high-contrast',
+  },
+  floating: {
+    control: 'boolean',
+    description: 'Specifies whether the component is floating or not',
+  },
+  dropShadow: {
+    control: 'boolean',
+    description:
+      'Specify whether a drop shadow should be rendered on the popover',
+  },
+  position: {
+    control: 'object',
+    description:
+      'Fine tune the position of the target in pixels. Applies only to Beacons',
   },
 };
 
@@ -52,7 +74,7 @@ export const Tooltip = {
   },
   argTypes,
 
-  render: (args) => {
+  render: (args: any) => {
     return html`
       <style>
         ${styles}
@@ -73,7 +95,7 @@ export const Tooltip = {
           >
           </c4p-coachmark-beacon>
           <c4p-coachmark-header
-            closeIconDescription="close icon"
+            closeIconDescription="Close"
             class="coachmark-header"
           ></c4p-coachmark-header>
           <c4p-coachmark-body class="coachmark-body">
@@ -116,8 +138,8 @@ export const Floating = {
             >Show information ${iconLoader(Crossroads as any, { slot: 'icon' })}
           </cds-button>
           <c4p-coachmark-header
-            closeIconDescription="close icon"
-            dragIconDescription="drag icon"
+            closeIconDescription="Close"
+            dragIconDescription="Drag"
             class="coachmark-header"
           ></c4p-coachmark-header>
           <c4p-coachmark-body class="coachmark-body">

--- a/packages/ibm-products-web-components/src/components/coachmark/coachmark.test.ts
+++ b/packages/ibm-products-web-components/src/components/coachmark/coachmark.test.ts
@@ -154,8 +154,8 @@ describe('c4p-coachmark', function () {
       `${carbonPrefix}-button`
     ) as HTMLElement;
     expect(closeButton).to.exist;
-    expect(closeButton.hasAttribute('icondescription')).to.be.true;
-    expect(closeButton.getAttribute('icondescription')).to.equal('close icon');
+    expect(closeButton.hasAttribute('tooltip-text')).to.be.true;
+    expect(closeButton.getAttribute('tooltip-text')).to.equal('close icon');
 
     closeButton?.click();
 
@@ -199,6 +199,6 @@ describe('c4p-coachmark', function () {
     expect(headerSlot).to.exist;
 
     const buttons = headerShadow.querySelectorAll(`${carbonPrefix}-button`);
-    expect(buttons[0].getAttribute('icondescription')).to.equal('drag icon');
+    expect(buttons[0].getAttribute('tooltip-text')).to.equal('drag icon');
   });
 });

--- a/packages/ibm-products-web-components/src/components/coachmark/coachmark.ts
+++ b/packages/ibm-products-web-components/src/components/coachmark/coachmark.ts
@@ -166,6 +166,13 @@ class CDSCoachmark extends SignalWatcher(HostListenerMixin(LitElement)) {
     }
   }
 
+  private _handlePopoverClosed = (event: Event) => {
+    // Prevent closing on outside click when floating
+    if (this.floating) {
+      event.preventDefault();
+    }
+  };
+
   render() {
     return html`
       <cds-popover
@@ -175,6 +182,7 @@ class CDSCoachmark extends SignalWatcher(HostListenerMixin(LitElement)) {
         ?highContrast=${this.highContrast}
         align=${this.align}
         ?dropShadow=${this.dropShadow}
+        @cds-popover-beingclosed=${this._handlePopoverClosed}
       >
         <slot name="trigger"></slot>
         <cds-popover-content>

--- a/packages/ibm-products/src/components/Coachmark/next/Coachmark/Coachmark.stories.jsx
+++ b/packages/ibm-products/src/components/Coachmark/next/Coachmark/Coachmark.stories.jsx
@@ -132,7 +132,9 @@ const TooltipTemplate = ({ ...args }, context) => {
             <Coachmark.Content.Body>
               <h2>Hello World</h2>
               <p>this is a description test</p>
-              <Button size="sm">Done</Button>
+              <Button size="sm" onClick={handleClose}>
+                Done
+              </Button>
             </Coachmark.Content.Body>
           </Coachmark.Content>
         </Coachmark>
@@ -181,7 +183,9 @@ const FloatingTemplate = ({ ...args }, context) => {
             <Coachmark.Content.Body>
               <h2>Hello World</h2>
               <p>this is a description test</p>
-              <Button size="sm">Done</Button>
+              <Button size="sm" onClick={handleClose}>
+                Done
+              </Button>
             </Coachmark.Content.Body>
           </Coachmark.Content>
         </Coachmark>

--- a/packages/ibm-products/src/components/Coachmark/next/Coachmark/CoachmarkContent.tsx
+++ b/packages/ibm-products/src/components/Coachmark/next/Coachmark/CoachmarkContent.tsx
@@ -73,15 +73,24 @@ const CoachmarkContent = forwardRef<HTMLDivElement, CoachmarkContentProps>(
     useEffect(() => {
       if (open && 'current' in bubbleRef && bubbleRef.current) {
         requestAnimationFrame(() => {
-          const contentBody = bubbleRef.current?.querySelector(
-            `.${contentBodyClass}`
-          );
+          if (floating) {
+            // Focus drag icon for floating coachmark
+            const dragIcon = bubbleRef.current?.querySelector(
+              `.${blockClass}--content-header--drag-icon`
+            ) as HTMLElement;
+            dragIcon?.focus();
+          } else {
+            // Focus first focusable element in body for non-floating coachmark
+            const contentBody = bubbleRef.current?.querySelector(
+              `.${contentBodyClass}`
+            );
 
-          if (contentBody) {
-            const firstFocusable = Array.from(
-              contentBody.querySelectorAll<HTMLElement>('*')
-            ).find((el) => el.tabIndex >= 0);
-            firstFocusable?.focus();
+            if (contentBody) {
+              const firstFocusable = Array.from(
+                contentBody.querySelectorAll<HTMLElement>('*')
+              ).find((el) => el.tabIndex >= 0);
+              firstFocusable?.focus();
+            }
           }
         });
       }
@@ -90,6 +99,11 @@ const CoachmarkContent = forwardRef<HTMLDivElement, CoachmarkContentProps>(
 
     useEffect(() => {
       const handleOutsideClick = (event: MouseEvent) => {
+        // Don't close on outside click when floating
+        if (floating) {
+          return;
+        }
+
         const targetElement = document.getElementById(targetId || '');
         const bubbleElement =
           bubbleRef && 'current' in bubbleRef ? bubbleRef.current : null;


### PR DESCRIPTION
Closes #9100

Addressed the parity issues 

1. Primary button focus disparity: Button focus in web components does not align with Carbon guidance
    This is issue with carbon popover - I already created an [issue](https://github.com/carbon-design system/carbon/issues/21438) for this.
2. Close button disparity ✅
3. Drag button disparity  ✅
4. Tooltip and Floating coachmark tab order ✅ ( it got resolved with carbon upgrade )
5. Floating coachmark tab order - the initial focus is set to drag button for floating variant ✅
6. Floating coachmark missing controls ✅
7. Floating coachmark UX ✅
8. Icon buttons colors + themes ✅ ( it got resolved with carbon upgrade )

#### What did you change? coachmark react and web component version

#### How did you test and verify your work? yarn storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
