### PR TITLE
feat(coachmark): add triggerRef prop

### DIFF
--- a/packages/ibm-products/src/components/Coachmark/next/Coachmark/Coachmark.stories.jsx
+++ b/packages/ibm-products/src/components/Coachmark/next/Coachmark/Coachmark.stories.jsx
@@ -216,6 +216,63 @@ const FloatingTemplate = ({ ...args }, context) => {
   );
 };
 
+const TriggerRefTemplate = ({ ...args }, context) => {
+  const sbDocs = context.viewMode !== 'docs';
+  const carbonTheme = sbDocs ? useCarbonTheme() : 'white';
+  const [isOpen, setIsOpen] = useState(true);
+  const triggerButtonRef = useRef(null);
+
+  const handleClose = () => {
+    setIsOpen(false);
+    setTimeout(() => {
+      triggerButtonRef.current?.focus();
+    }, 0);
+  };
+
+  const handleButtonClick = () => {
+    setIsOpen((open) => !open);
+  };
+
+  return (
+    <Theme theme={carbonTheme}>
+      <main style={{ marginLeft: '100px' }}>
+        <Button
+          id="CoachmarkTriggerRefBtn"
+          kind="tertiary"
+          size="md"
+          renderIcon={Crossroads}
+          onClick={handleButtonClick}
+          ref={triggerButtonRef}
+        >
+          Show information
+        </Button>
+        <Coachmark
+          open={isOpen}
+          onClose={handleClose}
+          triggerRef={triggerButtonRef}
+          selectorPrimaryFocus=".coachmark-trigger-ref-done-button"
+          {...args}
+        >
+          <Coachmark.Content>
+            <Coachmark.Content.Header closeIconDescription="Close"></Coachmark.Content.Header>
+            <Coachmark.Content.Body>
+              <h2>Hello World</h2>
+              <p>Coachmark using the triggerRef prop.</p>
+              <Button
+                size="sm"
+                className="coachmark-trigger-ref-done-button"
+                onClick={handleClose}
+              >
+                Done
+              </Button>
+            </Coachmark.Content.Body>
+          </Coachmark.Content>
+        </Coachmark>
+      </main>
+    </Theme>
+  );
+};
+
 /**
  * TODO: Declare one or more stories, generally one per design scenario.
  * NB no need for a 'Playground' because all stories have all controls anyway.
@@ -227,5 +284,10 @@ Tooltip.args = {
 
 export const Floating = FloatingTemplate.bind({});
 Floating.args = {
+  align: 'bottom',
+};
+
+export const TriggerRef = TriggerRefTemplate.bind({});
+TriggerRef.args = {
   align: 'bottom',
 };

--- a/packages/ibm-products/src/components/Coachmark/next/Coachmark/Coachmark.tsx
+++ b/packages/ibm-products/src/components/Coachmark/next/Coachmark/Coachmark.tsx
@@ -90,6 +90,10 @@ export interface CoachmarkPropsNext {
    * If not provided, no automatic focus management will occur.
    */
   selectorPrimaryFocus?: string;
+  /**
+   * Optional ref for an external trigger element, used when the trigger is not part of the coachmark.
+   */
+  triggerRef?: RefObject<HTMLElement>;
 }
 
 type CoachmarkContentComponent = FC<CoachmarkContentProps> & {
@@ -122,9 +126,11 @@ export const Coachmark = forwardRef<HTMLDivElement, CoachmarkPropsNext>(
       highContrast,
       caret,
       selectorPrimaryFocus,
+      triggerRef: triggerRefProp,
       ...rest
     } = props;
-    const triggerRef = useRef<HTMLElement>(null);
+    const internalTriggerRef = useRef<HTMLElement>(null);
+    const triggerRef = triggerRefProp ?? internalTriggerRef;
     const internalRef = useRef<HTMLDivElement | null>(null);
     const [contentRef, setContentRef] = useState<HTMLElement | null>(null);
     const [openState, setOpenState] = useState(false);
@@ -143,6 +149,10 @@ export const Coachmark = forwardRef<HTMLDivElement, CoachmarkPropsNext>(
       caret !== undefined ? caret : floating === true ? false : true;
 
     useEffect(() => {
+      if (triggerRefProp?.current) {
+        return;
+      }
+
       const container = internalRef.current;
       if (!container) {
         return;
@@ -159,14 +169,14 @@ export const Coachmark = forwardRef<HTMLDivElement, CoachmarkPropsNext>(
       if (firstFocusable) {
         triggerRef.current = firstFocusable;
       }
-    }, [children]);
+    }, [children, triggerRef, triggerRefProp]);
 
     useEffect(() => {
       const el = triggerRef.current;
       if (el) {
         el.setAttribute('aria-expanded', String(!!open));
       }
-    }, [open]);
+    }, [open, triggerRef]);
 
     // Reset position when coachmark closes
     useEffect(() => {
@@ -237,6 +247,17 @@ export const Coachmark = forwardRef<HTMLDivElement, CoachmarkPropsNext>(
             highContrast={highContrast ?? true}
             dropShadow={dropShadow}
           >
+            {triggerRefProp?.current ? (
+              <span
+                aria-hidden="true"
+                style={{ display: 'contents' }}
+                ref={(node) => {
+                  if (node && triggerRefProp.current) {
+                    node.replaceWith(triggerRefProp.current);
+                  }
+                }}
+              />
+            ) : null}
             {children}
           </Popover>
         </div>
@@ -303,4 +324,10 @@ Coachmark.propTypes = {
    * CSS selector for the element that should receive focus when the coachmark opens.
    */
   selectorPrimaryFocus: PropTypes.string,
+  /**
+   * Optional ref for an external trigger element, used when the trigger is not part of the coachmark.
+   */
+  triggerRef: PropTypes.shape({
+    current: PropTypes.any,
+  }),
 };


### PR DESCRIPTION
Closes #9277 

Added a new prop called triggerRef for Coachmark component that accepts the trigger element ref. 

#### What did you change? Coachmark Next

#### How did you test and verify your work? yarn storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
