### PR TITLE
fix: open in stackblitz style issue fixed

### DIFF
--- a/packages/ibm-products-web-components/previewer/codePreviewer.tsx
+++ b/packages/ibm-products-web-components/previewer/codePreviewer.tsx
@@ -135,6 +135,9 @@ export const stackblitzPrefillConfig = async ({
   }
 
   const scssImports = (c: string) =>
+    (!/@carbon\/styles\/scss\/reset/.test(c)
+      ? "@use '@carbon/styles/scss/reset';\n"
+      : '') +
     (!/@carbon\/styles\/scss\/theme/.test(c)
       ? "@use '@carbon/styles/scss/theme';\n"
       : '') +
@@ -240,8 +243,13 @@ const filterStoryCode = (storyCode, args) => {
       ''
     )
     //replace the render closing braces
-    .replace(/}\s*$/, '');
-  // Remove <style>${styles}</style> injections anywhere
+    .replace(/}\s*$/, '')
+    // Remove <style>${styles}</style> injections anywhere
+    .replace(/<style>\s*\$\{styles\}\s*<\/style>/g, '')
+    // Replace ${prefix} with the literal prefix value 'c4p'
+    .replace(/\$\{prefix\}/g, 'c4p')
+    // Replace ${storyPrefix} — story-local variable not available in Stackblitz
+    .replace(/\$\{storyPrefix\}/g, '');
 
   // Unwrap ifDefined(args.xxx) → args.xxx so the replacement loop handles them normally
   storyCodeUpdated = storyCodeUpdated.replace(

--- a/packages/ibm-products-web-components/previewer/codePreviewer.tsx
+++ b/packages/ibm-products-web-components/previewer/codePreviewer.tsx
@@ -240,9 +240,14 @@ const filterStoryCode = (storyCode, args) => {
       ''
     )
     //replace the render closing braces
-    .replace(/}\s*$/, '')
-    // Remove <style>${styles}</style> injections anywhere
-    .replace(/<style>\s*\$\{styles\}\s*<\/style>/g, '');
+    .replace(/}\s*$/, '');
+  // Remove <style>${styles}</style> injections anywhere
+
+  // Unwrap ifDefined(args.xxx) → args.xxx so the replacement loop handles them normally
+  storyCodeUpdated = storyCodeUpdated.replace(
+    /ifDefined\(\s*(args\.[a-zA-Z0-9_]+)\s*\)/g,
+    '$1'
+  );
 
   // Replace all placeholders in the code with actual arg values
   Object.entries((args = args ?? {})).forEach(([key, value]) => {
@@ -279,10 +284,16 @@ const filterStoryCode = (storyCode, args) => {
       );
     } else {
       const valueStr = JSON.stringify(value);
-      const regex = new RegExp(`args\\.${escapedKey}`, 'g');
+      const regex = new RegExp(`args\\.${escapedKey}\\b`, 'g');
       storyCodeUpdated = storyCodeUpdated.replace(regex, valueStr);
     }
   });
+  // Catch-all: any args.xxx still present were not in story.args — replace with empty string
+  storyCodeUpdated = storyCodeUpdated.replace(
+    /\$\{\s*args\.[a-zA-Z0-9_]+\s*\}/g,
+    '""'
+  );
+
   return storyCodeUpdated;
 };
 

--- a/packages/ibm-products-web-components/previewer/configFiles.tsx
+++ b/packages/ibm-products-web-components/previewer/configFiles.tsx
@@ -76,6 +76,7 @@ import './App';
 `;
 
 export const rootStyleImports: string = `
+@use '@carbon/styles/scss/reset';
 @use '@carbon/styles/scss/theme';
 @use '@carbon/styles/scss/themes';
 `;
@@ -83,5 +84,7 @@ export const rootStyleImports: string = `
 export const rootStyleFooter: string = `
 :root {
   @include theme.theme(themes.$white);
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
 }
 `;

