### PR TITLE
fix(page-header): make tabs, tags, and scroller button responsive

### DIFF
--- a/packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
+++ b/packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
@@ -977,7 +977,16 @@ $duration: 1000ms;
   }
 
   .#{$block-class}__tab-bar {
+    // On smaller screens, use flex to keep scroller button in flow
+    position: relative;
+    display: flex;
+    align-items: center;
     background-color: $layer;
+
+    // On max breakpoint and above, use block to maintain Carbon alignment (scroller uses absolute positioning)
+    @include breakpoint(max) {
+      display: block;
+    }
   }
 
   .#{$block-class}__tab-bar--tablist {
@@ -1051,20 +1060,17 @@ $duration: 1000ms;
     align-content: center;
     justify-content: flex-end;
     inline-size: 40%;
+    padding-inline-end: $spacing-03;
     text-align: end;
 
     .#{$carbon-prefix}--tag {
       flex-shrink: 0;
       margin-inline-end: $spacing-03;
     }
-
-    @include breakpoint-down(md) {
-      inline-size: auto;
-    }
   }
 
   .#{$block-class}--tag-overflow-popover__hidden {
-    visibility: hidden;
+    display: none;
   }
 
   .#{$block-class}__tag-item {
@@ -1085,8 +1091,18 @@ $duration: 1000ms;
 
   .#{$pkg-prefix}--page-header--scroller-button-container {
     position: relative;
+    display: inline-flex;
+    align-items: center;
     margin-inline-start: $spacing-03;
-    padding-inline-end: $spacing-05;
+
+    // On max breakpoint and above, position absolutely to the right (enough gutter space)
+    @include breakpoint(max) {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-end: 0;
+      margin-inline-start: 0;
+      padding-inline-end: 0;
+    }
   }
 
   @keyframes page-header-title-breadcrumb-animation {

--- a/packages/ibm-products-web-components/src/components/page-header/page-header-actions-set/page-header-actions-set.scss
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header-actions-set/page-header-actions-set.scss
@@ -54,26 +54,20 @@ $block-class: #{$prefix}--page-header-actions-set;
 @media screen and (prefers-reduced-motion: reduce) {
   [data-offset] {
     flex-shrink: 0;
-    opacity: 1;
     transition: none;
 
     &[data-hidden] {
-      opacity: 0;
-      pointer-events: none;
-      visibility: hidden;
+      display: none;
     }
   }
 }
 
 [data-offset] {
   flex-shrink: 0;
-  opacity: 1;
   transition: opacity 0.15s ease-in-out;
 
   &[data-hidden] {
-    opacity: 0;
-    pointer-events: none;
-    visibility: hidden;
+    display: none;
   }
 }
 

--- a/packages/ibm-products-web-components/src/components/page-header/page-header.scss
+++ b/packages/ibm-products-web-components/src/components/page-header/page-header.scss
@@ -293,32 +293,71 @@ $carbon-prefix: 'cds';
   // TODO: remove above styles when styles from React have been migrated
   // and use the extend below
   // @extend .#{$prefix}--page-header__tab-bar;
+  position: relative;
+
+  .#{$carbon-prefix}--css-grid {
+    // On small screens, use flex to keep grid and scroller on same line
+    display: flex;
+    align-items: center;
+
+    // On max breakpoint and above, use grid for proper Carbon alignment
+    @include breakpoint(max) {
+      display: grid;
+    }
+  }
+
   .#{$carbon-prefix}--css-grid .#{$carbon-prefix}--css-grid-column {
+    // On small screens, allow column to flex
+    flex: 1;
     margin: 0;
+    min-inline-size: 0;
+
+    @include breakpoint(max) {
+      flex: none;
+    }
   }
 }
 
 :host(#{$prefix}-page-header-tabs) .#{$prefix}--page-header__tab-bar--tablist {
   display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  inline-size: 100%;
+  align-items: center;
 }
 
 :host(#{$prefix}-page-header-tabs) ::slotted([slot='tags']) {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: right;
-  inline-size: 100%;
-  max-inline-size: 500px;
+  justify-content: flex-end;
+  inline-size: 40%;
+  margin-inline-start: auto;
+  min-inline-size: 0;
   // TODO: remove above styles when styles from React have been migrated
   // and use the extend below
   // @extend .#{$prefix}--page-header__tags;
 }
 
+// When scroller is present, adjust tags styling
+:host(#{$prefix}-page-header-tabs:has([slot='scroller']))
+  ::slotted([slot='tags']) {
+  transform: translateX(calc($spacing-06 * -1));
+
+  @include breakpoint(md) {
+    padding-inline-end: $spacing-03;
+    transform: translateX(0);
+  }
+  @include breakpoint(max) {
+    padding-inline-end: $spacing-05;
+  }
+}
+
+// Scroller positioning: relative on small screens, absolute on max+
 :host(#{$prefix}-page-header-tabs) ::slotted([slot='scroller']) {
-  position: absolute;
-  inset-inline-end: 0;
+  position: relative;
+
+  @include breakpoint(max) {
+    position: absolute;
+    inset-block-start: 0;
+    inset-inline-end: 0;
+  }
 }
 
 :host(#{$prefix}-page-header-breadcrumb),

--- a/packages/ibm-products/src/components/PageHeader/next/PageHeaderTabBar.tsx
+++ b/packages/ibm-products/src/components/PageHeader/next/PageHeaderTabBar.tsx
@@ -50,9 +50,9 @@ export const PageHeaderTabBar = React.forwardRef<
         <Grid condensed>
           <Column lg={16} md={8} sm={4}>
             {children}
-            {renderScroller()}
           </Column>
         </Grid>
+        {renderScroller()}
       </div>
     );
   }
@@ -69,10 +69,10 @@ export const PageHeaderTabBar = React.forwardRef<
           >
             {children}
             {tags}
-            {renderScroller()}
           </div>
         </Column>
       </Grid>
+      {renderScroller()}
     </div>
   );
 });


### PR DESCRIPTION
Closes #9330 

#### What did you change?
Resolved scroller button overlapping issue. And made tags responsive.

<img width="388" height="842" alt="image" src="https://github.com/user-attachments/assets/a7eebf7e-76d3-434c-b8e2-dd1a8bfb0bc9" />

<img width="641" height="97" alt="image" src="https://github.com/user-attachments/assets/7f369413-7ba2-48d4-af1d-d65aea479ac0" />


#### How did you test and verify your work?

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
