### PR TITLE
fix(Tearsheet next): correct Carbon layer hierarchy — body elevated instead of header

### DIFF
--- a/packages/ibm-products-styles/src/components/Tearsheet/_tearsheet_next.scss
+++ b/packages/ibm-products-styles/src/components/Tearsheet/_tearsheet_next.scss
@@ -176,6 +176,7 @@ $transform-start: translate3d(0, calc(min(95vh, 500px)), 0);
     display: flex;
     flex-wrap: wrap;
     align-content: space-between;
+    background-color: $layer;
     border-block-end: 1px solid $border-subtle-01;
     margin-block: 0;
     max-block-size: 50vh;
@@ -672,9 +673,15 @@ $transform-start: translate3d(0, calc(min(95vh, 500px)), 0);
   }
 }
 
+.#{$block-class__next}__layer {
+  display: contents;
+}
+
 .#{$block-class__next}__main-content {
   position: relative;
+  background-color: $background;
 }
+
 .#{$block-class__next}__side-panel {
   position: absolute;
   z-index: 9999;

--- a/packages/ibm-products-styles/src/components/Tearsheet/_tearsheet_next.scss
+++ b/packages/ibm-products-styles/src/components/Tearsheet/_tearsheet_next.scss
@@ -176,7 +176,6 @@ $transform-start: translate3d(0, calc(min(95vh, 500px)), 0);
     display: flex;
     flex-wrap: wrap;
     align-content: space-between;
-    background-color: $layer;
     border-block-end: 1px solid $border-subtle-01;
     margin-block: 0;
     max-block-size: 50vh;
@@ -671,10 +670,6 @@ $transform-start: translate3d(0, calc(min(95vh, 500px)), 0);
   &:focus {
     @include focus-outline.focus-outline('outline');
   }
-}
-
-.#{$block-class__next}__layer {
-  display: contents;
 }
 
 .#{$block-class__next}__main-content {

--- a/packages/ibm-products/src/components/Tearsheet/next/Tearsheet.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/next/Tearsheet.tsx
@@ -24,6 +24,7 @@ import {
   ComposedModal,
   type ComposedModalProps,
   unstable_FeatureFlags as FeatureFlags,
+  ModalBody,
   usePrefix,
 } from '@carbon/react';
 import { blockClass, TearsheetContext } from './context';
@@ -428,23 +429,20 @@ const TearsheetInternal = forwardRef<
           >
             {header}
 
-            <div
-              className={cx(
-                `${carbonPrefix}--modal-content`,
-                `${blockClass}__body-layout`,
-                {
-                  [`${blockClass}__body-layout--has-influencer`]:
-                    influencer && !isSm,
-                }
-              )}
+            <ModalBody
+              className={cx(`${blockClass}__body-layout`, {
+                [`${blockClass}__body-layout--has-influencer`]:
+                  influencer && !isSm,
+              })}
               ref={bodyRef}
+              level={0}
             >
               {influencer}
 
               {body}
 
               {footer}
-            </div>
+            </ModalBody>
           </ComposedModal>
         </FeatureFlags>
       </TearsheetContext.Provider>

--- a/packages/ibm-products/src/components/Tearsheet/next/Tearsheet.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/next/Tearsheet.tsx
@@ -24,8 +24,6 @@ import {
   ComposedModal,
   type ComposedModalProps,
   unstable_FeatureFlags as FeatureFlags,
-  Layer,
-  ModalBody,
   usePrefix,
 } from '@carbon/react';
 import { blockClass, TearsheetContext } from './context';
@@ -429,11 +427,16 @@ const TearsheetInternal = forwardRef<
             data-tearsheet-exiting={isExiting ? true : undefined}
           >
             {header}
-            <ModalBody
-              className={cx(`${blockClass}__body-layout`, {
-                [`${blockClass}__body-layout--has-influencer`]:
-                  influencer && !isSm,
-              })}
+
+            <div
+              className={cx(
+                `${carbonPrefix}--modal-content`,
+                `${blockClass}__body-layout`,
+                {
+                  [`${blockClass}__body-layout--has-influencer`]:
+                    influencer && !isSm,
+                }
+              )}
               ref={bodyRef}
             >
               {influencer}
@@ -441,7 +444,7 @@ const TearsheetInternal = forwardRef<
               {body}
 
               {footer}
-            </ModalBody>
+            </div>
           </ComposedModal>
         </FeatureFlags>
       </TearsheetContext.Provider>