--- a/packages/ibm-products-web-components/previewer/configFiles.tsx
+++ b/packages/ibm-products-web-components/previewer/configFiles.tsx
@@ -51,7 +51,6 @@ export const index: string = `
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + Lit</title>
-    <link rel="stylesheet" href="./src/index.css" />
     <script type="module" src="/src/main.ts"></script>
   </head>
   <body>

--- a/packages/ibm-products-web-components/src/components/about-modal/about-modal-helpers.ts
+++ b/packages/ibm-products-web-components/src/components/about-modal/about-modal-helpers.ts
@@ -13,7 +13,7 @@ import ansibleLogo from './_story-assets/ansible-logo.svg';
 import grafanaLogo from './_story-assets/grafana-logo.svg';
 import jsLogo from './_story-assets/js-logo.svg';
 
-export const blockClass = `${prefix}--about-modal`;
+export const blockClass = prefix + '--about-modal';
 export const storyPrefix = 'about-modal-stories__';
 export const getTitle = (index) => {
   switch (index) {

--- a/packages/ibm-products-web-components/src/components/about-modal/about-modal.mdx
+++ b/packages/ibm-products-web-components/src/components/about-modal/about-modal.mdx
@@ -9,6 +9,8 @@ export const customFunctionArr = [
     .replace(/import\s+.*?from\s+['"].*?['"];?\s*/g, '')
     .replace(/export\s+/g, '')
     .replace(/\/\*\*[\s\S]*?\*\//g, '')
+    .replace(/\bprefix\b/g, "'c4p'")
+    .replace(/'c4p'\s*\+\s*'--/g, "'c4p--")
     .trim()
 ];
 

--- a/packages/ibm-products-web-components/src/components/about-modal/about-modal.stories.ts
+++ b/packages/ibm-products-web-components/src/components/about-modal/about-modal.stories.ts
@@ -101,9 +101,10 @@ export const Default = {
     modalAriaLabel: '',
   },
   argTypes,
-  render: (args) => {
-    const openModal = () => {
-      document.querySelector(`${prefix}-about-modal`)?.toggleAttribute('open');
+  render: (args: any) => {
+    const openModal = (e: Event) => {
+      const root = (e.target as Element).getRootNode() as ShadowRoot | Document;
+      root.querySelector(`${prefix}-about-modal`)?.toggleAttribute('open');
     };
     return html`
       <style>
