### PR TITLE
fix(CreateFullPage): focus first element of visible step on step change

### DIFF
--- a/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.test.jsx
+++ b/packages/ibm-products/src/components/CreateFullPage/CreateFullPage.test.jsx
@@ -84,10 +84,10 @@ const renderComponent = ({ ...rest } = {}) =>
       {...rest}
     >
       <CreateFullPageStep title="Title 1" subtitle="Subtitle 1">
-        <p>1</p>
+        {stepFormField}
       </CreateFullPageStep>
       <CreateFullPageStep title="Title 2" description="2">
-        <p>2</p>
+        {stepFormField}
       </CreateFullPageStep>
     </CreateFullPage>
   );
@@ -689,5 +689,40 @@ describe(componentName, () => {
         `${carbon.prefix}--progress-step--current`
       )
     ).toBe(true);
+  });
+
+  it('moves focus to the first input of the visible step after clicking Next (issue #9864)', async () => {
+    const { click } = userEvent;
+    const { container } = renderCreateFullPage(defaultFullPageProps);
+
+    // Step 1 is visible on mount; its input should not be focused before Next.
+    const firstStepInput = container.querySelector(
+      `.${blockClass}__step__step--visible-step input`
+    );
+    expect(firstStepInput).toBeTruthy();
+
+    // Advance to step 2.
+    await act(() => click(screen.getByText(nextButtonText)));
+    await waitFor(() => expect(onNextStepFn).toHaveBeenCalled());
+
+    // The visible step is now step 2.
+    const visibleStep = container.querySelector(
+      `.${blockClass}__step__step--visible-step`
+    );
+    expect(visibleStep).toBeTruthy();
+
+    // The hook awaits a 10ms timeout before focusing; wait for focus to land.
+    await waitFor(() => {
+      const focusedInput = container.querySelector(
+        `.${blockClass}__step__step--visible-step input`
+      );
+      expect(focusedInput).toBeTruthy();
+      expect(document.activeElement).toBe(focusedInput);
+    });
+
+    // Focus must NOT be on the "Skip to main content" button or the body.
+    const skipLink = container.querySelector('a');
+    expect(document.activeElement).not.toBe(skipLink);
+    expect(document.activeElement).not.toBe(document.body);
   });
 });

--- a/packages/ibm-products/src/global/js/hooks/useCreateComponentFocus.js
+++ b/packages/ibm-products/src/global/js/hooks/useCreateComponentFocus.js
@@ -36,16 +36,16 @@ export const useCreateComponentFocus = ({
       );
     };
 
+    // The currently visible step is the one carrying the visible modifier
+    // class. NOTE: the `blockClass` prop ends with `__step` (`.prefix--create-
+    // full-page .prefix--create-full-page__step`), so appending
+    // `__step--visible-step` targets
+    // `.prefix--create-full-page__step__step--visible-step`.
+    // (Fix for carbon-design-system/ibm-products#9864: the previous inert-walk
+    // logic never matched because CreateFullPageStep hides steps with
+    // display:none instead of the `inert` attribute.)
     const getActiveStep = () => {
-      const allSteps = Array.from(document.querySelectorAll(blockClass));
-      return allSteps.find((el) => {
-        let currentStep = el;
-        while (currentStep) {
-          if (currentStep.hasAttribute('inert')) return false;
-          currentStep = currentStep.parentElement;
-        }
-        return true;
-      });
+      return document.querySelector(`${blockClass}__step--visible-step`);
     };
 
     const getFocusableElement = (containingElement) => {


### PR DESCRIPTION
Closes #9864

## Root cause

`getActiveStep()` in `useCreateComponentFocus.js` walked the DOM looking for a step whose ancestor chain contained no `[inert]` attribute. `CreateFullPageStep` never sets `inert` - it hides non-active steps exclusively with the `__step--hidden-step` CSS class (`display: none`). The walk therefore always returned the first step in DOM order, regardless of which step was active.

`getFocusableElement` then found interactive elements inside that hidden (`display: none`) step. Calling `.focus()` on an element inside a `display: none` subtree is a browser no-op, so focus never moved to the newly activated step and drifted to the next tab stop - often the "Skip to main content" link. Regression introduced between v2.43 and v2.44.

## Fix

Replace the `[inert]`-based walk with a direct query for the visible-step modifier class that `CreateFullPageStep` already applies:

```js
return document.querySelector(`${blockClass}__step--visible-step`);
```

The `blockClass` prop passed from `CreateFullPage` ends with `__step` (`.prefix--create-full-page .prefix--create-full-page__step`), so the composed selector targets the real DOM class `.prefix--create-full-page__step__step--visible-step`.

## Testing

- Added a regression test: renders a two-step `CreateFullPage` with text inputs, activates `Next` with the keyboard, and asserts focus lands on the first input of the newly visible step (not on the "Skip to main content" link or `document.body`).
- The test fails on `main` (focus never lands, waitFor timeout) and passes with this fix.
- Full `CreateFullPage.test.jsx` suite: 28/28 passing.