### PR TITLE
fix(apikeymodal): document parity

### DIFF
--- a/packages/ibm-products-web-components/src/components/api-key-modal/api-key-modal.mdx
+++ b/packages/ibm-products-web-components/src/components/api-key-modal/api-key-modal.mdx
@@ -6,6 +6,19 @@ import APIKeyModalStories from './api-key-modal.stories';
 
 # APIKeyModal
 
+[Usage guidelines](https://pages.github.ibm.com/carbon/ibm-products/patterns/generate-an-api-key/usage/)
+|
+[Carbon modal usage guidelines](https://www.carbondesignsystem.com/components/modal/usage)
+|
+[Carbon modal documentation](https://react.carbondesignsystem.com/?path=/docs/components-modal)
+
+## Table of Contents
+
+- [Overview](#overview).    
+- [Example usage](#example-usage)
+
+## Overview
+
 The APIKey Modal pattern is used When designing for the generation of API keys,
 ensure users know what the key is created for, the security implications, and
 the end destination of the key.
@@ -25,14 +38,13 @@ To build this pattern, we recommend including the following components:
 - [cds-text-input](https://web-components.carbondesignsystem.com/?path=/docs/components-text-input)
 - [cds-button](https://web-components.carbondesignsystem.com/?path=/docs/components-button)
 
+## Example usage
 
 > 💡 Check our
 > [Stackblitz](https://stackblitz.com/github/carbon-design-system/ibm-products/tree/main/packages/ibm-products-web-components/examples/api-key-modal)
 > example implementation.
 
 [![Edit carbon-web-components](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/ibm-products/tree/main/packages/ibm-products-web-components/examples/api-key-modal)
-
-## Getting started
 
 Here's a quick example to get you started.
 

--- a/packages/ibm-products/src/patterns/GenerateAnAPIKey/GenerateAnAPIKey.mdx
+++ b/packages/ibm-products/src/patterns/GenerateAnAPIKey/GenerateAnAPIKey.mdx
@@ -6,6 +6,10 @@ import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
 # Generate an API key
 
 [Usage guidelines](https://pages.github.ibm.com/carbon/ibm-products/patterns/generate-an-api-key/usage/)
+|
+[Carbon modal usage guidelines](https://www.carbondesignsystem.com/components/modal/usage)
+|
+[Carbon modal documentation](https://react.carbondesignsystem.com/?path=/docs/components-modal)
 
 ## Table of Contents
 
@@ -36,6 +40,82 @@ import { Button, Modal, TextInput, PasswordInput } from '@carbon/react';
 
 [![Edit react-patterns](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/carbon-design-system/ibm-products/tree/main/packages/ibm-products/src/patterns/GenerateAnAPIKey/example)
 {/* TODO: One example per designed use case. */}
+
+### Getting started
+
+```jsx
+import { Button, Modal, TextInput, PasswordInput } from '@carbon/react';
+import { InformationFilled, CheckmarkFilled } from '@carbon/react/icons';
+```
+
+```html
+
+<GenerateAnAPIKey
+  open={open}
+        onRequestClose={toggleModal}
+        primaryButtonDisabled={loading || name.length === 0}
+        secondaryButtonText="Close"
+        loadingDescription="Loading"
+        onLoadingSuccess={() => {}}
+        {...modalProps}
+      >
+        {key ? (
+          <>
+            <PasswordInput
+              id="generated-api-key"
+              labelText="Unique API key"
+              value={key}
+              readOnly
+              showPasswordLabel="Show key"
+              hidePasswordLabel="Hide key"
+              tooltipPosition="left"
+              helperText="This is your unique API key and is non-recoverable. If you lose this API key, you will have to reset it."
+            />
+            <div className={`${blockClass}__messaging`}>
+              <InformationFilled size={16} />
+              <APIKeyDownloader
+                apiKey={key}
+                body="This is your unique API key and is non-recoverable. If you lose this API key, you will have to reset it."
+                fileName="apikey"
+                linkText="Download as JSON"
+                fileType="json"
+                downloadLinkLabel="Download API Key in Java Script File format"
+              />
+            </div>
+             <div className={`${blockClass}__messaging`}>
+            <CheckmarkFilled
+              size={20}
+              className={`${blockClass}__checkmark-icon`}
+            />
+            <p
+              className={`${blockClass}__messaging-text`}
+              role="alert"
+              aria-live="assertive"
+            >
+              API key successfully created
+            </p>
+            </div>
+          </>
+        ) : (
+          <>
+            <p style={{ marginBlockEnd: '1rem' }}>
+              (Optional description text) To connect securely to [product name],
+              your application or tool needs an API key with permission to
+              access resources such as [product resource name].
+            </p>
+            <TextInput
+              id="app-name"
+              labelText="Name your application"
+              placeholder="Application name"
+              value={name}
+              onChange={handleName}
+              disabled={loading}
+              helperText="Providing the application name will help you identify your API key later."
+            />
+          </>
+        )}
+      </GenerateAnAPIKey>
+```
 
 <Canvas withSource="none">
   <Story of={stories.InstantTemplate} />


### PR DESCRIPTION
Closes #9048 and #9150

Aligned the Overview page to achieve parity between Web Components and React Storybook.

#### What did you change?  mdx files

#### How did you test and verify your work? yarn storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
