### PR TITLE
fix(createsidepanel): parity between the react and wc storybook

### DIFF
--- a/packages/ibm-products-web-components/examples/create-side-panel/src/create-side-panel-with-form-validation.ts
+++ b/packages/ibm-products-web-components/examples/create-side-panel/src/create-side-panel-with-form-validation.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/ibm-products-web-components/examples/create-side-panel/src/create-side-panel-with-form-validation.ts
+++ b/packages/ibm-products-web-components/examples/create-side-panel/src/create-side-panel-with-form-validation.ts
@@ -20,13 +20,35 @@ import styles from './styles.scss?lit';
 
 const blockClass = 'c4p--create-side-panel';
 
-@customElement('create-side-panel-default')
-export class CreateSidepanelDefault extends LitElement {
+@customElement('create-side-panel-with-form-validation')
+export class CreateSidepanelWithFormValidation extends LitElement {
   @state()
   open: boolean = false;
 
+  @state()
+  private topicName: string = '';
+
+  @state()
+  private invalid: boolean = false;
+
   private _openHandler() {
     this.open = !this.open;
+    // Reset form state when closing
+    if (!this.open) {
+      this.topicName = '';
+      this.invalid = false;
+    }
+  }
+
+  private _handleTopicNameInput(e: Event) {
+    this.topicName = (e.target as HTMLInputElement).value;
+    this.invalid = false;
+  }
+
+  private _handleTopicNameBlur() {
+    if (this.topicName.length === 0) {
+      this.invalid = true;
+    }
   }
 
   render() {
@@ -55,9 +77,17 @@ export class CreateSidepanelDefault extends LitElement {
             We recommend you fill out and evaluate these details at a minimum
             before deploying your topic.
           </p>
-          <cds-form id="example-form" class="${blockClass}__form">
+          <cds-form id="validation-form" class="${blockClass}__form">
             <cds-form-item>
-              <cds-text-input placeholder="Enter topic name" label="Topic name"></cds-text-input>
+              <cds-text-input
+                placeholder="Enter topic name"
+                label="Topic name"
+                value=${this.topicName}
+                ?invalid=${this.invalid}
+                invalid-text="This is a required field"
+                @input=${this._handleTopicNameInput}
+                @blur=${this._handleTopicNameBlur}
+              ></cds-text-input>
             </cds-form-item>
             <cds-form-item>
               <cds-number-input
@@ -130,7 +160,11 @@ export class CreateSidepanelDefault extends LitElement {
             @click=${this._openHandler}
             >Cancel</cds-button
           >
-          <cds-button slot="actions" kind="primary" @click=${this._openHandler}
+          <cds-button
+            slot="actions"
+            kind="primary"
+            ?disabled=${!this.topicName.length}
+            @click=${this._openHandler}
             >Create</cds-button
           >
         </c4p-side-panel>
@@ -139,4 +173,4 @@ export class CreateSidepanelDefault extends LitElement {
   }
 }
 
-export default CreateSidepanelDefault;
+export default CreateSidepanelWithFormValidation;

--- a/packages/ibm-products-web-components/examples/create-side-panel/src/index.ts
+++ b/packages/ibm-products-web-components/examples/create-side-panel/src/index.ts
@@ -8,3 +8,4 @@
  */
 
 export { default as CreateSidepanelDefault } from './create-side-panel-default';
+export { default as CreateSidepanelWithFormValidation } from './create-side-panel-with-form-validation';

--- a/packages/ibm-products-web-components/examples/create-side-panel/src/styles.scss
+++ b/packages/ibm-products-web-components/examples/create-side-panel/src/styles.scss
@@ -48,6 +48,13 @@ $block-class: #{$prefix}--create-side-panel;
   justify-content: center;
 }
 
+.#{$block-class}__retention-row {
+  display: grid;
+  align-items: flex-end;
+  grid-template-columns: 1fr 1fr;
+  column-gap: 1rem;
+}
+
 .#{$block-class}__form {
   padding-inline-start: 1rem;
 }

--- a/packages/ibm-products-web-components/src/patterns/create-side-panel/create-side-panel.mdx
+++ b/packages/ibm-products-web-components/src/patterns/create-side-panel/create-side-panel.mdx
@@ -24,6 +24,7 @@ To build this pattern, we recommend including the following components:
 
 - [c4p-sidepanel](https://ibm-products-web-components.netlify.app/?path=/docs/components-sidepanel--overview)
 - [cds-button](https://web-components.carbondesignsystem.com/?path=/docs/components-button--overview)
+- [cds-dropdown](https://web-components.carbondesignsystem.com/?path=/docs/components-dropdown--overview)
 - [cds-form-item](https://web-components.carbondesignsystem.com/?path=/docs/components-form--overview)
 - [cds-number-input](https://web-components.carbondesignsystem.com/?path=/docs/components-number-input--overview)
 - [cds-text-input](https://web-components.carbondesignsystem.com/?path=/docs/components-text-input--overview)
@@ -43,6 +44,7 @@ Here's a quick example to get you started.
 ```javascript
 import '@carbon/ibm-products-web-components/es/components/side-panel/index.js';
 import '@carbon/web-components/es/components/button/index.js';
+import '@carbon/web-components/es/components/dropdown/index.js';
 import '@carbon/web-components/es/components/form/form-item.js';
 import '@carbon/web-components/es/components/number-input/index.js';
 import '@carbon/web-components/es/components/text-input/index.js';
@@ -52,19 +54,15 @@ import '@carbon/web-components/es/components/text-input/index.js';
 
 ```html
 <div>
-  <cds-button @click=${this._openHandler}>Create partitions</cds-button>
+  <cds-button @click=${this._openHandler}>Open SidePanel</cds-button>
   <c4p-side-panel
     @c4p-side-panel-closed=${this._openHandler}
     class="${blockClass}"
     ?animate-title=${false}
-    include-overlay
     ?open=${this.open}
     size="md"
     title="Create partitions"
   >
-    <div slot="subtitle">
-      Specify the details of the partitions you're creating
-    </div>
     <h3
       class="${blockClass}__form-title-text ${blockClass}__content-text"
     >
@@ -76,13 +74,13 @@ import '@carbon/web-components/es/components/text-input/index.js';
     </p>
     <cds-form id="example-form" class="${blockClass}__form">
       <cds-form-item>
-        <cds-text-input value="Topic" label="Topic name"></cds-text-input>
+        <cds-text-input placeholder="Enter topic name" label="Topic name"></cds-text-input>
       </cds-form-item>
       <cds-form-item>
         <cds-number-input
-          value="50"
+          value="1"
           min="0"
-          max="100"
+          max="50"
           step="1"
           label="Partitions"
           size="md"
@@ -91,11 +89,53 @@ import '@carbon/web-components/es/components/text-input/index.js';
       </cds-form-item>
       <cds-form-item>
         <cds-number-input
-          value="50"
+          value="1"
           min="0"
-          max="100"
+          max="50"
           step="1"
           label="Replicas"
+          size="md"
+        >
+        </cds-number-input>
+      </cds-form-item>
+      <cds-form-item>
+        <cds-number-input
+          value="1"
+          min="0"
+          max="50"
+          step="1"
+          label="Minimum in-sync replicas"
+          size="md"
+        >
+        </cds-number-input>
+      </cds-form-item>
+      <cds-form-item class="${blockClass}__retention-row">
+        <cds-number-input
+          value="30"
+          min="0"
+          max="50"
+          step="1"
+          label="Retention time"
+          size="md"
+        >
+        </cds-number-input>
+        <cds-dropdown
+          title-text="Options"
+          label="Options"
+          value="Day(s)"
+        >
+          <cds-dropdown-item value="Day(s)">Day(s)</cds-dropdown-item>
+          <cds-dropdown-item value="Month(s)">Month(s)</cds-dropdown-item>
+          <cds-dropdown-item value="Year(s)">Year(s)</cds-dropdown-item>
+        </cds-dropdown>
+      </cds-form-item>
+      <cds-form-item>
+        <cds-number-input
+          value="1"
+          min="0"
+          max="50"
+          step="1"
+          label="Quantity"
           size="md"
         >
         </cds-number-input>
@@ -112,4 +152,49 @@ import '@carbon/web-components/es/components/text-input/index.js';
     >
   </c4p-side-panel>
 </div>
+```
+
+## With Form Validation
+
+The "With Form Validation" story extends the default pattern with basic form
+validation:
+
+- The **Create** button is disabled until the Topic name field contains text
+- The Topic name field shows an invalid state with error text when blurred while
+  empty
+- Form state (topic name and invalid flag) resets when the panel is closed
+
+### JS (via import)
+
+```javascript
+import '@carbon/ibm-products-web-components/es/components/side-panel/index.js';
+import '@carbon/web-components/es/components/button/index.js';
+import '@carbon/web-components/es/components/dropdown/index.js';
+import '@carbon/web-components/es/components/form/form-item.js';
+import '@carbon/web-components/es/components/number-input/index.js';
+import '@carbon/web-components/es/components/text-input/index.js';
+```
+
+### Key differences from Default
+
+```html
+<!-- Topic name input tracks value and shows validation -->
+<cds-text-input
+  placeholder="Enter topic name"
+  label="Topic name"
+  value=${this.topicName}
+  ?invalid=${this.invalid}
+  invalid-text="This is a required field"
+  @input=${this._handleTopicNameInput}
+  @blur=${this._handleTopicNameBlur}
+></cds-text-input>
+
+<!-- Create button disabled until topic name has a value -->
+<cds-button
+  slot="actions"
+  kind="primary"
+  ?disabled=${!this.topicName.length}
+  @click=${this._openHandler}
+  >Create</cds-button
+>
 ```

--- a/packages/ibm-products-web-components/src/patterns/create-side-panel/create-side-panel.stories.ts
+++ b/packages/ibm-products-web-components/src/patterns/create-side-panel/create-side-panel.stories.ts
@@ -19,3 +19,10 @@ export const Default = {
     return html`<create-side-panel-default></create-side-panel-default>`;
   },
 };
+
+export const WithFormValidation = {
+  render: () => {
+    return html`<create-side-panel-with-form-validation></create-side-panel-with-form-validation>`;
+  },
+};
+WithFormValidation.storyName = 'With Form Validation';


### PR DESCRIPTION
Closes #9602 

Ensure parity between the Create Side Panel pattern in react and in WC.

#### What did you change?
- Updated existing default story for Create Side Panel pattern (WC) to match the react version
- Added new With Form Validation story for Create Side Panel pattern (WC) same as how it is in react

#### How did you test and verify your work?
Storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
