### PR TITLE
chore: deprecate import and upload prebuilt pattern

### DIFF
--- a/e2e/components/ExportModal/ExportModal-test.avt.e2e.js
+++ b/e2e/components/ExportModal/ExportModal-test.avt.e2e.js
@@ -14,7 +14,7 @@ test.describe('ExportModal @avt', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'ExportModal',
-      id: 'patterns-prebuilt-patterns-exportmodal--standard',
+      id: 'deprecated-prebuilt-patterns-exportmodal--standard',
       globals: {
         carbonTheme: 'white',
       },

--- a/e2e/components/ImportModal/ImportModal-test.avt.e2e.js
+++ b/e2e/components/ImportModal/ImportModal-test.avt.e2e.js
@@ -15,7 +15,7 @@ test.describe('ImportModal @avt', () => {
   test('@avt-default-state', async ({ page }) => {
     await visitStory(page, {
       component: 'ImportModal',
-      id: 'patterns-prebuilt-patterns-importmodal--standard',
+      id: 'deprecated-prebuilt-patterns-importmodal--standard',
       globals: {
         carbonTheme: 'white',
       },

--- a/packages/ibm-products/src/components/ExportModal/ExportModal.mdx
+++ b/packages/ibm-products/src/components/ExportModal/ExportModal.mdx
@@ -15,6 +15,13 @@ export const customFunctionArr = [wait];
 |
 [Carbon modal documentation](https://react.carbondesignsystem.com/?path=/docs/components-modal)
 
+## Deprecation notice
+
+This component is deprecated and will be removed in the next major version.
+Please migrate to
+[Export Modal](https://carbon-for-ibm-products.netlify.app/?path=/docs/patterns-export-modal)
+pattern.
+
 ## Table of Contents
 
 - [Overview](#overview)

--- a/packages/ibm-products/src/components/ExportModal/ExportModal.stories.jsx
+++ b/packages/ibm-products/src/components/ExportModal/ExportModal.stories.jsx
@@ -10,9 +10,10 @@ import { Button } from '@carbon/react';
 import { ExportModal } from '.';
 import wait from '../../global/js/utils/wait';
 import mdx from './ExportModal.mdx';
+import { Annotation } from '../../../.storybook/Annotation';
 
 export default {
-  title: 'Patterns/Prebuilt patterns/ExportModal',
+  title: 'Deprecated/Prebuilt patterns/ExportModal',
   component: ExportModal,
   tags: ['autodocs'],
   parameters: {
@@ -20,6 +21,27 @@ export default {
       page: mdx,
     },
   },
+  decorators: [
+    (story) => (
+      <div>
+        <Annotation
+          type="deprecation-notice"
+          text={
+            <div>
+              This component is deprecated and will be removed in the next major
+              version. Please migrate to {/* cspell:disable-next-line */}
+              <a href="/?path=/docs/patterns-export-modal">
+                Export Modal true pattern
+              </a>
+              .
+            </div>
+          }
+        >
+          {story()}
+        </Annotation>
+      </div>
+    ),
+  ],
   argTypes: {
     validExtensions: {
       control: {

--- a/packages/ibm-products/src/components/ExportModal/ExportModal.test.jsx
+++ b/packages/ibm-products/src/components/ExportModal/ExportModal.test.jsx
@@ -31,6 +31,10 @@ const defaultProps = {
 };
 
 describe(componentName, () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
   it('renders body', async () => {
     render(<ExportModal {...defaultProps} />);
     screen.getByText(defaultProps.body);

--- a/packages/ibm-products/src/components/ExportModal/ExportModal.tsx
+++ b/packages/ibm-products/src/components/ExportModal/ExportModal.tsx
@@ -158,6 +158,7 @@ export interface ExportModalProps
 
 /**
  * Modal dialog version of the export pattern
+ * @deprecated This component is deprecated.
  */
 export const ExportModal = forwardRef(
   (
@@ -380,6 +381,12 @@ export const ExportModal = forwardRef(
 );
 
 // Return a placeholder if not released and not enabled by feature flag
+
+/**@ts-ignore*/
+ExportModal.deprecated = {
+  level: 'warn',
+  details: `Please replace ${componentName} with Export Modal pattern`,
+};
 
 ExportModal.propTypes = {
   /**

--- a/packages/ibm-products/src/components/ImportModal/ImportModal.mdx
+++ b/packages/ibm-products/src/components/ImportModal/ImportModal.mdx
@@ -12,6 +12,13 @@ import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
 |
 [Carbon modal documentation](https://react.carbondesignsystem.com/?path=/docs/components-modal)
 
+## Deprecation notice
+
+This component is deprecated and will be removed in the next major version.
+Please migrate to
+[Import and Upload](https://carbon-for-ibm-products.netlify.app/?path=/docs/patterns-import-and-upload)
+pattern.
+
 ## Table of Contents
 
 - [Overview](#overview)

--- a/packages/ibm-products/src/components/ImportModal/ImportModal.stories.jsx
+++ b/packages/ibm-products/src/components/ImportModal/ImportModal.stories.jsx
@@ -12,9 +12,10 @@ import { action } from 'storybook/actions';
 import { ImportModal } from '.';
 import mdx from './ImportModal.mdx';
 // import mdx from './ImportModal.mdx';
+import { Annotation } from '../../../.storybook/Annotation';
 
 export default {
-  title: 'Patterns/Prebuilt patterns/ImportModal',
+  title: 'Deprecated/Prebuilt patterns/ImportModal',
   component: ImportModal,
   tags: ['autodocs'],
   parameters: {
@@ -23,6 +24,27 @@ export default {
       page: mdx,
     },
   },
+  decorators: [
+    (story) => (
+      <div>
+        <Annotation
+          type="deprecation-notice"
+          text={
+            <div>
+              This component is deprecated and will be removed in the next major
+              version. Please migrate to {/* cspell:disable-next-line */}
+              <a href="/?path=/docs/patterns-import-and-upload">
+                Import and Upload true pattern
+              </a>
+              .
+            </div>
+          }
+        >
+          {story()}
+        </Annotation>
+      </div>
+    ),
+  ],
   argTypes: {
     accept: {
       control: {

--- a/packages/ibm-products/src/components/ImportModal/ImportModal.tsx
+++ b/packages/ibm-products/src/components/ImportModal/ImportModal.tsx
@@ -161,6 +161,9 @@ export interface ImportModalProps {
   title: string;
 }
 
+/**
+ * @deprecated This component is deprecated.
+ */
 export const ImportModal: React.FC<ImportModalProps> = forwardRef(
   (
     {
@@ -415,6 +418,12 @@ export const ImportModal: React.FC<ImportModalProps> = forwardRef(
 );
 
 // Return a placeholder if not released and not enabled by feature flag
+
+/**@ts-ignore*/
+ImportModal.deprecated = {
+  level: 'warn',
+  details: `Please replace ${componentName} with Import and Upload pattern`,
+};
 
 ImportModal.propTypes = {
   /**


### PR DESCRIPTION
Closes #9652 and #9653

Deprecate import and upload prebuilt pattern

#### What did you change? 

Standard deprecation approach for these two prebuilt patterns
- packages/ibm-products/src/components/ExportModal 
- packages/ibm-products/src/components/ImportModal

#### How did you test and verify your work? yarn storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
