### PR TITLE
fix(preview-pageheader): fix tags spacing when tabs are absent

### DIFF
--- a/packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
+++ b/packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
@@ -1057,9 +1057,13 @@ $duration: 1000ms;
   &.#{$block-class}.#{$block-class}--disable-sticky-tab-bar
     .#{$block-class}__tab-bar {
     position: static;
+    // On smaller screens, use flex to keep scroller button in flow
+    // position: relative;
     display: flex;
     align-items: center;
+    // background-color: $layer;
 
+    // // On max breakpoint and above, use block to maintain Carbon alignment (scroller uses absolute positioning)
     @include breakpoint(sm) {
       display: block;
     }

--- a/packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
+++ b/packages/ibm-products-styles/src/components/PageHeader/_page-header.scss
@@ -1046,22 +1046,20 @@ $duration: 1000ms;
   .#{$block-class}__tab-bar {
     position: sticky;
     z-index: 1;
+    align-content: center;
     background-color: $layer;
     /* stylelint-disable-next-line carbon/layout-use */
     inset-block-start: var(--#{$pkg-prefix}-page-header-breadcrumb-top);
+    min-block-size: $spacing-08;
   }
 
   // Disable sticky positioning for tab bar when disableStickyTabBar prop is true
   &.#{$block-class}.#{$block-class}--disable-sticky-tab-bar
     .#{$block-class}__tab-bar {
     position: static;
-    // On smaller screens, use flex to keep scroller button in flow
-    // position: relative;
     display: flex;
     align-items: center;
-    // background-color: $layer;
 
-    // // On max breakpoint and above, use block to maintain Carbon alignment (scroller uses absolute positioning)
     @include breakpoint(sm) {
       display: block;
     }


### PR DESCRIPTION
Closes #9706 

Fix tags spacing when tabs are absent.

#### What did you change?

- Add min block size of spacing-08
- Align content to center

#### How did you test and verify your work?
Storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