--- a/packages/ibm-products/src/components/Tearsheet/next/TearsheetBody.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/next/TearsheetBody.tsx
@@ -257,9 +257,6 @@ export const Influencer = forwardRef<HTMLDivElement, InfluencerProps>(
     }, [influencerPanelOpen, influencerPanelTriggerRef]);
 
     return !isSm ? (
-      // Wrap influencer in Layer to bump Carbon token level (matching old tearsheet behavior).
-      // __layer has display:contents so it doesn't affect layout.
-
       <aside
         aria-label={influencerPanelAriaLabel}
         className={cx(`${blockClass}__influencer`, className, {

--- a/packages/ibm-products/src/components/Tearsheet/next/TearsheetBody.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/next/TearsheetBody.tsx
@@ -98,8 +98,7 @@ export const MainContent = forwardRef<HTMLDivElement, MainContentProps>(
     });
 
     return (
-      <Layer
-        withBackground
+      <div
         className={cx(`${blockClass}__main-content`, className, {
           [`${blockClass}__flush`]: isFlush,
         })}
@@ -107,7 +106,7 @@ export const MainContent = forwardRef<HTMLDivElement, MainContentProps>(
         {...rest}
       >
         {children}
-      </Layer>
+      </div>
     );
   }
 );
@@ -258,15 +257,19 @@ export const Influencer = forwardRef<HTMLDivElement, InfluencerProps>(
     }, [influencerPanelOpen, influencerPanelTriggerRef]);
 
     return !isSm ? (
-      <aside
-        aria-label={influencerPanelAriaLabel}
-        className={cx(`${blockClass}__influencer`, className, {
-          [`${blockClass}__flush`]: isFlush,
-        })}
-        ref={ref}
-      >
-        {children}
-      </aside>
+      // Wrap influencer in Layer to bump Carbon token level (matching old tearsheet behavior).
+      // __layer has display:contents so it doesn't affect layout.
+      <Layer className={`${blockClass}__layer`}>
+        <aside
+          aria-label={influencerPanelAriaLabel}
+          className={cx(`${blockClass}__influencer`, className, {
+            [`${blockClass}__flush`]: isFlush,
+          })}
+          ref={ref}
+        >
+          {children}
+        </aside>
+      </Layer>
     ) : (
       <SidePanel
         size="sm"

--- a/packages/ibm-products/src/components/Tearsheet/next/TearsheetBody.tsx
+++ b/packages/ibm-products/src/components/Tearsheet/next/TearsheetBody.tsx
@@ -259,17 +259,16 @@ export const Influencer = forwardRef<HTMLDivElement, InfluencerProps>(
     return !isSm ? (
       // Wrap influencer in Layer to bump Carbon token level (matching old tearsheet behavior).
       // __layer has display:contents so it doesn't affect layout.
-      <Layer className={`${blockClass}__layer`}>
-        <aside
-          aria-label={influencerPanelAriaLabel}
-          className={cx(`${blockClass}__influencer`, className, {
-            [`${blockClass}__flush`]: isFlush,
-          })}
-          ref={ref}
-        >
-          {children}
-        </aside>
-      </Layer>
+
+      <aside
+        aria-label={influencerPanelAriaLabel}
+        className={cx(`${blockClass}__influencer`, className, {
+          [`${blockClass}__flush`]: isFlush,
+        })}
+        ref={ref}
+      >
+        {children}
+      </aside>
     ) : (
       <SidePanel
         size="sm"


### PR DESCRIPTION
Closes #9868

In the preview (`next`) Tearsheet, the body was elevated to the wrong Carbon layer level — the header should be the elevated surface, but the body was instead. This caused nested `<Layer>` components inside the body to immediately hit the layer ceiling, leaving no contrast between the body background and nested content in dark mode.

#### What did you change?

**`packages/ibm-products/src/components/Tearsheet/next/Tearsheet.tsx`**

Replaced Carbon's `<ModalBody>` with a plain `<div className="cds--modal-content ...">`. `ModalBody` internally renders as a `<Layer>`, which consumed one layer level before the consumer added anything. Since `ComposedModal` itself renders as `<Layer level={0}>`, the body content was starting at layer context **2** — one step from the ceiling. A plain `div` matches what the legacy `TearsheetShell` does and keeps the full layer progression (1 → 2 → 3) available to consumers.

**`packages/ibm-products/src/components/Tearsheet/next/TearsheetBody.tsx`**

- `MainContent`: removed `<Layer withBackground>` wrapper, replaced with a plain `<div>`. The background is now set via CSS (`background-color: $background`) 


**`packages/ibm-products-styles/src/components/Tearsheet/_tearsheet_next.scss`**

- Added `background-color: $background` to `.__main-content` — body starts at base level.

#### How did you test and verify your work?

- Verified in the `WithInfluencer` story using nested `<Layer>` components inside `MainContent`:
  ```jsx
  <TestComponent />           {/* base level — $background */}
  <Layer><TestComponent /></Layer>           {/* level 1 — $layer */}
  <Layer><Layer><TestComponent /></Layer></Layer>  {/* level 2 — $layer-02 */}
  ```
  All three render with visually distinct backgrounds in both White and G100 themes.
- Confirmed header background is elevated (`$layer`) and body background is at base (`$background`) in both light and dark themes.
- Verified influencer layout is unaffected by the `display: contents` Layer wrapper.

#### PR Checklist

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass
