### PR TITLE
fix(aboutmodal): hyperlink spacing

### DIFF
--- a/packages/ibm-products-styles/src/components/AboutModal/_about-modal.scss
+++ b/packages/ibm-products-styles/src/components/AboutModal/_about-modal.scss
@@ -70,9 +70,18 @@ $block-class: #{c4p-settings.$pkg-prefix}--about-modal;
 }
 
 .#{$block-class} .#{$block-class}__links-container a + a {
-  border-inline-start: 1px solid $border-strong-01;
-  margin-inline-start: $spacing-04;
-  padding-inline-start: $spacing-04;
+  position: relative;
+  margin-inline-start: $spacing-05;
+
+  &::before {
+    position: absolute;
+    background-color: $border-strong-01;
+    block-size: 1lh;
+    content: '';
+    inline-size: 1px;
+    inset-block-start: 0;
+    inset-inline-start: calc($spacing-03 * -1);
+  }
 }
 
 .#{$block-class} .#{$block-class}__content,

--- a/packages/ibm-products-styles/src/components/AboutModal/_about-modal.scss
+++ b/packages/ibm-products-styles/src/components/AboutModal/_about-modal.scss
@@ -71,8 +71,8 @@ $block-class: #{c4p-settings.$pkg-prefix}--about-modal;
 
 .#{$block-class} .#{$block-class}__links-container a + a {
   border-inline-start: 1px solid $border-strong-01;
-  margin-inline-start: $spacing-03;
-  padding-inline-start: $spacing-03;
+  margin-inline-start: $spacing-04;
+  padding-inline-start: $spacing-04;
 }
 
 .#{$block-class} .#{$block-class}__content,


### PR DESCRIPTION
Closes #9571 

Update about modal hyperlinks spacing to 16px margin total (8px before and 8px after the pipe)

#### What did you change?

- Update css of about modal so that hyperlinks spacing is now 16px margin instead of 8px padding+8px margin

#### How did you test and verify your work?
Storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
