### PR TITLE
fix(BigNumber): Use figure & figcaption in both react and wc

### DIFF
--- a/packages/ibm-products-styles/src/components/BigNumber/_big-number.scss
+++ b/packages/ibm-products-styles/src/components/BigNumber/_big-number.scss
@@ -23,6 +23,10 @@
 $block-class: #{c4p-settings.$pkg-prefix}--big-number;
 $skeleton-block-class: #{c4p-settings.$pkg-prefix}--big-number-skeleton;
 
+.#{$block-class} {
+  margin: 0;
+}
+
 .#{$block-class}__label {
   @include type-style('label-01');
 

--- a/packages/ibm-products-web-components/src/components/big-number/big-number.ts
+++ b/packages/ibm-products-web-components/src/components/big-number/big-number.ts
@@ -155,11 +155,11 @@ class CDSBigNumber extends LitElement {
     }
 
     return html`
-      <div class=${bigNumberClasses}>
+      <figure class=${bigNumberClasses}>
         <!-- Label and tooltip  -->
         <span class="${blockClass}__row">
           <slot name="label">
-            <h4 class="${blockClass}__label">${label}</h4>
+            <figcaption class="${blockClass}__label">${label}</figcaption>
           </slot>
         </span>
         <span class="${blockClass}__row" role="math">
@@ -196,7 +196,7 @@ class CDSBigNumber extends LitElement {
             <slot name="icon-button"></slot>
           </span>
         </span>
-      </div>
+      </figure>
     `;
   }
 

--- a/packages/ibm-products/src/components/BigNumber/BigNumber.tsx
+++ b/packages/ibm-products/src/components/BigNumber/BigNumber.tsx
@@ -56,7 +56,7 @@ export interface BigNumberProps {
  * of a button as well as tool tip functionality.
  * The default locale is English (`en-US`) if one is not provided or if the provided one is not supported.
  */
-export const BigNumber = forwardRef<HTMLDivElement, BigNumberProps>(
+export const BigNumber = forwardRef<HTMLElement, BigNumberProps>(
   (
     {
       // The component props, in alphabetical order (for consistency).
@@ -115,7 +115,7 @@ export const BigNumber = forwardRef<HTMLDivElement, BigNumberProps>(
     }
 
     return (
-      <div
+      <figure
         {...rest}
         className={cx(blockClass, bigNumberClasses, className)}
         ref={ref}
@@ -123,7 +123,7 @@ export const BigNumber = forwardRef<HTMLDivElement, BigNumberProps>(
       >
         {/* Label and tooltip */}
         <span className={`${blockClass}__row`}>
-          <h4 className={`${blockClass}__label`}>{label}</h4>
+          <figcaption className={`${blockClass}__label`}>{label}</figcaption>
           {tooltipDescription && (
             <Tooltip
               description={tooltipDescription}
@@ -166,7 +166,7 @@ export const BigNumber = forwardRef<HTMLDivElement, BigNumberProps>(
           )}
           <span className={`${blockClass}__icon-button`}>{iconButton}</span>
         </span>
-      </div>
+      </figure>
     );
   }
 );


### PR DESCRIPTION
Closes #7167 

Update div & h4 to use figure & figcaption in both react and wc.

#### What did you change?

- Update BigNumbers wrapper div to figure
- Update h4 to figcaption

#### How did you test and verify your work?
storybook and accessibility checker

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
