### PR TITLE
fix(ibm-products): enable tree-shaking of unused components

### DIFF
--- a/packages/ibm-products/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.jsx
+++ b/packages/ibm-products/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.jsx
@@ -355,7 +355,7 @@ export let BreadcrumbWithOverflow = ({
 };
 
 // Return a placeholder if not released and not enabled by feature flag
-BreadcrumbWithOverflow = pkg.checkComponentEnabled(
+BreadcrumbWithOverflow = /* @__PURE__ */ pkg.checkComponentEnabled(
   BreadcrumbWithOverflow,
   componentName
 );

--- a/packages/ibm-products/src/components/ButtonMenu/ButtonMenu.jsx
+++ b/packages/ibm-products/src/components/ButtonMenu/ButtonMenu.jsx
@@ -99,7 +99,10 @@ ButtonMenu.deprecated = {
 };
 
 // Return a placeholder if not released and not enabled by feature flag
-ButtonMenu = pkg.checkComponentEnabled(ButtonMenu, componentName);
+ButtonMenu = /* @__PURE__ */ pkg.checkComponentEnabled(
+  ButtonMenu,
+  componentName
+);
 
 // The display name of the component, used by React. Note that displayName
 // is used in preference to relying on function.name.

--- a/packages/ibm-products/src/components/ButtonMenu/ButtonMenuItem.jsx
+++ b/packages/ibm-products/src/components/ButtonMenu/ButtonMenuItem.jsx
@@ -27,6 +27,9 @@ export let ButtonMenuItem = React.forwardRef((props, ref) => (
 ));
 
 // Return a placeholder if not released and not enabled by feature flag
-ButtonMenuItem = pkg.checkComponentEnabled(ButtonMenuItem, componentName);
+ButtonMenuItem = /* @__PURE__ */ pkg.checkComponentEnabled(
+  ButtonMenuItem,
+  componentName
+);
 
 ButtonMenuItem.propTypes = OverflowMenuItem.propTypes;

--- a/packages/ibm-products/src/components/Decorator/Decorator.jsx
+++ b/packages/ibm-products/src/components/Decorator/Decorator.jsx
@@ -42,7 +42,7 @@ export let Decorator = React.forwardRef((props, ref) => {
 });
 
 // Return a placeholder if not released and not enabled by feature flag
-Decorator = pkg.checkComponentEnabled(Decorator, componentName);
+Decorator = /* @__PURE__ */ pkg.checkComponentEnabled(Decorator, componentName);
 
 // The display name of the component, used by React. Note that displayName
 // is used in preference to relying on function.name.

--- a/packages/ibm-products/src/components/DecoratorBase/DecoratorIcon.jsx
+++ b/packages/ibm-products/src/components/DecoratorBase/DecoratorIcon.jsx
@@ -94,7 +94,10 @@ export let DecoratorIcon = React.forwardRef(
 );
 
 // Return a placeholder if not released and not enabled by feature flag
-DecoratorIcon = pkg.checkComponentEnabled(DecoratorIcon, componentName);
+DecoratorIcon = /* @__PURE__ */ pkg.checkComponentEnabled(
+  DecoratorIcon,
+  componentName
+);
 
 // The display name of the component, used by React. Note that displayName
 // is used in preference to relying on function.name.

--- a/packages/ibm-products/src/components/DecoratorDualButton/DecoratorDualButton.jsx
+++ b/packages/ibm-products/src/components/DecoratorDualButton/DecoratorDualButton.jsx
@@ -44,7 +44,7 @@ DecoratorDualButton.deprecated = {
 };
 
 // Return a placeholder if not released and not enabled by feature flag
-DecoratorDualButton = pkg.checkComponentEnabled(
+DecoratorDualButton = /* @__PURE__ */ pkg.checkComponentEnabled(
   DecoratorDualButton,
   componentName
 );

--- a/packages/ibm-products/src/components/DecoratorLink/DecoratorLink.jsx
+++ b/packages/ibm-products/src/components/DecoratorLink/DecoratorLink.jsx
@@ -46,7 +46,10 @@ DecoratorLink.deprecated = {
 };
 
 // Return a placeholder if not released and not enabled by feature flag
-DecoratorLink = pkg.checkComponentEnabled(DecoratorLink, componentName);
+DecoratorLink = /* @__PURE__ */ pkg.checkComponentEnabled(
+  DecoratorLink,
+  componentName
+);
 
 // The display name of the component, used by React. Note that displayName
 // is used in preference to relying on function.name.

--- a/packages/ibm-products/src/components/DecoratorSingleButton/DecoratorSingleButton.jsx
+++ b/packages/ibm-products/src/components/DecoratorSingleButton/DecoratorSingleButton.jsx
@@ -46,7 +46,7 @@ DecoratorSingleButton.deprecated = {
 };
 
 // Return a placeholder if not released and not enabled by feature flag
-DecoratorSingleButton = pkg.checkComponentEnabled(
+DecoratorSingleButton = /* @__PURE__ */ pkg.checkComponentEnabled(
   DecoratorSingleButton,
   componentName
 );

--- a/packages/ibm-products/src/components/DescriptionList/DescriptionList.jsx
+++ b/packages/ibm-products/src/components/DescriptionList/DescriptionList.jsx
@@ -87,7 +87,10 @@ DescriptionList.deprecated = {
 };
 
 // Return a placeholder if not released and not enabled by feature flag
-DescriptionList = pkg.checkComponentEnabled(DescriptionList, componentName);
+DescriptionList = /* @__PURE__ */ pkg.checkComponentEnabled(
+  DescriptionList,
+  componentName
+);
 
 // The display name of the component, used by React. Note that displayName
 // is used in preference to relying on function.name.

--- a/packages/ibm-products/src/components/DescriptionList/DescriptionListBody.jsx
+++ b/packages/ibm-products/src/components/DescriptionList/DescriptionListBody.jsx
@@ -41,7 +41,7 @@ DescriptionListBody.propTypes = {
   /** Provide an optional class to be applied to the containing node */
   className: PropTypes.string,
 };
-DescriptionListBody = pkg.checkComponentEnabled(
+DescriptionListBody = /* @__PURE__ */ pkg.checkComponentEnabled(
   DescriptionListBody,
   componentName
 );

--- a/packages/ibm-products/src/components/DescriptionList/DescriptionListCell.jsx
+++ b/packages/ibm-products/src/components/DescriptionList/DescriptionListCell.jsx
@@ -41,7 +41,7 @@ DescriptionListCell.propTypes = {
   /** Provide an optional class to be applied to the containing node */
   className: PropTypes.string,
 };
-DescriptionListCell = pkg.checkComponentEnabled(
+DescriptionListCell = /* @__PURE__ */ pkg.checkComponentEnabled(
   DescriptionListCell,
   componentName
 );

--- a/packages/ibm-products/src/components/DescriptionList/DescriptionListRow.jsx
+++ b/packages/ibm-products/src/components/DescriptionList/DescriptionListRow.jsx
@@ -42,7 +42,7 @@ DescriptionListRow.propTypes = {
   /** Provide an optional class to be applied to the containing node */
   className: PropTypes.string,
 };
-DescriptionListRow = pkg.checkComponentEnabled(
+DescriptionListRow = /* @__PURE__ */ pkg.checkComponentEnabled(
   DescriptionListRow,
   componentName
 );

--- a/packages/ibm-products/src/components/ExampleComponent/ExampleComponent.jsx
+++ b/packages/ibm-products/src/components/ExampleComponent/ExampleComponent.jsx
@@ -143,7 +143,10 @@ export let ExampleComponent = React.forwardRef(
 );
 
 // Return a placeholder if not released and not enabled by feature flag.
-ExampleComponent = pkg.checkComponentEnabled(ExampleComponent, componentName);
+ExampleComponent = /* @__PURE__ */ pkg.checkComponentEnabled(
+  ExampleComponent,
+  componentName
+);
 
 // The display name of the component, used by React. Note that displayName
 // is used in preference to relying on function.name.

--- a/packages/ibm-products/src/components/ExampleComponent/ExampleDeprecatedComponent.jsx
+++ b/packages/ibm-products/src/components/ExampleComponent/ExampleDeprecatedComponent.jsx
@@ -26,7 +26,7 @@ ExampleDeprecatedComponent.deprecated = {
 };
 
 // The component enable should log the deprecation
-ExampleDeprecatedComponent = pkg.checkComponentEnabled(
+ExampleDeprecatedComponent = /* @__PURE__ */ pkg.checkComponentEnabled(
   ExampleDeprecatedComponent,
   componentName
 );

--- a/packages/ibm-products/src/components/FilterPanel/FilterPanel.jsx
+++ b/packages/ibm-products/src/components/FilterPanel/FilterPanel.jsx
@@ -43,7 +43,10 @@ FilterPanel.deprecated = {
 };
 
 // Return a placeholder if not released and not enabled by feature flag
-FilterPanel = pkg.checkComponentEnabled(FilterPanel, componentName);
+FilterPanel = /* @__PURE__ */ pkg.checkComponentEnabled(
+  FilterPanel,
+  componentName
+);
 
 FilterPanel.displayName = componentName;
 

--- a/packages/ibm-products/src/components/FilterPanel/FilterPanelAccordion/FilterPanelAccordion.jsx
+++ b/packages/ibm-products/src/components/FilterPanel/FilterPanelAccordion/FilterPanelAccordion.jsx
@@ -69,7 +69,7 @@ FilterPanelAccordion.deprecated = {
 };
 
 // Return a placeholder if not released and not enabled by feature flag
-FilterPanelAccordion = pkg.checkComponentEnabled(
+FilterPanelAccordion = /* @__PURE__ */ pkg.checkComponentEnabled(
   FilterPanelAccordion,
   componentName
 );

--- a/packages/ibm-products/src/components/FilterPanel/FilterPanelAccordionItem/FilterPanelAccordionItem.jsx
+++ b/packages/ibm-products/src/components/FilterPanel/FilterPanelAccordionItem/FilterPanelAccordionItem.jsx
@@ -78,7 +78,7 @@ FilterPanelAccordionItem.deprecated = {
   details: `This component is deprecated`,
 };
 // Return a placeholder if not released and not enabled by feature flag
-FilterPanelAccordionItem = pkg.checkComponentEnabled(
+FilterPanelAccordionItem = /* @__PURE__ */ pkg.checkComponentEnabled(
   FilterPanelAccordionItem,
   componentName
 );

--- a/packages/ibm-products/src/components/FilterPanel/FilterPanelCheckbox/FilterPanelCheckbox.jsx
+++ b/packages/ibm-products/src/components/FilterPanel/FilterPanelCheckbox/FilterPanelCheckbox.jsx
@@ -51,7 +51,7 @@ FilterPanelCheckbox.deprecated = {
 };
 
 // Return a placeholder if not released and not enabled by feature flag
-FilterPanelCheckbox = pkg.checkComponentEnabled(
+FilterPanelCheckbox = /* @__PURE__ */ pkg.checkComponentEnabled(
   FilterPanelCheckbox,
   componentName
 );

--- a/packages/ibm-products/src/components/FilterPanel/FilterPanelCheckboxWithOverflow/FilterPanelCheckboxWithOverflow.jsx
+++ b/packages/ibm-products/src/components/FilterPanel/FilterPanelCheckboxWithOverflow/FilterPanelCheckboxWithOverflow.jsx
@@ -129,7 +129,7 @@ FilterPanelCheckboxWithOverflow.deprecated = {
 };
 
 // Return a placeholder if not released and not enabled by feature flag
-FilterPanelCheckboxWithOverflow = pkg.checkComponentEnabled(
+FilterPanelCheckboxWithOverflow = /* @__PURE__ */ pkg.checkComponentEnabled(
   FilterPanelCheckboxWithOverflow,
   componentName
 );

--- a/packages/ibm-products/src/components/FilterPanel/FilterPanelGroup/FilterPanelGroup.jsx
+++ b/packages/ibm-products/src/components/FilterPanel/FilterPanelGroup/FilterPanelGroup.jsx
@@ -52,7 +52,10 @@ FilterPanelGroup.deprecated = {
 };
 
 // Return a placeholder if not released and not enabled by feature flag
-FilterPanelGroup = pkg.checkComponentEnabled(FilterPanelGroup, componentName);
+FilterPanelGroup = /* @__PURE__ */ pkg.checkComponentEnabled(
+  FilterPanelGroup,
+  componentName
+);
 
 FilterPanelGroup.displayName = componentName;
 

--- a/packages/ibm-products/src/components/FilterPanel/FilterPanelLabel/FilterPanelLabel.jsx
+++ b/packages/ibm-products/src/components/FilterPanel/FilterPanelLabel/FilterPanelLabel.jsx
@@ -39,7 +39,10 @@ export let FilterPanelLabel = React.forwardRef(
 );
 
 // Return a placeholder if not released and not enabled by feature flag
-FilterPanelLabel = pkg.checkComponentEnabled(FilterPanelLabel, componentName);
+FilterPanelLabel = /* @__PURE__ */ pkg.checkComponentEnabled(
+  FilterPanelLabel,
+  componentName
+);
 
 FilterPanelLabel.displayName = componentName;
 

--- a/packages/ibm-products/src/components/FilterPanel/FilterPanelSearch/FilterPanelSearch.jsx
+++ b/packages/ibm-products/src/components/FilterPanel/FilterPanelSearch/FilterPanelSearch.jsx
@@ -77,7 +77,10 @@ FilterPanelSearch.deprecated = {
   details: `This component is deprecated`,
 };
 // Return a placeholder if not released and not enabled by feature flag
-FilterPanelSearch = pkg.checkComponentEnabled(FilterPanelSearch, componentName);
+FilterPanelSearch = /* @__PURE__ */ pkg.checkComponentEnabled(
+  FilterPanelSearch,
+  componentName
+);
 
 FilterPanelSearch.displayName = componentName;
 

--- a/packages/ibm-products/src/components/Nav/Nav.jsx
+++ b/packages/ibm-products/src/components/Nav/Nav.jsx
@@ -165,7 +165,7 @@ Nav.propTypes = {
 };
 
 // Return a placeholder if not released and not enabled by feature flag
-Nav = pkg.checkComponentEnabled(Nav, componentName);
+Nav = /* @__PURE__ */ pkg.checkComponentEnabled(Nav, componentName);
 
 // The display name of the component, used by React. Note that displayName
 // is used in preference to relying on function.name.

--- a/packages/ibm-products/src/components/Nav/NavItem.jsx
+++ b/packages/ibm-products/src/components/Nav/NavItem.jsx
@@ -175,6 +175,6 @@ NavItem.propTypes = {
 };
 
 // Return a placeholder if not released and not enabled by feature flag
-NavItem = pkg.checkComponentEnabled(NavItem, componentName);
+NavItem = /* @__PURE__ */ pkg.checkComponentEnabled(NavItem, componentName);
 
 export default NavItem;

--- a/packages/ibm-products/src/components/Nav/NavList.jsx
+++ b/packages/ibm-products/src/components/Nav/NavList.jsx
@@ -178,6 +178,6 @@ NavList.propTypes = {
 NavList.displayName = componentName;
 
 // Return a placeholder if not released and not enabled by feature flag
-NavList = pkg.checkComponentEnabled(NavList, componentName);
+NavList = /* @__PURE__ */ pkg.checkComponentEnabled(NavList, componentName);
 
 export default NavList;

--- a/packages/ibm-products/src/components/PageHeader/PageHeader.tsx
+++ b/packages/ibm-products/src/components/PageHeader/PageHeader.tsx
@@ -60,9 +60,6 @@ import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 
 const componentName = 'PageHeader';
 
-pkg._silenceWarnings(true);
-pkg.component.ActionBar = true;
-
 // Default values for props
 const defaults = {
   fullWidthGrid: false,

--- a/packages/ibm-products/src/components/ScrollGradient/ScrollGradient.jsx
+++ b/packages/ibm-products/src/components/ScrollGradient/ScrollGradient.jsx
@@ -220,7 +220,10 @@ export let ScrollGradient = React.forwardRef(
 );
 
 // Return a placeholder if not released and not enabled by feature flag
-ScrollGradient = pkg.checkComponentEnabled(ScrollGradient, componentName);
+ScrollGradient = /* @__PURE__ */ pkg.checkComponentEnabled(
+  ScrollGradient,
+  componentName
+);
 
 // The display name of the component, used by React. Note that displayName
 // is used in preference to relying on function.name.

--- a/packages/ibm-products/src/components/StatusIndicator/StatusIndicator.jsx
+++ b/packages/ibm-products/src/components/StatusIndicator/StatusIndicator.jsx
@@ -74,7 +74,10 @@ StatusIndicator.deprecated = {
 };
 
 // Return a placeholder if not released and not enabled by feature flag
-StatusIndicator = pkg.checkComponentEnabled(StatusIndicator, componentName);
+StatusIndicator = /* @__PURE__ */ pkg.checkComponentEnabled(
+  StatusIndicator,
+  componentName
+);
 
 // The display name of the component, used by React. Note that displayName
 // is used in preference to relying on function.name.

--- a/packages/ibm-products/src/components/StatusIndicator/StatusIndicatorStep.jsx
+++ b/packages/ibm-products/src/components/StatusIndicator/StatusIndicatorStep.jsx
@@ -70,7 +70,7 @@ StatusIndicatorStep.deprecated = {
 };
 
 // Return a placeholder if not released and not enabled by feature flag
-StatusIndicatorStep = pkg.checkComponentEnabled(
+StatusIndicatorStep = /* @__PURE__ */ pkg.checkComponentEnabled(
   StatusIndicatorStep,
   componentName
 );

--- a/packages/ibm-products/src/components/StringFormatter/StringFormatter.jsx
+++ b/packages/ibm-products/src/components/StringFormatter/StringFormatter.jsx
@@ -133,7 +133,10 @@ StringFormatter.deprecated = {
   details: `Please replace ${componentName} with TruncatedText`,
 };
 
-StringFormatter = pkg.checkComponentEnabled(StringFormatter, componentName);
+StringFormatter = /* @__PURE__ */ pkg.checkComponentEnabled(
+  StringFormatter,
+  componentName
+);
 
 StringFormatter.displayName = componentName;
 


### PR DESCRIPTION
Closes #

Module-scope side effects were preventing bundlers from dropping unused components from `@carbon/ibm-products`, even though the package's `sideEffects` array already declared the component files as side-effect free. Two patterns were responsible.

#### What did you change?

**`PageHeader.tsx`** — removed two stale lines at module scope:
- `pkg._silenceWarnings(true)` — that helper is documented as test/storybook-only ("should only be used... in internal test suites and storybook builds"), and shipping it in production code silenced every package warning whenever PageHeader was imported.
- `pkg.component.ActionBar = true` — dead code. No call site reads `pkg.component.ActionBar`, and `ActionBar` has no `checkComponentEnabled` gate anywhere in the codebase. The assignment existed only because the `_silenceWarnings(true)` above suppressed the Proxy's "enabled via feature flags" warning it would otherwise emit.

**29 component files** — annotated `Foo = pkg.checkComponentEnabled(Foo, componentName)` reassignments with `/* @__PURE__ */` so bundlers (Rollup, esbuild, Webpack/Terser) treat the call as pure and can eliminate the module when the export is unused. Behavior is unchanged when the component IS used — the wrap still happens and the live binding still flows through to consumers.

Affected components: `BreadcrumbWithOverflow`, `ButtonMenu`, `ButtonMenuItem`, `Decorator`, `DecoratorBase/DecoratorIcon`, `DecoratorDualButton`, `DecoratorLink`, `DecoratorSingleButton`, `DescriptionList`, `DescriptionListBody`, `DescriptionListCell`, `DescriptionListRow`, `ExampleComponent`, `ExampleDeprecatedComponent`, `FilterPanel`, `FilterPanelAccordion`, `FilterPanelAccordionItem`, `FilterPanelCheckbox`, `FilterPanelCheckboxWithOverflow`, `FilterPanelGroup`, `FilterPanelLabel`, `FilterPanelSearch`, `Nav`, `NavItem`, `NavList`, `ScrollGradient`, `StatusIndicator`, `StatusIndicatorStep`, `StringFormatter`.

#### How did you test and verify your work?

- `yarn build:js` succeeds and the `/* @__PURE__ */` annotation is preserved in the emitted ESM output (verified `es/components/StringFormatter/StringFormatter.js`).
- Verified `es/components/PageHeader/` no longer contains any reference to `_silenceWarnings` or `component.ActionBar`.
- `tsc --noEmit` produces no new errors in the changed files (only pre-existing errors in `src/patterns/*/example/` apps, unrelated to this PR).
- All edits are non-behavioral: removed lines were either dead (`ActionBar`) or test-only (`_silenceWarnings`), and `/* @__PURE__ */` is a bundler hint that doesn't change runtime semantics.

#### PR Checklist

- [x] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples — ~not applicable; no public API change~
- [ ] Wrote passing tests that cover this change — ~tree-shaking effectiveness isn't covered by the existing jest suite; verified manually via the built output~
- [ ] Addressed any impact on accessibility (a11y) — ~not applicable~
- [ ] Tested for cross-browser consistency — ~not applicable; bundler-time change~
- [x] Validated that this code is ready for review and status checks should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)