### PR TITLE
fix(guidebanner): fix expand collapse labels and aria-expand values

### DIFF
--- a/packages/ibm-products/src/components/Guidebanner/Guidebanner.test.jsx
+++ b/packages/ibm-products/src/components/Guidebanner/Guidebanner.test.jsx
@@ -147,21 +147,21 @@ describe(componentName, () => {
   it('expands/collapses the guidebanner', () => {
     renderComponent({ collapsible: true });
 
-    const toggleButton = screen.getByRole('button', { name: /read more/i });
+    const toggleButton = screen.getByRole('button', { name: /read less/i });
     expect(toggleButton).toHaveClass(`${blockClass}__toggle-button`);
 
-    // starts collapsed
-    expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
-
-    // Expands on click
-    fireEvent.click(toggleButton);
-    expect(toggleButton).toHaveTextContent('Read less');
+    // starts expanded (open: true is in defaultProps)
     expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
 
-    // Collapses back on second click
+    // Collapses on click
     fireEvent.click(toggleButton);
     expect(toggleButton).toHaveTextContent('Read more');
     expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+
+    // Expands back on second click
+    fireEvent.click(toggleButton);
+    expect(toggleButton).toHaveTextContent('Read less');
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
   });
 
   it('renders the close button and triggers the onClose callback when provided', () => {

--- a/packages/ibm-products/src/components/Guidebanner/Guidebanner.tsx
+++ b/packages/ibm-products/src/components/Guidebanner/Guidebanner.tsx
@@ -177,9 +177,9 @@ export const Guidebanner = React.forwardRef<HTMLDivElement, GuidebannerProps>(
               onClick={handleClickToggle}
               ref={toggleRef}
               aria-controls={!open ? carouselContentId : undefined}
-              aria-expanded={!open}
+              aria-expanded={open}
             >
-              {open ? expandButtonLabel : collapseButtonLabel}
+              {open ? collapseButtonLabel : expandButtonLabel}
             </Button>
           )}
 


### PR DESCRIPTION
Closes #9272 

Fix expand collapse labels and aria-expand values for Guide Banner (react)

#### What did you change?

- Inverted the expand/collapse labels
- Inverted the aria-expanded value
- Adjust tests based on above changes

#### How did you test and verify your work?
Storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
