### PR TITLE
fix(pageheader): fix overflow breadcrumb menu zindex

### DIFF
--- a/packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
+++ b/packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
@@ -734,7 +734,7 @@ $duration: 1000ms;
 
   .#{$block-class}__breadcrumb-bar {
     position: sticky;
-    z-index: 1;
+    z-index: 2;
     background-color: $layer;
     block-size: to-rem(40px);
     /* stylelint-disable-next-line carbon/layout-use */


### PR DESCRIPTION
Closes #9630 

Fix overflow breadcrumb menu z-index

#### What did you change?
- fix overflow breadcrumb menu z-index value so that the menu displays above the tabs

#### How did you test and verify your work?
Storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
