### PR TITLE
fix(release): remove private utilities package from dependencies

### DIFF
--- a/packages/ibm-products-web-components/package.json
+++ b/packages/ibm-products-web-components/package.json
@@ -70,6 +70,7 @@
   "devDependencies": {
     "@aarsteinmedia/dotlottie-player": "^6.0.5",
     "@blockquote/rollup-plugin-externalize-source-dependencies": "^1.0.0",
+    "@carbon/ibm-products-utilities": "workspace:*",
     "@carbon/icon-helpers": "^10.75.0",
     "@carbon/icons": "^11.80.0",
     "@carbon/motion": "^11.45.0",

--- a/packages/ibm-products-web-components/package.json
+++ b/packages/ibm-products-web-components/package.json
@@ -58,7 +58,6 @@
   "dependencies": {
     "@carbon-labs/wc-empty-state": "^0.21.0",
     "@carbon/ibm-products-styles": "^2.88.0",
-    "@carbon/ibm-products-utilities": "^1.1.0",
     "@carbon/layout": "^11.52.0",
     "@carbon/styles": "^1.106.0",
     "@carbon/utilities": "^0.19.0",

--- a/packages/ibm-products-web-components/tasks/build.js
+++ b/packages/ibm-products-web-components/tasks/build.js
@@ -182,7 +182,12 @@ function getExternalPatterns() {
     ),
   ];
 
-  return deps.map((name) => {
+  // Filter out @carbon/ibm-products-utilities to embed it at build time
+  const filteredDeps = deps.filter(
+    (name) => name !== '@carbon/ibm-products-utilities'
+  );
+
+  return filteredDeps.map((name) => {
     // Transform the name of each dependency into a regex so that imports from
     // nested paths are correctly marked as external.
     //

--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -66,6 +66,7 @@
     "@babel/preset-env": "^7.26.9",
     "@babel/preset-react": "^7.26.3",
     "@babel/preset-typescript": "^7.26.0",
+    "@carbon/ibm-products-utilities": "workspace:*",
     "@carbon/styles": "^1.106.0",
     "@figma/code-connect": "^1.4.0",
     "@ibm/telemetry-js-config-generator": "^2.0.1",

--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -107,7 +107,6 @@
     "@carbon-labs/react-resizer": "^0.24.0",
     "@carbon/feature-flags": "^1.3.0",
     "@carbon/ibm-products-styles": "^2.88.0",
-    "@carbon/ibm-products-utilities": "^1.1.0",
     "@carbon/telemetry": "^0.1.0",
     "@carbon/utilities": "^0.19.0",
     "@carbon/utilities-react": "0.22.0",

--- a/packages/ibm-products/src/patterns/AddSelect/example/package.json
+++ b/packages/ibm-products/src/patterns/AddSelect/example/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "@carbon/react": "latest"
+    "@carbon/react": "latest",
+    "@carbon/ibm-products": "latest"
   },
   "devDependencies": {
     "@types/react": "^19.1.8",

--- a/packages/ibm-products/src/patterns/AddSelect/example/preview-components/MultiAddSelectWithModifiers/MultiAddSelectWithModifiers.tsx
+++ b/packages/ibm-products/src/patterns/AddSelect/example/preview-components/MultiAddSelectWithModifiers/MultiAddSelectWithModifiers.tsx
@@ -11,8 +11,7 @@ import {
   MultiAddSelectWithModifiers as MultiAddSelectWithModifiersComponent,
   ModifierConfig,
 } from '../../components/MultiAddSelectWithModifiers/MultiAddSelectWithModifiers';
-import { AddSelectItem } from '@carbon/ibm-products-utilities';
-import { UserAvatar } from '../../../../../components/UserAvatar';
+import { AddSelectItem, UserAvatar } from '@carbon/ibm-products';
 import './MultiAddSelectWithModifiers.scss';
 
 // Sample data for the with modifiers variant

--- a/packages/ibm-products/src/patterns/AddSelect/example/preview-components/NonHierarchicalWithPeekInsideItem/NonHierarchicalWithPeekInsideItem.tsx
+++ b/packages/ibm-products/src/patterns/AddSelect/example/preview-components/NonHierarchicalWithPeekInsideItem/NonHierarchicalWithPeekInsideItem.tsx
@@ -11,8 +11,7 @@ import {
   NonHierarchicalWithPeekInsideItem as NonHierarchicalWithPeekInsideItemComponent,
   ModifierConfig,
 } from '../../components/NonHierarchicalWithPeekInsideItem/NonHierarchicalWithPeekInsideItem';
-import { AddSelectItem } from '@carbon/ibm-products-utilities';
-import { UserAvatar } from '../../../../../components/UserAvatar';
+import { AddSelectItem, UserAvatar } from '@carbon/ibm-products';
 import './NonHierarchicalWithPeekInsideItem.scss';
 
 // Sample data matching the image - access groups with members

--- a/packages/ibm-products/tasks/build.js
+++ b/packages/ibm-products/tasks/build.js
@@ -204,7 +204,12 @@ function getExternalPatterns() {
     ...Object.keys(packageJson.dependencies || {}),
   ];
 
-  return deps.map((name) => {
+  // Filter out @carbon/ibm-products-utilities to embed it at build time
+  const filteredDeps = deps.filter(
+    (name) => name !== '@carbon/ibm-products-utilities'
+  );
+
+  return filteredDeps.map((name) => {
     const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     return new RegExp(`^${escapedName}(/.*)?`);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2495,7 +2495,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/ibm-products-utilities@npm:^1.1.0, @carbon/ibm-products-utilities@workspace:packages/ibm-products-utilities":
+"@carbon/ibm-products-utilities@workspace:packages/ibm-products-utilities":
   version: 0.0.0-use.local
   resolution: "@carbon/ibm-products-utilities@workspace:packages/ibm-products-utilities"
   dependencies:
@@ -2515,7 +2515,6 @@ __metadata:
     "@blockquote/rollup-plugin-externalize-source-dependencies": "npm:^1.0.0"
     "@carbon-labs/wc-empty-state": "npm:^0.21.0"
     "@carbon/ibm-products-styles": "npm:^2.88.0"
-    "@carbon/ibm-products-utilities": "npm:^1.1.0"
     "@carbon/icon-helpers": "npm:^10.75.0"
     "@carbon/icons": "npm:^11.80.0"
     "@carbon/layout": "npm:^11.52.0"
@@ -2580,7 +2579,6 @@ __metadata:
     "@carbon-labs/react-resizer": "npm:^0.24.0"
     "@carbon/feature-flags": "npm:^1.3.0"
     "@carbon/ibm-products-styles": "npm:^2.88.0"
-    "@carbon/ibm-products-utilities": "npm:^1.1.0"
     "@carbon/styles": "npm:^1.106.0"
     "@carbon/telemetry": "npm:^0.1.0"
     "@carbon/utilities": "npm:^0.19.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2495,7 +2495,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@carbon/ibm-products-utilities@workspace:packages/ibm-products-utilities":
+"@carbon/ibm-products-utilities@workspace:*, @carbon/ibm-products-utilities@workspace:packages/ibm-products-utilities":
   version: 0.0.0-use.local
   resolution: "@carbon/ibm-products-utilities@workspace:packages/ibm-products-utilities"
   dependencies:
@@ -2515,6 +2515,7 @@ __metadata:
     "@blockquote/rollup-plugin-externalize-source-dependencies": "npm:^1.0.0"
     "@carbon-labs/wc-empty-state": "npm:^0.21.0"
     "@carbon/ibm-products-styles": "npm:^2.88.0"
+    "@carbon/ibm-products-utilities": "workspace:*"
     "@carbon/icon-helpers": "npm:^10.75.0"
     "@carbon/icons": "npm:^11.80.0"
     "@carbon/layout": "npm:^11.52.0"
@@ -2579,6 +2580,7 @@ __metadata:
     "@carbon-labs/react-resizer": "npm:^0.24.0"
     "@carbon/feature-flags": "npm:^1.3.0"
     "@carbon/ibm-products-styles": "npm:^2.88.0"
+    "@carbon/ibm-products-utilities": "workspace:*"
     "@carbon/styles": "npm:^1.106.0"
     "@carbon/telemetry": "npm:^0.1.0"
     "@carbon/utilities": "npm:^0.19.0"


### PR DESCRIPTION
Fixes installation error where npm attempts to install the private
@carbon/ibm-products-utilities package from the registry.

The utilities package is an internal monorepo package that should be
bundled into the consuming packages rather than listed as an external
dependency. By removing it from dependencies, the build process now
correctly bundles the utilities code into @carbon/ibm-products and
@carbon/ibm-products-web-components.


#### What did you change?

- Remove @carbon/ibm-products-utilities from @carbon/ibm-products dependencies
- Remove @carbon/ibm-products-utilities from @carbon/ibm-products-web-components dependencies


#### How did you test and verify your work?

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