@@ -149,8 +150,9 @@ export const AboutModalWithAllPropsSet = {
   },
   argTypes,
   render: (args) => {
-    const openModal = () => {
-      document.querySelector(`${prefix}-about-modal`)?.toggleAttribute('open');
+    const openModal = (e: Event) => {
+      const root = (e.target as Element).getRootNode() as ShadowRoot | Document;
+      root.querySelector(`${prefix}-about-modal`)?.toggleAttribute('open');
     };
     return html`
       <style>

--- a/packages/ibm-products-web-components/src/components/coachmark/coachmark-helpers.ts
+++ b/packages/ibm-products-web-components/src/components/coachmark/coachmark-helpers.ts
@@ -7,7 +7,36 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { prefix } from '../../globals/settings';
+import { coachmarkDetailsSignal } from './coachmark-context';
+
 export const handleClick = () => {
   const coachmark = document.querySelector('c4p-coachmark');
   coachmark?.toggleAttribute('open');
+};
+
+export const handleDone = () => {
+  const coachmark = document.querySelector('c4p-coachmark');
+  coachmark?.removeAttribute('open');
+};
+
+export const handleCoachmarkOpened = () => {
+  const details = coachmarkDetailsSignal.get();
+
+  setTimeout(() => {
+    if (details.floating) {
+      // Focus on drag handle for floating coachmark
+      const header = document.querySelector(`${prefix}-coachmark-header`);
+      const dragHandle = header?.shadowRoot?.querySelector(
+        `.${prefix}--coachmark-header-drag-handle`
+      ) as HTMLElement;
+      dragHandle?.focus();
+    } else {
+      // Focus on done button for non-floating coachmark
+      const doneButton = document.querySelector(
+        '.coachmark-body cds-button'
+      ) as HTMLElement;
+      doneButton?.focus();
+    }
+  }, 100);
 };

--- a/packages/ibm-products-web-components/src/components/coachmark/coachmark-helpers.ts
+++ b/packages/ibm-products-web-components/src/components/coachmark/coachmark-helpers.ts
@@ -7,36 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { prefix } from '../../globals/settings';
-import { coachmarkDetailsSignal } from './coachmark-context';
-
 export const handleClick = () => {
   const coachmark = document.querySelector('c4p-coachmark');
   coachmark?.toggleAttribute('open');
-};
-
-export const handleDone = () => {
-  const coachmark = document.querySelector('c4p-coachmark');
-  coachmark?.removeAttribute('open');
-};
-
-export const handleCoachmarkOpened = () => {
-  const details = coachmarkDetailsSignal.get();
-
-  setTimeout(() => {
-    if (details.floating) {
-      // Focus on drag handle for floating coachmark
-      const header = document.querySelector(`${prefix}-coachmark-header`);
-      const dragHandle = header?.shadowRoot?.querySelector(
-        `.${prefix}--coachmark-header-drag-handle`
-      ) as HTMLElement;
-      dragHandle?.focus();
-    } else {
-      // Focus on done button for non-floating coachmark
-      const doneButton = document.querySelector(
-        '.coachmark-body cds-button'
-      ) as HTMLElement;
-      doneButton?.focus();
-    }
-  }, 100);
 };

--- a/packages/ibm-products-web-components/src/components/coachmark/coachmark.stories.ts
+++ b/packages/ibm-products-web-components/src/components/coachmark/coachmark.stories.ts
@@ -87,6 +87,7 @@ export const Tooltip = {
     ...args,
     align: 'bottom',
     caret: true,
+    selectorPrimaryFocus: '',
   },
   argTypes,
   render: (args: any) => {
@@ -103,7 +104,7 @@ export const Tooltip = {
           .floating=${args.floating}
           .position=${{ x: 150, y: 100 }}
           .caret=${args.caret}
-          selector-primary-focus=${args.selectorPrimaryFocus || ''}
+          selector-primary-focus=${args.selectorPrimaryFocus}
         >
           <c4p-coachmark-beacon
             label="Show information"
@@ -132,6 +133,7 @@ export const Floating = {
     ...args,
     align: 'bottom',
     floating: true,
+    selectorPrimaryFocus: '',
   },
   argTypes,
   render: (args: any) => {
@@ -148,7 +150,7 @@ export const Floating = {
           .floating=${args.floating}
           .caret=${args.caret}
           drag-aria-label="Coachmark is being dragged"
-          selector-primary-focus=${args.selectorPrimaryFocus || ''}
+          selector-primary-focus=${args.selectorPrimaryFocus}
         >
           <cds-button
             kind="tertiary"

--- a/packages/ibm-products-web-components/src/components/edit-in-place/edit-in-place-helpers.ts
+++ b/packages/ibm-products-web-components/src/components/edit-in-place/edit-in-place-helpers.ts
@@ -10,7 +10,7 @@
 import { prefix } from '../../globals/settings';
 import { EDIT_IN_PLACE_SIZE, TOOLTIP_ALIGNMENT } from './defs';
 
-export const blockClass = `${prefix}--edit-in-place`;
+export const blockClass = prefix + '--edit-in-place';
 export const storyClass = 'edit-in-place-example';
 
 export const sizes = {

--- a/packages/ibm-products-web-components/src/components/edit-in-place/edit-in-place.mdx
+++ b/packages/ibm-products-web-components/src/components/edit-in-place/edit-in-place.mdx
@@ -3,20 +3,28 @@ import { cdnJs, cdnCss } from '../../globals/internal/storybook-cdn';
 import * as EditInPlaceStories from './edit-in-place.stories';
 import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
 import helperSource from './edit-in-place-helpers.ts?raw';
+import defsSource from './defs.ts?raw';
 
 export const customFunctionArr = [
+  defsSource
+    .replace(/import\s+.*?from\s+['"].*?['"];?\s*/g, '')
+    .replace(/import\s+\{[^}]*\}\s+from\s+['"].*?['"];?\s*/g, '')
+    .replace(/export\s+/g, '')
+    .replace(/\/\*\*[\s\S]*?\*\//g, '')
+    .trim(),
   helperSource
     .replace(/import\s+.*?from\s+['"].*?['"];?\s*/g, '')
     .replace(/import\s+\{[^}]*\}\s+from\s+['"].*?['"];?\s*/g, '')
     .replace(/export\s+/g, '')
     .replace(/\/\*\*[\s\S]*?\*\//g, '')
-    .replace(/const\s+prefix\s*=.*?;/g, '')
-    .replace(/\$\{prefix\}/g, '${\'c4p\'}')
+    .replace(/\bprefix\b/g, "'c4p'")
+    .replace(/'c4p'\s*\+\s*'--/g, "'c4p--")
     .replace(/\s*\{\s+args:\s*defaultArgs,\s+render:\s*\(args:\s*any\)\s*=>\s*\{\s*/g, '')
     .trim()
 ];
 
 export const customImportArr = [`import '@carbon/web-components/es/components/tooltip/index.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 `];
 
 <Meta of={EditInPlaceStories} />

--- a/packages/ibm-products-web-components/src/components/options-tile/option-tile-helpers.ts
+++ b/packages/ibm-products-web-components/src/components/options-tile/option-tile-helpers.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const blockClass = 'options-tile';
+
+// spell-checker:disable
+export const languages = [
+  { label: 'English', value: 'en' },
+  { label: '简体中文 - Chinese Simplified', value: 'zh-CN' },
+  { label: '繁體中文 - Chinese Traditional', value: 'zh-TW' },
+  { label: 'Français - French', value: 'fr' },
+  { label: 'Deutsch - German', value: 'de' },
+  { label: 'Italiano - Italian', value: 'it' },
+  { label: '日本語 - Japanese', value: 'ja' },
+  { label: '한국어 - Korean', value: 'ko' },
+  { label: 'Polski - Polish', value: 'pl' },
+  { label: 'Português (brasileiro) - Portuguese (Brazilian)', value: 'pt-BR' },
+  { label: 'Русский - Russian', value: 'ru' },
+  { label: 'Español - Spanish', value: 'es' },
+];
+
+export const locales = [
+  { label: 'English', value: 'en' },
+  { label: 'English-US', value: 'en-US' },
+  { label: 'English-UK', value: 'en-UK' },
+  { label: 'English-Canada', value: 'en-CA' },
+  { label: 'English-Australia', value: 'en-AU' },
+  { label: 'Japanese', value: 'ja' },
+  { label: 'Korean', value: 'ko' },
+  { label: 'Chinese-PRC', value: 'zh-CN' },
+  { label: 'Chinese-Taiwan', value: 'zh-TW' },
+  { label: 'Vietnamese', value: 'vi' },
+  { label: 'Thai', value: 'th' },
+  { label: 'Russian', value: 'ru' },
+  { label: 'Polish', value: 'pl' },
+  { label: 'Greek', value: 'el' },
+  { label: 'Hebrew', value: 'he' },
+  { label: 'Arabic', value: 'ar' },
+  { label: 'Spanish', value: 'es' },
+  { label: 'German', value: 'de' },
+  { label: 'French', value: 'fr' },
+  { label: 'French-Canada', value: 'fr-CA' },
+  { label: 'Italian', value: 'it' },
+  { label: 'Portuguese-Brazil', value: 'pt-BR' },
+  { label: 'Turkish', value: 'tr' },
+];
+// spell-checker:enable

--- a/packages/ibm-products-web-components/src/components/options-tile/options-tile.mdx
+++ b/packages/ibm-products-web-components/src/components/options-tile/options-tile.mdx
@@ -2,10 +2,17 @@ import { ArgTypes, Markdown, Meta, Canvas } from '@storybook/addon-docs/blocks';
 import { cdnJs, cdnCss } from '../../globals/internal/storybook-cdn';
 import * as OptionsTileStories from './options-tile.stories';
 import { stackblitzPrefillConfig } from '../../../previewer/codePreviewer';
+import helperSource from './option-tile-helpers.ts?raw';
+
+export const customFunctionArr = [
+  helperSource
+    .replace(/import\s+.*?from\s+['"].*?['"];?\s*/g, '')
+    .replace(/export\s+/g, '')
+    .replace(/\/\*\*[\s\S]*?\*\//g, '')
+    .trim()
+];
 
 <Meta of={OptionsTileStories} />
-
-export const customFunctionArr=[`const blockClass = 'options-tile';`];
 
 # OptionsTile
 

--- a/packages/ibm-products-web-components/src/components/options-tile/options-tile.stories.ts
+++ b/packages/ibm-products-web-components/src/components/options-tile/options-tile.stories.ts
@@ -12,6 +12,7 @@ import { fn } from 'storybook/test';
 import './index';
 import '@carbon/web-components/es/components/toggle/index.js';
 import '@carbon/web-components/es/components/dropdown/index.js';
+import { languages, locales, blockClass } from './option-tile-helpers.ts';
 import styles from './story-styles.scss?lit';
 
 const argTypes = {
@@ -64,51 +65,6 @@ const argTypes = {
       'Provide a text explaining why the OptionsTile is in warning state.',
   },
 };
-
-const blockClass = 'options-tile';
-
-// spell-checker:disable
-const languages = [
-  { label: 'English', value: 'en' },
-  { label: '简体中文 - Chinese Simplified', value: 'zh-CN' },
-  { label: '繁體中文 - Chinese Traditional', value: 'zh-TW' },
-  { label: 'Français - French', value: 'fr' },
-  { label: 'Deutsch - German', value: 'de' },
-  { label: 'Italiano - Italian', value: 'it' },
-  { label: '日本語 - Japanese', value: 'ja' },
-  { label: '한국어 - Korean', value: 'ko' },
-  { label: 'Polski - Polish', value: 'pl' },
-  { label: 'Português (brasileiro) - Portuguese (Brazilian)', value: 'pt-BR' },
-  { label: 'Русский - Russian', value: 'ru' },
-  { label: 'Español - Spanish', value: 'es' },
-];
-
-const locales = [
-  { label: 'English', value: 'en' },
-  { label: 'English-US', value: 'en-US' },
-  { label: 'English-UK', value: 'en-UK' },
-  { label: 'English-Canada', value: 'en-CA' },
-  { label: 'English-Australia', value: 'en-AU' },
-  { label: 'Japanese', value: 'ja' },
-  { label: 'Korean', value: 'ko' },
-  { label: 'Chinese-PRC', value: 'zh-CN' },
-  { label: 'Chinese-Taiwan', value: 'zh-TW' },
-  { label: 'Vietnamese', value: 'vi' },
-  { label: 'Thai', value: 'th' },
-  { label: 'Russian', value: 'ru' },
-  { label: 'Polish', value: 'pl' },
-  { label: 'Greek', value: 'el' },
-  { label: 'Hebrew', value: 'he' },
-  { label: 'Arabic', value: 'ar' },
-  { label: 'Spanish', value: 'es' },
-  { label: 'German', value: 'de' },
-  { label: 'French', value: 'fr' },
-  { label: 'French-Canada', value: 'fr-CA' },
-  { label: 'Italian', value: 'it' },
-  { label: 'Portuguese-Brazil', value: 'pt-BR' },
-  { label: 'Turkish', value: 'tr' },
-];
-// spell-checker:enable
 
 export const Default = {
   args: {


### PR DESCRIPTION
Closes #9700

corrected styles in Open in stackblitz and few open in stackblitz are 

#### What did you change? 

Corrected stackblitz feature in below components
- Coachmark
- About Modal
- Option Tile
- Edit in Place
- User avatar


#### How did you test and verify your work? open in stackblitz and yarn storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
