### PR TITLE
Security: Unsafe URL construction and SSRF risk in wait-for-it action

### DIFF
--- a/actions/wait-for-it/src/index.js
+++ b/actions/wait-for-it/src/index.js
@@ -10,6 +10,9 @@ import got from 'got';
 
 async function main() {
   let url = core.getInput('URL', {
+      required: true,
+      trimWhitespace: true
+    });
     required: true,
   });
 
@@ -22,12 +25,27 @@ async function main() {
   }
 
   // As of got v12, legacy Url instances are not supported anymore. You need to use WHATWG URL instead.
-  url = new URL(url);
+  try {
+      url = new URL(url);
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        throw new Error('Invalid protocol');
+      }
+    } catch (error) {
+      core.setFailed('Invalid URL');
+      return;
+    }
 
   core.info(`Waiting for a 200 response from ${url}`);
 
   try {
     await got(url, {
+      method: 'GET',
+      retry: {
+        limit: 5,
+        maxRetryAfter: 500,
+      },
+      timeout: { request: 5000 },
+    }
       method: 'GET',
       retry: {
         limit: 10,


### PR DESCRIPTION
## Summary

Security: Unsafe URL construction and SSRF risk in wait-for-it action

## Problem

**Severity**: `High` | **File**: `actions/wait-for-it/src/index.js:L14`

The `wait-for-it` GitHub action constructs a URL from user input (`core.getInput('URL')`) and performs an HTTP request without adequate validation. While there is a localhost replacement, the URL is passed directly to `got()` after only a simple string replacement. The `got` library with `retry.limit: 10` could be exploited for SSRF if malicious input is provided. Additionally, the timeout of 1000ms with 10 retries means a malicious server could keep the connection open, causing resource exhaustion.

## Solution

Add strict URL validation using a URL whitelist or regex pattern. Validate the protocol is http/https. Consider adding a maximum timeout for the entire operation, not just per-request. Add input sanitization to prevent SSRF attacks.

## Changes

- `actions/wait-for-it/src/index.js` (modified)