### PR TITLE
fix(tagOverflow): remove usePortalTarget hook

### DIFF
--- a/packages/ibm-products/src/components/TagOverflow/TagOverflow.tsx
+++ b/packages/ibm-products/src/components/TagOverflow/TagOverflow.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, {
-  ReactNode,
   RefObject,
   createElement,
   forwardRef,
@@ -54,7 +53,7 @@ export interface TagOverflowProps {
   allTagsModalAriaLabel?: string;
   allTagsModalSearchLabel?: string;
   allTagsModalSearchPlaceholderText?: string;
-  allTagsModalTarget?: ReactNode;
+  allTagsModalTarget?: HTMLElement;
   allTagsModalTitle?: string;
   autoAlign?: boolean;
   className?: string;
@@ -277,9 +276,13 @@ TagOverflow.propTypes = {
    */
   allTagsModalSearchPlaceholderText: PropTypes.string,
   /**
-   * portal target for the all tags modal
+   * DOM element to portal the all tags modal into. Defaults to `document.body`.
    */
-  allTagsModalTarget: PropTypes.node,
+  allTagsModalTarget:
+    typeof HTMLElement === 'undefined'
+      ? PropTypes.object
+      : // eslint-disable-next-line ssr-friendly/no-dom-globals-in-module-scope
+        PropTypes.instanceOf(HTMLElement),
   /**
    * title for the show all modal. **Note: Required if more than 10 tags**
    */

--- a/packages/ibm-products/src/components/TagOverflow/TagOverflow.tsx
+++ b/packages/ibm-products/src/components/TagOverflow/TagOverflow.tsx
@@ -61,6 +61,13 @@ export interface TagOverflowProps {
    * @deprecated The `containingElementRef` prop is no longer going to be used in favor of the forwarded ref.
    */
   containingElementRef?: RefObject<HTMLDivElement>;
+  /**
+   * Disable the portal and render the modal inline. Useful for tests and
+   * contexts where you need to inherit React context from parent components.
+   *
+   * @default true
+   */
+  disablePortal?: boolean;
   items: TagOverflowItem[];
   maxVisible?: number;
   /**
@@ -110,6 +117,7 @@ export const TagOverflow = forwardRef<HTMLDivElement, TagOverflowProps>(
       allTagsModalTitle,
       autoAlign,
       className,
+      disablePortal,
       items,
       maxVisible,
       overflowAlign = 'bottom',
@@ -238,6 +246,7 @@ export const TagOverflow = forwardRef<HTMLDivElement, TagOverflowProps>(
                 searchLabel={allTagsModalSearchLabel}
                 searchPlaceholder={allTagsModalSearchPlaceholderText}
                 portalTarget={allTagsModalTarget}
+                disablePortal={disablePortal}
               />
             </div>
           )}
@@ -295,6 +304,11 @@ TagOverflow.propTypes = {
    * Provide an optional class to be applied to the containing node.
    */
   className: PropTypes.string,
+  /**
+   * Disable the portal and render the modal inline. Useful for tests and
+   * contexts where you need to inherit React context from parent components.
+   */
+  disablePortal: PropTypes.bool,
   /**
    * The items to be shown in the TagOverflow. Each item is specified as an object with properties:
    * **label**\* (required) to supply the content,

--- a/packages/ibm-products/src/components/TagOverflow/TagOverflowModal.tsx
+++ b/packages/ibm-products/src/components/TagOverflow/TagOverflowModal.tsx
@@ -5,7 +5,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-import React, { ReactNode, useState } from 'react';
+import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
@@ -20,7 +21,6 @@ import {
 
 import { pkg } from '../../settings';
 import { prepareProps } from '../../global/js/utils/props-helper';
-import { usePortalTarget } from '../../global/js/hooks/usePortalTarget';
 
 const componentName = 'TagOverflowModal';
 const blockClass = `${pkg.prefix}--tag-overflow-modal`;
@@ -40,12 +40,22 @@ type AllTags = (TagType & Omit<React.ComponentProps<typeof Tag>, 'filter'>)[];
 interface TagOverflowModalProps {
   allTags?: AllTags;
   className?: string;
+  /**
+   * Disable the portal and render the modal inline. Useful for tests and
+   * contexts where you need to inherit React context from parent components.
+   *
+   * @default false
+   */
+  disablePortal?: boolean;
   modalAriaLabel?: string;
   onClose?: () => void;
   onTagClose?: (params: { label: string; id: any }) => void;
   open?: boolean;
   overflowType?: 'default' | 'tag';
-  portalTarget?: ReactNode;
+  /**
+   * DOM element to portal the modal into. Defaults to `document.body`.
+   */
+  portalTarget?: HTMLElement | null;
   searchLabel?: string;
   searchPlaceholder?: string;
   title?: string;
@@ -56,6 +66,7 @@ export const TagOverflowModal = ({
 
   allTags,
   className,
+  disablePortal = false,
   title,
   modalAriaLabel = defaults.modalAriaLabel,
   onClose,
@@ -70,7 +81,7 @@ export const TagOverflowModal = ({
   ...rest
 }: TagOverflowModalProps) => {
   const [search, setSearch] = useState('');
-  const renderPortalUse = usePortalTarget(portalTargetIn);
+  const mountNode = disablePortal ? null : (portalTargetIn ?? document.body);
 
   const getFilteredItems = (): AllTags => {
     if (open && search && allTags) {
@@ -85,7 +96,7 @@ export const TagOverflowModal = ({
     setSearch(evt.target.value || '');
   };
 
-  return renderPortalUse(
+  const modal = (
     <ComposedModal
       {
         // Pass through any other property values as HTML attributes.
@@ -135,6 +146,8 @@ export const TagOverflowModal = ({
       </ModalBody>
     </ComposedModal>
   );
+
+  return mountNode ? createPortal(modal, mountNode) : modal;
 };
 
 TagOverflowModal.propTypes = {
@@ -145,11 +158,23 @@ TagOverflowModal.propTypes = {
     })
   ),
   className: PropTypes.string,
+  /**
+   * Disable the portal and render the modal inline. Useful for tests and
+   * contexts where you need to inherit React context from parent components.
+   */
+  disablePortal: PropTypes.bool,
   onClose: PropTypes.func,
   onTagClose: PropTypes.func,
   open: PropTypes.bool,
   overflowType: PropTypes.oneOf(['default', 'tag']),
-  portalTarget: PropTypes.node,
+  /**
+   * DOM element to portal the modal into. Defaults to `document.body`.
+   */
+  portalTarget:
+    typeof HTMLElement === 'undefined'
+      ? PropTypes.object
+      : // eslint-disable-next-line ssr-friendly/no-dom-globals-in-module-scope
+        PropTypes.instanceOf(HTMLElement),
   searchLabel: PropTypes.string,
   searchPlaceholder: PropTypes.string,
   title: PropTypes.string,


### PR DESCRIPTION
Closes #

Removed usePortalTarget hook as part of migration

#### What did you change? 
packages/ibm-products/src/components/TagOverflow/TagOverflowModal.tsx
packages/ibm-products/src/components/TagOverflow/TagOverflow.tsx

#### How did you test and verify your work? yarn storybook, yarn test

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
