### PR TITLE
fix(build): optimize Storybook build performance

### DIFF
--- a/packages/ibm-products-web-components/.storybook/main.ts
+++ b/packages/ibm-products-web-components/.storybook/main.ts
@@ -65,7 +65,7 @@ const config = {
     return mergeConfig(config, {
       plugins: [litStyleLoader(), litTemplateLoader()],
       optimizeDeps: {
-        include: ['@storybook/web-components-vite'],
+        include: ['@storybook/web-components-vite', 'lodash'],
         exclude: ['lit', 'lit-html'],
       },
       css: {

--- a/packages/ibm-products/.storybook/main.js
+++ b/packages/ibm-products/.storybook/main.js
@@ -102,6 +102,7 @@ export default {
         keepNames: true,
       },
       optimizeDeps: {
+        include: ['lodash'],
         esbuildOptions: {
           loader: {
             '.js': 'jsx',


### PR DESCRIPTION
Contributes #9266

optimizes Storybook build to prevent memory exhaustion. Storybook build used to fail often after Node version update from 22 to 24.

#### What did you change?
Added lodash to Vite's optimizeDeps to prevent memory exhaustion in storybook main.js

#### How did you test and verify your work?
netlify build

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
