### PR TITLE
fix: replace useLayoutEffect with useIsomorphicEffect in Tearsheet us…

### DIFF
--- a/packages/ibm-products/src/components/Tearsheet/usePresence.ts
+++ b/packages/ibm-products/src/components/Tearsheet/usePresence.ts
@@ -5,8 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useCallback, useLayoutEffect, useState, type RefObject } from 'react';
+import { useCallback, useState, type RefObject } from 'react';
 import { pkg } from '../../settings';
+import { useIsomorphicEffect } from '../../global/js/hooks';
 
 export const usePresence = (
   ref: RefObject<HTMLElement | null>,
@@ -32,7 +33,7 @@ export const usePresence = (
     setExitState('finished');
   }, []);
 
-  useLayoutEffect(() => {
+  useIsomorphicEffect(() => {
     if (!ref.current || !isExiting) {
       return;
     }


### PR DESCRIPTION
Closes #9390 

Replaces a reintroduced `useLayoutEffect` with the SSR-safe
`useIsomorphicEffect` hook, continuing the migration from #8630.

#### What did you change?

The `Tearsheet/usePresence.ts` hook (added after the original #8630
migration) used `useLayoutEffect` directly, which reintroduced the
SSR-related warnings that #8630 set out to eliminate.

- Removed `useLayoutEffect` from the `react` import in
  `packages/ibm-products/src/components/Tearsheet/usePresence.ts`
- Imported `useIsomorphicEffect` from `../../global/js/hooks` (the same
  barrel `TearsheetShell.tsx` already uses)
- Swapped the `useLayoutEffect(...)` call for `useIsomorphicEffect(...)`

This was the only new occurrence in shipped library source. The remaining
match in `CoachmarkStacked/example/components/CoachmarkStackedExample.tsx`
is Storybook demo code (never server-rendered, and the hook isn't part of
the public `@carbon/ibm-products` export), so it was left untouched —
consistent with #8630, which only migrated `components/` and `global/`
source.

#### How did you test and verify your work?

- Ran `yarn test` for the Tearsheet component; existing presence/animation
  tests pass. `useIsomorphicEffect` resolves to `useLayoutEffect` whenever
  `window` is defined (client + jsdom), so test behavior is unchanged; it
  only falls back to `useEffect` during server render.
- Confirmed no remaining `useLayoutEffect` in library source via grep
  (excluding tests, stories, examples, and the hook's own definition).
- Verified the hooks barrel does not import Tearsheet, so no circular
  import is introduced.

#### PR Checklist

As the author of this PR, before marking ready for review, confirm you:

- [x] Reviewed every line of the diff
- [ ] ~Updated documentation and storybook examples~ (no API/behavior change)
- [x] Wrote passing tests that cover this change <!-- existing Tearsheet tests cover this -->
- [ ] ~Addressed any impact on accessibility (a11y)~ (no a11y impact)
- [x] Tested for cross-browser consistency
- [x] Validated that this code is ready for review and status checks should pass