### PR TITLE
chore: deprecate status Icon

### DIFF
--- a/packages/ibm-products/src/components/StatusIcon/StatusIcon.docs-page.jsx
+++ b/packages/ibm-products/src/components/StatusIcon/StatusIcon.docs-page.jsx
@@ -11,12 +11,16 @@ import * as stories from './StatusIcon.stories';
 
 const DocsPage = () => (
   <StoryDocsPage
+    deprecationNotice="This component is deprecated and will be removed in the next major version. Please migrate to [Icon Indicator](https://react.carbondesignsystem.com/?path=/docs/preview-statusindicators-preview-iconindicator--overview) from Carbon."
     altGuidelinesHref={[
       {
         href: 'https://carbondesignsystem.com/patterns/status-indicator-pattern/',
         label: 'Carbon status indicator patterns',
       },
     ]}
+    altDescription={`Status icons are an important method of communicating severity level
+information to users. The shapes and colors, communicate severity that enable
+users to quickly assess and identify status and respond accordingly.`}
     blocks={[
       {
         story: stories.Default,

--- a/packages/ibm-products/src/components/StatusIcon/StatusIcon.stories.jsx
+++ b/packages/ibm-products/src/components/StatusIcon/StatusIcon.stories.jsx
@@ -11,9 +11,10 @@ import { StatusIcon } from '.';
 
 // import styles from './_storybook-styles.scss?inline'; // import storybook which includes component and additional storybook styles
 import DocsPage from './StatusIcon.docs-page';
+import { Annotation } from '../../../.storybook/Annotation';
 
 export default {
-  title: 'Patterns/Prebuilt patterns/StatusIcon',
+  title: 'Deprecated/Prebuilt patterns/StatusIcon',
   component: StatusIcon,
   tags: ['autodocs'],
   argTypes: {
@@ -54,6 +55,27 @@ export default {
       page: DocsPage,
     },
   },
+  decorators: [
+    (story) => (
+      <div>
+        <Annotation
+          type="deprecation-notice"
+          text={
+            <div>
+              This component is deprecated and will be removed in next major
+              version. Please migrate to{' '}
+              <a href="https://react.carbondesignsystem.com/?path=/docs/preview-statusindicators-preview-iconindicator--overview">
+                Icon indicator
+              </a>{' '}
+              from carbon.
+            </div>
+          }
+        >
+          {story()}
+        </Annotation>
+      </div>
+    ),
+  ],
 };
 
 const defaultProps = {

--- a/packages/ibm-products/src/components/StatusIcon/StatusIcon.test.jsx
+++ b/packages/ibm-products/src/components/StatusIcon/StatusIcon.test.jsx
@@ -54,6 +54,9 @@ const renderComponent = ({ ...rest } = {}) =>
   );
 
 describe(componentName, () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
   it('renders a component StatusIcon', async () => {
     const { container } = renderComponent();
     expect(container).toBeInTheDocument();

--- a/packages/ibm-products/src/components/StatusIcon/StatusIcon.tsx
+++ b/packages/ibm-products/src/components/StatusIcon/StatusIcon.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright IBM Corp. 2021, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import {
   CheckmarkFilled,
   CheckmarkOutline,
@@ -11,19 +18,12 @@ import {
   WarningAltFilled,
   WarningAltInvertedFilled,
 } from '@carbon/react/icons';
-/**
- * Copyright IBM Corp. 2021, 2022
- *
- * This source code is licensed under the Apache-2.0 license found in the
- * LICENSE file in the root directory of this source tree.
- */
 import React, {
   PropsWithChildren,
   ReactSVGElement,
   Ref,
   forwardRef,
 } from 'react';
-
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
@@ -31,16 +31,6 @@ import { pkg } from '../../settings';
 
 const blockClass = `${pkg.prefix}--status-icon`;
 const componentName = 'StatusIcon';
-
-/**
-The `StatusIcon` component follows the Carbon guidelines for status icons with
-some added specifications around illustration usage. For additional usage
-guidelines and documentation please refer to the links above.
-
-_Status icons_ are an important method of communicating severity level
-information to users. The shapes and colors, communicate severity that enable
-users to quickly assess and identify status and respond accordingly.
- */
 
 type Size = 'sm' | 'md' | 'lg' | 'xl';
 type Theme = 'light' | 'dark';
@@ -78,6 +68,18 @@ export interface StatusIconProps extends PropsWithChildren {
    */
   theme: Theme;
 }
+
+/**
+ * The `StatusIcon` component follows the Carbon guidelines for status icons with
+ * some added specifications around illustration usage. For additional usage
+ * guidelines and documentation please refer to the links above.
+ *
+ * _Status icons_ are an important method of communicating severity level
+ * information to users. The shapes and colors, communicate severity that enable
+ * users to quickly assess and identify status and respond accordingly.
+ *
+ * @deprecated This component is deprecated.
+ */
 export const StatusIcon = forwardRef<ReactSVGElement | null, StatusIconProps>(
   (
     { kind, theme, size, className, iconDescription, ...rest }: StatusIconProps,
@@ -266,6 +268,12 @@ export const StatusIcon = forwardRef<ReactSVGElement | null, StatusIconProps>(
 );
 
 StatusIcon.displayName = componentName;
+
+/**@ts-ignore*/
+StatusIcon.deprecated = {
+  level: 'warn',
+  details: `Please replace ${componentName} with Icon Indicator from Carbon`,
+};
 
 StatusIcon.propTypes = {
   /**


### PR DESCRIPTION
Closes #9873

Deprecated status Icon 

#### What did you change? 
Follows standard deprecation approach
Redirecting to Icon indicator in Carbon 

#### How did you test and verify your work? yarn storybook

#### PR Checklist

<!--
  Do not remove checklist items. If some do not apply, ~strike out the text with tilde's~
-->

As the author of this PR, before marking ready for review, confirm you:

- [ ] Reviewed every line of the diff
- [ ] Updated documentation and storybook examples
- [ ] Wrote passing tests that cover this change
- [ ] Addressed any impact on accessibility (a11y)
- [ ] Tested for cross-browser consistency
- [ ] Validated that this code is ready for review and status checks should pass

More details can be found in the [pull request](./CONTRIBUTING.md) section of
our contributing docs.
