### PR TITLE
fix(UserProfileImage): css deprecation issue

### DIFF
--- a/packages/ibm-products-styles/src/components/UserProfileImage/_user-profile-image.scss
+++ b/packages/ibm-products-styles/src/components/UserProfileImage/_user-profile-image.scss
@@ -47,7 +47,7 @@ $themes: (
   ),
 );
 
-$theme-keys: map-keys($themes);
+$theme-keys: map.keys($themes);
 
 @function carbon-get-background-color($color, $key, $contrast-key) {
   @return map.get(


### PR DESCRIPTION
Closes #9466 

Fix deprecation warning for UserProfileImage

#### What did you change?

- Change `map-keys` to `map.keys` to fix deprecation warning

#### How did you test and verify your work?
yarn build

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
