### PR TITLE
docs: fix ConditionBuilder usage guidelines link

### DIFF
--- a/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.mdx
+++ b/packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.mdx
@@ -5,7 +5,7 @@ import * as stories from './ConditionBuilder.stories';
 
 # ConditionBuilder
 
-[Usage guidelines](https://pages.github.ibm.com/carbon/ibm-products/components/condition-builder/usage/)
+[Usage guidelines](https://ibm-products.carbondesignsystem.com/?path=/story/preview-candidate-conditionbuilder--condition-builder)
 
 ## Table of Contents
 


### PR DESCRIPTION
# PR Draft: Fix ConditionBuilder usage guidelines link

## Title

docs: fix ConditionBuilder usage guidelines link

## Body

## Summary

- replace the broken internal ConditionBuilder usage guidelines URL with the public Storybook ConditionBuilder story URL suggested in the issue
- keep the change scoped to the existing MDX docs link

Fixes #9568.

## Verification

- `curl -I -L 'https://ibm-products.carbondesignsystem.com/?path=/story/preview-candidate-conditionbuilder--condition-builder'`
- `git diff --check`
- `yarn install --immutable`
- `yarn exec prettier --check packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.mdx`
- `yarn exec cspell packages/ibm-products/src/components/ConditionBuilder/ConditionBuilder.mdx --no-must-find-files`

## Scope note

This PR only updates the broken ConditionBuilder usage guidelines link reported in #9568.
