### PR TITLE
fix: resolve storybook build error

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Build Web Components Storybook
         run: |
           cd packages/ibm-products-web-components
-          yarn build:storybook --loglevel verbose
+          yarn build:storybook --loglevel info
 
       - name: Upload Web Components Storybook artifact
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Build Web Components Storybook
         run: |
           cd packages/ibm-products-web-components
-          yarn build:storybook --loglevel verbose
+          yarn build:storybook --loglevel info
 
       - name: Upload Web Components Storybook artifact
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0


### PR DESCRIPTION
Closes #9459 

<img width="2748" height="1416" alt="image" src="https://github.com/user-attachments/assets/fd7796b1-a777-4c5c-a9fd-0f40a67e4356" />

#### What did you change?

The --loglevel verbose flag is incompatible with Storybook 10. So changed to `info`.

#### How did you test and verify your work?

CI/CD

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
